### PR TITLE
(MINOR) Bump MSRV to 1.63.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [1.61.0, stable]
+        rust_version: [1.63.0, stable]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We welcome contributions to this project.  For information on contributing, prov
 
 ## Requirements
 
-The SDK requires **Rust version 1.61.0** or newer.
+The SDK requires **Rust version 1.63.0** or newer.
 
 ### Supported platforms
 

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.17.0"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 keywords = ["xmp", "metadata"]
 categories = ["api-bindings"]
 edition = "2018"
-rust-version = "1.61.0"
+rust-version = "1.63.0"
 exclude = ["tests/fixtures"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Reason: Upstream dependency [openssl-src](https://crates.io/crates/openssl-src/versions) released a minor version upgrade (111.25.1+1.1.1t) a few days ago which _says_ that it bumps MSRV to 1.57.0, but that appears to be incorrect. Local testing shows that it no longer compiles with any version prior to 1.63.0.
