### PR TITLE
Fix manifest.set_thumbnail when add_thumbnails is enabled

### DIFF
--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1232,12 +1232,12 @@ pub(crate) mod tests {
         let signer = temp_signer();
 
         let mut manifest = test_manifest();
-        manifest.set_thumbnail("image/jpeg",vec![1,2,3]);
+        manifest.set_thumbnail("image/jpeg", vec![1, 2, 3]);
         manifest.embed(&output, &output, &signer).expect("embed");
         let manifest_store = crate::ManifestStore::from_file(&output).expect("from_file");
         let active_manifest = manifest_store.get_active().unwrap();
         let (format, thumb) = active_manifest.thumbnail().unwrap();
         assert_eq!(format, "image/jpeg");
-        assert_eq!(thumb, vec![1,2,3]);
+        assert_eq!(thumb, vec![1, 2, 3]);
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Allow overriding a manifest thumbnail when the thumbnail feature is enabled.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
