### PR TITLE
Refactor code to limit memory usage and remove data copies during hash generation

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -531,12 +531,12 @@ fn adjust_stco_and_co64<W: Write + CAIRead>(
                 let new_offset = if adjust < 0 {
                     offset
                         - u32::try_from(adjust.abs()).map_err(|_| {
-                            Error::BadParam("bad bmff offset adjustment".to_string())
+                            Error::BadParam("Bad BMFF offset adjustment".to_string())
                         })?
                 } else {
                     offset
                         + u32::try_from(adjust).map_err(|_| {
-                            Error::BadParam("bad bmff offset adjustment".to_string())
+                            Error::BadParam("Bad BMFF offset adjustment".to_string())
                         })?
                 };
                 entries.push(new_offset);
@@ -582,12 +582,12 @@ fn adjust_stco_and_co64<W: Write + CAIRead>(
                 let new_offset = if adjust < 0 {
                     offset
                         - u64::try_from(adjust.abs()).map_err(|_| {
-                            Error::BadParam("bad bmff offset adjustment".to_string())
+                            Error::BadParam("Bad BMFF offset adjustment".to_string())
                         })?
                 } else {
                     offset
                         + u64::try_from(adjust).map_err(|_| {
-                            Error::BadParam("bad bmff offset adjustment".to_string())
+                            Error::BadParam("Bad BMFF offset adjustment".to_string())
                         })?
                 };
                 entries.push(new_offset);

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -12,7 +12,7 @@
 // each license.
 
 use std::collections::HashMap;
-use std::convert::From;
+use std::convert::{From, TryFrom};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -529,9 +529,15 @@ fn adjust_stco_and_co64<W: Write + CAIRead>(
             for _e in 0..entry_count {
                 let offset = output.read_u32::<BigEndian>()?;
                 let new_offset = if adjust < 0 {
-                    offset - adjust.abs() as u32
+                    offset
+                        - u32::try_from(adjust.abs()).map_err(|_| {
+                            Error::BadParam("bad bmff offset adjustment".to_string())
+                        })?
                 } else {
-                    offset + adjust as u32
+                    offset
+                        + u32::try_from(adjust).map_err(|_| {
+                            Error::BadParam("bad bmff offset adjustment".to_string())
+                        })?
                 };
                 entries.push(new_offset);
             }
@@ -574,9 +580,15 @@ fn adjust_stco_and_co64<W: Write + CAIRead>(
             for _e in 0..entry_count {
                 let offset = output.read_u64::<BigEndian>()?;
                 let new_offset = if adjust < 0 {
-                    offset - adjust.abs() as u64
+                    offset
+                        - u64::try_from(adjust.abs()).map_err(|_| {
+                            Error::BadParam("bad bmff offset adjustment".to_string())
+                        })?
                 } else {
-                    offset + adjust as u64
+                    offset
+                        + u64::try_from(adjust).map_err(|_| {
+                            Error::BadParam("bad bmff offset adjustment".to_string())
+                        })?
                 };
                 entries.push(new_offset);
             }

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -78,8 +78,7 @@ fn get_png_chunk_positions(f: &mut dyn CAIRead) -> Result<Vec<PngChunkPos>> {
             .map_err(|_err| Error::BadParam("PNG out of range".to_string()))?;
 
         // read crc
-        let _crc = f
-            .read_exact(&mut buf4)
+        f.read_exact(&mut buf4)
             .map_err(|_err| Error::BadParam("PNG out of range".to_string()))?;
 
         let chunk_name = String::from_utf8(name.to_vec())

--- a/sdk/src/utils/cbor_types.rs
+++ b/sdk/src/utils/cbor_types.rs
@@ -105,7 +105,7 @@ impl<'de> Deserialize<'de> for BytesT {
     }
 }
 
-impl<'a> AsRef<Vec<u8>> for BytesT {
+impl AsRef<Vec<u8>> for BytesT {
     fn as_ref(&self) -> &Vec<u8> {
         &self.0
     }

--- a/sdk/src/utils/cbor_types.rs
+++ b/sdk/src/utils/cbor_types.rs
@@ -42,7 +42,7 @@ impl<'de> Deserialize<'de> for DateT {
     }
 }
 
-impl<'a> AsRef<str> for DateT {
+impl AsRef<str> for DateT {
     fn as_ref(&self) -> &str {
         &self.0
     }
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for UriT {
     }
 }
 
-impl<'a> AsRef<str> for UriT {
+impl AsRef<str> for UriT {
     fn as_ref(&self) -> &str {
         &self.0
     }

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -212,7 +212,7 @@ pub fn hash_asset_by_alg(
             // if not enough range we will just calc to the end
             if data_len < exclusion_end as u64 {
                 return Err(Error::BadParam(
-                    "the exclusion range exceed the data length".to_string(),
+                    "The exclusion range exceed the data length".to_string(),
                 ));
             }
 

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -237,7 +237,7 @@ pub fn hash_asset_by_alg(
         let start = r.start();
         let end = r.end();
         let mut chunk_left = end - start + 1;
-     
+
         // move to start of range
         data.seek(SeekFrom::Start(*start))?;
 

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -11,7 +11,12 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::ops::RangeInclusive;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    ops::RangeInclusive,
+    path::Path,
+};
 
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
@@ -24,6 +29,10 @@ use range_set::RangeSet;
 
 // direct sha functions
 use sha2::{Digest, Sha256, Sha384, Sha512};
+
+use crate::{Error, Result};
+
+const MAX_HASH_BUF: usize = 1024 * 1024 * 1024; // cap memory usage to 1GB
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Exclusion {
@@ -106,7 +115,7 @@ impl Hasher {
     }
 }
 
-// return hash bytes for desired hashing algoritm
+// Return hash bytes for desired hashing algorithm.
 pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<Exclusion>>) -> Vec<u8> {
     use Hasher::*;
     let mut hasher_enum = match alg {
@@ -123,16 +132,7 @@ pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<Exclusion>>) -
     };
 
     match exclusions {
-        Some(mut e) => {
-            // hash all content
-            if e.is_empty() {
-                // add the data
-                hasher_enum.update(data);
-
-                // return the hash
-                return Hasher::finalize(hasher_enum);
-            }
-
+        Some(mut e) if !e.is_empty() => {
             // hash data skipping excluded regions
             // sort the exclusions
             e.sort_by_key(|a| a.start());
@@ -143,7 +143,7 @@ pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<Exclusion>>) -
             let data_len = data.len();
             let data_end = data_len - 1;
 
-            // if not enough range we will just cacl to the end
+            // if not enough range we will just calc to the end
             if data_len < exclusion_end {
                 debug!("the exclusion range exceed the data length");
                 return Vec::new();
@@ -164,7 +164,7 @@ pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<Exclusion>>) -
             // return the hash
             Hasher::finalize(hasher_enum)
         }
-        None => {
+        _ => {
             // add the data
             hasher_enum.update(data);
 
@@ -174,7 +174,92 @@ pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<Exclusion>>) -
     }
 }
 
-// verify the hash using the specifiied alogrithm
+// Return hash bytes for assset using desired hashing algorithm.
+pub fn hash_asset_by_alg(
+    alg: &str,
+    asset_path: &Path,
+    exclusions: Option<Vec<Exclusion>>,
+) -> Result<Vec<u8>> {
+    use Hasher::*;
+    let mut hasher_enum = match alg {
+        "sha256" => SHA256(Sha256::new()),
+        "sha384" => SHA384(Sha384::new()),
+        "sha512" => SHA512(Sha512::new()),
+        _ => {
+            warn!(
+                "Unsupported hashing algorithm: {}, substituting sha256",
+                alg
+            );
+            SHA256(Sha256::new())
+        }
+    };
+
+    let mut data = File::open(asset_path)?;
+    let data_len = data.seek(SeekFrom::End(0))?;
+    data.seek(SeekFrom::Start(0))?;
+
+    let ranges = match exclusions {
+        Some(mut e) if !e.is_empty() => {
+            // hash data skipping excluded regions
+            // sort the exclusions
+            e.sort_by_key(|a| a.start());
+
+            // verify structure of blocks
+            let num_blocks = e.len();
+            let exclusion_end = e[num_blocks - 1].start() + e[num_blocks - 1].length();
+            let data_end = data_len - 1;
+
+            // if not enough range we will just calc to the end
+            if data_len < exclusion_end as u64 {
+                return Err(Error::BadParam(
+                    "the exclusion range exceed the data length".to_string(),
+                ));
+            }
+
+            //build final ranges
+            let mut ranges = RangeSet::<[RangeInclusive<u64>; 1]>::from(0..=data_end);
+            for exclusion in e {
+                let end = (exclusion.start() + exclusion.length() - 1) as u64;
+                let exclusion_start = exclusion.start() as u64;
+                ranges.remove_range(exclusion_start..=end);
+            }
+
+            ranges
+        }
+        _ => {
+            let data_end = data_len - 1;
+            RangeSet::<[RangeInclusive<u64>; 1]>::from(0..=data_end)
+        }
+    };
+
+    // hash the data for ranges
+    for r in ranges.into_smallvec() {
+        let start = r.start();
+        let end = r.end();
+        let mut chunk_left = end - start + 1;
+     
+        // move to start of range
+        data.seek(SeekFrom::Start(*start))?;
+
+        loop {
+            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+
+            data.read_exact(&mut chunk)?;
+
+            hasher_enum.update(&chunk);
+
+            chunk_left -= chunk.len() as u64;
+            if chunk_left == 0 {
+                break;
+            }
+        }
+    }
+
+    // return the hash
+    Ok(Hasher::finalize(hasher_enum))
+}
+
+// verify the hash using the specified alogrithm
 pub fn verify_by_alg(
     alg: &str,
     hash: &[u8],
@@ -186,6 +271,20 @@ pub fn verify_by_alg(
     vec_compare(hash, &data_hash)
 }
 
+// verify the hash using the specified alogrithm
+pub fn verify_asset_by_alg(
+    alg: &str,
+    hash: &[u8],
+    asset_path: &Path,
+    exclusions: Option<Vec<Exclusion>>,
+) -> bool {
+    // hash with the same algorithm as target
+    if let Ok(data_hash) = hash_asset_by_alg(alg, asset_path, exclusions) {
+        vec_compare(hash, &data_hash)
+    } else {
+        false
+    }
+}
 /// Return a multihash (Sha256) of array of bytes
 #[allow(dead_code)]
 pub fn hash256(data: &[u8]) -> String {


### PR DESCRIPTION
## Changes in this pull request
The PR refactors the hashing of data to be more flexible:

-  removes memory copies during hashing
-  caps the maximum memory usage during hash generation/validation
- updates functions to allow content from various sources (in-memory, from asset, from stream, etc.)
- setup for hardware based hash generation  
- significant speedup for large files

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
