### PR TITLE
Adds xmp_write feature to make xmp-toolkit inclusion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ c2pa = "0.4.2"
 
 * `async_signer` enables signing via asynchronous services which require `async` support.
 * `file_io` enables manifest generation, signing via OpenSSL, and embedding manifests in various file formats.
+* `xmp_write` enables updating XMP on embed with the dcterms:provenance field (requires xmp_toolkit)
 
 ## Rust version requirements
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.58.0"
 [features]
 async_signer = ["async-trait"]
 file_io = ["openssl"]
+xmp_write = ["xmp_toolkit"]
 
 # The diagnostics feature is unsupported and might be removed.
 # It enables some low-overhead timing features used in our development cycle.
@@ -65,7 +66,7 @@ url = "2.2.2"
 ureq = "2.4.0"
 instant = "0.1.0"
 openssl = { version = "0.10.31", features = ["vendored"], optional = true }
-xmp_toolkit = "0.3.4"
+xmp_toolkit = { version = "0.3.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "0.2", features = ["color"] }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -115,7 +115,7 @@ pub(crate) mod asset_io;
 pub(crate) mod claim;
 #[cfg(feature = "file_io")]
 pub(crate) mod cose_sign;
-#[cfg(feature = "file_io")]
+#[cfg(all(feature = "xmp_write", feature = "file_io"))]
 pub(crate) mod embedded_xmp;
 pub(crate) mod hashed_uri;
 #[allow(dead_code)]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -31,7 +31,6 @@ use crate::{
     asset_io::{HashBlockObjectType, HashObjectPositions},
     cose_sign::cose_sign,
     cose_validator::verify_cose,
-    embedded_xmp,
     jumbf_io::{
         get_supported_file_extension, load_jumbf_from_file, object_locations, save_jumbf_to_file,
     },
@@ -41,6 +40,9 @@ use crate::{
     },
     Signer,
 };
+
+#[cfg(all(feature = "xmp_write", feature = "file_io"))]
+use crate::embedded_xmp;
 
 #[cfg(feature = "async_signer")]
 use crate::AsyncSigner;
@@ -1324,20 +1326,20 @@ impl Store {
             fs::copy(&asset_path, &output_path).map_err(Error::IoError)?;
         }
 
-        // get the provenance claim
-        let pp = self.provenance_path();
-        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
-
         //  update file following the steps outlined in CAI spec
 
         // 1) Add DC provenance XMP
         // update XMP info & add xmp hash to provenance claim
-        if let Some(provenance) = pp {
+        #[cfg(feature = "xmp_write")]
+        if let Some(provenance) = self.provenance_path() {
             embedded_xmp::add_manifest_uri_to_file(output_path, &provenance)
                 .map_err(|_err| Error::XmpWriteError)?;
         } else {
             return Err(Error::XmpWriteError);
         }
+
+        // get the provenance claim
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
 
         // 2) Get hash ranges if needed, do not generate for update manifests
         let mut hash_ranges = object_locations(output_path)?;


### PR DESCRIPTION
## Changes in this pull request
Adds xmp_write feature to make xmp-toolkit inclusion optional.
The dc:provenance XMP data will not be written unless this feature is enabled.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
