### PR TITLE
Add all of the MIME types that are associated with WAV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The SDK has been tested on the following operating systems:
  | `png`         | `image/png`                                         |
  | `svg`         | `image/svg+xml`                                     |
  | `tif`,`tiff`  | `image/tiff`                                        |
- | `wav`         | `audio/x-wav`                                       |
+ | `wav`         | `audio/wav`                                         |
  | `webp`        | `image/webp`                                        |
 
 ## Usage

--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -31,12 +31,15 @@ use crate::{
     utils::xmp_inmemory_utils::{add_provenance, MIN_XMP},
 };
 
-static SUPPORTED_TYPES: [&str; 9] = [
+static SUPPORTED_TYPES: [&str; 12] = [
     "avi",
     "wav",
     "webp",
     "image/webp",
+    "audio/wav",
+    "audio/wave",
     "audio/x-wav",
+    "audio/vnd.wave",
     "application/x-troff-msvideo",
     "video/avi",
     "video/msvideo",


### PR DESCRIPTION
## Overview
This was causing browser integrations to fail based on the detected MIME type for WAV files.

## Changes in this pull request
- Associate `audio/wav`, `audio/x-wav`, `audio/wave` and `audio/vnd.wave` as valid WAV MIME types based on [this comment](https://github.com/jshttp/mime-db/issues/22#issuecomment-107128888).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
