### PR TITLE
Fix use of deprecated method `chrono::NaiveDateTime::timestamp`

### DIFF
--- a/sdk/src/ocsp_utils.rs
+++ b/sdk/src/ocsp_utils.rs
@@ -236,11 +236,13 @@ pub(crate) fn check_ocsp_response(
                                     DATE_FMT,
                                 )
                                 .map_err(|_e| Error::CoseInvalidCert)?
+                                .and_utc()
                                 .timestamp();
 
                                 let next_update = if let Some(nu) = &single_response.next_update {
                                     NaiveDateTime::parse_from_str(&nu.to_string(), DATE_FMT)
                                         .map_err(|_e| Error::CoseInvalidCert)?
+                                        .and_utc()
                                         .timestamp()
                                 } else {
                                     this_update
@@ -295,6 +297,7 @@ pub(crate) fn check_ocsp_response(
                                             DATE_FMT,
                                         )
                                         .map_err(|_e| Error::CoseInvalidCert)?
+                                        .and_utc()
                                         .timestamp();
 
                                         // check to see if we are within range or current time within range


### PR DESCRIPTION
Use `.and_utc().timestamp()` instead.
