### PR TITLE
Add support for embeddable manifests with RemoteSigner

### DIFF
--- a/sdk/examples/data_hash.rs
+++ b/sdk/examples/data_hash.rs
@@ -108,7 +108,7 @@ fn user_data_hash_with_sdk_hashing() {
 
     // get the composed manifest ready to insert into a file (returns manifest of same length as finished manifest)
     let unfinished_manifest = manifest
-        .data_hash_placeholder(signer.as_ref(), "jpg")
+        .data_hash_placeholder(signer.reserve_size(), "jpg")
         .unwrap();
 
     // Figure out where you want to put the manifest, let's put it at the beginning of the JPEG as first segment
@@ -225,7 +225,7 @@ fn user_data_hash_with_user_hashing() {
 
     // get the composed manifest ready to insert into a file (returns manifest of same length as finished manifest)
     let unfinished_manifest = manifest
-        .data_hash_placeholder(signer.as_ref(), "jpg")
+        .data_hash_placeholder(signer.reserve_size(), "jpg")
         .unwrap();
 
     // Figure out where you want to put the manifest, let's put it at the beginning of the JPEG as first segment

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -51,7 +51,7 @@ use crate::{
         hash_utils::{hash256, HashRange},
         patch::patch_bytes,
     },
-    validation_status, AsyncSigner, ManifestStoreReport, Signer,
+    validation_status, AsyncSigner, ManifestStoreReport, RemoteSigner, Signer,
 };
 #[cfg(feature = "file_io")]
 use crate::{
@@ -1659,22 +1659,10 @@ impl Store {
         Ok(composed)
     }
 
-    /// Returns a finalized, signed manifest.  The manfiest are only supported
-    /// for cases when the client has provided a data hash content hash binding.  Note,
-    /// this function will not work for cases like BMFF where the position
-    /// of the content is also encoded.  This function is not compatible with
-    /// BMFF hash binding.  If a BMFF data hash or box hash is detected that is
-    /// an error.  The DataHash placeholder assertion will be  adjusted to the contain
-    /// the correct values.  If the asset_reader value is supplied it will also perform
-    /// the hash calulations, otherwise the function uses the caller supplied values.  
-    /// It is an error if `get_data_hashed_manifest_placeholder` was not called first
-    /// as this call inserts the DataHash placeholder assertion to reserve space for the
-    /// actual hash values not required when using BoxHashes.  
-    pub fn get_data_hashed_embeddable_manifest(
+    fn prep_embeddable_store(
         &mut self,
+        reserve_size: usize,
         dh: &DataHash,
-        signer: &dyn Signer,
-        format: &str,
         asset_reader: Option<&mut dyn CAIRead>,
     ) -> Result<Vec<u8>> {
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
@@ -1705,23 +1693,53 @@ impl Store {
         // update the placeholder hash
         pc.update_data_hash(adusted_dh)?;
 
-        // reborrow immuttable
-        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
-        let mut jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+        self.to_jumbf_internal(reserve_size)
+    }
 
-        // sign contents
-        let sig = self.sign_claim(pc, signer, signer.reserve_size())?;
-
-        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
-
+    fn finish_embeddable_store(
+        &mut self,
+        sig: &[u8],
+        sig_placeholder: &[u8],
+        jumbf_bytes: &mut Vec<u8>,
+        format: &str,
+    ) -> Result<Vec<u8>> {
         if sig_placeholder.len() != sig.len() {
             return Err(Error::CoseSigboxTooSmall);
         }
 
-        patch_bytes(&mut jumbf_bytes, &sig_placeholder, &sig)
-            .map_err(|_| Error::JumbfCreationError)?;
+        patch_bytes(jumbf_bytes, sig_placeholder, sig).map_err(|_| Error::JumbfCreationError)?;
 
         self.get_composed_manifest(&jumbf_bytes, format)
+    }
+
+    /// Returns a finalized, signed manifest.  The manfiest are only supported
+    /// for cases when the client has provided a data hash content hash binding.  Note,
+    /// this function will not work for cases like BMFF where the position
+    /// of the content is also encoded.  This function is not compatible with
+    /// BMFF hash binding.  If a BMFF data hash or box hash is detected that is
+    /// an error.  The DataHash placeholder assertion will be  adjusted to the contain
+    /// the correct values.  If the asset_reader value is supplied it will also perform
+    /// the hash calulations, otherwise the function uses the caller supplied values.  
+    /// It is an error if `get_data_hashed_manifest_placeholder` was not called first
+    /// as this call inserts the DataHash placeholder assertion to reserve space for the
+    /// actual hash values not required when using BoxHashes.  
+    pub fn get_data_hashed_embeddable_manifest(
+        &mut self,
+        dh: &DataHash,
+        signer: &dyn Signer,
+        format: &str,
+        asset_reader: Option<&mut dyn CAIRead>,
+    ) -> Result<Vec<u8>> {
+        let mut jumbf_bytes =
+            self.prep_embeddable_store(signer.reserve_size(), dh, asset_reader)?;
+
+        // sign contents
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+        let sig = self.sign_claim(pc, signer, signer.reserve_size())?;
+
+        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
+
+        self.finish_embeddable_store(&sig, &sig_placeholder, &mut jumbf_bytes, format)
     }
 
     /// Returns a finalized, signed manifest.  The manfiest are only supported
@@ -1742,53 +1760,49 @@ impl Store {
         format: &str,
         asset_reader: Option<&mut dyn CAIRead>,
     ) -> Result<Vec<u8>> {
-        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
-
-        // make sure there are data hashes present before generating
-        if pc.hash_assertions().is_empty() {
-            return Err(Error::BadParam(
-                "Claim must have hash binding assertion".to_string(),
-            ));
-        }
-
-        // don't allow BMFF assertions to be present
-        if !pc.bmff_hash_assertions().is_empty() {
-            return Err(Error::BadParam(
-                "BMFF assertions not supported in embeddable manifests".to_string(),
-            ));
-        }
-
-        let mut adusted_dh = DataHash::new("jumbf manifest", pc.alg());
-        adusted_dh.exclusions = dh.exclusions.clone();
-        adusted_dh.hash = dh.hash.clone();
-
-        if let Some(reader) = asset_reader {
-            // calc hashes
-            adusted_dh.gen_hash_from_stream(reader)?;
-        }
-
-        // update the placeholder hash
-        pc.update_data_hash(adusted_dh)?;
-
-        // reborrow immuttable
-        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
-        let mut jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+        let mut jumbf_bytes =
+            self.prep_embeddable_store(signer.reserve_size(), dh, asset_reader)?;
 
         // sign contents
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
         let sig = self
             .sign_claim_async(pc, signer, signer.reserve_size())
             .await?;
 
         let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
 
-        if sig_placeholder.len() != sig.len() {
-            return Err(Error::CoseSigboxTooSmall);
-        }
+        self.finish_embeddable_store(&sig, &sig_placeholder, &mut jumbf_bytes, format)
+    }
 
-        patch_bytes(&mut jumbf_bytes, &sig_placeholder, &sig)
-            .map_err(|_| Error::JumbfCreationError)?;
+    /// Returns a finalized, signed manifest.  The manfiest are only supported
+    /// for cases when the client has provided a data hash content hash binding.  Note,
+    /// this function will not work for cases like BMFF where the position
+    /// of the content is also encoded.  This function is not compatible with
+    /// BMFF hash binding.  If a BMFF data hash or box hash is detected that is
+    /// an error.  The DataHash placeholder assertion will be  adjusted to the contain
+    /// the correct values.  If the asset_reader value is supplied it will also perform
+    /// the hash calulations, otherwise the function uses the caller supplied values.  
+    /// It is an error if `get_data_hashed_manifest_placeholder` was not called first
+    /// as this call inserts the DataHash placeholder assertion to reserve space for the
+    /// actual hash values not required when using BoxHashes.  
+    pub async fn get_data_hashed_embeddable_manifest_remote(
+        &mut self,
+        dh: &DataHash,
+        signer: &dyn RemoteSigner,
+        format: &str,
+        asset_reader: Option<&mut dyn CAIRead>,
+    ) -> Result<Vec<u8>> {
+        let mut jumbf_bytes =
+            self.prep_embeddable_store(signer.reserve_size(), dh, asset_reader)?;
 
-        self.get_composed_manifest(&jumbf_bytes, format)
+        // sign contents
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+        let claim_bytes = pc.data()?;
+        let sig = signer.sign_remote(&claim_bytes).await?;
+
+        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
+
+        self.finish_embeddable_store(&sig, &sig_placeholder, &mut jumbf_bytes, format)
     }
 
     /// Returns a finalized, signed manifest.  The client is required to have

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1709,7 +1709,7 @@ impl Store {
 
         patch_bytes(jumbf_bytes, sig_placeholder, sig).map_err(|_| Error::JumbfCreationError)?;
 
-        self.get_composed_manifest(&jumbf_bytes, format)
+        self.get_composed_manifest(jumbf_bytes, format)
     }
 
     /// Returns a finalized, signed manifest.  The manfiest are only supported


### PR DESCRIPTION
## Changes in this pull request
Add RemoteSigner version for the data hash embeddable manifest case.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
