### PR TITLE
Add workflow for automatically releasing c2pa crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get latest existing tag
+      uses: actions-ecosystem/action-get-latest-tag@v1
+      id: get-latest-tag
+      with:
+        semver_only: true
+
+    - name: Set new version
+      uses: paulhatch/semantic-version@v4.0.2
+      id: set-version
+      with:
+        tag_prefix: "v"
+        format: "${major}.${minor}.${patch}"
+        major_pattern: "(MAJOR)"
+        minor_pattern: "(MINOR)"
+
+    - name: Generate changelog since last tag
+      uses: mathiasvr/command-output@v1
+      id: changelog
+      with:
+        run: git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD
+
+    - name: Log version & changelog
+      run: |
+        echo "Version: $VERSION"
+        echo "Version tag: $VERSION_TAG"
+        echo "Latest tag detected: $LATEST_TAG"
+        echo "Changelog: $CHANGELOG"
+      env:
+        VERSION: ${{ steps.set-version.outputs.version }}
+        VERSION_TAG: ${{ steps.set-version.outputs.version_tag }}
+        LATEST_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+        CHANGELOG: ${{ steps.changelog.outputs.stdout }}
+
+    - name: Prevent empty release
+      if: ${{ steps.changelog.outputs.stdout == '' }}
+      uses: actions/github-script@v3
+      with:
+        script: |
+          core.setFailed("No changes since prior release")
+
+    - name: Update changelog
+      run: |
+        (head -8 CHANGELOG.md && echo "## $VERSION" && date "+_%e %B %Y_" && echo "" && echo "$CHANGELOG" && tail -n +9 CHANGELOG.md) > CHANGELOG.new.md
+        mv CHANGELOG.new.md CHANGELOG.md
+      env:
+        VERSION: ${{ steps.set-version.outputs.version }}
+        CHANGELOG: ${{ steps.changelog.outputs.stdout }}
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Install cargo-edit
+      run: cargo install cargo-edit
+
+    - name: Bump crate versions
+      run: cargo set-version --workspace ${{ steps.set-version.outputs.version }}
+
+    - name: Report differences for "prepare (release)" commit
+      run: git diff
+
+    - name: Commit cargo.toml and changelog
+      uses: stefanzweifel/git-auto-commit-action@v4
+      id: commit
+      with:
+        commit_message: Prepare ${{ steps.set-version.outputs.version }} release
+        commit_user_name: Adobe CAI Team
+        commit_user_email: noreply@adobe.com
+
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        body: ${{ steps.changelog.outputs.stdout }}
+        commit: ${{ steps.commit.outputs.commit_hash }}
+        prerelease: true # remove at 1.0
+        tag: ${{ steps.set-version.outputs.version_tag }}
+
+    - name: Publish crate
+      run: |
+        cargo publish --token $CRATES_IO_SECRET -p c2pa
+      env:
+        CRATES_IO_SECRET: ${{ secrets.CRATES_IO_SECRET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# Changelog for v0.x Series
+# Changelog
+
+All changes to this project are documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
+
+Do not manually edit this file. It will be automatically updated when a new release is published.
 
 ## v0.1.0
 _23 May 2022_
 
-* Initial public release.
+* Initial public release


### PR DESCRIPTION
## Changes in This Pull Request
This adds a manually-triggered GitHub Actions workflow which will automatically:

* Choose a new version number
* Update CHANGELOG.md
* Update cargo.toml for both crates
* Commit the above changes and tag the release
* Add a GitHub release with the changelog summary (currently tagged as "prerelease")
* Publish the c2pa crate to crates.io (I'll add c2patool in a subsequent PR)

NOTE: This workflow can only be triggered by GitHub users with commit access to this repo.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
