### PR TITLE
(PATCH) ensures temp files are removed

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -27,7 +27,7 @@ use tempfile::Builder;
 use crate::{
     assertions::{BmffMerkleMap, ExclusionsMap},
     asset_io::{
-        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
+        rename_or_move, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         HashObjectPositions, RemoteRefEmbed, RemoteRefEmbedType,
     },
     error::{Error, Result},
@@ -1290,7 +1290,7 @@ impl AssetIO for BmffIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -1312,7 +1312,7 @@ impl AssetIO for BmffIO {
         self.remove_cai_store_from_stream(&mut input_file, &mut temp_file)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn new(asset_type: &str) -> Self

--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -32,7 +32,7 @@ use tempfile::Builder;
 use crate::{
     assertions::{BoxMap, C2PA_BOXHASH},
     asset_io::{
-        rename_or_copy, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
+        rename_or_move, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
         RemoteRefEmbedType,
     },
@@ -477,7 +477,7 @@ impl AssetIO for JpegIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(&self, asset_path: &Path) -> Result<Vec<HashObjectPositions>> {

--- a/sdk/src/asset_handlers/mp3_io.rs
+++ b/sdk/src/asset_handlers/mp3_io.rs
@@ -25,7 +25,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
+        rename_or_move, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
         CAIReadWriteWrapper, CAIReader, CAIWriter, HashBlockObjectType, HashObjectPositions,
         RemoteRefEmbed,
     },
@@ -213,7 +213,7 @@ impl AssetIO for Mp3IO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -26,7 +26,7 @@ use tempfile::Builder;
 use crate::{
     assertions::{BoxMap, C2PA_BOXHASH},
     asset_io::{
-        rename_or_copy, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
+        rename_or_move, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
         RemoteRefEmbedType,
     },
@@ -488,7 +488,7 @@ impl AssetIO for PngIO {
         self.write_cai(&mut stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -24,7 +24,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
+        rename_or_move, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
         CAIReadWriteWrapper, CAIReader, CAIWriter, HashBlockObjectType, HashObjectPositions,
         RemoteRefEmbed, RemoteRefEmbedType,
     },
@@ -369,7 +369,7 @@ impl AssetIO for RiffIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(

--- a/sdk/src/asset_handlers/svg_io.rs
+++ b/sdk/src/asset_handlers/svg_io.rs
@@ -26,7 +26,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        rename_or_copy,
+        rename_or_move,
         AssetIO,
         AssetPatch,
         CAIRead,
@@ -124,7 +124,7 @@ impl AssetIO for SvgIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -148,7 +148,7 @@ impl AssetIO for SvgIO {
         self.remove_cai_store_from_stream(&mut input_file, &mut temp_file)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -27,7 +27,7 @@ use tempfile::Builder;
 
 use crate::{
     asset_io::{
-        rename_or_copy, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
+        rename_or_move, AssetIO, AssetPatch, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
         RemoteRefEmbedType,
     },
@@ -1428,7 +1428,7 @@ impl AssetIO for TiffIO {
         self.write_cai(&mut input_stream, &mut temp_file, store_bytes)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn get_object_locations(
@@ -1452,7 +1452,7 @@ impl AssetIO for TiffIO {
         self.remove_cai_store_from_stream(&mut input_file, &mut temp_file)?;
 
         // copy temp file to asset
-        rename_or_copy(temp_file, asset_path)
+        rename_or_move(temp_file, asset_path)
     }
 
     fn new(_asset_type: &str) -> Self

--- a/sdk/src/asset_io.rs
+++ b/sdk/src/asset_io.rs
@@ -12,7 +12,7 @@
 // each license.
 
 use std::{
-    fmt,
+    fmt, fs,
     io::{Cursor, Read, Seek, Write},
     path::Path,
 };
@@ -259,20 +259,28 @@ pub trait ComposedManifestRef {
     fn compose_manifest(&self, manifest_data: &[u8], format: &str) -> Result<Vec<u8>>;
 }
 
-/// Utility function to rename or copy a temp file to a permanent location.
+/// Utility function to rename a file or, if the provided paths are on separate mounting points,
+/// move a file from a temporary location to its final location.
 ///
-/// If the rename is not possible, due to cross volume references & etc, it will copy instead.
-pub fn rename_or_copy<P>(temp_file: NamedTempFile, asset_path: P) -> Result<()>
+/// If the rename is not possible due to cross volume references, the file will be copied to the
+/// final and then the temp file we be deleted.
+pub fn rename_or_move<P>(temp_file: NamedTempFile, asset_path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
-    // clear temp flag for Windows
+    // Clear temp flag for Windows.
     let (_, path) = temp_file
         .keep()
         .map_err(|e| crate::Error::OtherError(Box::new(e)))?;
 
-    std::fs::rename(&path, asset_path.as_ref())
-        // if rename fails, try to copy in case we are on different volumes
-        .or_else(|_| std::fs::copy(&path, asset_path).and(Ok(())))
+    // Move the temp_file to the asset's final path.
+    fs::rename(&path, asset_path.as_ref())
+        // Attempt to copy the file instead if the file's final location is on a different volume.
+        .or_else(|_| {
+            fs::copy(&path, asset_path).map(|_| ()).and_then(|_| {
+                // Remove the temporary file.
+                fs::remove_file(path)
+            })
+        })
         .map_err(crate::Error::IoError)
 }


### PR DESCRIPTION
## Changes in this pull request

This PR changes the behavior of the `asset_io::rename_or_copy` function by deleting the copied file after it has been copied to the destination path.

This mainly affected our windows clients as the `std::fs::rename` fails when renaming a file from one drive to another drive on windows.

The new behavior is the following:

1. Atttempt to rename the file
2. If that fails, copy the file
3. If the copy succeeds, delete the temporary file.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
