### PR TITLE
(PATCH) switches af relationship for a reference to the c2pa data to an array of references, one of which is the c2pa spec

### DIFF
--- a/sdk/src/asset_handlers/pdf_io.rs
+++ b/sdk/src/asset_handlers/pdf_io.rs
@@ -15,7 +15,7 @@ use std::{fs::File, path::Path};
 
 use crate::{
     asset_handlers::pdf::{C2paPdf, Pdf},
-    asset_io::{AssetIO, CAIReader, CAIWriter, HashObjectPositions},
+    asset_io::{AssetIO, CAIReader, CAIWriter, ComposedManifestRef, HashObjectPositions},
     CAIRead, Error,
     Error::{JumbfNotFound, NotImplemented, PdfReadError},
 };
@@ -107,6 +107,16 @@ impl AssetIO for PdfIO {
 
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
+    }
+    fn composed_data_ref(&self) -> Option<&dyn ComposedManifestRef> {
+        Some(self)
+    }
+}
+
+impl ComposedManifestRef for PdfIO {
+    // Return entire CAI block as Vec<u8>
+    fn compose_manifest(&self, manifest_data: &[u8], _format: &str) -> Result<Vec<u8>> {
+        Ok(manifest_data.to_vec())
     }
 }
 

--- a/sdk/src/asset_handlers/pdf_io.rs
+++ b/sdk/src/asset_handlers/pdf_io.rs
@@ -108,6 +108,7 @@ impl AssetIO for PdfIO {
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
     }
+
     fn composed_data_ref(&self) -> Option<&dyn ComposedManifestRef> {
         Some(self)
     }
@@ -115,7 +116,7 @@ impl AssetIO for PdfIO {
 
 impl ComposedManifestRef for PdfIO {
     // Return entire CAI block as Vec<u8>
-    fn compose_manifest(&self, manifest_data: &[u8], _format: &str) -> Result<Vec<u8>> {
+    fn compose_manifest(&self, manifest_data: &[u8], _format: &str) -> Result<Vec<u8>, Error> {
         Ok(manifest_data.to_vec())
     }
 }


### PR DESCRIPTION
## Changes in this pull request
This is a small change that changes the value of the AF relationship key in the PDF's catalog from a reference to an array of references. This change was made because a PDF can have multiple associated files. The previous version assumed the c2pa file spec reference would be the only associated file.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
