### PR TITLE
Generate old COSE headers for temporary backwards support

### DIFF
--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -17,7 +17,7 @@
 
 use ciborium::value::Value;
 use coset::{
-    iana::{self, EnumI64},
+    iana::{self},
     CoseSign1, CoseSign1Builder, Header, HeaderBuilder, Label, ProtectedHeader,
     TaggedCborSerializable,
 };
@@ -197,7 +197,7 @@ fn build_headers(
     ta_url: Option<String>,
     ocsp_val: Option<Vec<u8>>,
 ) -> Result<(Header, Header)> {
-    let mut protected_h = match alg {
+    let protected_h = match alg {
         SigningAlg::Ps256 => HeaderBuilder::new().algorithm(iana::Algorithm::PS256),
         SigningAlg::Ps384 => HeaderBuilder::new().algorithm(iana::Algorithm::PS384),
         SigningAlg::Ps512 => HeaderBuilder::new().algorithm(iana::Algorithm::PS512),
@@ -218,14 +218,15 @@ fn build_headers(
         }
     };
 
-    // unexposed feature that protects code we are not ready to expose
-    if cfg!(feature = "spec_1.3") {
-        // add certs to protected header (spec 1.3 now requires integer 33(X5Chain) in favor of string "x5chain" going forward)
-        protected_h = protected_h.value(
-            iana::HeaderParameter::X5Chain.to_i64(),
-            sc_der_array_or_bytes.clone(),
-        );
-    }
+    // enable this block of code when we want to switch to 1.3 headers
+    /*
+    // add certs to protected header (spec 1.3 now requires integer 33(X5Chain) in favor of string "x5chain" going forward)
+    protected_h = protected_h.value(
+        iana::HeaderParameter::X5Chain.to_i64(),
+        sc_der_array_or_bytes.clone(),
+    );
+    */
+
     let protected_header = protected_h.build();
 
     let mut unprotected_h = if let Some(url) = ta_url {
@@ -245,10 +246,8 @@ fn build_headers(
         HeaderBuilder::new()
     };
 
-    // generate old Cose header when spec_1.3 is not defined
-    if !cfg!(feature = "spec_1.3") {
-        unprotected_h = unprotected_h.text_value("x5chain".to_string(), sc_der_array_or_bytes)
-    }
+    // generate old Cose header todo: remove this line when protected headers are enabled
+    unprotected_h = unprotected_h.text_value("x5chain".to_string(), sc_der_array_or_bytes);
 
     // set the ocsp responder response if available
     if let Some(ocsp) = ocsp_val {


### PR DESCRIPTION
## Changes in this pull request
This PR temporarily reverts the generation of 1.3 COSE headers until more client apps have been updated to the 1.3 spec.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
