### PR TITLE
(MINOR) Support databox thumbnails CAI-4142

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -702,7 +702,7 @@ impl Claim {
         let mut databox_uri = C2PAAssertion::new(link, Some(self.alg().to_string()), &hash);
         databox_uri.add_salt(salt);
 
-        // add credential to vcstore
+        // add databox to databox store
         self.data_boxes.push((databox_uri.clone(), new_db));
 
         Ok(databox_uri)

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -31,9 +31,7 @@ use crate::{
     hashed_uri::HashedUri,
     jumbf::{
         self,
-        labels::{
-            assertion_label_from_uri, manifest_label_from_uri, to_assertion_uri, to_relative_uri,
-        },
+        labels::{manifest_label_from_uri, to_assertion_uri},
     },
     jumbf_io::load_jumbf_from_stream,
     resource_store::{skip_serializing_resources, ResourceRef, ResourceStore},
@@ -189,6 +187,15 @@ impl Ingredient {
             format: format.into(),
             ..Default::default()
         }
+    }
+
+    // try to determine if this is a V2 ingredient
+    pub(crate) fn is_v2(&self) -> bool {
+        self.instance_id.is_none()
+            || self.data.is_some()
+            || self.description.is_some()
+            || self.informational_uri.is_some()
+            || self.relationship == Relationship::InputTo
     }
 
     /// Returns a user-displayable title for this ingredient.
@@ -491,34 +498,9 @@ impl Ingredient {
             .unwrap_or_else(|| "".into())
             .to_lowercase();
 
-        let format = match extension.as_ref() {
-            "jpg" | "jpeg" => "image/jpeg",
-            "png" => "image/png",
-            "gif" => "image/gif",
-            "psd" => "image/vnd.adobe.photoshop",
-            "tiff" => "image/tiff",
-            "svg" => "image/svg+xml",
-            "ico" => "image/x-icon",
-            "bmp" => "image/bmp",
-            "webp" => "image/webp",
-            "dng" => "image/dng",
-            "heic" => "image/heic",
-            "heif" => "image/heif",
-            "mp2" | "mpa" | "mpe" | "mpeg" | "mpg" | "mpv2" => "video/mpeg",
-            "mp4" => "video/mp4",
-            "avif" => "image/avif",
-            "mov" | "qt" => "video/quicktime",
-            "m4a" => "audio/mp4",
-            "mid" | "rmi" => "audio/mid",
-            "mp3" => "audio/mpeg",
-            "wav" => "audio/vnd.wav",
-            "aif" | "aifc" | "aiff" => "audio/aiff",
-            "ogg" => "audio/ogg",
-            "pdf" => "application/pdf",
-            "ai" => "application/postscript",
-            _ => "application/octet-stream",
-        }
-        .to_owned();
+        let format = crate::utils::mime::extension_to_mime(&extension)
+            .unwrap_or("application/binary")
+            .to_owned();
         (title, extension, format)
     }
 
@@ -960,17 +942,32 @@ impl Ingredient {
                 Some(label) => label,           // use the manifest from the thumbnail uri
                 None => claim_label.to_owned(), /* relative so use the whole url from the thumbnail assertion */
             };
-            match store.get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_claim_label) {
-                Some(assertion) => {
-                    let (format, image) = Self::thumbnail_from_assertion(assertion);
-                    let assertion_label = assertion_label_from_uri(&hashed_uri.url())
-                        .unwrap_or_else(|| "thumbnail".to_owned());
-                    // construct an id from the manifest and assertion labels
-                    let mut id = to_assertion_uri(&target_claim_label, &assertion_label);
-                    if target_claim_label == claim_label {
-                        id = to_relative_uri(&id);
-                    }
-                    ingredient.thumbnail = Some(ingredient.resources.add_uri(&id, &format, image)?);
+            let maybe_resource_ref = match hashed_uri.url() {
+                uri if uri.contains(jumbf::labels::ASSERTIONS) => {
+                    // if this is a claim thumbnail, then use the label from the thumbnail uri
+                    store
+                        .get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_claim_label)
+                        .map(|assertion| {
+                            let (format, image) = Self::thumbnail_from_assertion(assertion);
+                            ingredient
+                                .resources
+                                .add_uri(&hashed_uri.url(), &format, image)
+                        })
+                }
+                uri if uri.contains(jumbf::labels::DATABOXES) => store
+                    .get_data_box_from_uri_and_claim(&hashed_uri.url(), &target_claim_label)
+                    .map(|data_box| {
+                        ingredient.resources.add_uri(
+                            &hashed_uri.url(),
+                            &data_box.format,
+                            data_box.data.clone(),
+                        )
+                    }),
+                _ => None,
+            };
+            match maybe_resource_ref {
+                Some(data_ref) => {
+                    ingredient.thumbnail = Some(data_ref?);
                 }
                 None => {
                     error!("failed to get {} from {}", hashed_uri.url(), ingredient_uri);
@@ -979,7 +976,7 @@ impl Ingredient {
                             .set_url(hashed_uri.url()),
                     );
                 }
-            }
+            };
         };
 
         if let Some(data_uri) = ingredient_assertion.data.as_ref() {
@@ -1076,11 +1073,10 @@ impl Ingredient {
                                         .map(|t| {
                                             // convert ingredient uris to absolute when adding them
                                             // since this uri references a different manifest
-                                            let assertion_label =
-                                                jumbf::labels::assertion_label_from_uri(&t.url())
-                                                    .unwrap_or_default();
-                                            let url =
-                                                to_assertion_uri(&manifest_label, &assertion_label);
+                                            let url = jumbf::labels::to_absolute_uri(
+                                                &manifest_label,
+                                                &t.url(),
+                                            );
                                             HashedUri::new(url, t.alg(), &t.hash())
                                         });
                                 }
@@ -1115,13 +1111,22 @@ impl Ingredient {
                 }
                 None => {
                     let data = self.thumbnail_bytes()?;
-                    claim.add_assertion(&Thumbnail::new(
-                        &labels::add_thumbnail_format(
-                            labels::INGREDIENT_THUMBNAIL,
+                    if self.is_v2() {
+                        // v2 ingredients use databoxes for thumbnails
+                        claim.add_databox(
                             &thumb_ref.format,
-                        ),
-                        data.into_owned(),
-                    ))?
+                            data.into_owned(),
+                            thumb_ref.data_types.clone(),
+                        )?
+                    } else {
+                        claim.add_assertion(&Thumbnail::new(
+                            &labels::add_thumbnail_format(
+                                labels::INGREDIENT_THUMBNAIL,
+                                &thumb_ref.format,
+                            ),
+                            data.into_owned(),
+                        ))?
+                    }
                 }
             };
             thumbnail = Some(hash_url);
@@ -1816,7 +1821,7 @@ mod tests_file_io {
     fn test_input_to_file_based_ingredient() {
         let mut folder = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         folder.push("tests/fixtures");
-        let mut ingredient = Ingredient::new("title", "format", "instance_id");
+        let mut ingredient = Ingredient::new_v2("title", "format");
         ingredient.resources.set_base_path(folder);
         //let mut _data_ref = ResourceRef::new("image/jpg", "foo");
         //data_ref.data_types = vec!["c2pa.types.dataset.pytorch".to_string()];

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -29,7 +29,12 @@ use crate::{
     claim::{Claim, ClaimAssetData},
     error::{Error, Result},
     hashed_uri::HashedUri,
-    jumbf,
+    jumbf::{
+        self,
+        labels::{
+            assertion_label_from_uri, manifest_label_from_uri, to_assertion_uri, to_relative_uri,
+        },
+    },
     jumbf_io::load_jumbf_from_stream,
     resource_store::{skip_serializing_resources, ResourceRef, ResourceStore},
     status_tracker::{log_item, DetailedStatusTracker, StatusTracker},
@@ -379,6 +384,7 @@ impl Ingredient {
     /// This is only used for internally generated thumbnails - when
     /// reading thumbnails from files, we don't want to write these to file
     /// So this ensures they stay in memory unless written out.
+    #[deprecated(note = "Please use set_thumbnail instead")]
     pub fn set_memory_thumbnail<S: Into<String>, B: Into<Vec<u8>>>(
         &mut self,
         format: S,
@@ -913,26 +919,7 @@ impl Ingredient {
 
         let active_manifest = ingredient_assertion
             .c2pa_manifest
-            .and_then(|hash_url| jumbf::labels::manifest_label_from_uri(&hash_url.url()));
-
-        let thumbnail = ingredient_assertion.thumbnail.and_then(|hashed_uri| {
-            // This could be a relative or absolute thumbnail reference to another manifest
-            let target_label = match jumbf::labels::manifest_label_from_uri(&hashed_uri.url()) {
-                Some(label) => label,           // use the manifest from the thumbnail uri
-                None => claim_label.to_owned(), // relative so use the whole url from the thumbnail assertion
-            };
-            match store.get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_label) {
-                Some(assertion) => Some(Self::thumbnail_from_assertion(assertion)),
-                None => {
-                    error!("failed to get {} from {}", hashed_uri.url(), ingredient_uri);
-                    validation_status.push(
-                        ValidationStatus::new(validation_status::ASSERTION_MISSING.to_string())
-                            .set_url(hashed_uri.url()),
-                    );
-                    None
-                }
-            }
-        });
+            .and_then(|hash_url| manifest_label_from_uri(&hash_url.url()));
 
         debug!(
             "Adding Ingredient {} {:?}",
@@ -948,15 +935,40 @@ impl Ingredient {
                 .unwrap_or_else(default_instance_id),
         );
         ingredient.document_id = ingredient_assertion.document_id;
+        ingredient.resources.set_label(claim_label); // set the label for relative paths
 
         #[cfg(feature = "file_io")]
         if let Some(base_path) = resource_path {
             ingredient.resources_mut().set_base_path(base_path)
         }
 
-        if let Some((format, image)) = thumbnail {
-            ingredient.set_thumbnail(format, image)?;
-        }
+        if let Some(hashed_uri) = ingredient_assertion.thumbnail.as_ref() {
+            // This could be a relative or absolute thumbnail reference to another manifest
+            let target_claim_label = match manifest_label_from_uri(&hashed_uri.url()) {
+                Some(label) => label,           // use the manifest from the thumbnail uri
+                None => claim_label.to_owned(), /* relative so use the whole url from the thumbnail assertion */
+            };
+            match store.get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_claim_label) {
+                Some(assertion) => {
+                    let (format, image) = Self::thumbnail_from_assertion(assertion);
+                    let assertion_label = assertion_label_from_uri(&hashed_uri.url())
+                        .unwrap_or_else(|| "thumbnail".to_owned());
+                    // construct an id from the manifest and assertion labels
+                    let mut id = to_assertion_uri(&target_claim_label, &assertion_label);
+                    if target_claim_label == claim_label {
+                        id = to_relative_uri(&id);
+                    }
+                    ingredient.thumbnail = Some(ingredient.resources.add_uri(&id, &format, image)?);
+                }
+                None => {
+                    error!("failed to get {} from {}", hashed_uri.url(), ingredient_uri);
+                    validation_status.push(
+                        ValidationStatus::new(validation_status::ASSERTION_MISSING.to_string())
+                            .set_url(hashed_uri.url()),
+                    );
+                }
+            }
+        };
 
         if let Some(data_uri) = ingredient_assertion.data.as_ref() {
             let data_box = store
@@ -968,9 +980,8 @@ impl Ingredient {
                     }
                 })?;
 
-            let id_base = ingredient.instance_id().to_owned();
-            let mut data_ref = ingredient.resources_mut().add_with(
-                &id_base,
+            let mut data_ref = ingredient.resources_mut().add_uri(
+                &data_uri.url(),
                 &data_box.format,
                 data_box.data.clone(),
             )?;
@@ -1011,7 +1022,7 @@ impl Ingredient {
                     true => redactions.as_ref().map(|redactions| {
                         redactions
                             .iter()
-                            .map(|r| jumbf::labels::to_assertion_uri(&manifest_label, r))
+                            .map(|r| to_assertion_uri(&manifest_label, r))
                             .collect()
                     }),
                     false => None,
@@ -1056,10 +1067,8 @@ impl Ingredient {
                                             let assertion_label =
                                                 jumbf::labels::assertion_label_from_uri(&t.url())
                                                     .unwrap_or_default();
-                                            let url = jumbf::labels::to_assertion_uri(
-                                                &manifest_label,
-                                                &assertion_label,
-                                            );
+                                            let url =
+                                                to_assertion_uri(&manifest_label, &assertion_label);
                                             HashedUri::new(url, t.alg(), &t.hash())
                                         });
                                 }

--- a/sdk/src/jumbf/labels.rs
+++ b/sdk/src/jumbf/labels.rs
@@ -122,6 +122,17 @@ pub(crate) fn to_normalized_uri(uri: &str) -> String {
     }
 }
 
+// Converts a possibly relative JUMBF URI to an absolute URI to the manifest store.
+pub(crate) fn to_absolute_uri(manifest_label: &str, uri: &str) -> String {
+    let raw_uri = to_normalized_uri(uri);
+    let parts: Vec<&str> = raw_uri.split('/').collect();
+    if parts.len() > 2 && parts[1] == MANIFEST_STORE {
+        uri.to_string()
+    } else {
+        format!("{}/{}", to_manifest_uri(manifest_label), raw_uri)
+    }
+}
+
 // Converts an absolute JUMBF URI to a URI relative to the manifest store.
 pub(crate) fn to_relative_uri(uri: &str) -> String {
     let raw_uri = to_normalized_uri(uri);

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -525,6 +525,7 @@ impl Manifest {
         }
 
         manifest.set_label(claim.label());
+        manifest.resources.set_label(claim.label()); // default manifest for relative urls
         manifest.claim_generator_hints = claim.get_claim_generator_hint_map().cloned();
 
         // get credentials converting from AssertionData to Value
@@ -629,7 +630,13 @@ impl Manifest {
                 }
                 label if label.starts_with(labels::CLAIM_THUMBNAIL) => {
                     let thumbnail = Thumbnail::from_assertion(assertion)?;
-                    manifest.set_thumbnail(thumbnail.content_type, thumbnail.data)?;
+                    let id = jumbf::labels::to_assertion_uri(claim.label(), label);
+                    let id = jumbf::labels::to_relative_uri(&id);
+                    manifest.thumbnail = Some(manifest.resources.add_uri(
+                        &id,
+                        &thumbnail.content_type,
+                        thumbnail.data,
+                    )?);
                 }
                 _ => {
                     // inject assertions for all other assertions

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -509,15 +509,10 @@ impl Manifest {
 
         if let Some(info_vec) = claim.claim_generator_info() {
             let mut generators = Vec::new();
-            let id_base = manifest.instance_id().to_owned();
             for claim_info in info_vec {
                 let mut info = claim_info.to_owned();
                 if let Some(icon) = claim_info.icon.as_ref() {
-                    info.set_icon(icon.to_resource_ref(
-                        manifest.resources_mut(),
-                        claim,
-                        &id_base,
-                    )?);
+                    info.set_icon(icon.to_resource_ref(manifest.resources_mut(), claim)?);
                 }
                 generators.push(info);
             }
@@ -565,18 +560,13 @@ impl Manifest {
             match base_label.as_ref() {
                 base if base.starts_with(labels::ACTIONS) => {
                     let mut actions = Actions::from_assertion(assertion)?;
-                    let id = manifest.instance_id().to_owned();
 
                     for action in actions.actions_mut() {
                         if let Some(SoftwareAgent::ClaimGeneratorInfo(info)) =
                             action.software_agent_mut()
                         {
                             if let Some(icon) = info.icon.as_mut() {
-                                let icon = icon.to_resource_ref(
-                                    manifest.resources_mut(),
-                                    claim,
-                                    id.as_str(),
-                                )?;
+                                let icon = icon.to_resource_ref(manifest.resources_mut(), claim)?;
                                 info.set_icon(icon);
                             }
                         }
@@ -587,11 +577,9 @@ impl Manifest {
                         for template in templates {
                             // replace icon with resource ref
                             template.icon = match template.icon.take() {
-                                Some(icon) => Some(icon.to_resource_ref(
-                                    manifest.resources_mut(),
-                                    claim,
-                                    id.as_str(),
-                                )?),
+                                Some(icon) => {
+                                    Some(icon.to_resource_ref(manifest.resources_mut(), claim)?)
+                                }
                                 None => None,
                             };
 
@@ -599,11 +587,8 @@ impl Manifest {
                             template.software_agent = match template.software_agent.take() {
                                 Some(SoftwareAgent::ClaimGeneratorInfo(mut info)) => {
                                     if let Some(icon) = info.icon.as_mut() {
-                                        let icon = icon.to_resource_ref(
-                                            manifest.resources_mut(),
-                                            claim,
-                                            id.as_str(),
-                                        )?;
+                                        let icon =
+                                            icon.to_resource_ref(manifest.resources_mut(), claim)?;
                                         info.set_icon(icon);
                                     }
                                     Some(SoftwareAgent::ClaimGeneratorInfo(info))

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -554,7 +554,10 @@ impl Manifest {
         manifest.set_format(claim.format());
         manifest.set_instance_id(claim.instance_id());
 
-        for claim_assertion in claim.claim_assertion_store().iter() {
+        for assertion in claim.assertions() {
+            let claim_assertion = store.get_claim_assertion_from_uri(
+                &jumbf::labels::to_absolute_uri(claim.label(), &assertion.url()),
+            )?;
             let assertion = claim_assertion.assertion();
             let label = claim_assertion.label();
             let base_label = assertion.label();
@@ -1659,8 +1662,8 @@ pub(crate) mod tests {
             .expect("embed");
 
         //let manifest_store = crate::ManifestStore::from_file(&sidecar).expect("from_file");
-        let manifest_store =
-            crate::ManifestStore::from_bytes("c2pa", &c2pa_data, true).expect("from_bytes");
+        let manifest_store = crate::ManifestStore::from_bytes("application/c2pa", &c2pa_data, true)
+            .expect("from_bytes");
         assert_eq!(manifest_store.active_label(), Some("MyLabel"));
         assert_eq!(
             manifest_store.get_active().unwrap().title().unwrap(),

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -58,7 +58,6 @@ impl UriOrResource {
         &self,
         resources: &mut ResourceStore,
         claim: &Claim,
-        _id: &str,
     ) -> Result<UriOrResource> {
         match self {
             UriOrResource::ResourceRef(r) => Ok(UriOrResource::ResourceRef(r.clone())),

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -39,7 +39,7 @@ use crate::{
     jumbf::{
         self,
         boxes::*,
-        labels::{ASSERTIONS, CREDENTIALS, DATABOXES, SIGNATURE},
+        labels::{to_absolute_uri, ASSERTIONS, CREDENTIALS, DATABOXES, SIGNATURE},
     },
     jumbf_io::{
         get_assetio_handler, load_jumbf_from_stream, object_locations_from_stream,
@@ -352,6 +352,11 @@ impl Store {
             None => self.get_claim(target_claim_label), //  relative so use the target claim label
         }
         .and_then(|claim| {
+            let uri = if target_claim_label != self.label() {
+                to_absolute_uri(target_claim_label, uri)
+            } else {
+                uri.to_owned()
+            };
             claim
                 .databoxes()
                 .iter()

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
+    Some(match extension {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "psd" => "image/vnd.adobe.photoshop",
+        "tiff" => "image/tiff",
+        "svg" => "image/svg+xml",
+        "ico" => "image/x-icon",
+        "bmp" => "image/bmp",
+        "webp" => "image/webp",
+        "dng" => "image/dng",
+        "heic" => "image/heic",
+        "heif" => "image/heif",
+        "mp2" | "mpa" | "mpe" | "mpeg" | "mpg" | "mpv2" => "video/mpeg",
+        "mp4" => "video/mp4",
+        "avif" => "image/avif",
+        "mov" | "qt" => "video/quicktime",
+        "m4a" => "audio/mp4",
+        "mid" | "rmi" => "audio/mid",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/vnd.wav",
+        "aif" | "aifc" | "aiff" => "audio/aiff",
+        "ogg" => "audio/ogg",
+        "pdf" => "application/pdf",
+        "ai" => "application/postscript",
+        _ => return None,
+    })
+}
+
+pub fn format_to_extension(format: &str) -> Option<&'static str> {
+    Some(match format {
+        "jpg" | "jpeg" | "image/jpeg" => "jpg",
+        "png" | "image/png" => "png",
+        "gif" | "image/gif" => "gif",
+        "psd" | "image/vnd.adobe.photoshop" => "psd",
+        "tiff" | "image/tiff" => "tiff",
+        "svg" | "image/svg+xml" => "svg",
+        "ico" | "image/x-icon" => "ico",
+        "bmp" | "image/bmp" => "bmp",
+        "webp" | "image/webp" => "webp",
+        "dng" | "image/dng" => "dng",
+        "heic" | "image/heic" => "heic",
+        "heif" | "image/heif" => "heif",
+        "mp2" | "mpa" | "mpe" | "mpeg" | "mpg" | "mpv2" | "video/mpeg" => "mp2",
+        "mp4" | "video/mp4" => "mp4",
+        "avif" | "image/avif" => "avif",
+        "mov" | "qt" | "video/quicktime" => "mov",
+        "m4a" | "audio/mp4" => "m4a",
+        "mid" | "rmi" | "audio/mid" => "mid",
+        "mp3" | "audio/mpeg" => "mp3",
+        "wav" | "audio/vnd.wav" => "wav",
+        "aif" | "aifc" | "aiff" | "audio/aiff" => "aif",
+        "ogg" | "audio/ogg" => "ogg",
+        "pdf" | "application/pdf" => "pdf",
+        "ai" | "application/postscript" => "ai",
+        _ => return None,
+    })
+}

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+/// Converts a file extension to a MIME type
 pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
     Some(match extension {
         "jpg" | "jpeg" => "image/jpeg",
@@ -41,6 +42,7 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
     })
 }
 
+/// Converts a format to a file extension
 pub fn format_to_extension(format: &str) -> Option<&'static str> {
     Some(match format {
         "jpg" | "jpeg" | "image/jpeg" => "jpg",

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod cbor_types;
 #[allow(dead_code)]
 pub(crate) mod hash_utils;
 pub(crate) mod merkle;
+#[cfg(feature = "file_io")]
+pub(crate) mod mime;
 #[allow(dead_code)] // for wasm build
 pub(crate) mod patch;
 #[cfg(feature = "add_thumbnails")]


### PR DESCRIPTION
Support databox thumbnails
Use jumbf uris for databox entries in manifeststore
[CAI-4141] always return application/c2pa for format instead of c2pa
Separates mime extension handling into a mime.rs utility.
