### PR TITLE
Fix for XMP links being mistaken for remote URLs

### DIFF
--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -887,7 +887,7 @@ fn validate_with_cert(
     let pk_der = pk.raw;
 
     if validator.validate(sig, data, pk_der)? {
-        Ok(extract_subject_from_cert(&signcert)?)
+        extract_subject_from_cert(&signcert).or_else(|_| Ok("".to_string()))
     } else {
         Err(Error::CoseSignature)
     }
@@ -928,7 +928,7 @@ async fn validate_with_cert_async(
     let validator = get_validator(signing_alg);
 
     if validator.validate(sig, data, pk_der)? {
-        Ok(extract_subject_from_cert(&signcert)?)
+        extract_subject_from_cert(&signcert).or_else(|_| Ok("".to_string()))
     } else {
         Err(Error::CoseSignature)
     }

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -887,7 +887,7 @@ fn validate_with_cert(
     let pk_der = pk.raw;
 
     if validator.validate(sig, data, pk_der)? {
-        extract_subject_from_cert(&signcert).or_else(|_| Ok("".to_string()))
+        Ok(extract_subject_from_cert(&signcert).unwrap_or_default())
     } else {
         Err(Error::CoseSignature)
     }
@@ -906,7 +906,7 @@ async fn validate_with_cert_async(
     let pk_der = pk.raw;
 
     if validate_async(signing_alg, sig, data, pk_der).await? {
-        Ok(extract_subject_from_cert(&signcert)?)
+        Ok(extract_subject_from_cert(&signcert).unwrap_or_default())
     } else {
         Err(Error::CoseSignature)
     }
@@ -928,7 +928,7 @@ async fn validate_with_cert_async(
     let validator = get_validator(signing_alg);
 
     if validator.validate(sig, data, pk_der)? {
-        extract_subject_from_cert(&signcert).or_else(|_| Ok("".to_string()))
+        Ok(extract_subject_from_cert(&signcert).unwrap_or_default())
     } else {
         Err(Error::CoseSignature)
     }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1987,7 +1987,7 @@ impl Store {
     /// check the input url to see if it is a supported remotes URI
     pub fn is_valid_remote_url(url: &str) -> bool {
         match url::Url::parse(url) {
-            Ok(u) => u.scheme().starts_with("http"),
+            Ok(u) => u.scheme() == "http" || u.scheme() == "https",
             Err(_) => false,
         }
     }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1888,7 +1888,10 @@ impl Store {
                     )
                     .provenance
                     {
-                        if cfg!(feature = "fetch_remote_manifests") {
+                        // verify provenance path is remote url
+                        let is_remote_url = Store::is_valid_remote_url(&ext_ref);
+
+                        if cfg!(feature = "fetch_remote_manifests") && is_remote_url {
                             Store::fetch_remote_manifest(&ext_ref)
                         } else {
                             // return an error with the url that should be read
@@ -1978,6 +1981,14 @@ impl Store {
             Some(ext_ref)
         } else {
             None
+        }
+    }
+
+    /// check the input url to see if it is a supported remotes URI
+    pub fn is_valid_remote_url(url: &str) -> bool {
+        match url::Url::parse(url) {
+            Ok(u) => !(u.scheme() != "http" && u.scheme() != "https"),
+            Err(_) => false,
         }
     }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1987,7 +1987,7 @@ impl Store {
     /// check the input url to see if it is a supported remotes URI
     pub fn is_valid_remote_url(url: &str) -> bool {
         match url::Url::parse(url) {
-            Ok(u) => !(u.scheme() != "http" && u.scheme() != "https"),
+            Ok(u) => u.scheme().starts_with("http"),
             Err(_) => false,
         }
     }


### PR DESCRIPTION
Add change to cose_validator so that certs without organization is not an error

## Changes in this pull request
_Give a narrative description of what has been changed._
Old CAI manifests may still have XMP jumbf references.  This PR check to make sure those references are valid URLs before attempting a remote manifest fetch.  Also fix bogus error when a certificate does not have an organization set.  That is not a C2PA requirement.  

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
