### PR TITLE
(IGNORE) Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [1.65.0, stable]
+        rust_version: [stable, 1.65.0]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
           components: llvm-tools-preview
-          override: true
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v1
@@ -54,10 +53,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
           
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -81,11 +79,10 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}
           components: llvm-tools-preview
-          override: true
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v1
@@ -101,10 +98,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
 
       - name: Install clippy
         run: rustup component add clippy
@@ -128,10 +124,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
           components: rustfmt
 
       - name: Check format
@@ -151,10 +146,9 @@ jobs:
         # Nightly is used here because the docs.rs build
         # uses nightly and we use doc_cfg features that are
         # not in stable Rust as of this writing (Rust 1.62).
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
 
       - name: Run cargo docs
         # This is intended to mimic the docs.rs build
@@ -197,10 +191,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
 
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
@@ -217,10 +210,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
 
       - name: Get latest existing tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         CHANGELOG: ${{ steps.changelog.outputs.stdout }}
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
 


### PR DESCRIPTION
actions-rs/toolchain appears to be unmaintained (Last commit was in 2020.)
