### PR TITLE
Update C2PA manifest store mime type

### DIFF
--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -93,7 +93,9 @@ pub fn get_assetio_handler(ext: &str) -> Option<Box<dyn AssetIO>> {
 pub fn get_cailoader_handler(asset_type: &str) -> Option<Box<dyn CAILoader>> {
     let asset_type = asset_type.to_lowercase();
     match asset_type.as_ref() {
-        "c2pa" | "application/c2pa" => Some(Box::new(C2paIO {})),
+        "c2pa" | "application/c2pa" | "application/x-c2pa-manifest-store" => {
+            Some(Box::new(C2paIO {}))
+        }
         "jpg" | "jpeg" | "image/jpeg" => Some(Box::new(JpegIO {})),
         "png" | "image/png" => Some(Box::new(PngIO {})),
         "avif" | "heif" | "heic" | "mp4" | "m4a" | "application/mp4" | "audio/mp4"


### PR DESCRIPTION
## Changes in this pull request
Adding `application/x-c2pa-manifest-store` to the list of mime-types for manifest store files to comply with [the 1.0 spec](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_external_manifests).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
