### PR TITLE
Convert status_log error val to a string so that we can return full errors

### DIFF
--- a/sdk/src/status_tracker.rs
+++ b/sdk/src/status_tracker.rs
@@ -47,6 +47,14 @@ impl LogItem {
         }
     }
 
+    // add an error value
+    pub fn set_error(self, err: &Error) -> Self {
+        LogItem {
+            err_val: Some(format!("{:?}", err)),
+            ..self
+        }
+    }
+
     /// returns a reference to the error string if there is one
     pub fn error_str(&self) -> Option<&str> {
         self.err_val.as_deref()

--- a/sdk/src/status_tracker.rs
+++ b/sdk/src/status_tracker.rs
@@ -22,7 +22,7 @@ pub struct LogItem {
     pub function: String, // Function where failure occurred
     pub line: String,  // Line number for error
     pub description: String, // Description of the failure
-    pub err_val: Option<Error>, // Actual error code
+    err_val: Option<String>, // Actual error code as string
     pub validation_status: Option<String>, // C2PA code if available
 }
 
@@ -42,9 +42,14 @@ impl LogItem {
     // add an error value
     pub fn error(self, err: Error) -> Self {
         LogItem {
-            err_val: Some(err),
+            err_val: Some(format!("{:?}", err)),
             ..self
         }
+    }
+
+    /// returns a reference to the error string if there is one
+    pub fn error_str(&self) -> Option<&str> {
+        self.err_val.as_deref()
     }
 
     // add an error value
@@ -191,14 +196,12 @@ pub fn report_has_status(report: &[LogItem], val: &str) -> bool {
 }
 
 /// Check to see if report contains a specific error
-/// Note: Only the out error object is matched for nested errors like
-/// "Error::InvalidClaim(InvalidClaimError::ClaimSignatureDescriptionBoxInvalid)".
-/// In this case any "InvalidClaim" would match
 #[allow(dead_code)] // in case we make use of these or export this
 pub fn report_has_err(report: &[LogItem], err: Error) -> bool {
+    let err_type = format!("{:?}", &err);
     report.iter().any(|vi| {
         if let Some(e) = &vi.err_val {
-            std::mem::discriminant(e) == std::mem::discriminant(&err)
+            e == &err_type
         } else {
             false
         }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2617,10 +2617,7 @@ pub mod tests {
         );
         assert!(!report.get_log().is_empty());
         let errors = report_split_errors(report.get_log_mut());
-        assert!(matches!(
-            errors[0].err_val.as_ref(),
-            Some(Error::IoError(_err))
-        ));
+        assert!(errors[0].error_str().unwrap().starts_with("IoError"));
     }
 
     #[test]
@@ -2636,10 +2633,7 @@ pub mod tests {
         );
         assert!(!report.get_log().is_empty());
         let errors = report_split_errors(report.get_log_mut());
-        assert!(matches!(
-            errors[0].err_val.as_ref(),
-            Some(Error::PrereleaseError)
-        ));
+        assert!(errors[0].error_str().unwrap().starts_with("Prerelease"));
     }
 
     #[test]
@@ -2763,10 +2757,14 @@ pub mod tests {
         // modify a required field label in the claim - causes failure to read claim from cbor
         let report = patch_and_report("C.jpg", b"claim_generator", b"claim_generatur");
         assert!(!report.get_log().is_empty());
-        assert!(matches!(
-            report.get_log()[0].err_val,
-            Some(Error::ClaimDecoding)
-        ));
+        assert!(report.get_log()[0]
+            .error_str()
+            .unwrap()
+            .starts_with("ClaimDecoding"))
+        // assert!(matches!(
+        //     report.get_log()[0].err_val,
+        //     Some(Error::ClaimDecoding)
+        // ));
         //assert_eq!(report[0].validation_status.as_deref(), Some(???));  // what validation status should we have for this?
     }
 
@@ -2781,7 +2779,7 @@ pub mod tests {
         assert!(!report.get_log().is_empty());
         let errors = report_split_errors(report.get_log_mut());
 
-        assert!(matches!(errors[0].err_val, Some(Error::HashMismatch(_))));
+        assert!(errors[0].error_str().unwrap().starts_with("HashMismatch"));
         assert_eq!(
             errors[0].validation_status.as_deref(),
             Some(validation_status::ASSERTION_DATAHASH_MISMATCH)

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1906,18 +1906,16 @@ impl Store {
                 Ok(store)
             })
             .map_err(|e| {
-                let err = match e {
-                    Error::PrereleaseError => Error::PrereleaseError,
-                    Error::JumbfNotFound => Error::JumbfNotFound,
-                    Error::IoError(_) => {
-                        Error::FileNotFound(asset_path.to_string_lossy().to_string())
-                    }
-                    Error::UnsupportedType => Error::UnsupportedType,
+                validation_log.log_silent(
+                    log_item!("asset", "error loading file", "load_from_asset").set_error(&e),
+                );
+                match e {
+                    Error::PrereleaseError
+                    | Error::JumbfNotFound
+                    | Error::IoError(_)
+                    | Error::UnsupportedType => e,
                     _ => Error::LogStop,
-                };
-                let log_item = log_item!("asset", "error loading file", "load_from_asset").error(e);
-                validation_log.log_silent(log_item);
-                err
+                }
             })
     }
 
@@ -1937,16 +1935,14 @@ impl Store {
         Self::load_cai_from_memory(asset_type, data, validation_log)
             .map(|store| (store, xmp))
             .map_err(|e| {
-                let err = match e {
-                    Error::PrereleaseError => Error::PrereleaseError,
-                    Error::JumbfNotFound => Error::JumbfNotFound,
-                    Error::UnsupportedType => Error::UnsupportedType,
+                validation_log.log_silent(
+                    log_item!("asset", "error loading asset", "get_store_from_memory")
+                        .set_error(&e),
+                );
+                match e {
+                    Error::PrereleaseError | Error::JumbfNotFound | Error::UnsupportedType => e,
                     _ => Error::LogStop,
-                };
-                let log_item =
-                    log_item!("asset", "error loading asset", "get_store_from_memory").error(e);
-                validation_log.log_silent(log_item);
-                err
+                }
             })
     }
 

--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -92,6 +92,18 @@ impl ValidationStatus {
     }
 
     // Maps errors into validation_status codes.
+    fn code_from_error_str(error: &str) -> &str {
+        match error {
+            e if e.starts_with("ClaimMissing") => CLAIM_MISSING,
+            e if e.starts_with("AssertionMissing") => ASSERTION_MISSING,
+            e if e.starts_with("AssertionDecoding") => STATUS_ASSERTION_MALFORMED, // todo: no code for invalid assertion format
+            e if e.starts_with("HashMismatch") => ASSERTION_DATAHASH_MATCH,
+            e if e.starts_with("PrereleaseError") => STATUS_PRERELEASE,
+            _ => STATUS_OTHER,
+        }
+    }
+
+    // Maps errors into validation_status codes.
     fn code_from_error(error: &Error) -> &str {
         match error {
             Error::ClaimMissing { .. } => CLAIM_MISSING,
@@ -121,8 +133,8 @@ impl ValidationStatus {
             ),
             // If we don't have a validation_status, then make one from the err_val
             // using the description plus error text explanation.
-            None => item.err_val.as_ref().map(|e| {
-                let code = Self::code_from_error(e);
+            None => item.error_str().as_ref().map(|e| {
+                let code = Self::code_from_error_str(e);
                 Self::new(code.to_string())
                     .set_url(item.label.to_string())
                     .set_explanation(format!("{}: {}", item.description, e))


### PR DESCRIPTION
## Changes in this pull request
Allows us to return complex errors while still adding them to logs. You can't copy an error, but you can display it.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
