### PR TITLE
Update image crate dependency and limit features

### DIFF
--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -17,7 +17,7 @@ c2pa = { path = "../sdk", features = [
 env_logger = "0.10"
 log = "0.4.8" 
 half = "<2.3.0, < 3" # fix for older versions of rust
-image = "0.24.2"
+image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"] }
 nom = "7.1.1"
 regex = "1.5.6"
 serde = "1.0.137"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -16,7 +16,6 @@ c2pa = { path = "../sdk", features = [
 ] }
 env_logger = "0.10"
 log = "0.4.8" 
-half = "<2.3.0, < 3" # fix for older versions of rust
 image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"] }
 nom = "7.1.1"
 regex = "1.5.6"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -109,7 +109,7 @@ x509-certificate = "0.19.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2.4.0"
 half = "<2.3.0, < 3" # fix for older versions of rust
-image = { version = "0.24.2", optional = true }
+image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"], optional = true }
 instant = "0.1.12"
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }
 openssl-sys = { version = "=0.9.92", optional = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -108,7 +108,6 @@ x509-certificate = "0.19.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2.4.0"
-half = "<2.3.0, < 3" # fix for older versions of rust
 image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"], optional = true }
 instant = "0.1.12"
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }


### PR DESCRIPTION
This should help resolve recent build failures on Windows.