### PR TITLE
OCSP certificate should be valid at signing time

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -91,6 +91,7 @@ fast-xml = "0.23.1"
 hex = "0.4.3"
 # Version 1.13.0 doesn't compile under Rust < 1.75, pinning to 1.12.0
 id3 = "=1.12.0"
+icu_collections = "1.4.0"
 img-parts = "0.3.0"
 jfifdump = "0.5.1"
 log = "0.4.8"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -91,7 +91,6 @@ fast-xml = "0.23.1"
 hex = "0.4.3"
 # Version 1.13.0 doesn't compile under Rust < 1.75, pinning to 1.12.0
 id3 = "=1.12.0"
-icu_collections = "1.4.0"
 img-parts = "0.3.0"
 jfifdump = "0.5.1"
 log = "0.4.8"
@@ -157,9 +156,6 @@ web-sys = { version = "0.3.58", features = [
 	"Window",
 	"WorkerGlobalScope",
 ] }
-
-[package.metadata.cargo-udeps.ignore]
-normal = ["icu_collections"] # remove when licnese has been reviewed
 
 [dev-dependencies]
 anyhow = "1.0.40"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -158,6 +158,9 @@ web-sys = { version = "0.3.58", features = [
 	"WorkerGlobalScope",
 ] }
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["icu_collections"] # remove when licnese has been reviewed
+
 [dev-dependencies]
 anyhow = "1.0.40"
 mockall = "0.11.2"

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -713,7 +713,7 @@ pub(crate) fn check_ocsp_status(
                 // if we get a valid response validate the certs
                 if ocsp_data.revoked_at.is_none() {
                     if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
-                        check_cert(&ocsp_certs[0], th, validation_log, None)?;
+                        check_cert(&ocsp_certs[0], th, validation_log, Some(tst_info))?;
                     }
                 }
                 result = Ok(ocsp_data);


### PR DESCRIPTION
## Changes in this pull request
This is a fix to a recent regression during validation.  We not validate the certificates contained in the OCSP response.  The certificates validity should be checked against the timestamp time vs the current time with stapled.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
