### PR TITLE
(IGNORE) Several small CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,57 @@ jobs:
         run: wasm-pack test --chrome --headless
         working-directory: ./sdk
 
+  test-default-disabled:
+    name: Unit tests with default features disabled
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        rust_version: [stable]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: llvm-tools-preview
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run tests
+        run: cargo test --all-targets --no-default-features
+
+  test-direct-minimal-versions:
+    name: Unit tests with minimum versions of direct dependencies
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run tests
+        run: cargo +nightly test -Z direct-minimal-versions --all-targets --all-features
+
   publish-preflight:
     name: Preflight crate publish
     runs-on: ${{ matrix.os }}
@@ -200,6 +251,23 @@ jobs:
         with:
           version: latest
           args: --all-targets --all-features
+
+  unknown-features-cfg:
+    name: Check for unknown features in cfg attributes and macros
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Check for unknown features
+        env:
+          RUSTFLAGS: "-D unexpected-cfgs"
+        run: cargo +nightly check -Z unstable-options -Z check-cfg=features --tests
 
   version_bump:
     name: Ensure (MINOR) tag is used when making an API breaking change

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -7,16 +7,14 @@ edition = "2018"
 rust-version = "1.65.0"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.40"
 blake3 = "1.0.0"
 c2pa = { path="../sdk", features = ["file_io", "xmp_write"] }
 env_logger = "0.10"
-log = "0.4" 
+log = "0.4.8" 
 image = "0.24.5"
 nom = "7.1.1"
 regex = "1.5.6"
 serde = "1.0.137"
 serde_json = "1.0.81"
 twoway = "0.2.2"
-
-

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -53,7 +53,7 @@ atree = "0.5.2"
 base64 = "0.13.0"
 bcder = "0.7.1"
 blake3 = "1.0.0"
-bytes = "1.1.0"
+bytes = "1.4.0"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
 chrono = { version = "0.4.24", default-features = false, features = ["serde", "wasmbind"] }
@@ -72,17 +72,17 @@ png_pong = "0.8.2"
 range-set = "0.0.9"
 ring = "0.16.20"
 riff = "1.0.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.137", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_cbor = "0.11.1"
-serde_derive = "1.0.127"
-serde_json = "1.0.66"
+serde_derive = "1.0.137"
+serde_json = "1.0.81"
 serde-transcode = "1.1.1"
 sha2 = "0.10.2"
 tempfile = "3.1.0"
 thiserror = "1.0.40"
 treeline = "0.1.0"
-twoway = "0.2.1"
+twoway = "0.2.2"
 url = "2.2.2"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.11.0"
@@ -90,8 +90,8 @@ x509-certificate = "0.19.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2.4.0"
-image = { version = "0.24.2", optional = true }
-instant = "0.1.0"
+image = { version = "0.24.5", optional = true }
+instant = "0.1.12"
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }
 xmp_toolkit = { version = "1.0", optional = true }
 


### PR DESCRIPTION
I recently added these to XMP Toolkit's automation and they seem like good ideas. Adding them here:

* Run unit tests with default features disabled
* Run unit tests with minimum versions of direct dependencies
* Check for undeclared features in cfg attributes and macros
