### PR TITLE
Return assertion instance values starting at `1` instead of `2`

### DIFF
--- a/sdk/src/manifest_assertion.rs
+++ b/sdk/src/manifest_assertion.rs
@@ -101,7 +101,7 @@ impl ManifestAssertion {
     /// This can be used to set an instance number, but generally should not be used
     /// Instance numbers will be assigned automatically when the assertions are embedded
     pub(crate) fn set_instance(mut self, instance: usize) -> Self {
-        self.instance = if instance > 1 { Some(instance) } else { None };
+        self.instance = if instance > 0 { Some(instance) } else { None };
         self
     }
 
@@ -215,8 +215,10 @@ pub(crate) mod tests {
         let mut ma = ManifestAssertion::new(Actions::LABEL.to_owned(), value);
         assert_eq!(ma.label(), Actions::LABEL);
 
-        ma = ma.set_instance(1);
+        ma = ma.set_instance(0);
         assert_eq!(ma.instance, None);
+        ma = ma.set_instance(1);
+        assert_eq!(ma.instance(), 1);
         ma = ma.set_instance(2);
         assert_eq!(ma.instance(), 2);
         assert_eq!(ma.kind(), &ManifestAssertionKind::Cbor);


### PR DESCRIPTION
## Changes in this pull request

The 1.0 spec says:

>If a manifest contains three assertions of this type, the labels will be `stds.schema-org.CreativeWork`, `stds.schema-org.CreativeWork__1` and `stds.schema-org.CreativeWork__2`.

Currently, in the code, processing the labels above would give the following values for `instance`:

- `stds.schema-org.CreativeWork` would give `None`
- `stds.schema-org.CreativeWork__1` would give `None`
- `stds.schema-org.CreativeWork__2` would give `Some(2)`

This results in only `stds.schema-org.CreativeWork__2` giving back a value for `instance` in the serialized data. However, we should be getting:

- `stds.schema-org.CreativeWork` would give `None`
- `stds.schema-org.CreativeWork__1` would give `Some(1)`
- `stds.schema-org.CreativeWork__2` would give `Some(2)`

This adds a fix for this logic.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
