### PR TITLE
Disable Windows builds with latest Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         rust_version: [stable, 1.70.0]
+        exclude:
+          - os: windows-latest
+            rust_version: stable
+            # Disable latest Windows version due to build instability.
+            # See https://github.com/rust-lang/cargo/issues/12979.
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Workaround for https://github.com/rust-lang/cargo/issues/12979.
