### PR TITLE
Fix issue where value was inadvertently included in Exclusion structure

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -36,7 +36,9 @@ const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
 pub struct Exclusion {
     start: usize,
     length: usize,
-    bmff_offset: Option<u64>, // optional offset position to include in BMFF_V2 hashes in BE format
+
+    #[serde(skip)]
+    bmff_offset: Option<u64>, // optional tracking of offset positions to include in BMFF_V2 hashes in BE format
 }
 
 impl Exclusion {


### PR DESCRIPTION
## Changes in this pull request
Working bmff_offset should not be written into the exclusion map

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
