### PR TITLE
Fix broken documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,8 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  doc_format:
-    name: Doc format
+  docs_rs:
+    name: Preflight docs.rs build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -163,9 +163,14 @@ jobs:
           override: true
 
       - name: Run cargo docs
+        # This is intended to mimic the docs.rs build
+        # environment. The goal is to fail PR validation
+        # if the subsequent release would result in a failed
+        # documentation build on docs.rs.
         run: cargo +nightly doc --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
+          DOCS_RS: 1
 
   cargo-deny:
     name: License / vulnerability audit
@@ -178,7 +183,7 @@ jobs:
           - advisories
           - bans licenses sources
 
-    # Prevent sudden announcement of a new advisory from failing ci:
+    # Prevent sudden announcement of a new advisory from failing CI:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -74,7 +74,7 @@ url = "2.2.2"
 ureq = "2.4.0"
 instant = "0.1.0"
 openssl = { version = "0.10.31", features = ["vendored"], optional = true }
-xmp_toolkit = { version = "=0.5.0", optional = true }
+xmp_toolkit = { version = "0.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "0.2", features = ["color"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -74,7 +74,7 @@ url = "2.2.2"
 ureq = "2.4.0"
 instant = "0.1.0"
 openssl = { version = "0.10.31", features = ["vendored"], optional = true }
-xmp_toolkit = { version = "0.5.0", optional = true }
+xmp_toolkit = { version = "=0.5.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "0.2", features = ["color"] }


### PR DESCRIPTION
## Changes in this pull request
Release 0.7.1 [failed to build on docs.rs](https://docs.rs/crate/c2pa/0.7.1) because the so-called "no-op" C++ code in XMP Toolkit contained a reference to a field that was disabled elsewhere. (See https://github.com/adobe/xmp-toolkit-rs/pull/67.)

This PR incorporates the fixed version of XMP Toolkit and and updates the PR validation loop to more closely mimic the docs.rs runtime environment so we detect future errors of this type.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
