### PR TITLE
Make remote manifest handling consistent across input types

### DIFF
--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1427,7 +1427,8 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
+    #[allow(dead_code)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "file_io")), actix::test)]
     #[cfg(not(target_arch = "wasm32"))]
     async fn test_jpg_cloud_from_memory() {
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
@@ -1445,9 +1446,9 @@ mod tests {
     }
 
     #[allow(dead_code)]
-    #[cfg_attr(not(target_arch = "wasm32"), ignore)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "file_io")), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    async fn test_jpg_cloud_from_memory_wasm() {
+    async fn test_jpg_cloud_from_memory_no_file_io() {
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
         let ingredient = Ingredient::from_memory_async(format, image_bytes)

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -918,8 +918,8 @@ impl Ingredient {
         let thumbnail = ingredient_assertion.thumbnail.and_then(|hashed_uri| {
             // This could be a relative or absolute thumbnail reference to another manifest
             let target_label = match jumbf::labels::manifest_label_from_uri(&hashed_uri.url()) {
-                Some(label) => label,       // use the manifest from the thumbnail uri
-                None => claim_label.to_owned(),     // relative so use the whole url from the thumbnail assertion
+                Some(label) => label,           // use the manifest from the thumbnail uri
+                None => claim_label.to_owned(), // relative so use the whole url from the thumbnail assertion
             };
             match store.get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_label) {
                 Some(assertion) => Some(Self::thumbnail_from_assertion(assertion)),
@@ -1435,7 +1435,7 @@ mod tests {
         let ingredient = Ingredient::from_memory_async(format, image_bytes)
             .await
             .expect("from_memory_async");
-        //println!("ingredient = {ingredient}");
+        println!("ingredient = {ingredient}");
         assert!(ingredient.validation_status().is_some());
         assert_eq!(
             ingredient.validation_status().unwrap()[0].code(),

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1428,14 +1428,32 @@ mod tests {
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(not(target_arch = "wasm32"))]
     async fn test_jpg_cloud_from_memory() {
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
         let ingredient = Ingredient::from_memory_async(format, image_bytes)
             .await
             .expect("from_memory_async");
-        println!("ingredient = {ingredient}");
+        // println!("ingredient = {ingredient}");
+        assert_eq!(&ingredient.title, "untitled");
+        assert_eq!(ingredient.format(), format);
+        assert!(ingredient.provenance().is_some());
+        assert!(ingredient.provenance().unwrap().starts_with("https:"));
+        assert!(ingredient.manifest_data().is_some());
+        assert!(ingredient.validation_status().is_none());
+    }
+
+    #[allow(dead_code)]
+    #[cfg_attr(not(target_arch = "wasm32"), ignore)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_jpg_cloud_from_memory_wasm() {
+        let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
+        let format = "image/jpeg";
+        let ingredient = Ingredient::from_memory_async(format, image_bytes)
+            .await
+            .expect("from_memory_async");
+        // println!("ingredient = {ingredient}");
         assert!(ingredient.validation_status().is_some());
         assert_eq!(
             ingredient.validation_status().unwrap()[0].code(),

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2292,17 +2292,14 @@ impl Store {
         }
     }
 
+    /// Handles remote manifests when file_io/fetch_remote_manifests feature is enabled
+    #[cfg(feature = "file_io")]
     fn handle_remote_manifest(ext_ref: &str) -> Result<Vec<u8>> {
         // verify provenance path is remote url
         let is_remote_url = Store::is_valid_remote_url(ext_ref);
 
         if cfg!(feature = "fetch_remote_manifests") && is_remote_url {
-            // not supported in wasm
-            if cfg!(target_arch = "wasm32") {
-                Err(Error::JumbfNotFound)
-            } else {
-                Store::fetch_remote_manifest(ext_ref)
-            }
+            Store::fetch_remote_manifest(ext_ref)
         } else {
             // return an error with the url that should be read
             if is_remote_url {
@@ -2310,6 +2307,19 @@ impl Store {
             } else {
                 Err(Error::JumbfNotFound)
             }
+        }
+    }
+
+    /// Handles remote manifests for Wasm or when the file_io/fetch_remote_manifests feature is disabled
+    #[cfg(not(feature = "file_io"))]
+    fn handle_remote_manifest(ext_ref: &str) -> Result<Vec<u8>> {
+        // verify provenance path is remote url
+        let is_remote_url = Store::is_valid_remote_url(ext_ref);
+
+        if is_remote_url {
+            Err(Error::RemoteManifestUrl(ext_ref.to_owned()))
+        } else {
+            Err(Error::JumbfNotFound)
         }
     }
 
@@ -4161,7 +4171,7 @@ pub mod tests {
         let url_string: String = url.into();
 
         // set claim for side car with remote manifest embedding generation
-        claim.set_remote_manifest(url_string.clone()).unwrap();
+        claim.set_remote_manifest(url_string).unwrap();
 
         store.commit_claim(claim).unwrap();
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2324,7 +2324,7 @@ impl Store {
     }
 
     /// Return Store from in memory asset
-    pub fn load_cai_from_memory(
+    fn load_cai_from_memory(
         asset_type: &str,
         data: &[u8],
         validation_log: &mut impl StatusTracker,


### PR DESCRIPTION
## Changes in this pull request
While working on the Node.js SDK, I noticed that we were only listening to the `fetch_remote_manifests` flag when we were going through the file-based code path, not the in-memory ones. This attempts to make the remote fetching consistent whenever we try to load a store from a file, stream, or buffer.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
