### PR TITLE
Add `Send` to `CAIRead` trait so that it can be used across threads

### DIFF
--- a/sdk/src/asset_io.rs
+++ b/sdk/src/asset_io.rs
@@ -40,7 +40,7 @@ pub struct HashObjectPositions {
     pub htype: HashBlockObjectType, // type of hash block object
 }
 /// CAIReader trait to insure CAILoader method support both Read & Seek
-pub trait CAIRead: Read + Seek {}
+pub trait CAIRead: Read + Seek + Send {}
 
 impl CAIRead for std::fs::File {}
 impl CAIRead for std::io::Cursor<&[u8]> {}


### PR DESCRIPTION
## Changes in this pull request
I need to pass asset data across threads when working in the Node.js SDK due to how we need to offload computation off of the main thread. Since we operate off the `CAIRead` trait, we need to explicitly add the `Send` trait to allow this functionality.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
