### PR TITLE
Add `video/quicktime` to the list of BMFF MIME types

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -65,7 +65,7 @@ const FULL_BOX_TYPES: &[&str; 80] = &[
     "txtC", "mime", "uri ", "uriI", "hmhd", "sthd", "vvhd", "medc",
 ];
 
-static SUPPORTED_TYPES: [&str; 12] = [
+static SUPPORTED_TYPES: [&str; 13] = [
     "avif",
     "heif",
     "heic",
@@ -78,6 +78,7 @@ static SUPPORTED_TYPES: [&str; 12] = [
     "image/heic",
     "image/heif",
     "video/mp4",
+    "video/quicktime",
 ];
 
 macro_rules! boxtype {


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
