### PR TITLE
url crate version 2.5.1 introduces new license "Unicode-3.0"

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -121,7 +121,7 @@ sha2 = "0.10.2"
 tempfile = "3.10.1"
 thiserror = "1.0.40"
 treeline = "0.1.0"
-url = "2.2.2"
+url = "2.2.2, <2.5.1"  # Can't use 2.5.1 or newer until new license is reviewed.
 uuid = { version = "1.3.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.15.1"
 x509-certificate = "0.19.0"


### PR DESCRIPTION
We need legal review on this license before we can accept it.

Related to https://github.com/servo/rust-url/pull/923
