### PR TITLE
(IGNORE) Add crate private API Claim::replace_assertion

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -942,6 +942,7 @@ impl Claim {
     // Patch an existing assertion with new contents.
     //
     // `replace_with` should match in name and size of an existing assertion.
+    #[cfg(feature = "file_io")]
     pub(crate) fn replace_assertion(&mut self, replace_with: Assertion) -> Result<()> {
         self.update_assertion(
             replace_with,

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -936,8 +936,15 @@ impl Claim {
     // Crate private function to allow for patching a BMFF hash with final contents.
     #[cfg(feature = "file_io")]
     pub(crate) fn update_bmff_hash(&mut self, bmff_hash: BmffHash) -> Result<()> {
+        self.replace_assertion(bmff_hash.to_assertion()?)
+    }
+
+    // Patch an existing assertion with new contents.
+    //
+    // `replace_with` should match in name and size of an existing assertion.
+    pub(crate) fn replace_assertion(&mut self, replace_with: Assertion) -> Result<()> {
         self.update_assertion(
-            bmff_hash.to_assertion()?,
+            replace_with,
             |_: &ClaimAssertion| true,
             |_: &ClaimAssertion, a: Assertion| Ok(a),
         )


### PR DESCRIPTION
Simpler version of Claim::update_assertion for simpler use cases.
