### PR TITLE
Ingredient async and thumbnail support

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -391,7 +391,6 @@ pub mod tests {
                     .set_data_source(DataSource::new(GENERATOR_REE)),
             );
 
-        dbg!(&original);
         assert_eq!(original.actions.len(), 2);
         let assertion = original.to_assertion().expect("build_assertion");
         assert_eq!(assertion.mime_type(), "application/cbor");

--- a/sdk/src/assertions/creative_work.rs
+++ b/sdk/src/assertions/creative_work.rs
@@ -182,7 +182,6 @@ pub mod tests {
         assert_eq!(assertion.mime_type(), "application/json");
         assert_eq!(assertion.label(), CreativeWork::LABEL);
         let result = CreativeWork::from_assertion(&assertion).expect("extract_assertion");
-        //dbg!(serde_json::to_string(&result).unwrap());
         assert_eq!(
             original.author().unwrap()[0].name(),
             result.author().unwrap()[0].name()

--- a/sdk/src/assertions/creative_work.rs
+++ b/sdk/src/assertions/creative_work.rs
@@ -182,7 +182,7 @@ pub mod tests {
         assert_eq!(assertion.mime_type(), "application/json");
         assert_eq!(assertion.label(), CreativeWork::LABEL);
         let result = CreativeWork::from_assertion(&assertion).expect("extract_assertion");
-        dbg!(serde_json::to_string(&result).unwrap());
+        //dbg!(serde_json::to_string(&result).unwrap());
         assert_eq!(
             original.author().unwrap()[0].name(),
             result.author().unwrap()[0].name()
@@ -192,7 +192,6 @@ pub mod tests {
     #[test]
     fn from_creative_work_sample() {
         let original = CreativeWork::from_json_str(SAMPLE_CREATIVE_WORK).expect("from_json_str");
-        dbg!(&original);
         let original_publisher: SchemaDotOrgPerson = original.get("publisher").unwrap();
         let assertion = original.to_assertion().expect("build_assertion");
         assert_eq!(assertion.mime_type(), "application/json");
@@ -207,7 +206,6 @@ pub mod tests {
     #[test]
     fn from_creative_work_stock() {
         let original = CreativeWork::from_json_str(STOCK_CREATIVE_WORK).expect("from_json_str");
-        dbg!(&original);
         let original_url: String = original.get("url").unwrap();
         let assertion = original.to_assertion().expect("build_assertion");
         assert_eq!(assertion.mime_type(), "application/json");

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1761,7 +1761,7 @@ pub(crate) mod tests {
 
     #[test]
     #[cfg(feature = "file_io")]
-    fn test_crate_file_based_ingredient() {
+    fn test_create_file_based_ingredient() {
         let mut folder = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         folder.push("tests/fixtures");
         let mut manifest = Manifest::new("claim_generator");

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1032,12 +1032,12 @@ pub(crate) mod tests {
         status_tracker::{DetailedStatusTracker, StatusTracker},
         store::Store,
         utils::test::{fixture_path, temp_dir_path, temp_fixture_path, TEST_SMALL_JPEG},
-        validation_status, Ingredient,
+        validation_status,
     };
     use crate::{
         assertions::{c2pa_action, Action, Actions},
         utils::test::{temp_signer, TEST_VC},
-        Manifest, Result,
+        Ingredient, Manifest, Result,
     };
 
     // example of random data structure as an assertion
@@ -1480,6 +1480,13 @@ pub(crate) mod tests {
                 r#"{"my_tag":"Anything I want"}"#,
             ))
             .unwrap();
+
+        // add a parent ingredient
+        let mut ingredient = Ingredient::from_memory_async("jpeg", image)
+            .await
+            .expect("from_stream_async");
+        ingredient.set_title("parent.jpg");
+        manifest.set_parent(ingredient).expect("set_parent");
 
         let signer = MyRemoteSigner {};
 

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -92,7 +92,6 @@ impl ResourceStore {
             id = format!("{id_base}-{count}{ext}");
             count += 1;
         }
-        dbg!(&id);
         id
     }
 


### PR DESCRIPTION
Adds Ingredient::from_memory_async, from_stream_async and from_stream_info, set_memory_thumbnail
