### PR TITLE
Steps toward removing RemoteSigner APIs.

### DIFF
--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -77,6 +77,14 @@ pub trait Signer {
     fn ocsp_val(&self) -> Option<Vec<u8>> {
         None
     }
+
+    /// If this returns true the sign function is responsible for for direct handling of the COSE structure.
+    ///
+    /// This is useful for cases where the signer needs to handle the COSE structure directly.
+    /// Not recommended for general use.
+    fn direct_cose_handling(&self) -> bool {
+        false
+    }
 }
 
 /// Trait to allow loading of signing credential from external sources


### PR DESCRIPTION
Support direct_cose_handling() on on all signing methods, sync and async.
Adds:
manifest.data_hash_embeddable_manifest_async
manifest.box_hash_embeddable_manifest_async.

We should be able to deprecate and then remote all RemoteSinger code once this is integrated.