### PR TITLE
Docs.rs will now include feature-gated items

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,6 +12,10 @@ edition = "2018"
 rust-version = "1.58.0"
 exclude = ["tests/fixtures"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 async_signer = ["async-trait"]
 bmff = []  # Work in progress support for BMFF-based containers

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 
 //! This library supports reading, creating and embedding C2PA data
 //! with JPEG and PNG images.


### PR DESCRIPTION
Also (using a nightly feature) it will automatically add annotations about the crate feature that is required to gain access to such items.

See https://docs.rs/symmetrical-spork/latest/symmetrical_spork/index.html for an example of these annotations.

This addresses the missing-docs concern I raised in #72.