### PR TITLE
Fix dependency reference from c2patool crate to c2pa crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload code coverage results
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: ${{ matrix.os != 'macos-latest' }
+          fail_ci_if_error: ${{ matrix.os != 'macos-latest' }}
             # Disregard build errors on Mac until
             # https://github.com/codecov/codecov-action/issues/745
             # is fixed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,4 +205,4 @@ jobs:
         uses: aig787/cargo-udeps-action@v1
         with:
           version: latest
-          args: --all-targets
+          args: --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Upload code coverage results
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ matrix.os != 'macos-latest' }
+            # Disregard build errors on Mac until
+            # https://github.com/codecov/codecov-action/issues/745
+            # is fixed.
           verbose: true
 
   tests-msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,10 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload code coverage results
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          verbose: true
 
   tests-msrv:
     name: Unit tests

--- a/c2patool/Cargo.toml
+++ b/c2patool/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.58.0"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { path = "../sdk", features = ["file_io"] }
+c2pa = "0.1"
 dirs = "4.0" 
 env_logger = "0.9"
 log = "0.4" 

--- a/c2patool/Cargo.toml
+++ b/c2patool/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.58.0"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = "0.1"
+c2pa = { version = "0.1", features = ["file_io"] }
 dirs = "4.0" 
 env_logger = "0.9"
 log = "0.4" 


### PR DESCRIPTION
## Changes in This Pull Request
Intra-repo dependencies are not allowed when publishing on crates.io.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
