### PR TITLE
Finish async signing implementation for cose_sign

### DIFF
--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -286,6 +286,28 @@ impl crate::Signer for TestGoodSigner {
     }
 }
 
+pub(crate) struct AsyncTestGoodSigner {}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl crate::AsyncSigner for AsyncTestGoodSigner {
+    async fn sign(&self, _data: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(b"not a valid signature".to_vec())
+    }
+
+    fn alg(&self) -> SigningAlg {
+        SigningAlg::Ps256
+    }
+
+    fn certs(&self) -> Result<Vec<Vec<u8>>> {
+        Ok(Vec::new())
+    }
+
+    fn reserve_size(&self) -> usize {
+        1024
+    }
+}
+
 /// Create a [`Signer`] instance that can be used for testing purposes using ps256 alg.
 ///
 /// # Returns


### PR DESCRIPTION
## Changes in this pull request
- add async_generic parameters to cose_sign::sign_claim
- update cose_sign::sign_claim to call cose_sign_async when the async version of the function is called 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
