### PR TITLE
Add Unicode license to allow-list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ allow = [
   "LicenseRef-ring",
   "MIT",
   "MPL-2.0",
+  "Unicode-DFS-2016",
   "Zlib",
 ]
 copyleft = "deny"


### PR DESCRIPTION
This will be needed for the next XMP Toolkit release.