### PR TITLE
(MINOR) Return specific errors for FileNotFound and UnsupportedType

### DIFF
--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.58.0"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { path="../sdk", features = ["file_io"] }
+c2pa = { path="../sdk", features = ["file_io", "xmp_write"] }
 env_logger = "0.9"
 log = "0.4" 
 image = "0.23.10"

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -33,8 +33,6 @@ use std::collections::HashMap;
 #[cfg(feature = "file_io")]
 use std::path::Path;
 
-const GH_UA: &str = "Sec-CH-UA";
-
 /// A Manifest represents all the information in a c2pa manifest
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Manifest {
@@ -494,10 +492,6 @@ impl Manifest {
         for ingredient in &self.ingredients {
             ingredient.add_to_claim(&mut claim, self.redactions.clone())?;
         }
-
-        // add a claim_generator_hint for the version of the library used to create the claim
-        let lib_hint = format!("\"{}\";v=\"{}\"", crate::NAME, crate::VERSION);
-        claim.add_claim_generator_hint(GH_UA, Value::from(lib_hint));
 
         let salt = DefaultSalt::default();
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1649,6 +1649,10 @@ impl Store {
                 let err = match e {
                     Error::PrereleaseError => Error::PrereleaseError,
                     Error::JumbfNotFound => Error::JumbfNotFound,
+                    Error::IoError(_) => {
+                        Error::FileNotFound(asset_path.to_string_lossy().to_string())
+                    }
+                    Error::UnsupportedType => Error::UnsupportedType,
                     _ => Error::LogStop,
                 };
                 let log_item = log_item!("asset", "error loading file", "load_from_asset").error(e);
@@ -1676,6 +1680,7 @@ impl Store {
                 let err = match e {
                     Error::PrereleaseError => Error::PrereleaseError,
                     Error::JumbfNotFound => Error::JumbfNotFound,
+                    Error::UnsupportedType => Error::UnsupportedType,
                     _ => Error::LogStop,
                 };
                 let log_item =
@@ -2273,11 +2278,10 @@ pub mod tests {
 
     #[test]
     fn test_unsupported_type() {
-        // test bad xmp
         let ap = fixture_path("Purple Square.psd");
         let mut report = DetailedStatusTracker::new();
-        let _r = Store::load_from_asset(&ap, true, &mut report);
-
+        let result = Store::load_from_asset(&ap, true, &mut report);
+        assert!(matches!(result, Err(Error::UnsupportedType)));
         println!("Error report for {}: {:?}", ap.as_display(), report);
         assert!(!report.get_log().is_empty());
 


### PR DESCRIPTION
## Changes in this pull request
Return specific errors for FileNotFound and Unsupported type
Remove Sec-CH-UA hint injection

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
