### PR TITLE
Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-wasm-web:
 	
 # Full local validation, build and test all features including wasm
 # Run this before pushing a PR to pre-validate
-test: check-format check-docs clippy test-localte test-wasm
+test: check-format check-docs clippy test-local test-wasm-web
 
 # Auto format code according to standards
 fmt: 

--- a/Makefile
+++ b/Makefile
@@ -25,18 +25,15 @@ clippy:
 test-local:
 	cargo test --all-features
 
-test-no-defaults:
-	cd sdk && cargo test --features="file_io, xmp_write, bmff" --no-default-features 
-
 test-wasm:
 	cd sdk && wasm-pack test --node
 
 test-wasm-web:
-	cd sdk && wasm-pack test --chrome --headless -- --features="remote_wasm_sign"
+	cd sdk && wasm-pack test --chrome --headless -- --features="serialize_thumbnails"
 	
 # Full local validation, build and test all features including wasm
 # Run this before pushing a PR to pre-validate
-test: check-format check-docs clippy test-local test-no-defaults test-wasm
+test: check-format check-docs clippy test-localte test-wasm
 
 # Auto format code according to standards
 fmt: 


### PR DESCRIPTION
repair make test 
remove test-no-defaults
run test-wasm-web instead of test-wasm

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
