### PR TITLE
Adds a way to force no claim thumbnail generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We welcome contributions to this project.  For information on contributing, prov
 
 ## Requirements
 
-The SDK requires **Rust version 1.65.0** or newer.
+The SDK requires **Rust version 1.70.0** or newer.
 
 ### Supported platforms
 

--- a/sdk/src/assertions/thumbnail.rs
+++ b/sdk/src/assertions/thumbnail.rs
@@ -40,7 +40,7 @@ impl Thumbnail {
             "tiff" => "image/tiff",
             "ico" => "image/x-icon",
             "webp" => "image/webp",
-            _ => "octet-stream",
+            _ => "application/octet-stream",
         }
         .to_string();
 
@@ -116,7 +116,7 @@ pub mod tests {
         thumbnail_test(labels::JPEG_INGREDIENT_THUMBNAIL, "image/jpeg");
         thumbnail_test(labels::PNG_INGREDIENT_THUMBNAIL, "image/png");
         // unrecognized labels will be formatted as octet_streams
-        thumbnail_test("foo", "octet-stream");
+        thumbnail_test("foo", "application/octet-stream");
     }
 
     #[test]


### PR DESCRIPTION
When add_thumbnails is enabled, setting the manifest thumbnail format = "none" will force no claim thumbnail generation
