### PR TITLE
Increase actix requirement to 0.13.1

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -138,4 +138,4 @@ anyhow = "1.0.40"
 wasm-bindgen-test = "0.3.31"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-actix = "0.13.0"
+actix = "0.13.1"


### PR DESCRIPTION
This appears to resolve a recently-introduced build error with the `actix::test` macro in the 0.13.0 release.
