### PR TITLE
manifest_data was missing for remote manifests

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -78,7 +78,6 @@ serde-transcode = "1.1.1"
 sha2 = "0.10.2"
 tempfile = "3.1.0"
 thiserror = ">= 1.0.20, < 1.0.32"
-time = ">= 0.2.23"
 twoway = "0.2.1"
 url = "2.2.2"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1871,8 +1871,7 @@ impl Store {
             Ok(manifest_bytes) => Ok(manifest_bytes),
             Err(Error::JumbfNotFound) => {
                 if external_manifest.exists() {
-                    let external_manifest_bytes = std::fs::read(external_manifest)?;
-                    Ok(external_manifest_bytes)
+                    std::fs::read(external_manifest).map_err(Error::IoError)
                 } else {
                     // check for remote manifest
                     let mut asset_reader = std::fs::File::open(in_path)?;
@@ -1884,8 +1883,7 @@ impl Store {
                     .provenance
                     {
                         if cfg!(feature = "fetch_remote_manifests") {
-                            let remote_manifest_bytes = Store::fetch_remote_manifest(&ext_ref)?;
-                            Ok(remote_manifest_bytes)
+                            Store::fetch_remote_manifest(&ext_ref)
                         } else {
                             // return an error with the url that should be read
                             Err(Error::RemoteManifestUrl(ext_ref))

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1857,26 +1857,22 @@ impl Store {
         }
     }
 
-    /// load a CAI store from  a file
+    /// load jumbf given a file path
+    ///
+    /// This handles, embedded, sidecar and remote manifests
     ///
     /// in_path -  path to source file
     /// validation_log - optional vec to contain addition info about the asset
     #[cfg(feature = "file_io")]
-    fn load_cai_from_file(
-        in_path: &Path,
-        validation_log: &mut impl StatusTracker,
-    ) -> Result<Store> {
+    pub fn load_jumbf_from_path(in_path: &Path) -> Result<Vec<u8>> {
         let external_manifest = in_path.with_extension(MANIFEST_STORE_EXT);
 
         match load_jumbf_from_file(in_path) {
-            Ok(manifest_bytes) => {
-                // load and validate with CAI toolkit and dump if desired
-                Store::from_jumbf(&manifest_bytes, validation_log)
-            }
+            Ok(manifest_bytes) => Ok(manifest_bytes),
             Err(Error::JumbfNotFound) => {
                 if external_manifest.exists() {
                     let external_manifest_bytes = std::fs::read(external_manifest)?;
-                    Store::from_jumbf(&external_manifest_bytes, validation_log)
+                    Ok(external_manifest_bytes)
                 } else {
                     // check for remote manifest
                     let mut asset_reader = std::fs::File::open(in_path)?;
@@ -1889,7 +1885,7 @@ impl Store {
                     {
                         if cfg!(feature = "fetch_remote_manifests") {
                             let remote_manifest_bytes = Store::fetch_remote_manifest(&ext_ref)?;
-                            Store::from_jumbf(&remote_manifest_bytes, validation_log)
+                            Ok(remote_manifest_bytes)
                         } else {
                             // return an error with the url that should be read
                             Err(Error::RemoteManifestUrl(ext_ref))
@@ -1898,6 +1894,24 @@ impl Store {
                         Err(Error::JumbfNotFound)
                     }
                 }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// load a CAI store from  a file
+    ///
+    /// in_path -  path to source file
+    /// validation_log - optional vec to contain addition info about the asset
+    #[cfg(feature = "file_io")]
+    fn load_cai_from_file(
+        in_path: &Path,
+        validation_log: &mut impl StatusTracker,
+    ) -> Result<Store> {
+        match Self::load_jumbf_from_path(in_path) {
+            Ok(manifest_bytes) => {
+                // load and validate with CAI toolkit
+                Store::from_jumbf(&manifest_bytes, validation_log)
             }
             Err(e) => Err(e),
         }


### PR DESCRIPTION
## Changes in this pull request
Inrgredient::from_file was not returning manifest_data for remote manifests.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
