### PR TITLE
Fixed temp file auto delete

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2128,7 +2128,7 @@ impl Store {
     ) -> Result<Vec<u8>> {
         // set up temp dir, contents auto deleted
         let td = tempfile::TempDir::new()?;
-        let temp_path = td.into_path();
+        let temp_path = td.path();
         let temp_file = temp_path.join(
             dest_path
                 .file_name()
@@ -2183,7 +2183,7 @@ impl Store {
     ) -> Result<Vec<u8>> {
         // set up temp dir, contents auto deleted
         let td = tempfile::TempDir::new()?;
-        let temp_path = td.into_path();
+        let temp_path = td.path();
         let temp_file = temp_path.join(
             dest_path
                 .file_name()
@@ -2240,7 +2240,7 @@ impl Store {
     ) -> Result<Vec<u8>> {
         // set up temp dir, contents auto deleted
         let td = tempfile::TempDir::new()?;
-        let temp_path = td.into_path();
+        let temp_path = td.path();
         let temp_file = temp_path.join(
             dest_path
                 .file_name()


### PR DESCRIPTION
## Changes in this pull request
Change the api call of tempfile to fix the temp file is not auto deleted after the store save is completed.
The method [into_path](https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#method.into_path) will not delete temp file automatically, here should change to use method [path](https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#method.path) to access temp dir.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
