### PR TITLE
Fix timestamp Accuracy decoding

### DIFF
--- a/sdk/src/asn1/rfc3161.rs
+++ b/sdk/src/asn1/rfc3161.rs
@@ -467,8 +467,12 @@ impl Accuracy {
     ) -> Result<Self, DecodeError<S::Error>> {
         let seconds =
             cons.take_opt_primitive_if(Tag::INTEGER, |prim| Integer::from_primitive(prim))?;
-        let millis = cons.take_opt_constructed_if(Tag::CTX_0, |cons| Integer::take_from(cons))?;
-        let micros = cons.take_opt_constructed_if(Tag::CTX_1, |cons| Integer::take_from(cons))?;
+
+        let millis =
+            cons.take_opt_primitive_if(Tag::CTX_0, |prim| Integer::from_primitive(prim))?;
+
+        let micros =
+            cons.take_opt_primitive_if(Tag::CTX_1, |prim| Integer::from_primitive(prim))?;
 
         Ok(Self {
             seconds,

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3898,7 +3898,7 @@ pub mod tests {
 
     #[test]
     fn test_display() {
-        let ap = fixture_path("tp-1.3.jpg");
+        let ap = fixture_path("CA.jpg");
         let mut report = DetailedStatusTracker::new();
         let store = Store::load_from_asset(&ap, true, &mut report).expect("load_from_asset");
         let _errors = report_split_errors(report.get_log_mut());

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3898,7 +3898,7 @@ pub mod tests {
 
     #[test]
     fn test_display() {
-        let ap = fixture_path("CA.jpg");
+        let ap = fixture_path("tp-1.3.jpg");
         let mut report = DetailedStatusTracker::new();
         let store = Store::load_from_asset(&ap, true, &mut report).expect("load_from_asset");
         let _errors = report_split_errors(report.get_log_mut());


### PR DESCRIPTION
## Changes in this pull request
Restore fix to rfc3161.rs to properly decode Accuracy values.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
