### PR TITLE
Avoid writing thumbnail when reading a manifest as an ingredient

### DIFF
--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -253,6 +253,23 @@ impl Manifest {
         Ok(self)
     }
 
+    fn set_thumbnail_no_write<S: Into<String>, B: Into<Vec<u8>>>(
+        &mut self,
+        format: S,
+        thumbnail: B,
+    ) -> Result<&mut Self> {
+        let base_id = self
+            .label()
+            .unwrap_or_else(|| self.instance_id())
+            .to_string();
+        self.thumbnail = Some(self.resources.add_with_no_write(
+            &base_id,
+            &format.into(),
+            thumbnail,
+        )?);
+        Ok(self)
+    }
+
     /// If set, the embed calls will create a sidecar .c2pa manifest file next to the output file
     /// No change will be made to the output file
     pub fn set_sidecar_manifest(&mut self) -> &mut Self {
@@ -629,7 +646,7 @@ impl Manifest {
         if self.thumbnail().is_none() {
             #[cfg(feature = "add_thumbnails")]
             if let Ok((format, image)) = crate::utils::thumbnail::make_thumbnail(path.as_ref()) {
-                self.set_thumbnail(format, image)?;
+                self.set_thumbnail_no_write(format, image)?;
             }
         }
         Ok(())

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -103,6 +103,20 @@ impl ResourceStore {
         Ok(ResourceRef::new(format, id))
     }
 
+    pub(crate) fn add_with_no_write<R>(
+        &mut self,
+        key: &str,
+        format: &str,
+        value: R,
+    ) -> crate::Result<ResourceRef>
+    where
+        R: Into<Vec<u8>>,
+    {
+        let id = self.id_from(key, format);
+        self.add_no_write(&id, value)?;
+        Ok(ResourceRef::new(format, id))
+    }
+
     /// Adds a resource, using a given id value.
     pub fn add<S, R>(&mut self, id: S, value: R) -> crate::Result<()>
     where
@@ -117,6 +131,15 @@ impl ResourceStore {
             std::fs::write(path, value.into())?;
             return Ok(());
         }
+        self.add_no_write(id, value)
+    }
+
+    /// Adds a resource, using a given id value.
+    pub(crate) fn add_no_write<S, R>(&mut self, id: S, value: R) -> crate::Result<()>
+    where
+        S: Into<String>,
+        R: Into<Vec<u8>>,
+    {
         self.resources.insert(id.into(), value.into());
         Ok(())
     }


### PR DESCRIPTION
Alternative approach to #205.