### PR TITLE
(MINOR) Add asset attribute getters for manifest

### DIFF
--- a/sdk/examples/client/client.rs
+++ b/sdk/examples/client/client.rs
@@ -30,15 +30,13 @@ fn show_manifest(manifest_store: &ManifestStore, manifest_label: &str, level: us
 
     println!("{}manifest_label: {}", indent, manifest_label);
     if let Some(manifest) = manifest_store.get(manifest_label) {
-        if let Some(asset) = manifest.asset().as_ref() {
-            println!(
-                "{}title: {} , format: {}, instance_id: {}",
-                indent,
-                asset.title(),
-                asset.format(),
-                asset.instance_id()
-            );
-        }
+        println!(
+            "{}title: {} , format: {}, instance_id: {}",
+            indent,
+            manifest.title().unwrap_or_default(),
+            manifest.format(),
+            manifest.instance_id()
+        );
 
         for assertion in manifest.assertions().iter() {
             println!("{}", assertion.label_with_instance());

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -200,7 +200,7 @@ impl Ingredient {
         self.manifest_data.as_deref()
     }
 
-    /// Sets a human-readable title for this manifest.
+    /// Sets a human-readable title for this ingredient.
     pub fn set_title<S: Into<String>>(&mut self, title: S) -> &mut Self {
         self.title = title.into();
         self

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -94,7 +94,7 @@ impl Manifest {
         self.claim_generator.as_str()
     }
 
-    /// Returns a MIME content_type for this asset associated with this manifest.
+    /// Returns a MIME content_type for the asset associated with this manifest.
     pub fn format(&self) -> &str {
         self.asset().map(|asset| asset.format()).unwrap_or_default()
     }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -94,8 +94,30 @@ impl Manifest {
         self.claim_generator.as_str()
     }
 
+    /// Returns a MIME content_type for this asset associated with this manifest.
+    pub fn format(&self) -> &str {
+        self.asset().map(|asset| asset.format()).unwrap_or_default()
+    }
+
+    /// Returns the instance identifier.
+    pub fn instance_id(&self) -> &str {
+        self.asset()
+            .map(|asset| asset.instance_id())
+            .unwrap_or_default()
+    }
+
+    /// Returns a user-displayable title for this manifest
+    pub fn title(&self) -> Option<&str> {
+        self.asset().map(|asset| asset.title())
+    }
+
+    /// Returns a tuple with thumbnail format and image bytes or `None`.
+    pub fn thumbnail(&self) -> Option<(&str, &[u8])> {
+        self.asset().and_then(|asset| asset.thumbnail())
+    }
+
     /// Returns an [Ingredient] reference to the asset associated with this manifest
-    pub fn asset(&self) -> Option<&Ingredient> {
+    pub(crate) fn asset(&self) -> Option<&Ingredient> {
         self.asset.as_ref()
     }
 
@@ -726,6 +748,10 @@ pub(crate) mod tests {
         let _store = manifest
             .embed(&source_path, &test_output, &signer)
             .expect("embed");
+
+        assert_eq!(manifest.format(), "image/jpeg");
+        assert_eq!(manifest.title(), Some("wc_embed_test.jpg"));
+        assert!(manifest.thumbnail().is_some());
 
         let ingredient = Ingredient::from_file(&test_output).expect("load_from_asset");
         assert!(ingredient.active_manifest().is_some());

--- a/sdk/tests/integration.rs
+++ b/sdk/tests/integration.rs
@@ -111,7 +111,7 @@ mod integration_1 {
 
         assert!(manifest_store.get_active().is_some());
         if let Some(manifest) = manifest_store.get_active() {
-            assert!(manifest.asset().is_some());
+            assert!(manifest.title().is_some());
             assert_eq!(manifest.ingredients().len(), 2);
         } else {
             panic!("no manifest in store");


### PR DESCRIPTION
## Changes in this pull request
1141851: Add asset attribute getters for manifest
format, title, instance_id and thumbnail
make asset getter crate private


## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
