### PR TITLE
When saving, create box hash assertion if asset handler supports box hashing

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -913,8 +913,17 @@ impl Claim {
         Ok(())
     }
 
-    pub(crate) fn update_box_hash(&mut self, box_hash: BoxHash) -> Result<()> {
-        self.replace_assertion(box_hash.to_assertion()?)
+    // Replaces the existing box hash assertion with a new one.
+    pub(crate) fn replace_box_hash(&mut self, box_hash: BoxHash) -> Result<()> {
+        self.update_assertion(
+            box_hash.to_assertion()?,
+            // No need for additional search criteria; the default search
+            // compares against label, and there should only be one box hash
+            // assertion.
+            |_: &ClaimAssertion| true,
+            // Do a full replacement (no update).
+            |_: &ClaimAssertion, a: Assertion| Ok(a),
+        )
     }
 
     // Crate private function to allow for patching a data hash with final contents.

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -913,6 +913,10 @@ impl Claim {
         Ok(())
     }
 
+    pub(crate) fn update_box_hash(&mut self, box_hash: BoxHash) -> Result<()> {
+        self.replace_assertion(box_hash.to_assertion()?)
+    }
+
     // Crate private function to allow for patching a data hash with final contents.
     pub(crate) fn update_data_hash(&mut self, mut data_hash: DataHash) -> Result<()> {
         let dh_name = data_hash.name.clone();

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1493,13 +1493,12 @@ pub(crate) mod tests {
 
         let signer = temp_signer();
 
-        let c2pa_data = manifest
+        let _ = manifest
             .embed(&output, &output, signer.as_ref())
             .expect("embed");
         let mut validation_log = DetailedStatusTracker::new();
 
-        let store1 = Store::load_from_memory("c2pa", &c2pa_data, true, &mut validation_log)
-            .expect("load from memory");
+        let store1 = Store::load_from_asset(&output, true, &mut validation_log).unwrap();
         let claim1_label = store1.provenance_label().unwrap();
         let claim = store1.provenance_claim().unwrap();
         assert!(claim.get_claim_assertion(ASSERTION_LABEL, 0).is_some()); // verify the assertion is there
@@ -1517,7 +1516,7 @@ pub(crate) mod tests {
 
         //embed a claim in output2
         let signer = temp_signer();
-        let _store2 = manifest2
+        let _ = manifest2
             .embed(&output2, &output2, signer.as_ref())
             .expect("embed");
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2401,7 +2401,7 @@ impl Store {
                         box_hash_handler,
                         false,
                     )?;
-                    pc.update_box_hash(box_hash)?;
+                    pc.replace_box_hash(box_hash)?;
                 }
                 // Otherwise, fall back to data hashing.
                 else {
@@ -2643,7 +2643,7 @@ impl Store {
                             box_hash_handler,
                             false,
                         )?;
-                        pc.update_box_hash(box_hash)?;
+                        pc.replace_box_hash(box_hash)?;
                     }
                     // Otherwise, fall back to data hashing.
                     else {
@@ -3198,7 +3198,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
-        assertions::{labels::BOX_HASH, Action, Actions, BoxHash, Uuid},
+        assertions::{labels::BOX_HASH, Action, Actions, Uuid},
         claim::AssertionStoreJsonFormat,
         jumbf_io::{get_assetio_handler_from_path, update_file_jumbf},
         status_tracker::*,


### PR DESCRIPTION
## Changes in this pull request

This PR makes box hashing the default hashing assertion if an asset supports it.

In order to make box hashing the default, we modified the core `store.rs` code in the following ways:
- If an asset handler supports box hashing (`handler.asset_box_hash_ref()` is `Some`) we'll always generate a box hash assertion (otherwise we'll fall back to a normal data hash assertion)
- We removed a comparison (at the end of `start_save` and `start_save_stream`) which compared the preliminary JUMBF store size to the actual JUMBF store size.  We believe this comparison was invalid - the preliminary JUMBF store won't include a `c2pa` box if the asset has never been signed previously.  When generating the real JUMBF store the `c2pa` box has been added in, which then causes a size difference between the preliminary and actual stores.
- Bug fix - `start_save` in was incorrectly calling `pc.box_hash_assertions().is_empty()` to check for any existing hash assertion; we'll now call `pc.hash_assertions().is_empty()`

We also had a separate bug fix in `manifest.rs` unit tests (which was now exposed as jpegs default to box hashing):
- Bug fix - the `c2pa::manifest::tests::test_redaction` was incorrectly using `load_from_asset()` to create a store from the previously returned JUMBF store data (from the `.embed()`) method.  The UT requests that we do validation, which will never work when creating the store from the store data (he doesn't have the original asset to hash); this only worked when doing data hashes because he's ignoring the error which gets written to the log.  This change was required for box hashing because any error in validation for box hashes is actually returned with an `Err` result.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
