### PR TITLE
Add remote manifest support to MP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The library has been tested on the following operating systems:
  | `tif`,`tiff`  | `image/tiff`                                        |
  | `wav`         | `audio/wav`                                         |
  | `webp`        | `image/webp`                                        |
+ | `mp3`         | `audio/mpeg`                                        |
 
 ## Usage
 

--- a/sdk/src/asset_handlers/mp3_io.rs
+++ b/sdk/src/asset_handlers/mp3_io.rs
@@ -12,14 +12,17 @@
 // each license.
 
 use std::{
-    fs::{File, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::{Cursor, Seek, SeekFrom, Write},
     path::Path,
 };
 
 use byteorder::{BigEndian, ReadBytesExt};
 use conv::ValueFrom;
-use id3::{frame::EncapsulatedObject, *};
+use id3::{
+    frame::{EncapsulatedObject, Private},
+    *,
+};
 use memchr::memmem;
 use tempfile::Builder;
 
@@ -27,9 +30,10 @@ use crate::{
     asset_io::{
         rename_or_move, AssetIO, AssetPatch, CAIRead, CAIReadWrapper, CAIReadWrite,
         CAIReadWriteWrapper, CAIReader, CAIWriter, HashBlockObjectType, HashObjectPositions,
-        RemoteRefEmbed,
+        RemoteRefEmbed, RemoteRefEmbedType,
     },
     error::{Error, Result},
+    utils::xmp_inmemory_utils::{self, MIN_XMP},
 };
 
 static SUPPORTED_TYPES: [&str; 2] = ["mp3", "audio/mpeg"];
@@ -140,9 +144,97 @@ impl CAIReader for Mp3IO {
         manifest.ok_or(Error::JumbfNotFound)
     }
 
-    // Get XMP block
-    fn read_xmp(&self, _input_stream: &mut dyn CAIRead) -> Option<String> {
+    fn read_xmp(&self, input_stream: &mut dyn CAIRead) -> Option<String> {
+        if let Ok(tag) = Tag::read_from(input_stream) {
+            for frame in tag.frames() {
+                if let Content::Private(private) = frame.content() {
+                    if &private.owner_identifier == "XMP" {
+                        return String::from_utf8(private.private_data.clone()).ok();
+                    }
+                }
+            }
+        }
+
         None
+    }
+}
+
+impl RemoteRefEmbed for Mp3IO {
+    fn embed_reference(&self, asset_path: &Path, embed_ref: RemoteRefEmbedType) -> Result<()> {
+        match &embed_ref {
+            RemoteRefEmbedType::Xmp(_) => {
+                let mut input_stream = File::open(asset_path)?;
+                let mut output_stream = Cursor::new(Vec::new());
+                self.embed_reference_to_stream(&mut input_stream, &mut output_stream, embed_ref)?;
+                fs::write(asset_path, output_stream.into_inner())?;
+                Ok(())
+            }
+            _ => Err(Error::UnsupportedType),
+        }
+    }
+
+    fn embed_reference_to_stream(
+        &self,
+        source_stream: &mut dyn CAIRead,
+        output_stream: &mut dyn CAIReadWrite,
+        embed_ref: RemoteRefEmbedType,
+    ) -> Result<()> {
+        match embed_ref {
+            RemoteRefEmbedType::Xmp(url) => {
+                let header = ID3V2Header::read_header(source_stream)?;
+                source_stream.rewind()?;
+
+                let mut out_tag = Tag::new();
+
+                let reader = CAIReadWrapper {
+                    reader: source_stream,
+                };
+                if let Ok(tag) = Tag::read_from(reader) {
+                    for f in tag.frames() {
+                        match f.content() {
+                            Content::Private(private) => {
+                                if &private.owner_identifier != "XMP" {
+                                    out_tag.add_frame(f.clone());
+                                }
+                            }
+                            _ => {
+                                out_tag.add_frame(f.clone());
+                            }
+                        }
+                    }
+                }
+
+                let xmp = xmp_inmemory_utils::add_provenance(
+                    &self
+                        .read_xmp(source_stream)
+                        .unwrap_or_else(|| format!("http://ns.adobe.com/xap/1.0/\0 {}", MIN_XMP)),
+                    &url,
+                )?;
+                let frame = Frame::with_content(
+                    "PRIV",
+                    Content::Private(Private {
+                        // Null-terminated
+                        owner_identifier: "XMP\0".to_owned(),
+                        private_data: xmp.into_bytes(),
+                    }),
+                );
+
+                out_tag.add_frame(frame);
+
+                let writer = CAIReadWriteWrapper {
+                    reader_writer: output_stream,
+                };
+                out_tag
+                    .write_to(writer, Version::Id3v24)
+                    .map_err(|_e| Error::EmbeddingError)?;
+
+                source_stream.seek(SeekFrom::Start(header.get_size() as u64))?;
+                std::io::copy(source_stream, output_stream)?;
+
+                Ok(())
+            }
+            _ => Err(Error::UnsupportedType),
+        }
     }
 }
 
@@ -230,7 +322,7 @@ impl AssetIO for Mp3IO {
     }
 
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {
-        None
+        Some(self)
     }
 
     fn supported_types(&self) -> &[&str] {
@@ -470,5 +562,27 @@ pub mod tests {
             Err(Error::JumbfNotFound) => (),
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn test_remote_ref() -> Result<()> {
+        let mp3_io = Mp3IO::new("mp3");
+
+        let mut stream = File::open(fixture_path("sample1.mp3"))?;
+        assert!(mp3_io.read_xmp(&mut stream).is_none());
+        stream.rewind()?;
+
+        let mut output_stream1 = Cursor::new(Vec::new());
+        mp3_io.embed_reference_to_stream(
+            &mut stream,
+            &mut output_stream1,
+            RemoteRefEmbedType::Xmp("Test".to_owned()),
+        )?;
+        output_stream1.rewind()?;
+
+        let xmp = mp3_io.read_xmp(&mut output_stream1);
+        assert_eq!(xmp, Some("http://ns.adobe.com/xap/1.0/\0<?xpacket begin=\"\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n<x:xmpmeta xmlns:x=\"adobe:ns:meta/\" x:xmptk=\"XMP Core 6.0.0\">\n  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n    <rdf:Description rdf:about=\"\" xmlns:dcterms=\"http://purl.org/dc/terms/\" dcterms:provenance=\"Test\">\n    </rdf:Description>\n  </rdf:RDF>\n</x:xmpmeta>".to_owned()));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Adds XMP (remote manifest) support to MP3. Closes #367  

From XMP spec:
![image](https://github.com/contentauth/c2pa-rs/assets/25470747/9b8cd8c6-7b32-45c8-bb85-0006fdd226cd)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
