### PR TITLE
Async Signer: add support for async OCSP call

### DIFF
--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -204,7 +204,12 @@ fn build_headers(signer: &dyn Signer, data: &[u8], alg: SigningAlg) -> Result<(H
     };
 
     let certs = signer.certs()?;
-    let ocsp_val = signer.ocsp_val();
+
+    let ocsp_val = if _sync {
+        signer.ocsp_val()
+    } else {
+        signer.ocsp_val().await
+    };
 
     let sc_der_array_or_bytes = match certs.len() {
         1 => Value::Bytes(certs[0].clone()), // single cert

--- a/sdk/src/openssl/temp_signer_async.rs
+++ b/sdk/src/openssl/temp_signer_async.rs
@@ -95,7 +95,7 @@ impl crate::AsyncSigner for AsyncSignerAdapter {
         self.tsa_url.clone()
     }
 
-    fn ocsp_val(&self) -> Option<Vec<u8>> {
+    async fn ocsp_val(&self) -> Option<Vec<u8>> {
         self.ocsp_val.clone()
     }
 }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -157,7 +157,7 @@ pub trait AsyncSigner: Sync {
     /// This is the only C2PA supported cert revocation method.
     /// By pre-querying the value for a your signing cert the value can
     /// be cached taking pressure off of the CA (recommended by C2PA spec)
-    fn ocsp_val(&self) -> Option<Vec<u8>> {
+    async fn ocsp_val(&self) -> Option<Vec<u8>> {
         None
     }
 


### PR DESCRIPTION
## Changes in this pull request
Updates ocsp_val in async signer to be async

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
