### PR TITLE
Expose DataHash and BoxHash to public SDK

### DIFF
--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -20,11 +20,10 @@ mod bmff_hash;
 pub use bmff_hash::{BmffHash, BmffMerkleMap, DataMap, ExclusionsMap, SubsetMap};
 
 mod box_hash;
-pub(crate) use box_hash::{BoxHash, BoxMap, C2PA_BOXHASH};
+pub use box_hash::{BoxHash, BoxMap, C2PA_BOXHASH};
 
-#[allow(dead_code)] // will become public later
 mod data_hash;
-pub(crate) use data_hash::DataHash;
+pub use data_hash::DataHash;
 
 mod creative_work;
 pub use creative_work::CreativeWork;


### PR DESCRIPTION
Expose DataHash and BoxHash to public SDK
somehow I missed this on the previous release