### PR TITLE
Adds Action changes field as option vec of serde_json value

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "0.4.27", default-features = false, features = [
 	"wasmbind",
 ] }
 ciborium = "0.2.0"
-config = "0.14.0"
+config = {version = "0.14.0", features = ["json", "json5", "toml"]}
 conv = "0.3.3"
 coset = "0.3.1"
 extfmt = "0.1.1"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "0.4.27", default-features = false, features = [
 	"wasmbind",
 ] }
 ciborium = "0.2.0"
-config = {version = "0.14.0", features = ["json", "json5", "toml"]}
+config = {version = "0.14.0", default-features = false, features = ["json", "json5", "toml", "ron", "ini"]}
 conv = "0.3.3"
 coset = "0.3.1"
 extfmt = "0.1.1"

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -158,7 +158,8 @@ impl Action {
         matches!(
             self.software_agent,
             Some(SoftwareAgent::ClaimGeneratorInfo(_))
-        ) || self.changed.is_some() // was a String in v1 but never used so presume v2 if see it
+        ) ||
+        self.changes.is_some() // only defined for v2
     }
 
     /// Returns the label for this action.
@@ -249,7 +250,6 @@ impl Action {
 
     /// Sets the list of the parts of the resource that were changed
     /// since the previous event history.
-    #[deprecated(since = "0.33.0", note = "Use add_changed instead")]
     pub fn set_changed(mut self, changed: Option<&Vec<&str>>) -> Self {
         self.changed = changed.map(|v| v.join(";"));
         self
@@ -523,6 +523,7 @@ pub mod tests {
             .unwrap()
             .set_parameter("ingredient".to_owned(), make_hashed_uri1())
             .unwrap()
+            .set_changed(Some(&["this", "that"].to_vec()))
             .set_instance_id("xmp.iid:cb9f5498-bb58-4572-8043-8c369e6bfb9b")
             .set_actors(Some(
                 &[Actor::new(

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -158,8 +158,7 @@ impl Action {
         matches!(
             self.software_agent,
             Some(SoftwareAgent::ClaimGeneratorInfo(_))
-        ) ||
-        self.changes.is_some() // only defined for v2
+        ) || self.changes.is_some() // only defined for v2
     }
 
     /// Returns the label for this action.

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -104,7 +104,6 @@ pub struct Action {
     software_agent: Option<SoftwareAgent>,
 
     /// A semicolon-delimited list of the parts of the resource that were changed since the previous event history.
-    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     changed: Option<String>,
 

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -105,7 +105,6 @@ pub struct Action {
 
     /// A semicolon-delimited list of the parts of the resource that were changed since the previous event history.
     ///
-    /// This is deprecated in favor of the `changes` field.
     #[serde(skip_serializing_if = "Option::is_none")]
     changed: Option<String>,
 

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -639,7 +639,13 @@ impl Manifest {
                 _ => {
                     // inject assertions for all other assertions
                     match assertion.decode_data() {
-                        AssertionData::Json(_) | AssertionData::Cbor(_) => {
+                        AssertionData::Cbor(_) => {
+                            let value = assertion.as_json_object()?;
+                            let ma = ManifestAssertion::new(base_label, value)
+                                .set_instance(claim_assertion.instance());
+                            manifest.assertions.push(ma);
+                        }
+                        AssertionData::Json(_) => {
                             let value = assertion.as_json_object()?;
                             let ma = ManifestAssertion::new(base_label, value)
                                 .set_instance(claim_assertion.instance())

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1484,7 +1484,9 @@ pub(crate) mod tests {
         let store = manifest.to_store().expect("valid action to_store");
         let m2 = Manifest::from_store(&store, &store.provenance_label().unwrap(), None)
             .expect("from_store");
-        let actions: Actions = m2.find_assertion("c2pa.actions.v2").expect("find_assertion");
+        let actions: Actions = m2
+            .find_assertion("c2pa.actions.v2")
+            .expect("find_assertion");
         assert_eq!(actions.actions()[0].action(), "c2pa.edited");
         assert_eq!(actions.actions()[1].action(), "c2pa.dubbed");
     }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1484,9 +1484,7 @@ pub(crate) mod tests {
         let store = manifest.to_store().expect("valid action to_store");
         let m2 = Manifest::from_store(&store, &store.provenance_label().unwrap(), None)
             .expect("from_store");
-        //println!("{m2:?}");
-        // todo:: this looks correct, but it isn't since it is stored as a JSON assertion instead of CBOR
-        let actions: Actions = m2.find_assertion("c2pa.actions").expect("find_assertion");
+        let actions: Actions = m2.find_assertion("c2pa.actions.v2").expect("find_assertion");
         assert_eq!(actions.actions()[0].action(), "c2pa.edited");
         assert_eq!(actions.actions()[1].action(), "c2pa.dubbed");
     }

--- a/sdk/src/settings.rs
+++ b/sdk/src/settings.rs
@@ -222,7 +222,7 @@ impl Settings {
             "json5" => FileFormat::Json5,
             "ini" => FileFormat::Ini,
             "toml" => FileFormat::Toml,
-            "yaml" => FileFormat::Yaml,
+            //"yaml" => FileFormat::Yaml,
             "ron" => FileFormat::Ron,
             _ => return Err(Error::UnsupportedType),
         };


### PR DESCRIPTION
There are no Rust APIS for this yet.
But it allows the values to pass through via actions.
This is a minimal change to allow the new actions. changes field to be set via JSON and read back that way.
Adding detailed Rust APIs should wait until the spec for this is completed
