### PR TITLE
Gpeacock/embed_remote_settings

### DIFF
--- a/2024_API_NOTES.md
+++ b/2024_API_NOTES.md
@@ -1,4 +1,4 @@
-## V2 API Notes
+## 2024 API Notes
 
 ### Goals
 Provide a consistent flexible well tested API focusing on core functionality.
@@ -12,7 +12,7 @@ Provide a consistent flexible well tested API focusing on core functionality.
 - Enable builds for cameras and other embedded environments.
 - Provide a consistent model for setting runtime options.
 - Write unit tests, integration tests and documentation for all the v2 APIs.
-- Keep v1 to v2 porting as simple as possible.
+- Keep porting as simple as possible.
 
 
 ### Resource References
@@ -53,7 +53,7 @@ If there is no parent ingredient defined, and the source has a manifest store, t
 ### Remote URLs and embedding
 The default operation of c2pa signing is to embed a c2pa manifest store into an asset.
 We also return the c2pa manifest store so that it can be written to a sidecar or uploaded to a remote service.
-- The API supports embedding a a remote url reference into the asset. 
+- The API supports embedding a remote url reference into the asset. 
 - The remote URL is stored in different ways depending on the asset, but is often stored in XMP data.
 - The remote URL must be added to the asset before signing so that it can be hashed along with the asset.
 - Not all file formats support embedding remote URLs or embedding manifests stores.

--- a/V2_API_NOTES.md
+++ b/V2_API_NOTES.md
@@ -50,6 +50,19 @@ The source asset is the asset that we will hash and sign. It can the output from
 
 If there is no parent ingredient defined, and the source has a manifest store, the sdk will generate a parent ingredient from the parent.
 
+### Remote URLs and embedding
+The default operation of c2pa signing is to embed a c2pa manifest store into an asset.
+We also return the c2pa manifest store so that it can be written to a sidecar or uploaded to a remote service.
+- The API supports embedding a a remote url reference into the asset. 
+- The remote URL is stored in different ways depending on the asset, but is often stored in XMP data.
+- The remote URL must be added to the asset before signing so that it can be hashed along with the asset.
+- Not all file formats support embedding remote URLs or embedding manifests stores.
+- If you embed a manifest or a remote URL, a new asset will be created with the new data embedded.
+- If you don't embed, then the original asset is unmodified and there is no need to write one out.
+- The remote url can be set with builder.remote_url.
+- If embedding is not needed, set the builder.no_embed flag to true.
+
+
 ## Testing
 We need a more comprehensive set of tests for the rust codebase.
 

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -17,7 +17,7 @@ use std::{
     fmt, fs,
     io::{BufReader, Cursor, SeekFrom},
     ops::Deref,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use mp4::*;
@@ -37,8 +37,8 @@ use crate::{
     cbor_types::UriT,
     utils::{
         hash_utils::{
-            concat_and_hash, hash_asset_by_alg, hash_stream_by_alg, vec_compare,
-            verify_stream_by_alg, HashRange, Hasher,
+            concat_and_hash, hash_stream_by_alg, vec_compare, verify_stream_by_alg, HashRange,
+            Hasher,
         },
         merkle::C2PAMerkleTree,
     },
@@ -254,9 +254,6 @@ pub struct BmffHash {
     url: Option<UriT>, // deprecated in V2 and not to be used
 
     #[serde(skip)]
-    pub path: PathBuf,
-
-    #[serde(skip)]
     bmff_version: usize,
 }
 
@@ -271,7 +268,6 @@ impl BmffHash {
             merkle: None,
             name: Some(name.to_string()),
             url,
-            path: PathBuf::new(),
             bmff_version: ASSERTION_CREATION_VERSION,
         }
     }
@@ -326,22 +322,24 @@ impl BmffHash {
     }
 
     /// Generate the hash value for the asset using the range from the BmffHash.
+    pub fn gen_hash_from_stream(&mut self, stream: &mut dyn CAIRead) -> crate::error::Result<()> {
+        self.hash = Some(ByteBuf::from(self.hash_from_stream(stream)?));
+        //self.path = PathBuf::from(asset_path);
+        Ok(())
+    }
+
+    /// Generate the hash value for the asset using the range from the BmffHash.
+    #[cfg(feature = "file_io")]
     pub fn gen_hash(&mut self, asset_path: &Path) -> crate::error::Result<()> {
-        self.hash = Some(ByteBuf::from(self.hash_from_asset(asset_path)?));
-        self.path = PathBuf::from(asset_path);
+        let mut file = std::fs::File::open(asset_path)?;
+        self.hash = Some(ByteBuf::from(self.hash_from_stream(&mut file)?));
+        //self.path = PathBuf::from(asset_path);
         Ok(())
     }
 
-    /// Generate the hash again.
-    pub fn regen_hash(&mut self) -> crate::error::Result<()> {
-        let p = self.path.clone();
-        self.hash = Some(ByteBuf::from(self.hash_from_asset(p.as_path())?));
-        Ok(())
-    }
-
-    /// Generate the asset hash from a file asset using the constructed
+    /// Generate the asset hash from an asset stream using the constructed
     /// start and length values.
-    fn hash_from_asset(&mut self, asset_path: &Path) -> crate::error::Result<Vec<u8>> {
+    fn hash_from_stream(&mut self, stream: &mut dyn CAIRead) -> crate::error::Result<Vec<u8>> {
         if self.is_remote_hash() {
             return Err(Error::BadParam(
                 "asset hash is remote, not yet supported".to_owned(),
@@ -356,11 +354,10 @@ impl BmffHash {
         let bmff_exclusions = &self.exclusions;
 
         // convert BMFF exclusion map to flat exclusion list
-        let mut data = fs::File::open(asset_path)?;
-        let exclusions =
-            bmff_to_jumbf_exclusions(&mut data, bmff_exclusions, self.bmff_version > 1)?;
+        //let mut data = fs::File::open(asset_path)?;
+        let exclusions = bmff_to_jumbf_exclusions(stream, bmff_exclusions, self.bmff_version > 1)?;
 
-        let hash = hash_asset_by_alg(&alg, asset_path, Some(exclusions))?;
+        let hash = hash_stream_by_alg(&alg, stream, Some(exclusions), true)?;
 
         if hash.is_empty() {
             Err(Error::BadParam("could not generate data hash".to_string()))

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -354,7 +354,6 @@ impl BmffHash {
         let bmff_exclusions = &self.exclusions;
 
         // convert BMFF exclusion map to flat exclusion list
-        //let mut data = fs::File::open(asset_path)?;
         let exclusions = bmff_to_jumbf_exclusions(stream, bmff_exclusions, self.bmff_version > 1)?;
 
         let hash = hash_stream_by_alg(&alg, stream, Some(exclusions), true)?;

--- a/sdk/src/asset_handlers/c2pa_io.rs
+++ b/sdk/src/asset_handlers/c2pa_io.rs
@@ -120,6 +120,10 @@ impl AssetIO for C2paIO {
         self
     }
 
+    fn get_writer(&self, asset_type: &str) -> Option<Box<dyn CAIWriter>> {
+        Some(Box::new(C2paIO::new(asset_type)))
+    }
+
     fn supported_types(&self) -> &[&str] {
         &SUPPORTED_TYPES
     }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -193,6 +193,12 @@ pub struct Builder {
     #[serde(flatten)]
     pub definition: ManifestDefinition,
 
+    /// Optional remote URL for the manifest
+    pub remote_url: Option<String>,
+
+    // If true, the manifest store will not be embedded in the asset on sign
+    pub no_embed: bool,
+
     /// container for binary assets (like thumbnails)
     #[serde(skip)]
     resources: ResourceStore,
@@ -481,16 +487,13 @@ impl Builder {
             claim.add_claim_generator_info(claim_info);
         }
 
-        let remote_url =
-            crate::settings::get_settings_value::<Option<String>>("builder.remote_url")?;
-        let embed = crate::settings::get_settings_value::<bool>("builder.embed")?;
-        if let Some(remote_url) = &remote_url {
-            if embed {
-                claim.set_embed_remote_manifest(remote_url)?;
-            } else {
+        if let Some(remote_url) = &self.remote_url {
+            if self.no_embed {
                 claim.set_remote_manifest(remote_url)?;
+            } else {
+                claim.set_embed_remote_manifest(remote_url)?;
             }
-        } else if !embed {
+        } else if self.no_embed {
             claim.set_external_manifest()
         }
 
@@ -784,7 +787,7 @@ mod tests {
     use wasm_bindgen_test::*;
 
     use super::*;
-    use crate::{manifest_store::ManifestStore, utils::test::temp_signer};
+    use crate::{utils::test::temp_signer, Reader};
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -832,6 +835,8 @@ mod tests {
         .to_string()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    const TEST_IMAGE_CLEAN: &[u8] = include_bytes!("../tests/fixtures/IMG_0003.jpg");
     const TEST_IMAGE: &[u8] = include_bytes!("../tests/fixtures/CA.jpg");
 
     #[test]
@@ -957,7 +962,7 @@ mod tests {
         zipped.rewind().unwrap();
         let mut _builder = Builder::from_archive(&mut zipped).unwrap();
 
-        // sign the ManifestStoreBuilder and write it to the output stream
+        // sign and write to the output stream
         let signer = temp_signer();
         builder
             .sign(format, &mut source, &mut dest, signer.as_ref())
@@ -965,13 +970,12 @@ mod tests {
 
         // read and validate the signed manifest store
         dest.rewind().unwrap();
-        let manifest_store =
-            ManifestStore::from_stream(format, &mut dest, true).expect("from_bytes");
+        let manifest_store = Reader::from_stream(format, &mut dest).expect("from_bytes");
 
         println!("{}", manifest_store);
         assert!(manifest_store.validation_status().is_none());
-        assert!(manifest_store.get_active().is_some());
-        let manifest = manifest_store.get_active().unwrap();
+        assert!(manifest_store.active_manifest().is_some());
+        let manifest = manifest_store.active_manifest().unwrap();
         assert_eq!(manifest.title().unwrap(), "Test_Manifest");
         let test_assertion: TestAssertion = manifest.find_assertion("org.life.meaning").unwrap();
         assert_eq!(test_assertion.answer, 42);
@@ -990,17 +994,17 @@ mod tests {
             .add_resource("thumbnail1.jpg", Cursor::new(TEST_IMAGE))
             .unwrap();
 
-        // sign the ManifestStoreBuilder and write it to the output stream
+        // sign and write to the output stream
         let signer = temp_signer();
         builder.sign_file(source, &dest, signer.as_ref()).unwrap();
 
         // read and validate the signed manifest store
-        let manifest_store = ManifestStore::from_file(&dest).expect("from_bytes");
+        let manifest_store = Reader::from_file(&dest).expect("from_bytes");
 
         println!("{}", manifest_store);
         assert!(manifest_store.validation_status().is_none());
         assert_eq!(
-            manifest_store.get_active().unwrap().title().unwrap(),
+            manifest_store.active_manifest().unwrap().title().unwrap(),
             "Test_Manifest"
         );
     }
@@ -1014,15 +1018,14 @@ mod tests {
             "sample1.webp",
             "TUSCANY.TIF",
             "sample1.svg",
-            //"APC_0808.dng",
             "sample1.wav",
             "test.avi",
-            //"sample1.mp3",
-            //"sample1.avif",
-            //"sample1.heic",
-            //"sample1.heif",
-            //"video1.mp4",
-            //"cloud_manifest.c2pa",
+            "sample1.mp3",
+            "sample1.avif",
+            "sample1.heic",
+            "sample1.heif",
+            "video1.mp4",
+            "cloud_manifest.c2pa",
         ];
         for file_name in TESTFILES {
             let extension = file_name.split('.').last().unwrap();
@@ -1042,7 +1045,7 @@ mod tests {
                 .add_resource("thumbnail1.jpg", Cursor::new(TEST_IMAGE))
                 .unwrap();
 
-            // sign the ManifestStoreBuilder and write it to the output stream
+            // sign and write to the output stream
             let signer = temp_signer();
             builder
                 .sign(format, &mut source, &mut dest, signer.as_ref())
@@ -1050,13 +1053,15 @@ mod tests {
 
             // read and validate the signed manifest store
             dest.rewind().unwrap();
-            let manifest_store =
-                ManifestStore::from_stream(format, &mut dest, true).expect("from_bytes");
+            let manifest_store = Reader::from_stream(format, &mut dest).expect("from_bytes");
 
             println!("{}", manifest_store);
-            assert!(manifest_store.validation_status().is_none());
+            if format != "c2pa" {
+                // c2pa files will not validate since they have no associated asset
+                assert!(manifest_store.validation_status().is_none());
+            }
             assert_eq!(
-                manifest_store.get_active().unwrap().title().unwrap(),
+                manifest_store.active_manifest().unwrap().title().unwrap(),
                 "Test_Manifest"
             );
 
@@ -1097,15 +1102,48 @@ mod tests {
 
         // read and validate the signed manifest store
         dest.rewind().unwrap();
-        let manifest_store =
-            ManifestStore::from_stream(format, &mut dest, true).expect("from_bytes");
+        let manifest_store = Reader::from_stream(format, &mut dest).expect("from_bytes");
 
         println!("{}", manifest_store);
         #[cfg(not(target_arch = "wasm32"))] // skip this until we get wasm async signing working
         assert!(manifest_store.validation_status().is_none());
         assert_eq!(
-            manifest_store.get_active().unwrap().title().unwrap(),
+            manifest_store.active_manifest().unwrap().title().unwrap(),
             "Test_Manifest"
         );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn test_builder_remote_url() {
+        let mut source = Cursor::new(TEST_IMAGE_CLEAN);
+        let mut dest = Cursor::new(Vec::new());
+
+        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        builder.remote_url = Some("http://my_remote_url".to_string());
+        builder.no_embed = true;
+
+        builder
+            .add_resource("thumbnail1.jpg", Cursor::new(TEST_IMAGE))
+            .unwrap();
+
+        // sign the ManifestStoreBuilder and write it to the output stream
+        let signer = temp_signer();
+        let manifest_data = builder
+            .sign("image/jpeg", &mut source, &mut dest, signer.as_ref())
+            .unwrap();
+
+        // check to make sure we have a remote url and no manifest data
+        dest.set_position(0);
+        let _err = c2pa::Reader::from_stream("image/jpeg", &mut dest).expect_err("from_bytes");
+
+        // now validate the manifest against the written asset
+        dest.set_position(0);
+        let reader =
+            c2pa::Reader::from_manifest_data_and_stream(&manifest_data, "image/jpeg", &mut dest)
+                .expect("from_bytes");
+
+        println!("{}", reader.json());
+        assert!(reader.validation_status().is_none());
     }
 }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -938,7 +938,6 @@ impl Claim {
     }
 
     // Crate private function to allow for patching a BMFF hash with final contents.
-    #[cfg(feature = "file_io")]
     pub(crate) fn update_bmff_hash(&mut self, bmff_hash: BmffHash) -> Result<()> {
         self.replace_assertion(bmff_hash.to_assertion()?)
     }
@@ -946,7 +945,6 @@ impl Claim {
     // Patch an existing assertion with new contents.
     //
     // `replace_with` should match in name and size of an existing assertion.
-    #[cfg(feature = "file_io")]
     pub(crate) fn replace_assertion(&mut self, replace_with: Assertion) -> Result<()> {
         self.update_assertion(
             replace_with,

--- a/sdk/src/settings.rs
+++ b/sdk/src/settings.rs
@@ -180,16 +180,12 @@ impl SettingsValidate for Verify {}
 #[allow(unused)]
 pub(crate) struct Builder {
     auto_thumbnail: bool,
-    embed: bool,
-    remote_url: Option<String>,
 }
 
 impl Default for Builder {
     fn default() -> Self {
         Self {
             auto_thumbnail: true,
-            embed: true,
-            remote_url: None,
         }
     }
 }

--- a/sdk/src/settings.rs
+++ b/sdk/src/settings.rs
@@ -175,22 +175,26 @@ impl Default for Verify {
 
 impl SettingsValidate for Verify {}
 
-// Settings for manifest API options
+// Settings for Builder API options
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[allow(unused)]
-pub(crate) struct Manifest {
+pub(crate) struct Builder {
     auto_thumbnail: bool,
+    embed: bool,
+    remote_url: Option<String>,
 }
 
-impl Default for Manifest {
+impl Default for Builder {
     fn default() -> Self {
         Self {
             auto_thumbnail: true,
+            embed: true,
+            remote_url: None,
         }
     }
 }
 
-impl SettingsValidate for Manifest {}
+impl SettingsValidate for Builder {}
 
 // Settings configuration for C2PA-RS.  Default configuration values
 // are lazy loaded on first use.  Values can also be loaded from a configuration
@@ -202,7 +206,7 @@ pub(crate) struct Settings {
     trust: Trust,
     core: Core,
     verify: Verify,
-    manifest: Manifest,
+    builder: Builder,
 }
 
 impl Settings {
@@ -270,7 +274,7 @@ impl SettingsValidate for Settings {
         self.trust.validate()?;
         self.core.validate()?;
         self.trust.validate()?;
-        self.manifest.validate()
+        self.builder.validate()
     }
 }
 
@@ -415,7 +419,7 @@ pub mod tests {
         assert_eq!(settings.core, Core::default());
         assert_eq!(settings.trust, Trust::default());
         assert_eq!(settings.verify, Verify::default());
-        assert_eq!(settings.manifest, Manifest::default());
+        assert_eq!(settings.builder, Builder::default());
 
         reset_default_settings().unwrap();
     }
@@ -430,8 +434,8 @@ pub mod tests {
             Core::default().hash_alg
         );
         assert_eq!(
-            get_settings_value::<bool>("manifest.auto_thumbnail").unwrap(),
-            Manifest::default().auto_thumbnail
+            get_settings_value::<bool>("builder.auto_thumbnail").unwrap(),
+            Builder::default().auto_thumbnail
         );
         assert_eq!(
             get_settings_value::<Option<String>>("trust.private_anchors").unwrap(),
@@ -445,8 +449,8 @@ pub mod tests {
             Verify::default()
         );
         assert_eq!(
-            get_settings_value::<Manifest>("manifest").unwrap(),
-            Manifest::default()
+            get_settings_value::<Builder>("builder").unwrap(),
+            Builder::default()
         );
         assert_eq!(
             get_settings_value::<Trust>("trust").unwrap(),
@@ -457,7 +461,7 @@ pub mod tests {
         let hash_alg: String = get_settings_value("core.hash_alg").unwrap();
         let remote_manifest_fetch: bool =
             get_settings_value("verify.remote_manifest_fetch").unwrap();
-        let auto_thumbnail: bool = get_settings_value("manifest.auto_thumbnail").unwrap();
+        let auto_thumbnail: bool = get_settings_value("builder.auto_thumbnail").unwrap();
         let private_anchors: Option<String> = get_settings_value("trust.private_anchors").unwrap();
 
         assert_eq!(hash_alg, Core::default().hash_alg);
@@ -465,18 +469,18 @@ pub mod tests {
             remote_manifest_fetch,
             Verify::default().remote_manifest_fetch
         );
-        assert_eq!(auto_thumbnail, Manifest::default().auto_thumbnail);
+        assert_eq!(auto_thumbnail, Builder::default().auto_thumbnail);
         assert_eq!(private_anchors, Trust::default().private_anchors);
 
         // test implicit deserialization on objects
         let core: Core = get_settings_value("core").unwrap();
         let verify: Verify = get_settings_value("verify").unwrap();
-        let manifest: Manifest = get_settings_value("manifest").unwrap();
+        let builder: Builder = get_settings_value("builder").unwrap();
         let trust: Trust = get_settings_value("trust").unwrap();
 
         assert_eq!(core, Core::default());
         assert_eq!(verify, Verify::default());
-        assert_eq!(manifest, Manifest::default());
+        assert_eq!(builder, Builder::default());
         assert_eq!(trust, Trust::default());
 
         reset_default_settings().unwrap();
@@ -491,7 +495,7 @@ pub mod tests {
         // test updating values
         set_settings_value("core.hash_alg", "sha512").unwrap();
         set_settings_value("verify.remote_manifest_fetch", false).unwrap();
-        set_settings_value("manifest.auto_thumbnail", false).unwrap();
+        set_settings_value("builder.auto_thumbnail", false).unwrap();
         set_settings_value(
             "trust.private_anchors",
             Some(String::from_utf8(ts.to_vec()).unwrap()),
@@ -503,7 +507,7 @@ pub mod tests {
             "sha512"
         );
         assert!(!get_settings_value::<bool>("verify.remote_manifest_fetch").unwrap());
-        assert!(!get_settings_value::<bool>("manifest.auto_thumbnail").unwrap());
+        assert!(!get_settings_value::<bool>("builder.auto_thumbnail").unwrap());
         assert_eq!(
             get_settings_value::<Option<String>>("trust.private_anchors").unwrap(),
             Some(String::from_utf8(ts.to_vec()).unwrap())
@@ -516,8 +520,8 @@ pub mod tests {
             Verify::default()
         );
         assert_ne!(
-            get_settings_value::<Manifest>("manifest").unwrap(),
-            Manifest::default()
+            get_settings_value::<Builder>("builder").unwrap(),
+            Builder::default()
         );
         assert_ne!(
             get_settings_value::<Trust>("trust").unwrap(),
@@ -596,8 +600,8 @@ pub mod tests {
 
         // check a few defaults to make sure they are still there
         assert_eq!(
-            get_settings_value::<bool>("manifest.auto_thumbnail").unwrap(),
-            Manifest::default().auto_thumbnail
+            get_settings_value::<bool>("builder.auto_thumbnail").unwrap(),
+            Builder::default().auto_thumbnail
         );
 
         assert_eq!(

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -29,11 +29,6 @@ fn test_builder_ca_jpg() -> Result<()> {
 
     let mut dest = Cursor::new(Vec::new());
     builder.sign(format, &mut source, &mut dest, &test_signer())?;
-
-    // dest.set_position(0);
-    // let path = common::known_good_path("CA_test.json");
-    // let reader = c2pa::Reader::from_stream(format, &mut dest)?;
-    // std::fs::write(path, reader.json())?;
-
+    dest.set_position(0);
     compare_stream_to_known_good(&mut dest, format, "CA_test.json")
 }


### PR DESCRIPTION
Adds a way to set the remote_url and no_embed option for Builder.
Enables BMFF format for streams.
Adds io and streaming tests.