### PR TITLE
(MINOR) Update from_bytes(_async) to return a Result

### DIFF
--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -115,13 +115,11 @@ impl ManifestStore {
     }
 
     /// generate a Store from a format string and bytes
-    pub fn from_bytes(format: &str, image_bytes: Vec<u8>, verify: bool) -> Option<ManifestStore> {
+    pub fn from_bytes(format: &str, image_bytes: Vec<u8>, verify: bool) -> Result<ManifestStore> {
         let mut validation_log = DetailedStatusTracker::new();
 
-        match Store::load_from_memory(format, &image_bytes, verify, &mut validation_log) {
-            Ok(store) => Some(Self::from_store(&store, &mut validation_log)),
-            Err(_err) => None,
-        }
+        Store::load_from_memory(format, &image_bytes, verify, &mut validation_log)
+            .map(|store| Self::from_store(&store, &mut validation_log))
     }
 
     #[cfg(feature = "file_io")]
@@ -149,14 +147,12 @@ impl ManifestStore {
         format: &str,
         image_bytes: Vec<u8>,
         verify: bool,
-    ) -> Option<ManifestStore> {
+    ) -> Result<ManifestStore> {
         let mut validation_log = DetailedStatusTracker::new();
 
-        match Store::load_from_memory_async(format, &image_bytes, verify, &mut validation_log).await
-        {
-            Ok(store) => Some(Self::from_store(&store, &mut validation_log)),
-            Err(_err) => None,
-        }
+        Store::load_from_memory_async(format, &image_bytes, verify, &mut validation_log)
+            .await
+            .map(|store| Self::from_store(&store, &mut validation_log))
     }
 }
 


### PR DESCRIPTION
## Changes in this pull request
`from_bytes`/`from_bytes_async` previously returned an `Option`, swallowing the error. This changes this over to use a `Result` instead of an `Option` as discussed with @gpeacock.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
