### PR TITLE
Update README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         # environment. The goal is to fail PR validation
         # if the subsequent release would result in a failed
         # documentation build on docs.rs.
-        run: cargo +nightly doc --all-features
+        run: cargo +nightly doc --all-features --no-deps
         env:
           RUSTDOCFLAGS: --cfg docsrs
           DOCS_RS: 1

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Refer to the [CHANGELOG](CHANGELOG.md) for detailed Git changes
 _23 March 2023_
 
 * Added support for many new file formats, see Supported File Formats above.
-* new api to return 
+* new api to return supported formats
 * Streaming APIs added to support manifest creation without file_io
 * Manifest and Ingredient JSON formats replace the `is_parent` field with `relationship`
 * ResourceRef replaces `content-type` with `format`

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Refer to the [CHANGELOG](CHANGELOG.md) for detailed Git changes
 _23 March 2023_
 
 * Added support for many new file formats, see Supported File Formats above.
-* new api to return supported formats
-* Streaming APIs added to support manifest creation without file_io
-* Manifest and Ingredient JSON formats replace the `is_parent` field with `relationship`
-* ResourceRef replaces `content-type` with `format`
-* `bmff` feature no longer required
+* New api to return supported formats.
+* Streaming APIs for manifest creation without file_io for some formats.
+* Manifest and Ingredient JSON formats replace the `is_parent` field with `relationship`.
+* ResourceRef replaces `content-type` with `format`.
+* The `bmff` feature no longer required.

--- a/README.md
+++ b/README.md
@@ -6,22 +6,18 @@ The **[Coalition for Content Provenance and Authenticity](https://c2pa.org)** (C
 
 ## Key features
 
-The C2PA Rust SDK implements a subset of the [C2PA 1.0 technical specification](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html). 
+The C2PA Rust SDK implements a subset of the [C2PA 1.2 technical specification](https://c2pa.org/specifications/specifications/1.2/specs/C2PA_Specification.html). 
 
 The SDK enables a desktop, mobile, or embedded application to: 
-* Create and sign C2PA [claims](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_claims) and [manifests](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_manifests).
+* Create and sign C2PA [claims](https://c2pa.org/specifications/specifications/1.2/specs/C2PA_Specification.html#_claims) and [manifests](https://c2pa.org/specifications/specifications/1.2/specs/C2PA_Specification.html#_manifests).
 * Embed manifests in certain file formats.
 * Parse and validate manifests found in certain file formats.
 
-The SDK supports several common C2PA [assertions](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_c2pa_standard_assertions) and [hard bindings](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_hard_bindings).
+The SDK supports several common C2PA [assertions](https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_c2pa_standard_assertions) and [hard bindings](https://c2pa.org/specifications/specifications/1.2/specs/C2PA_Specification.html#_hard_bindings).
 
 ## State of the project
 
-This is an early release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
-
-The SDK:
-* Supports a variety of image and video formats. For details, see [c2patool supported file formats](https://opensource.contentauthenticity.org/docs/c2patool/#supported-file-formats).
-* Does not parse identity structures (verifiable credentials).
+This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
 
 ### Contributions and feedback
 
@@ -38,8 +34,27 @@ The SDK has been tested on the following operating systems:
 * Windows
 * MacOS (Intel and Apple silicon)
 * Ubuntu Linux
-* WebAssembly (Wasm); NOTE: claim _generation_ is not available on Wasm.
+* WebAssembly (Wasm)
 
+## Supported file formats
+
+ | Extensions    | MIME type                                           | 
+ |---------------| --------------------------------------------------- | 
+ | `avi`         | `video/msvideo`, `video/avi`, `application-msvideo` |
+ | `avif`        | `image/avif`                                        | 
+ | `c2pa`        | `application/x-c2pa-manifest-store`,                |
+ | `dng`         | `image/x-adobe-dng`                                 | 
+ | `heic`        | `image/heic`                                        | 
+ | `heif`        | `image/heif`                                        | 
+ | `jpg`, `jpeg` | `image/jpeg`                                        | 
+ | `m4a`         | `audio/mp4`                                         | 
+ | `mp4`         | `video/mp4`, `application/mp4`                      | 
+ | `mov`         | `video/quicktime`                                   |
+ | `png`         | `image/png`                                         | 
+ | `tif`,`tiff`  | `image/tiff`                                        | 
+ | `wav`         | `audio/x-wav`                                       | 
+ | `webp`        | `image/webp`                                        | 
+ 
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -51,7 +66,7 @@ c2pa = "0.19.0"
 
 If you want to read or write a manifest file, add the `file_io` dependency to your `Cargo.toml`. For example:
 ```
-c2pa = { version = "0.11.0", features = ["file_io"] }
+c2pa = { version = "0.19.0", features = ["file_io"] }
 ```
 
 NOTE: If you are building for WASM, omit the `file_io` dependency.
@@ -71,3 +86,19 @@ The Rust SDK crate provides:
 The `c2pa` crate is distributed under the terms of both the [MIT license](https://github.com/contentauth/c2pa-rs/blob/main/LICENSE-MIT) and the [Apache License (Version 2.0)](https://github.com/contentauth/c2pa-rs/blob/main/LICENSE-APACHE).
 
 Note that some components and dependent crates are licensed under different terms; please check the license terms for each crate and component for details.
+
+## Release Notes
+
+This section gives a highlight of noteworthy changes 
+
+Refer to the [CHANGELOG](CHANGELOG.md) for detailed Git changes
+
+## 0.19.0
+_23 March 2023_
+
+* Added support for many new file formats, see Supported File Formats above.
+* new api to return 
+* Streaming APIs added to support manifest creation without file_io
+* Manifest and Ingredient JSON formats replace the `is_parent` field with `relationship`
+* ResourceRef replaces `content-type` with `format`
+* `bmff` feature no longer required

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -14,7 +14,7 @@
 //! Assertion helpers to build, validate, and parse assertions.
 
 mod actions;
-pub use actions::*;
+pub use actions::{c2pa_action, Action, Actions};
 
 mod bmff_hash;
 pub use bmff_hash::{BmffHash, DataMap, ExclusionsMap, SubsetMap};
@@ -36,7 +36,7 @@ pub(crate) use ingredient::{Ingredient, Relationship};
 pub mod labels;
 
 mod metadata;
-pub use metadata::{Actor, DataSource, Metadata, ReviewRating, *};
+pub use metadata::{c2pa_source, Actor, DataSource, Metadata, ReviewCode, ReviewRating};
 
 mod schema_org;
 pub use schema_org::{SchemaDotOrg, SchemaDotOrgPerson};

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -49,7 +49,7 @@ const TILEOFFSETS: u16 = 324;
 
 const SUBFILES: [u16; 3] = [SUBFILE_TAG, EXIFIFD_TAG, GPSIFD_TAG];
 
-static SUPPORTED_TYPES: [&str; 4] = ["dng", "tif", "tiff", "image/tiff"];
+static SUPPORTED_TYPES: [&str; 5] = ["tif", "tiff", "image/tiff", "dng", "image/x-adobe-dng"];
 
 // The type of an IFD entry
 enum IFDEntryType {

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -49,6 +49,7 @@ pub struct Manifest {
     pub claim_generator: String,
 
     /// A human-readable title, generally source filename.
+    #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
 
     /// The format of the source file as a MIME type.


### PR DESCRIPTION
reference c2pa 1.2 spec
add file formats section
adds a Release Notes section
adds x-adobe-dng to supported mime types

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
