### PR TITLE
Fix hash algo warning in Wasm and hashing for RSA-PSS SHA-384/512

### DIFF
--- a/sdk/src/wasm/webcrypto_validator.rs
+++ b/sdk/src/wasm/webcrypto_validator.rs
@@ -154,7 +154,10 @@ async fn async_validate(
                 .map_err(|err| Error::WasmRsaKeyImport(err.to_string()))?;
             let (_, seq) = parse_ber_sequence(spki.subject_public_key)
                 .map_err(|err| Error::WasmRsaKeyImport(err.to_string()))?;
-            let hashed_data = hash_by_alg(&hash, &data, None);
+            // We need to normalize this from SHA-256 (the format WebCrypto uses) to sha256
+            // (the format the util function expects) so that it maps correctly
+            let normalized_hash = hash.clone().replace("-", "").to_lowercase();
+            let hashed_data = hash_by_alg(&normalized_hash, &data, None);
             let modulus = biguint_val(&seq[0]);
             let exp = biguint_val(&seq[1]);
             let public_key = RsaPublicKey::new(modulus, exp)


### PR DESCRIPTION
## Changes in this pull request

Since WebCrypto uses a hashing identifier such as `SHA-256` and the hashing utils (and I'm guessing the OpenSSL code) uses `sha256`, we were getting a warning that it couldn't find a match and that it defaulted to `sha256`. This also probably broke hash verification with RSA-PSS SHA-384 and SHA-512.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
