### PR TITLE
(IGNORE) Fail a crate release if an API breaking change is made …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,11 @@ jobs:
         commit_user_name: Adobe CAI Team
         commit_user_email: noreply@adobe.com
 
+    - name: Ensure semantic versioning requirements are met
+      uses: obi1kenobi/cargo-semver-checks-action@v1
+      with:
+        crate-name: c2pa
+
     - name: Create release
       uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
… without an appropriate version bump

This new step uses the `cargo-semver-checks` crate to compare the proposed new API surface against the previous release and will fail the publish step if the appropriate (MINOR) or (MAJOR) tag was omitted from any PR.

(You can "fix" the problem by submitting an empty PR with the appropriate tag and then re-attempting the publish.)