### PR TITLE
Make Assertions opaque in the public SDK

### DIFF
--- a/sdk/examples/custom_assertion.rs
+++ b/sdk/examples/custom_assertion.rs
@@ -13,7 +13,7 @@
 
 //! Example: Creating a custom assertion
 //!
-use c2pa::{Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult, Manifest, Result};
+use c2pa::{Assertion, AssertionBase, AssertionCbor, Manifest, Result};
 use serde::{Deserialize, Serialize};
 
 /// Defines a Custom assertion
@@ -54,7 +54,7 @@ impl AssertionBase for Custom {
         Self::to_cbor_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_cbor_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -12,7 +12,7 @@
 // each license.
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult},
+    assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::{labels, Actor, Metadata},
     error::Result,
     Error,
@@ -188,7 +188,7 @@ impl AssertionBase for Actions {
         Self::to_cbor_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_cbor_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/creative_work.rs
+++ b/sdk/src/assertions/creative_work.rs
@@ -14,7 +14,7 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionDecodeResult, AssertionJson},
+    assertion::{Assertion, AssertionBase, AssertionJson},
     assertions::{labels, SchemaDotOrg, SchemaDotOrgPerson},
     error::Result,
 };
@@ -96,7 +96,7 @@ impl AssertionBase for CreativeWork {
         Self::to_json_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_json_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/data_hash.rs
+++ b/sdk/src/assertions/data_hash.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult},
+    assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::labels,
     cbor_types::UriT,
     error::{wrap_io_err, Error, Result},
@@ -199,7 +199,7 @@ impl DataHash {
     }
 
     /// Create a new instance from Assertion
-    pub fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    pub fn from_assertion(assertion: &Assertion) -> Result<Self> {
         assertion.check_version_from_label(ASSERTION_CREATION_VERSION)?;
         Self::from_cbor_assertion(assertion)
     }
@@ -220,7 +220,7 @@ impl AssertionBase for DataHash {
         Self::to_cbor_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_cbor_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -14,7 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult},
+    assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::{labels, Metadata, ReviewRating},
     error::Result,
     hashed_uri::HashedUri,
@@ -141,7 +141,7 @@ impl AssertionBase for Ingredient {
         Self::to_cbor_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_cbor_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/metadata.rs
+++ b/sdk/src/assertions/metadata.rs
@@ -12,7 +12,7 @@
 // each license.
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult},
+    assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::labels,
     error::Result,
     hashed_uri::HashedUri,
@@ -111,7 +111,7 @@ impl AssertionBase for Metadata {
         Self::to_cbor_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_cbor_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -14,7 +14,7 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    assertion::{Assertion, AssertionBase, AssertionDecodeResult, AssertionJson},
+    assertion::{Assertion, AssertionBase, AssertionJson},
     assertions::labels,
     error::{Error, Result},
     hashed_uri::HashedUri,
@@ -125,7 +125,7 @@ impl AssertionBase for SchemaDotOrg {
         Self::to_json_assertion(self)
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         Self::from_json_assertion(assertion)
     }
 }

--- a/sdk/src/assertions/thumbnail.rs
+++ b/sdk/src/assertions/thumbnail.rs
@@ -14,7 +14,6 @@
 use crate::{
     assertion::{
         get_thumbnail_image_type, Assertion, AssertionBase, AssertionData, AssertionDecodeError,
-        AssertionDecodeResult,
     },
     assertions::labels,
     error::Result,
@@ -68,7 +67,7 @@ impl AssertionBase for Thumbnail {
         Ok(Assertion::new(&self.label, None, data).set_content_type(&self.content_type))
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Thumbnail> {
+    fn from_assertion(assertion: &Assertion) -> Result<Thumbnail> {
         match assertion.decode_data() {
             AssertionData::Binary(data) => Ok(Self {
                 data: data.to_owned(),
@@ -77,7 +76,8 @@ impl AssertionBase for Thumbnail {
             }),
             ad => Err(AssertionDecodeError::from_assertion_unexpected_data_type(
                 assertion, ad, "binary",
-            )),
+            )
+            .into()),
         }
     }
 }

--- a/sdk/src/assertions/user_cbor.rs
+++ b/sdk/src/assertions/user_cbor.rs
@@ -14,9 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    assertion::{
-        Assertion, AssertionBase, AssertionData, AssertionDecodeError, AssertionDecodeResult,
-    },
+    assertion::{Assertion, AssertionBase, AssertionData, AssertionDecodeError},
     error::{Error, Result},
 };
 
@@ -51,18 +49,22 @@ impl AssertionBase for UserCbor {
         Ok(Assertion::new(&self.label, None, data))
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         match assertion.decode_data() {
             AssertionData::Cbor(data) => {
                 // validate cbor
-                let _value: serde_cbor::Value = serde_cbor::from_slice(data)
-                    .map_err(|e| AssertionDecodeError::from_assertion_and_cbor_err(assertion, e))?;
+                let _value: serde_cbor::Value = serde_cbor::from_slice(data).map_err(|e| {
+                    Error::AssertionDecoding(AssertionDecodeError::from_assertion_and_cbor_err(
+                        assertion, e,
+                    ))
+                })?;
 
                 Ok(Self::new(&assertion.label(), data.clone()))
             }
             ad => Err(AssertionDecodeError::from_assertion_unexpected_data_type(
                 assertion, ad, "cbor",
-            )),
+            )
+            .into()),
         }
     }
 }

--- a/sdk/src/assertions/uuid_assertion.rs
+++ b/sdk/src/assertions/uuid_assertion.rs
@@ -12,9 +12,7 @@
 // each license.
 
 use crate::{
-    assertion::{
-        Assertion, AssertionBase, AssertionData, AssertionDecodeError, AssertionDecodeResult,
-    },
+    assertion::{Assertion, AssertionBase, AssertionData, AssertionDecodeError},
     error::{Error, Result},
 };
 
@@ -56,14 +54,15 @@ impl AssertionBase for Uuid {
         Ok(Assertion::new(&self.label, None, data).set_content_type("application/octet-stream"))
     }
 
-    fn from_assertion(assertion: &Assertion) -> AssertionDecodeResult<Self> {
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
         match assertion.decode_data() {
             AssertionData::Uuid(s, data) => {
                 Ok(Uuid::new(&assertion.label(), s.clone(), data.clone()))
             }
             ad => Err(AssertionDecodeError::from_assertion_unexpected_data_type(
                 assertion, ad, "uuid",
-            )),
+            )
+            .into()),
         }
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -66,9 +66,7 @@
 //! # }
 //! ```
 
-pub use assertion::{
-    Assertion, AssertionBase, AssertionCbor, AssertionDecodeResult, AssertionJson,
-};
+pub use assertion::{Assertion, AssertionBase, AssertionCbor, AssertionJson};
 pub mod assertions;
 
 mod cose_validator;


### PR DESCRIPTION
## Changes in This Pull Request
Make Assertions opaque in the public SDK
AssertionDecodeResult is no longer exposed

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
