### PR TITLE
(IGNORE) Disregard grep non-zero exit status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
 
       - name: Has (MINOR) tag been used in a previous commit?
         uses: mathiasvr/command-output@v1
+        continue-on-error: true
         id: bump_exists
         if: ${{ !contains(github.event.pull_request.title, '(MINOR)') }}
         with:


### PR DESCRIPTION
Grep exits non-zero when no results are found, but we don't want to fail the entire CI workflow because of that.