### PR TITLE
CAI-5041 Clear Windows temp attribute

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ ignore = [
   "RUSTSEC-2021-0127", # serde_cbor
   "RUSTSEC-2021-0146", # twoway (see https://github.com/contentauth/c2pa-rs/issues/234)
   "RUSTSEC-2022-0081", # json (see https://github.com/contentauth/c2pa-rs/issues/318)
+  "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
 ]
 
 # Deny multiple versions unless explicitly skipped.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -121,6 +121,7 @@ getrandom = { version = "0.2.7", features = ["js"] }
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.58"
 rand = "0.8.5"
+rsa = "0.9.6"
 serde-wasm-bindgen = "0.5.0"
 spki = "0.6.0"
 wasm-bindgen = "0.2.83"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -121,7 +121,7 @@ getrandom = { version = "0.2.7", features = ["js"] }
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.58"
 rand = "0.8.5"
-rsa = "0.9.6"
+rsa = "0.6.1"
 serde-wasm-bindgen = "0.5.0"
 spki = "0.6.0"
 wasm-bindgen = "0.2.83"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -121,7 +121,6 @@ getrandom = { version = "0.2.7", features = ["js"] }
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.58"
 rand = "0.8.5"
-rsa = "0.6.1"
 serde-wasm-bindgen = "0.5.0"
 spki = "0.6.0"
 wasm-bindgen = "0.2.83"

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -28,8 +28,8 @@ use tempfile::Builder;
 use crate::{
     assertions::{BmffMerkleMap, ExclusionsMap},
     asset_io::{
-        AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, HashObjectPositions, RemoteRefEmbed,
-        RemoteRefEmbedType,
+        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, HashObjectPositions,
+        RemoteRefEmbed, RemoteRefEmbedType,
     },
     error::{Error, Result},
     utils::hash_utils::{vec_compare, HashRange},
@@ -1372,10 +1372,7 @@ impl AssetIO for BmffIO {
         )?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -1503,10 +1500,7 @@ impl AssetIO for BmffIO {
         }
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn new(asset_type: &str) -> Self

--- a/sdk/src/asset_handlers/mp3_io.rs
+++ b/sdk/src/asset_handlers/mp3_io.rs
@@ -25,8 +25,9 @@ use twoway::find_bytes;
 
 use crate::{
     asset_io::{
-        AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite, CAIReadWriteWrapper, CAIReader,
-        CAIWriter, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
+        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
+        CAIReadWriteWrapper, CAIReader, CAIWriter, HashBlockObjectType, HashObjectPositions,
+        RemoteRefEmbed,
     },
     error::{Error, Result},
 };
@@ -212,10 +213,7 @@ impl AssetIO for Mp3IO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -25,8 +25,9 @@ use tempfile::Builder;
 use crate::{
     assertions::{BoxMap, C2PA_BOXHASH},
     asset_io::{
-        AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, ComposedManifestRef,
-        HashBlockObjectType, HashObjectPositions, RemoteRefEmbed, RemoteRefEmbedType,
+        rename_or_copy, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
+        ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
+        RemoteRefEmbedType,
     },
     error::{Error, Result},
 };
@@ -486,10 +487,7 @@ impl AssetIO for PngIO {
         self.write_cai(&mut stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -24,8 +24,9 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite, CAIReadWriteWrapper, CAIReader,
-        CAIWriter, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed, RemoteRefEmbedType,
+        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
+        CAIReadWriteWrapper, CAIReader, CAIWriter, HashBlockObjectType, HashObjectPositions,
+        RemoteRefEmbed, RemoteRefEmbedType,
     },
     error::{Error, Result},
     utils::xmp_inmemory_utils::{add_provenance, MIN_XMP},
@@ -368,10 +369,7 @@ impl AssetIO for RiffIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/svg_io.rs
+++ b/sdk/src/asset_handlers/svg_io.rs
@@ -26,6 +26,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
+        rename_or_copy,
         AssetIO,
         AssetPatch,
         CAIRead,
@@ -123,10 +124,7 @@ impl AssetIO for SvgIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -150,10 +148,7 @@ impl AssetIO for SvgIO {
         self.remove_cai_store_from_stream(&mut input_file, &mut temp_file)?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -26,7 +26,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, ComposedManifestRef,
+        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, ComposedManifestRef,
         HashBlockObjectType, HashObjectPositions, RemoteRefEmbed, RemoteRefEmbedType,
     },
     error::{Error, Result},
@@ -1399,10 +1399,7 @@ impl AssetIO for TiffIO {
         tiff_clone_with_tags(&mut temp_file, &mut reader, vec![entry])?;
 
         // copy temp file to asset
-        std::fs::rename(temp_file.path(), asset_path)
-            // if rename fails, try to copy in case we are on different volumes
-            .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-            .map_err(Error::IoError)
+        rename_or_copy(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -1458,10 +1455,7 @@ impl AssetIO for TiffIO {
                 tc.clone_tiff(&mut idfs, page_0, &mut asset_reader)?;
 
                 // copy temp file to asset
-                std::fs::rename(temp_file.path(), asset_path)
-                    // if rename fails, try to copy in case we are on different volumes
-                    .or_else(|_| std::fs::copy(temp_file.path(), asset_path).and(Ok(())))
-                    .map_err(Error::IoError)
+                rename_or_copy(temp_file, asset_path)
             }
             None => Ok(()),
         }


### PR DESCRIPTION
NamedTempFile sets the windows Temp attribute, so clear it before renaming
