### PR TITLE
Generate full cert chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v1
+      
+      - name: Sniff OpenSSL version
+        run: openssl version
 
       - name: Run self tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,15 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v1
       
-      - name: Sniff OpenSSL version
+      - name: Update OpenSSL
+        run: brew install openssl
+        if: matrix.os == 'macos-latest'
+
+      - name: Update OpenSSL
+        run: sudo apt-get install openssl
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Verify OpenSSL version
         run: openssl version
 
       - name: Run self tests

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -1079,23 +1079,23 @@ pub mod tests {
         let (_, cert_path) = temp_signer::get_rsa_signer(&temp_dir.path(), "ps256", None);
         let rsa_pss256_cert = std::fs::read(&cert_path).unwrap();
 
-        if let Ok(signcert) = openssl::x509::X509::from_pem(&es256_cert) {
-            let der_bytes = signcert.to_der().unwrap();
+        if let Ok(signcert) = openssl::x509::X509::stack_from_pem(&es256_cert) {
+            let der_bytes = signcert[0].to_der().unwrap();
             assert!(check_cert("es256", &der_bytes, &mut validation_log, None).is_ok());
         }
 
-        if let Ok(signcert) = openssl::x509::X509::from_pem(&es384_cert) {
-            let der_bytes = signcert.to_der().unwrap();
+        if let Ok(signcert) = openssl::x509::X509::stack_from_pem(&es384_cert) {
+            let der_bytes = signcert[0].to_der().unwrap();
             assert!(check_cert("es384", &der_bytes, &mut validation_log, None).is_ok());
         }
 
-        if let Ok(signcert) = openssl::x509::X509::from_pem(&es512_cert) {
-            let der_bytes = signcert.to_der().unwrap();
+        if let Ok(signcert) = openssl::x509::X509::stack_from_pem(&es512_cert) {
+            let der_bytes = signcert[0].to_der().unwrap();
             assert!(check_cert("es512", &der_bytes, &mut validation_log, None).is_ok());
         }
 
-        if let Ok(signcert) = openssl::x509::X509::from_pem(&rsa_pss256_cert) {
-            let der_bytes = signcert.to_der().unwrap();
+        if let Ok(signcert) = openssl::x509::X509::stack_from_pem(&rsa_pss256_cert) {
+            let der_bytes = signcert[0].to_der().unwrap();
             assert!(check_cert("ps256", &der_bytes, &mut validation_log, None).is_ok());
         }
     }


### PR DESCRIPTION
## Changes in This Pull Request
[from @mauricefisher64] Rather than a single self-signed certificate, generate a cert chain from root -> intermediate -> signer to simulate expected certificates. This change will allow us to disable self signed certs in a future PR.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
