### PR TITLE
(IGNORE) Add info on PR title prefixes (IGNORE), (MINOR), and (MAJOR) to contribution guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,15 @@ These include such things as Rust code format, Clippy/lint checks, and unit test
 We encourage you to raise an issue in GitHub before starting work on a major addition to the crate.
 This will give us an opportunity to discuss API design and avoid duplicate efforts.
 
+### Pull request titles
+
+The build process automatically adds a pull request (PR) to the [CHANGELOG](CHANGELOG.md) unless the title of the PR begins with `(IGNORE)`, which 
+is appropriate for minor documentation updates and other trivial fixes that you want to specifically exclude from the CHANGELOG.
+
+Additionally, the build process takes specific actions if the title of a PR begins with certain special strings:
+- `MINOR`: Increments the minor version, per [semantic versioning](https://semver.org/) convention.
+- `MAJOR`: Increments the major version number, per [semantic versioning](https://semver.org/) convention.
+
 ## From contributor to committer
 
 We love contributions from our community! If you'd like to go a step beyond contributor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,11 @@ This will give us an opportunity to discuss API design and avoid duplicate effor
 
 ### Pull request titles
 
-The build process automatically adds a pull request (PR) to the [CHANGELOG](CHANGELOG.md) unless the title of the PR begins with `(IGNORE)`, which 
-is appropriate for minor documentation updates and other trivial fixes that you want to specifically exclude from the CHANGELOG.
+The build process automatically adds a pull request (PR) to the [CHANGELOG](CHANGELOG.md) unless the title of the PR begins with `(IGNORE)`. Start PR titles with `(IGNORE)` for minor documentation updates and other trivial fixes that you want to specifically exclude from the CHANGELOG.
 
 Additionally, the build process takes specific actions if the title of a PR begins with certain special strings:
-- `MINOR`: Increments the minor version, per [semantic versioning](https://semver.org/) convention.
-- `MAJOR`: Increments the major version number, per [semantic versioning](https://semver.org/) convention.
+- `(MINOR)`: Increments the minor version, per [semantic versioning](https://semver.org/) convention.
+- `(MAJOR)`: Increments the major version number, per [semantic versioning](https://semver.org/) convention.
 
 ## From contributor to committer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ This will give us an opportunity to discuss API design and avoid duplicate effor
 The build process automatically adds a pull request (PR) to the [CHANGELOG](CHANGELOG.md) unless the title of the PR begins with `(IGNORE)`. Start PR titles with `(IGNORE)` for minor documentation updates and other trivial fixes that you want to specifically exclude from the CHANGELOG.
 
 Additionally, the build process takes specific actions if the title of a PR begins with certain special strings:
-- `(MINOR)`: Increments the minor version, per [semantic versioning](https://semver.org/) convention.
+- `(MINOR)`: Increments the minor version, per [semantic versioning](https://semver.org/) convention. **IMPORTANT:** This flag should be used for any API change that breaks compatibility with previous releases while this crate is in prerelease (version 0.x) status.
 - `(MAJOR)`: Increments the major version number, per [semantic versioning](https://semver.org/) convention.
 
 ## From contributor to committer


### PR DESCRIPTION
## Changes in this pull request

Adds info on PR title prefixes `(IGNORE)`, `(MINOR)`, and `(MAJOR)`.  This came up in discussion earlier this week.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
