### PR TITLE
Move signer to first parameter on Builder.sign

### DIFF
--- a/make_test_images/src/make_test_images.rs
+++ b/make_test_images/src/make_test_images.rs
@@ -430,7 +430,7 @@ impl MakeTestImages {
 
         let mut dest = fs::File::create(&dst_path)?;
         builder
-            .sign(format, &mut temp, &mut dest, signer.as_ref())
+            .sign(signer.as_ref(), format, &mut temp, &mut dest)
             .context("signing")?;
 
         Ok(dst_path)
@@ -503,7 +503,7 @@ impl MakeTestImages {
         let mut dest = fs::File::create(&dst_path)?;
         let signer = self.config.get_signer()?;
         builder
-            .sign(format, &mut source, &mut dest, signer.as_ref())
+            .sign(signer.as_ref(), format, &mut source, &mut dest)
             .context("signing")?;
 
         Ok(dst_path)

--- a/sdk/examples/v2api.rs
+++ b/sdk/examples/v2api.rs
@@ -128,7 +128,7 @@ fn main() -> Result<()> {
     let mut builder = Builder::from_archive(&mut zipped)?;
     // sign the ManifestStoreBuilder and write it to the output stream
     let mut dest = Cursor::new(Vec::new());
-    builder.sign(format, &mut source, &mut dest, &signer)?;
+    builder.sign(&signer, format, &mut source, &mut dest)?;
 
     // read and validate the signed manifest store
     dest.rewind()?;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -84,9 +84,9 @@
 //! // embed a manifest using the signer
 //! std::fs::remove_file("../target/tmp/lib_sign.jpg"); // ensure the file does not exist
 //! builder.sign_file(
+//!     &*signer,
 //!     "tests/fixtures/C.jpg",
 //!     "../target/tmp/lib_sign.jpg",
-//!     &*signer,
 //! )?;
 //! # Ok(())
 //! # }

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -429,10 +429,10 @@ mod tests {
         let mut output_image = Cursor::new(Vec::new());
         builder
             .sign(
+                &*signer,
                 "image/jpeg",
                 &mut Cursor::new(image),
                 &mut output_image,
-                &*signer,
             )
             .expect("sign");
 

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -28,7 +28,7 @@ fn test_builder_ca_jpg() -> Result<()> {
     let mut source = Cursor::new(TEST_IMAGE);
 
     let mut dest = Cursor::new(Vec::new());
-    builder.sign(format, &mut source, &mut dest, &test_signer())?;
+    builder.sign(&test_signer(), format, &mut source, &mut dest)?;
 
     // dest.set_position(0);
     // let path = common::known_good_path("CA_test.json");

--- a/sdk/tests/v2_api_integration.rs
+++ b/sdk/tests/v2_api_integration.rs
@@ -107,7 +107,7 @@ mod integration_v2 {
             let mut builder = Builder::from_archive(&mut zipped)?;
             // sign the ManifestStoreBuilder and write it to the output stream
             let mut dest = Cursor::new(Vec::new());
-            builder.sign(format, &mut source, &mut dest, &signer)?;
+            builder.sign(&signer, format, &mut source, &mut dest)?;
 
             // read and validate the signed manifest store
             dest.rewind()?;


### PR DESCRIPTION
Move signer to first parameter on Builder.sign. It makes sense for it always be the first paramter on signing operations.