### PR TITLE
Fixes support for instanceId on action and generate parameters.ingredient field when possible

### DIFF
--- a/make_test_images/src/make_test_images.rs
+++ b/make_test_images/src/make_test_images.rs
@@ -279,11 +279,9 @@ impl MakeTestImages {
                 // create and add the ingredient
                 let ingredient =
                     Ingredient::from_file_with_options(ing_path, &ImageOptions::new())?;
-                actions =
-                    actions.add_action(Action::new(c2pa_action::PLACED).set_parameter(
-                        "identifier".to_owned(),
-                        ingredient.instance_id().to_owned(),
-                    )?);
+                actions = actions.add_action(
+                    Action::new(c2pa_action::PLACED).set_instance_id(ingredient.instance_id()),
+                );
                 manifest.add_ingredient(ingredient);
 
                 x += width;

--- a/make_test_images/src/make_test_images.rs
+++ b/make_test_images/src/make_test_images.rs
@@ -218,8 +218,7 @@ impl MakeTestImages {
                 let parent = Ingredient::from_file_with_options(src_path, &ImageOptions::new())?;
 
                 actions = actions.add_action(
-                    Action::new(c2pa_action::OPENED)
-                        .set_parameter("identifier".to_owned(), parent.instance_id().to_owned())?,
+                    Action::new(c2pa_action::OPENED).set_instance_id(parent.instance_id()),
                 );
                 manifest.set_parent(parent)?;
 

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -66,7 +66,7 @@ pub mod c2pa_action {
 /// the action.
 ///
 /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_actions>.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Action {
     /// The label associated with this action. See ([`c2pa_action`]).
     action: String,
@@ -277,6 +277,12 @@ impl Actions {
     /// Returns the assertion's [`Metadata`], if it exists.
     pub fn metadata(&self) -> Option<&Metadata> {
         self.metadata.as_ref()
+    }
+
+    /// Internal method to update actions to meet spec requirements
+    pub(crate) fn update_action(mut self, index: usize, action: Action) -> Self {
+        self.actions[index] = action;
+        self
     }
 
     /// Adds an [`Action`] to this assertion's list of actions.

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -88,7 +88,7 @@ pub struct Action {
     changed: Option<String>,
 
     /// The value of the `xmpMM:InstanceID` property for the modified (output) resource.
-    #[serde(rename = "InstanceId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "instanceId", skip_serializing_if = "Option::is_none")]
     instance_id: Option<String>,
 
     /// Additional parameters of the action. These vary by the type of action.
@@ -469,7 +469,6 @@ pub mod tests {
     #[test]
     fn test_binary_round_trip() {
         let assertion = Actions::new()
-            // .set_dictionary("http://testdictionary")
             .add_action(
                 Action::new("c2pa.cropped")
                     .set_parameter(
@@ -521,7 +520,8 @@ pub mod tests {
                     }
                   },
                   {
-                    "action": "c2pa.edited",
+                    "action": "c2pa.opened",
+                    "instanceId": "xmp.iid:7b57930e-2f23-47fc-affe-0400d70b738d",
                     "parameters": {
                       "description": "import"
                     },

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -614,8 +614,12 @@ impl Manifest {
                         .iter()
                         .enumerate()
                         .filter_map(|(i, a)| {
-                            (a.instance_id().is_some() && a.get_parameter("ingredient").is_none())
-                                .then_some((i, a.clone()))
+                            if a.instance_id().is_some() && a.get_parameter("ingredient").is_none()
+                            {
+                                Some((i, a.clone()))
+                            } else {
+                                None
+                            }
                         })
                         .collect();
 

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -608,17 +608,10 @@ impl Manifest {
                 Actions::LABEL => {
                     let mut actions: Actions = manifest_assertion.to_assertion()?;
 
-                    // fixup parameters field from instance_id to ingredient uri for
-                    // c2pa.transcoded, c2pa.repackaged, and c2pa.placed action
+                    // fixup parameters field from instance_id to ingredient uri
                     let needs_ingredient: Vec<(usize, crate::assertions::Action)> = actions
                         .actions()
                         .iter()
-                        .filter(|a| {
-                            matches!(
-                                a.action(),
-                                "c2pa.transcoded" | "c2pa.repackaged" | "c2pa.placed"
-                            )
-                        })
                         .enumerate()
                         .filter_map(|(i, a)| {
                             (a.instance_id().is_some() && a.get_parameter("ingredient").is_none())


### PR DESCRIPTION
## Changes in this pull request
fix support for ingredientId on action and generate parameters.ingredient field when possible
Update make_test_images to add instanceId to actions

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
