### PR TITLE
Perform early check to catch when CoseSign1 will not fix in signature…

### DIFF
--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -145,7 +145,12 @@ pub fn cose_sign(signer: &dyn Signer, data: &[u8], box_size: usize) -> Result<Ve
 
     // println!("sig: {}", Hexlify(&c2pa_sig_data));
 
-    Ok(c2pa_sig_data)
+    // make sure the completed size will fit in the reserved box
+    if c2pa_sig_data.len() > signer.reserve_size() {
+        Err(Error::CoseSigboxTooSmall)
+    } else {
+        Ok(c2pa_sig_data)
+    }
 }
 
 const PAD: &str = "pad";


### PR DESCRIPTION
… box.

## Changes in this pull request
This is a hardening check to catch CoseSign1 data that is too big for the the reserved JUMBF box

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
