### PR TITLE
(IGNORE) Enable `reorder_impl_items` rustfmt option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -11,4 +11,5 @@ edition = "2018"
 group_imports = "StdExternalCrate"
 hex_literal_case = "Lower"
 imports_granularity = "Crate"
+reorder_impl_items = true
 unstable_features = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,6 +6,7 @@
 # rustup toolchain add nightly
 # cargo +nightly fmt
 
+blank_lines_upper_bound = 1
 edition = "2018"
 group_imports = "StdExternalCrate"
 hex_literal_case = "Lower"

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -117,6 +117,11 @@ pub struct BmffHash {
 }
 
 impl BmffHash {
+    /// Label prefix for a BMFF hash assertion.
+    ///
+    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_bmff_based_hash>.
+    pub const LABEL: &'static str = labels::BMFF_HASH;
+
     pub fn new(name: &str, alg: &str, url: Option<UriT>) -> Self {
         BmffHash {
             exclusions: Vec::new(),
@@ -129,11 +134,6 @@ impl BmffHash {
             bmff_version: ASSERTION_CREATION_VERSION,
         }
     }
-
-    /// Label prefix for a BMFF hash assertion.
-    ///
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_bmff_based_hash>.
-    pub const LABEL: &'static str = labels::BMFF_HASH;
 
     pub fn exclusions(&self) -> &[ExclusionsMap] {
         self.exclusions.as_ref()
@@ -270,7 +270,9 @@ impl AssertionCbor for BmffHash {}
 
 impl AssertionBase for BmffHash {
     const LABEL: &'static str = Self::LABEL;
-    const VERSION: Option<usize> = Some(ASSERTION_CREATION_VERSION); // todo: this mechanism needs to change since a struct could support different versions
+    const VERSION: Option<usize> = Some(ASSERTION_CREATION_VERSION);
+
+    // todo: this mechanism needs to change since a struct could support different versions
 
     fn to_assertion(&self) -> Result<Assertion> {
         Self::to_cbor_assertion(self)

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -134,10 +134,10 @@ impl AssertionBase for SchemaDotOrg {
 pub struct SchemaDotOrgPerson(SchemaDotOrg);
 
 impl SchemaDotOrgPerson {
-    pub const PERSON: &'static str = "Person";
-    pub const NAME: &'static str = "name";
-    pub const IDENTIFIER: &'static str = "identifier";
     pub const CREDENTIAL: &'static str = "credential";
+    pub const IDENTIFIER: &'static str = "identifier";
+    pub const NAME: &'static str = "name";
+    pub const PERSON: &'static str = "Person";
 
     pub fn new() -> Self {
         Self(SchemaDotOrg::new(Self::PERSON.to_owned()))

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -187,6 +187,7 @@ impl BoxHeaderLite {
             large_size: false,
         }
     }
+
     pub fn read<R: Read + ?Sized>(reader: &mut R) -> Result<Self> {
         // Create and read to buf.
         let mut buf = [0u8; 8]; // 8 bytes for box header.
@@ -1133,6 +1134,7 @@ impl AssetIO for BmffIO {
         let mut f = File::open(asset_path)?;
         self.read_cai(&mut f)
     }
+
     fn save_cai_store(&self, asset_path: &std::path::Path, store_bytes: &[u8]) -> Result<()> {
         let mut input = File::open(asset_path)?;
         let size = input.seek(SeekFrom::End(0))?;
@@ -1426,6 +1428,7 @@ impl AssetIO for BmffIO {
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {
         Some(self)
     }
+
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
     }

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -589,6 +589,7 @@ impl RemoteRefEmbed for PngIO {
             crate::asset_io::RemoteRefEmbedType::Watermark(_) => Err(Error::UnsupportedType),
         }
     }
+
     fn embed_reference_to_stream(
         &self,
         _source_stream: &mut dyn CAIRead,

--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -196,6 +196,7 @@ impl AssetIO for RiffIO {
         let mut f = File::open(asset_path)?;
         self.read_cai(&mut f)
     }
+
     fn save_cai_store(&self, asset_path: &std::path::Path, store_bytes: &[u8]) -> Result<()> {
         let asset = std::fs::read(asset_path)?;
         let mut chunk_reader = Cursor::new(asset);
@@ -278,6 +279,7 @@ impl AssetIO for RiffIO {
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {
         Some(self)
     }
+
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
     }

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -1371,6 +1371,7 @@ impl AssetIO for TiffIO {
     fn asset_patch_ref(&self) -> Option<&dyn AssetPatch> {
         Some(self)
     }
+
     fn read_cai_store(&self, asset_path: &std::path::Path) -> Result<Vec<u8>> {
         let mut reader = std::fs::File::open(asset_path)?;
 
@@ -1484,6 +1485,7 @@ impl AssetIO for TiffIO {
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {
         Some(self)
     }
+
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
     }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -479,6 +479,7 @@ impl Claim {
 
         Ok(())
     }
+
     pub fn set_external_manifest(&mut self) {
         self.remote_manifest = RemoteManifest::SideCar;
     }
@@ -490,6 +491,7 @@ impl Claim {
     pub(crate) fn set_update_manifest(&mut self, is_update_manifest: bool) {
         self.update_manifest = is_update_manifest;
     }
+
     pub fn add_claim_generator_hint(&mut self, hint_key: &str, hint_value: Value) {
         if self.claim_generator_hints.is_none() {
             self.claim_generator_hints = Some(HashMap::new());
@@ -1245,6 +1247,7 @@ impl Claim {
         let dummy_bmff_hash = Assertion::new(assertions::labels::BMFF_HASH, None, dummy_bmff_data);
         self.assertions_by_type(&dummy_bmff_hash)
     }
+
     /// Return list of ingredient assertions. This function
     /// is only useful on commited or loaded claims since ingredients
     /// are resolved at commit time.

--- a/sdk/src/hashed_uri.rs
+++ b/sdk/src/hashed_uri.rs
@@ -43,6 +43,7 @@ impl HashedUri {
     pub fn url(&self) -> String {
         self.url.clone()
     }
+
     pub fn is_relative_url(&self) -> bool {
         crate::jumbf::labels::manifest_label_from_uri(&self.url).is_none()
     }

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -525,6 +525,7 @@ impl Ingredient {
     ) -> Result<Self> {
         Self::from_file_impl(path.as_ref(), options)
     }
+
     // Internal implementation to avoid code bloat.
     #[cfg(feature = "file_io")]
     fn from_file_impl(path: &Path, options: &dyn IngredientOptions) -> Result<Self> {
@@ -1141,9 +1142,11 @@ mod tests_file_io {
             fn title(&self, _path: &Path) -> Option<String> {
                 Some("MyTitle".to_string())
             }
+
             fn hash(&self, _path: &Path) -> Option<String> {
                 Some("1234568abcdef".to_string())
             }
+
             fn thumbnail(&self, _path: &Path) -> Option<(String, Vec<u8>)> {
                 Some(("image/foo".to_string(), "bits".as_bytes().to_owned()))
             }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -126,6 +126,7 @@ impl Manifest {
             ..Default::default()
         }
     }
+
     /// Returns a User Agent formatted string identifying the software/hardware/system produced this claim
     pub fn claim_generator(&self) -> &str {
         self.claim_generator.as_str()
@@ -989,6 +990,7 @@ impl Manifest {
             .save_to_asset_remote_signed(source_path.as_ref(), signer, dest_path.as_ref())
             .await
     }
+
     #[cfg(feature = "file_io")]
     pub fn remove_manifest<P: AsRef<Path>>(asset_path: P) -> Result<()> {
         use crate::jumbf_io::remove_jumbf_from_file;
@@ -1371,6 +1373,7 @@ pub(crate) mod tests {
                 // this would happen on some remote server
                 crate::cose_sign::cose_sign_async(&signer, claim_bytes, self.reserve_size()).await
             }
+
             fn reserve_size(&self) -> usize {
                 10000
             }
@@ -1459,6 +1462,7 @@ pub(crate) mod tests {
             // fake sig
             Ok(sign_bytes.into_inner())
         }
+
         fn reserve_size(&self) -> usize {
             10000
         }

--- a/sdk/src/manifest_store_report.rs
+++ b/sdk/src/manifest_store_report.rs
@@ -300,6 +300,7 @@ impl ManifestReport {
             signature,
         })
     }
+
     /// create a json string representation of this structure, omitting binaries
     fn to_json(&self) -> String {
         let mut json = serde_json::to_string_pretty(self).unwrap_or_else(|e| e.to_string());

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -88,6 +88,7 @@ trait PushGetIndex {
 
 impl<T> PushGetIndex for Vec<T> {
     type Item = T;
+
     fn push_get_index(&mut self, item: T) -> usize {
         let index = self.len();
         self.push(item);
@@ -2771,6 +2772,7 @@ pub mod tests {
             // this would happen on some remote server
             crate::cose_sign::cose_sign_async(&signer, claim_bytes, self.reserve_size()).await
         }
+
         fn reserve_size(&self) -> usize {
             10000
         }


### PR DESCRIPTION
Among other things, enforces a blank line between method definitions. 

https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#reorder_impl_items
