### PR TITLE
Make hashing compatible with blake3 traits-preview

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -551,7 +551,7 @@ pub fn blake3_from_asset(path: &Path) -> Result<String> {
         }
     }
 
-    let hash = hasher.finalize();
+    let hash = blake3::Hasher::finalize(&hasher);
 
     Ok(hash.to_hex().as_str().to_owned())
 }


### PR DESCRIPTION
Currently, hash_utils is incompatible with the [blake3 `traits-preview` feature](https://rustdoc.swc.rs/blake3/index.html#cargo-features).

By default, [blake3::Hash](https://rustdoc.swc.rs/blake3/struct.Hash.html) is of type `[u8; 32]`. However, `traits-preview` changes this to type [`GenericArray<u8, U64>`](https://crates.io/crates/digest).

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
