### PR TITLE
Remove make_test_images from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "make_test_images/**/*"


### PR DESCRIPTION
## Changes in this pull request
make_test_images is not really part of the SDK. IMHO we should not include it in coverage report.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
