### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,33 @@ jobs:
         run: wasm-pack test --chrome --headless
         working-directory: ./sdk
 
+  publish-preflight:
+    name: Preflight crate publish
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ubuntu-latest
+        rust_version: stable
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: llvm-tools-preview
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Dry-run of crate publish
+        run: cargo publish -p c2pa --dry-run
+
   clippy_check:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes in this pull request
A [recent crate publish operation failed](https://github.com/contentauth/c2pa-rs/runs/7413936641?check_suite_focus=true), so we're taking two steps to mitigate:

1. Run `cargo publish --dry-run -p c2pa` as part of PR validation loop.2. 
2. Fix the error identified in this particular case.
