### PR TITLE
Add sign feature for signing manifests without file i/o 

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -20,12 +20,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["add_thumbnails"]
 add_thumbnails = ["image"]
 async_signer = ["async-trait", "file_io"]
-bmff = []  # Work in progress support for BMFF-based containers
-file_io = ["openssl"]
+bmff = []
+file_io = ["sign"]
 serialize_thumbnails = []
 xmp_write = ["xmp_toolkit"]
 no_interleaved_io = ["file_io"]
 fetch_remote_manifests = ["file_io"]
+sign = ["openssl"]
 
 # The diagnostics feature is unsupported and might be removed.
 # It enables some low-overhead timing features used in our development cycle.

--- a/sdk/src/asset_io.rs
+++ b/sdk/src/asset_io.rs
@@ -44,6 +44,11 @@ impl CAIRead for std::fs::File {}
 impl CAIRead for std::io::Cursor<&[u8]> {}
 impl CAIRead for std::io::Cursor<Vec<u8>> {}
 
+pub trait CAIReadWrite: CAIRead + Write {}
+
+impl CAIReadWrite for std::fs::File {}
+impl CAIReadWrite for std::io::Cursor<Vec<u8>> {}
+
 // Interface for in memory CAI reading
 pub trait CAILoader {
     // Return entire CAI block as Vec<u8>
@@ -55,12 +60,12 @@ pub trait CAILoader {
 
 pub trait CAIWriter {
     // Return entire CAI block as Vec<u8>
-    fn write_cai(
+    fn write_cai(&self, stream: &mut dyn CAIReadWrite, store_bytes: &[u8]) -> Result<()>;
+
+    fn get_object_locations_from_stream(
         &self,
-        reader: &mut dyn CAIRead,
-        writer: &mut dyn Write,
-        store_bytes: &[u8],
-    ) -> Result<()>;
+        stream: &mut dyn CAIReadWrite,
+    ) -> Result<Vec<HashObjectPositions>>;
 }
 
 pub trait AssetIO {

--- a/sdk/src/asset_io.rs
+++ b/sdk/src/asset_io.rs
@@ -13,7 +13,7 @@
 
 use std::{
     fmt,
-    io::{Read, Seek},
+    io::{Read, Seek, Write},
     path::Path,
 };
 
@@ -51,6 +51,16 @@ pub trait CAILoader {
 
     // Get XMP block
     fn read_xmp(&self, asset_reader: &mut dyn CAIRead) -> Option<String>;
+}
+
+pub trait CAIWriter {
+    // Return entire CAI block as Vec<u8>
+    fn write_cai(
+        &self,
+        reader: &mut dyn CAIRead,
+        writer: &mut dyn Write,
+        store_bytes: &[u8],
+    ) -> Result<()>;
 }
 
 pub trait AssetIO {

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -647,7 +647,7 @@ impl Claim {
     }
 
     // crate private function to allow for patching a data hash with final contents
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     pub(crate) fn update_data_hash(&mut self, mut data_hash: DataHash) -> Result<()> {
         let mut replacement_assertion = data_hash.to_assertion()?;
 

--- a/sdk/src/create_signer.rs
+++ b/sdk/src/create_signer.rs
@@ -15,7 +15,7 @@
 
 //! The `create_signer` module provides a way to obtain a [`Signer`]
 //! instance for each signing format supported by this crate.
-
+#[cfg(feature = "file_io")]
 use std::path::Path;
 
 use crate::{
@@ -65,6 +65,7 @@ pub fn from_keys(
 /// * `pkey_path` - Path to the private key file
 /// * `alg` - Format for signing
 /// * `tsa_url` - Optional URL for a timestamp authority
+#[cfg(feature = "file_io")]
 pub fn from_files<P: AsRef<Path>>(
     signcert_path: P,
     pkey_path: P,

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -241,7 +241,7 @@ pub enum Error {
     CborError(#[from] serde_cbor::Error),
 
     #[error(transparent)]
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     OpenSslError(#[from] openssl::error::ErrorStack),
 
     #[error(transparent)]
@@ -254,6 +254,7 @@ pub enum Error {
 /// A specialized `Result` type for C2PA toolkit operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[cfg(feature = "file_io")]
 pub(crate) fn wrap_io_err(err: std::io::Error) -> Error {
     Error::IoError(err)
 }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -259,7 +259,7 @@ pub(crate) fn wrap_io_err(err: std::io::Error) -> Error {
     Error::IoError(err)
 }
 
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub(crate) fn wrap_openssl_err(err: openssl::error::ErrorStack) -> Error {
     Error::OpenSslError(err)
 }

--- a/sdk/src/hashed_uri.rs
+++ b/sdk/src/hashed_uri.rs
@@ -50,7 +50,7 @@ impl HashedUri {
         self.hash.clone()
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     pub(crate) fn update_hash(&mut self, hash: Vec<u8>) {
         self.hash = hash;
     }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -86,7 +86,7 @@ pub mod assertions;
 
 mod cose_validator;
 
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub mod create_signer;
 
 mod error;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -110,14 +110,14 @@ mod signing_alg;
 #[cfg(feature = "file_io")]
 pub use ingredient::{DefaultOptions, IngredientOptions};
 pub use signing_alg::{SigningAlg, UnknownAlgorithmError};
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub(crate) mod ocsp_utils;
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 mod openssl;
 
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 mod signer;
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub use signer::Signer;
 #[cfg(feature = "async_signer")]
 pub use signer::{AsyncSigner, RemoteSigner};
@@ -129,7 +129,7 @@ pub(crate) mod asset_handlers;
 pub(crate) mod asset_io;
 pub(crate) mod claim;
 
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub mod cose_sign;
 
 #[cfg(all(feature = "xmp_write", feature = "file_io"))]

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -20,8 +20,6 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-#[cfg(feature = "file_io")]
-use crate::Signer;
 use crate::{
     assertion::{AssertionBase, AssertionData},
     assertions::{labels, Actions, CreativeWork, Thumbnail, User, UserCbor},
@@ -32,6 +30,8 @@ use crate::{
     store::Store,
     Ingredient, ManifestAssertion, ManifestAssertionKind,
 };
+#[cfg(feature = "sign")]
+use crate::{asset_io::CAIReadWrite, Signer};
 #[cfg(all(feature = "async_signer", feature = "file_io"))]
 use crate::{AsyncSigner, RemoteSigner};
 
@@ -735,6 +735,26 @@ impl Manifest {
         store.save_to_asset(source_path.as_ref(), signer, dest_path.as_ref())
     }
 
+    /// Embed a signed manifest into a stream using a supplied signer.
+    ///
+    #[cfg(feature = "sign")]
+    pub fn embed_stream(
+        &mut self,
+        format: &str,
+        stream: &mut dyn CAIReadWrite,
+        signer: &dyn Signer,
+    ) -> Result<Vec<u8>> {
+        self.set_format(format);
+        // todo:: read instance_id from xmp from stream
+        self.set_instance_id(format!("xmp:iid:{}", Uuid::new_v4()));
+        // todo: generate thumbnail if we don't already have one
+
+        // convert the manifest to a store
+        let mut store = self.to_store()?;
+
+        // sign and write our store to to the output image file
+        store.save_to_stream(format, stream, signer)
+    }
     /// Embed a signed manifest into the target file using a supplied [`AsyncSigner`].
     #[cfg(feature = "file_io")]
     #[cfg(feature = "async_signer")]
@@ -797,6 +817,8 @@ pub(crate) mod tests {
     #[cfg(feature = "file_io")]
     use tempfile::tempdir;
 
+    #[cfg(feature = "sign")]
+    use crate::utils::test::temp_signer;
     use crate::{
         assertions::{c2pa_action, Action, Actions},
         utils::test::TEST_VC,
@@ -806,9 +828,7 @@ pub(crate) mod tests {
     use crate::{
         status_tracker::{DetailedStatusTracker, StatusTracker},
         store::Store,
-        utils::test::{
-            fixture_path, temp_dir_path, temp_fixture_path, temp_signer, TEST_SMALL_JPEG,
-        },
+        utils::test::{fixture_path, temp_dir_path, temp_fixture_path, TEST_SMALL_JPEG},
         Ingredient,
     };
 
@@ -1157,5 +1177,40 @@ pub(crate) mod tests {
             manifest_store.get_active().unwrap().title().unwrap(),
             TEST_SMALL_JPEG
         );
+    }
+
+    #[test]
+    #[cfg(feature = "sign")]
+    fn test_embed_stream() {
+        use crate::assertions::User;
+        let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg").to_vec();
+        // convert buffer to cursor with Read/Write/Seek capability
+        let mut stream = std::io::Cursor::new(image);
+
+        let mut manifest = Manifest::new("my_app".to_owned());
+        manifest.set_title("EmbedStream");
+        manifest
+            .add_assertion(&User::new(
+                "org.contentauth.mylabel",
+                r#"{"my_tag":"Anything I want"}"#,
+            ))
+            .unwrap();
+
+        let signer = temp_signer();
+        // Embed a manifest using the signer.
+        manifest
+            .embed_stream("jpeg", &mut stream, &signer)
+            .expect("embed_stream");
+
+        // get the updated image
+        let image = stream.into_inner();
+
+        let manifest_store =
+            crate::ManifestStore::from_bytes("jpeg", image, true).expect("from_bytes");
+        assert_eq!(
+            manifest_store.get_active().unwrap().title().unwrap(),
+            "EmbedStream"
+        );
+        println!("{}", manifest_store);
     }
 }

--- a/sdk/src/openssl/ec_signer.rs
+++ b/sdk/src/openssl/ec_signer.rs
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#[cfg(feature = "file_io")]
 use std::{fs, path::Path};
 
 use openssl::{
@@ -45,6 +46,7 @@ pub struct EcSigner {
 }
 
 impl ConfigurableSigner for EcSigner {
+    #[cfg(feature = "file_io")]
     fn from_files<P: AsRef<Path>>(
         signcert_path: P,
         pkey_path: P,
@@ -206,6 +208,7 @@ fn der_to_p1363(data: &[u8], alg: SigningAlg) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "file_io")]
 mod tests {
     #![allow(clippy::unwrap_used)]
 

--- a/sdk/src/openssl/ec_signer.rs
+++ b/sdk/src/openssl/ec_signer.rs
@@ -26,7 +26,7 @@ use x509_parser::der_parser::{
 
 use super::check_chain_order;
 use crate::{
-    error::{wrap_io_err, wrap_openssl_err, Error, Result},
+    error::{wrap_openssl_err, Error, Result},
     signer::ConfigurableSigner,
     Signer, SigningAlg,
 };
@@ -51,8 +51,8 @@ impl ConfigurableSigner for EcSigner {
         alg: SigningAlg,
         tsa_url: Option<String>,
     ) -> Result<Self> {
-        let signcert = fs::read(signcert_path).map_err(wrap_io_err)?;
-        let pkey = fs::read(pkey_path).map_err(wrap_io_err)?;
+        let signcert = fs::read(signcert_path).map_err(Error::IoError)?;
+        let pkey = fs::read(pkey_path).map_err(Error::IoError)?;
 
         Self::from_signcert_and_pkey(&signcert, &pkey, alg, tsa_url)
     }

--- a/sdk/src/openssl/ec_validator.rs
+++ b/sdk/src/openssl/ec_validator.rs
@@ -72,6 +72,7 @@ fn wrap_openssl_err(err: openssl::error::ErrorStack) -> Error {
 }
 
 #[cfg(test)]
+#[cfg(feature = "file_io")]
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;

--- a/sdk/src/openssl/ed_signer.rs
+++ b/sdk/src/openssl/ed_signer.rs
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#[cfg(feature = "file_io")]
 use std::{fs, path::Path};
 
 use openssl::{
@@ -35,14 +36,15 @@ pub struct EdSigner {
 }
 
 impl ConfigurableSigner for EdSigner {
+    #[cfg(feature = "file_io")]
     fn from_files<P: AsRef<Path>>(
         signcert_path: P,
         pkey_path: P,
         alg: SigningAlg,
         tsa_url: Option<String>,
     ) -> Result<Self> {
-        let signcert = fs::read(signcert_path).map_err(wrap_io_err)?;
-        let pkey = fs::read(pkey_path).map_err(wrap_io_err)?;
+        let signcert = fs::read(signcert_path).map_err(Error::IoError)?;
+        let pkey = fs::read(pkey_path).map_err(Error::IoError)?;
 
         Self::from_signcert_and_pkey(&signcert, &pkey, alg, tsa_url)
     }
@@ -113,15 +115,12 @@ impl Signer for EdSigner {
     }
 }
 
-fn wrap_io_err(err: std::io::Error) -> Error {
-    Error::IoError(err)
-}
-
 fn wrap_openssl_err(err: openssl::error::ErrorStack) -> Error {
     Error::OpenSslError(err)
 }
 
 #[cfg(test)]
+#[cfg(feature = "file_io")]
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;

--- a/sdk/src/openssl/ed_validator.rs
+++ b/sdk/src/openssl/ed_validator.rs
@@ -39,6 +39,7 @@ impl CoseValidator for EdValidator {
 }
 
 #[cfg(test)]
+#[cfg(feature = "file_io")]
 mod tests {
     #![allow(clippy::unwrap_used)]
 

--- a/sdk/src/openssl/rsa_signer.rs
+++ b/sdk/src/openssl/rsa_signer.rs
@@ -11,7 +11,9 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::{cell::Cell, fs, path::Path};
+use std::cell::Cell;
+#[cfg(feature = "file_io")]
+use std::{fs, path::Path};
 
 //use extfmt::Hexlify;
 use openssl::{
@@ -66,14 +68,15 @@ impl RsaSigner {
 }
 
 impl ConfigurableSigner for RsaSigner {
+    #[cfg(feature = "file_io")]
     fn from_files<P: AsRef<Path>>(
         signcert_path: P,
         pkey_path: P,
         alg: SigningAlg,
         tsa_url: Option<String>,
     ) -> Result<Self> {
-        let signcert = fs::read(signcert_path).map_err(wrap_io_err)?;
-        let pkey = fs::read(pkey_path).map_err(wrap_io_err)?;
+        let signcert = fs::read(signcert_path).map_err(Error::IoError)?;
+        let pkey = fs::read(pkey_path).map_err(Error::IoError)?;
 
         Self::from_signcert_and_pkey(&signcert, &pkey, alg, tsa_url)
     }
@@ -195,10 +198,6 @@ impl Signer for RsaSigner {
             None
         }
     }
-}
-
-fn wrap_io_err(err: std::io::Error) -> Error {
-    Error::IoError(err)
 }
 
 fn wrap_openssl_err(err: openssl::error::ErrorStack) -> Error {

--- a/sdk/src/openssl/temp_signer.rs
+++ b/sdk/src/openssl/temp_signer.rs
@@ -31,8 +31,10 @@
 #![allow(clippy::panic)]
 #![allow(clippy::unwrap_used)]
 
+#[cfg(feature = "file_io")]
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "file_io")]
 use crate::{
     openssl::{EcSigner, EdSigner, RsaSigner},
     signer::ConfigurableSigner,
@@ -57,6 +59,7 @@ use crate::{
 /// # Panics
 ///
 /// Can panic if unable to invoke OpenSSL executable properly.
+#[cfg(feature = "file_io")]
 pub fn get_ec_signer<P: AsRef<Path>>(
     path: P,
     alg: SigningAlg,
@@ -101,6 +104,7 @@ pub fn get_ec_signer<P: AsRef<Path>>(
 /// # Panics
 ///
 /// Can panic if unable to invoke OpenSSL executable properly.
+#[cfg(feature = "file_io")]
 pub fn get_ed_signer<P: AsRef<Path>>(
     path: P,
     alg: SigningAlg,
@@ -142,6 +146,7 @@ pub fn get_ed_signer<P: AsRef<Path>>(
 /// # Panics
 ///
 /// Can panic if unable to invoke OpenSSL executable properly.
+#[cfg(feature = "file_io")]
 pub fn get_rsa_signer<P: AsRef<Path>>(
     path: P,
     alg: SigningAlg,

--- a/sdk/src/salt.rs
+++ b/sdk/src/salt.rs
@@ -55,13 +55,13 @@ impl Default for DefaultSalt {
 
 impl SaltGenerator for DefaultSalt {
     fn generate_salt(&self) -> Option<Vec<u8>> {
-        #[cfg(feature = "file_io")] // auto generation not supported on wasm
+        #[cfg(feature = "sign")] // auto generation not supported on wasm
         {
             let mut salt = vec![0; self.salt_len];
             openssl::rand::rand_bytes(&mut salt).ok()?;
             Some(salt)
         }
-        #[cfg(not(feature = "file_io"))]
+        #[cfg(not(feature = "sign"))]
         {
             None
         }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -48,6 +48,7 @@ pub trait Signer {
 /// Trait to allow loading of signing credential from external sources
 pub(crate) trait ConfigurableSigner: Signer + Sized {
     /// Create signer form credential files
+    #[cfg(feature = "file_io")]
     fn from_files<P: AsRef<std::path::Path>>(
         signcert_path: P,
         pkey_path: P,

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3238,6 +3238,6 @@ pub mod tests {
         // make sure we can read from new file
         let mut report = DetailedStatusTracker::new();
         let _new_store = Store::load_from_memory("jpeg", &result, true, &mut report).unwrap();
-        std::fs::write("foo.jpg", result).unwrap();
+        // std::fs::write("target/test.jpg", result).unwrap();
     }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -11,33 +11,26 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#[cfg(feature = "sign")]
+use std::io::SeekFrom;
 use std::{collections::HashMap, io::Cursor};
 #[cfg(feature = "file_io")]
 use std::{fs, path::Path};
 
-#[cfg(feature = "file_io")]
 use log::error;
 
 #[cfg(all(feature = "xmp_write", feature = "file_io"))]
 use crate::embedded_xmp;
 #[cfg(feature = "async_signer")]
 use crate::AsyncSigner;
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 use crate::{
     assertion::AssertionData,
-    assertions::{BmffHash, DataHash, DataMap, ExclusionsMap, SubsetMap},
-    asset_io::{HashBlockObjectType, HashObjectPositions},
-    claim::RemoteManifest,
+    assertions::DataHash,
+    asset_io::{CAIReadWrite, HashBlockObjectType, HashObjectPositions},
     cose_sign::cose_sign,
     cose_validator::verify_cose,
-    jumbf_io::{
-        get_file_extension, get_supported_file_extension, is_bmff_format, load_jumbf_from_file,
-        object_locations, save_jumbf_to_file,
-    },
-    utils::{
-        hash_utils::{hash256, Exclusion},
-        patch::patch_bytes,
-    },
+    jumbf_io::{object_locations_from_stream, save_jumbf_to_stream},
     Signer,
 };
 use crate::{
@@ -50,6 +43,19 @@ use crate::{
     jumbf_io::load_jumbf_from_memory,
     status_tracker::{log_item, OneShotStatusTracker, StatusTracker},
     validation_status, ManifestStoreReport,
+};
+#[cfg(feature = "file_io")]
+use crate::{
+    assertions::{BmffHash, DataMap, ExclusionsMap, SubsetMap},
+    claim::RemoteManifest,
+    jumbf_io::{
+        get_file_extension, get_supported_file_extension, is_bmff_format, load_jumbf_from_file,
+        object_locations, save_jumbf_to_file,
+    },
+    utils::{
+        hash_utils::{hash256, Exclusion},
+        patch::patch_bytes,
+    },
 };
 
 const MANIFEST_STORE_EXT: &str = "c2pa"; // file extension for external manifests
@@ -318,7 +324,7 @@ impl Store {
 
     // Returns placeholder that will be searched for and replaced
     // with actual signature data.
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     fn sign_claim_placeholder(&self, claim: &Claim, min_reserve_size: usize) -> Vec<u8> {
         let placeholder_str = format!("signature placeholder:{}", claim.label());
         let mut placeholder = hash256(placeholder_str.as_bytes()).as_bytes().to_vec();
@@ -330,7 +336,7 @@ impl Store {
     }
 
     /// Sign the claim and return signature.
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     pub fn sign_claim(
         &self,
         claim: &Claim,
@@ -429,7 +435,7 @@ impl Store {
         self.claims_map.insert(label, index);
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     fn add_assertion_to_jumbf_store(
         store: &mut CAIAssertionStore,
         claim_assertion: &ClaimAssertion,
@@ -591,7 +597,7 @@ impl Store {
         self.to_jumbf_internal(signer.reserve_size())
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     fn to_jumbf_internal(&self, min_reserve_size: usize) -> Result<Vec<u8>> {
         // Create the CAI block.
         let mut cai_block = Cai::new();
@@ -1222,13 +1228,26 @@ impl Store {
         block_locations: &mut Vec<HashObjectPositions>,
         calc_hashes: bool,
     ) -> Result<Vec<DataHash>> {
+        let mut file = std::fs::File::open(asset_path)?;
+        Self::generate_data_hashes_for_stream(&mut file, alg, block_locations, calc_hashes)
+    }
+
+    // generate a list of AssetHashes based on the location of objects in the stream
+    #[cfg(feature = "sign")]
+    fn generate_data_hashes_for_stream(
+        stream: &mut dyn CAIReadWrite,
+        alg: &str,
+        block_locations: &mut Vec<HashObjectPositions>,
+        calc_hashes: bool,
+    ) -> Result<Vec<DataHash>> {
         if block_locations.is_empty() {
             let out: Vec<DataHash> = vec![];
             return Ok(out);
         }
 
-        let metadata = asset_path.metadata().map_err(crate::error::wrap_io_err)?;
-        let file_len: u64 = metadata.len();
+        let stream_len = stream.seek(SeekFrom::End(0))?;
+        stream.seek(SeekFrom::Start(0))?;
+
         let mut hashes: Vec<DataHash> = Vec::new();
 
         // sort blocks by offset
@@ -1253,7 +1272,7 @@ impl Store {
             }
         }
 
-        if block_end as u64 > file_len {
+        if block_end as u64 > stream_len {
             return Err(Error::BadParam(
                 "data hash exclusions out of range".to_string(),
             ));
@@ -1266,7 +1285,7 @@ impl Store {
                 dh.add_exclusion(Exclusion::new(block_start, block_end - block_start));
             }
             if calc_hashes {
-                dh.gen_hash(asset_path)?;
+                dh.gen_hash_from_stream(stream)?;
             } else {
                 match alg {
                     "sha256" => dh.set_hash([0u8; 32].to_vec()),
@@ -1406,6 +1425,35 @@ impl Store {
             }
         }
         Ok(())
+    }
+
+    /// Embed the claims store as jumbf into a stream. Updates XMP with provenance record.
+    /// When called, the stream should contain an asset matching format.
+    /// on return, the stream will contain the new manifest signed with signer
+    /// This directly modifies the asset in stream, backup stream first if you need to preserve it.
+    #[cfg(feature = "sign")]
+    pub fn save_to_stream(
+        &mut self,
+        format: &str,
+        stream: &mut dyn CAIReadWrite,
+        signer: &dyn Signer,
+    ) -> Result<Vec<u8>> {
+        let jumbf_bytes = self.start_save_stream(format, stream, signer.reserve_size())?;
+
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+        let sig = self.sign_claim(pc, signer, signer.reserve_size())?;
+        let sig_placeholder = self.sign_claim_placeholder(pc, signer.reserve_size());
+
+        match self.finish_save_stream(jumbf_bytes, format, stream, sig, &sig_placeholder) {
+            Ok((s, m)) => {
+                // save sig so store is up to date
+                let pc_mut = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+                pc_mut.set_signature_val(s);
+
+                Ok(m)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Embed the claims store as jumbf into an asset. Updates XMP with provenance record.
@@ -1574,6 +1622,91 @@ impl Store {
             }
             Err(e) => Err(e),
         }
+    }
+
+    #[cfg(feature = "sign")]
+    fn start_save_stream(
+        &mut self,
+        format: &str,
+        stream: &mut dyn CAIReadWrite,
+        reserve_size: usize,
+    ) -> Result<Vec<u8>> {
+        let mut data;
+        // 1) Add DC provenance XMP
+
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+        // todo:: stream support for XMP write
+
+        // 2) Get hash ranges if needed, do not generate for update manifests
+        let mut hash_ranges = object_locations_from_stream(format, stream)?;
+        let hashes: Vec<DataHash> = if pc.update_manifest() {
+            Vec::new()
+        } else {
+            Store::generate_data_hashes_for_stream(stream, pc.alg(), &mut hash_ranges, false)?
+        };
+
+        // add the placeholder data hashes to provenance claim so that the required space is reserved
+        for mut hash in hashes {
+            // add padding to account for possible cbor expansion of final DataHash
+            let padding: Vec<u8> = vec![0x0; 10];
+            hash.add_padding(padding);
+
+            pc.add_assertion(&hash)?;
+        }
+
+        // 3) Generate in memory CAI jumbf block
+        // and write preliminary jumbf store to file
+        // source and dest the same so save_jumbf_to_file will use the same file since we have already cloned
+        data = self.to_jumbf_internal(reserve_size)?;
+        let jumbf_size = data.len();
+        save_jumbf_to_stream(format, stream, &data)?;
+
+        // 4)  determine final object locations and patch the asset hashes with correct offset
+        // replace the source with correct asset hashes so that the claim hash will be correct
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+
+        // get the final hash ranges, but not for update manifests
+        let mut new_hash_ranges = object_locations_from_stream(format, stream)?;
+        let updated_hashes = if pc.update_manifest() {
+            Vec::new()
+        } else {
+            Store::generate_data_hashes_for_stream(stream, pc.alg(), &mut new_hash_ranges, true)?
+        };
+
+        // patch existing claim hash with updated data
+        for hash in updated_hashes {
+            pc.update_data_hash(hash)?;
+        }
+
+        // regenerate the jumbf because the cbor changed
+        data = self.to_jumbf_internal(reserve_size)?;
+        if jumbf_size != data.len() {
+            return Err(Error::JumbfCreationError);
+        }
+
+        Ok(data) // return JUMBF data
+    }
+
+    #[cfg(feature = "sign")]
+    fn finish_save_stream(
+        &self,
+        mut jumbf_bytes: Vec<u8>,
+        format: &str,
+        stream: &mut dyn CAIReadWrite,
+        sig: Vec<u8>,
+        sig_placeholder: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
+        if sig_placeholder.len() != sig.len() {
+            return Err(Error::CoseSigboxTooSmall);
+        }
+
+        patch_bytes(&mut jumbf_bytes, sig_placeholder, &sig)
+            .map_err(|_| Error::JumbfCreationError)?;
+
+        // re-save to file
+        save_jumbf_to_stream(format, stream, &jumbf_bytes)?;
+
+        Ok((sig, jumbf_bytes))
     }
 
     #[cfg(feature = "file_io")]
@@ -3078,5 +3211,33 @@ pub mod tests {
                 _ => panic!("unexepected error"),
             },
         }
+    }
+
+    #[actix::test]
+    #[cfg(feature = "file_io")]
+    async fn test_jumbf_generation_stream() {
+        // test adding to actual image
+        let ap = fixture_path("earth_apollo17.jpg");
+        // Load the exported file into a buffer
+        let file_buffer = std::fs::read(&ap).unwrap();
+        let mut buf_io = Cursor::new(file_buffer);
+
+        // Create claims store.
+        let mut store = Store::new();
+
+        // Create a new claim.
+        let claim1 = create_test_claim().unwrap();
+
+        let signer = temp_signer(); // todo:: temp_signer depends on file_io
+
+        store.commit_claim(claim1).unwrap();
+
+        store.save_to_stream("jpeg", &mut buf_io, &signer).unwrap();
+
+        let result = buf_io.into_inner();
+        // make sure we can read from new file
+        let mut report = DetailedStatusTracker::new();
+        let _new_store = Store::load_from_memory("jpeg", &result, true, &mut report).unwrap();
+        std::fs::write("foo.jpg", result).unwrap();
     }
 }

--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -127,7 +127,7 @@ pub fn get_ta_url() -> Option<String> {
 
 /// internal only function to work around bug in serialization of TimeStampResponse
 /// so we just return the data directly
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 fn time_stamp_request_http(
     url: &str,
     request: &crate::asn1::rfc3161::TimeStampReq,
@@ -194,7 +194,8 @@ fn time_stamp_request_http(
 ///
 /// This is a wrapper around [time_stamp_request_http] that constructs the low-level
 /// ASN.1 request object with reasonable defaults.
-#[cfg(feature = "file_io")]
+
+#[cfg(feature = "sign")]
 fn time_stamp_message_http(
     url: &str,
     message: &[u8],
@@ -238,7 +239,7 @@ impl std::ops::Deref for TimeStampResponse {
 
 impl TimeStampResponse {
     /// Whether the time stamp request was successful.
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     pub fn is_success(&self) -> bool {
         matches!(
             self.0.status.status,
@@ -289,7 +290,7 @@ impl TimeStampResponse {
 /// Generate TimeStamp based on rfc3161 using "data" as MessageImprint and return raw TimeStampRsp bytes
 #[allow(unused_variables)]
 pub fn timestamp_data(url: &str, data: &[u8]) -> Result<Vec<u8>> {
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     {
         let ts = time_stamp_message_http(url, data, x509_certificate::DigestAlgorithm::Sha256)?;
 
@@ -298,12 +299,11 @@ pub fn timestamp_data(url: &str, data: &[u8]) -> Result<Vec<u8>> {
 
         Ok(ts)
     }
-    #[cfg(not(feature = "file_io"))]
+    #[cfg(not(feature = "sign"))]
     {
         Err(Error::WasmNoCrypto)
     }
 }
-
 pub fn gt_to_datetime(
     gt: x509_certificate::asn1time::GeneralizedTime,
 ) -> chrono::DateTime<chrono::Utc> {
@@ -392,7 +392,7 @@ impl TstContainer {
         }
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "sign")]
     pub fn add_token(&mut self, token: TstToken) {
         self.tst_tokens.push(token);
     }
@@ -405,7 +405,7 @@ impl Default for TstContainer {
 }
 
 /// Wrap rfc3161 TimeStampRsp in COSE sigTst object
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 pub fn make_cose_timestamp(ts_data: &[u8]) -> TstContainer {
     let token = TstToken {
         val: ts_data.to_vec(),

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -25,12 +25,9 @@ use crate::{
     Result,
 };
 #[cfg(feature = "file_io")]
-use crate::{
-    create_signer,
-    openssl::RsaSigner,
-    signer::{ConfigurableSigner, Signer},
-    SigningAlg,
-};
+use crate::{create_signer, Signer};
+#[cfg(feature = "sign")]
+use crate::{openssl::RsaSigner, signer::ConfigurableSigner, SigningAlg};
 
 pub const TEST_SMALL_JPEG: &str = "earth_apollo17.jpg";
 
@@ -196,7 +193,7 @@ pub fn temp_fixture_path(temp_dir: &TempDir, file_name: &str) -> PathBuf {
 /// Can panic if the certs cannot be read. (This function should only
 /// be used as part of testing infrastructure.)
 #[cfg(feature = "file_io")]
-pub fn temp_signer() -> RsaSigner {
+pub fn temp_signer_file() -> RsaSigner {
     #![allow(clippy::expect_used)]
     let mut sign_cert_path = fixture_path("certs");
     sign_cert_path.push("ps256");
@@ -207,6 +204,16 @@ pub fn temp_signer() -> RsaSigner {
     pem_key_path.set_extension("pem");
 
     RsaSigner::from_files(&sign_cert_path, &pem_key_path, SigningAlg::Ps256, None)
+        .expect("get_temp_signer")
+}
+
+#[cfg(feature = "sign")]
+pub fn temp_signer() -> RsaSigner {
+    #![allow(clippy::expect_used)]
+    let sign_cert = include_bytes!("../../tests/fixtures/certs/ps256.pub").to_vec();
+    let pem_key = include_bytes!("../../tests/fixtures/certs/ps256.pem").to_vec();
+
+    RsaSigner::from_signcert_and_pkey(&sign_cert, &pem_key, SigningAlg::Ps256, None)
         .expect("get_temp_signer")
 }
 

--- a/sdk/src/validator.rs
+++ b/sdk/src/validator.rs
@@ -13,7 +13,7 @@
 
 use chrono::{DateTime, Utc};
 
-#[cfg(feature = "file_io")]
+#[cfg(feature = "sign")]
 use crate::openssl::{EcValidator, EdValidator, RsaValidator};
 use crate::{Result, SigningAlg};
 
@@ -51,8 +51,8 @@ impl CoseValidator for DummyValidator {
 // • RS512	RSASSA-PKCS1-v1_5 using SHA-512
 // • ED25519 Edwards Curve ED25519
 
-/// return validator for supported C2PA  algorthms
-#[cfg(feature = "file_io")]
+/// return validator for supported C2PA  algorithms
+#[cfg(feature = "sign")]
 pub(crate) fn get_validator(alg: SigningAlg) -> Box<dyn CoseValidator> {
     match alg {
         SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
@@ -68,7 +68,7 @@ pub(crate) fn get_validator(alg: SigningAlg) -> Box<dyn CoseValidator> {
     }
 }
 
-#[cfg(not(feature = "file_io"))]
+#[cfg(not(feature = "sign"))]
 #[allow(dead_code)]
 pub(crate) fn get_validator(_alg: SigningAlg) -> Box<dyn CoseValidator> {
     Box::new(DummyValidator)


### PR DESCRIPTION
## Changes in this pull request
Add sign feature for signing manifests without file i/o 
Only supports jpeg in so far
Manifest.embed_stream method added

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
