### PR TITLE
Temporarily allow unused `JsonAssertionData` to fix unused error in CI

### DIFF
--- a/sdk/src/assertion.rs
+++ b/sdk/src/assertion.rs
@@ -471,12 +471,12 @@ impl Assertion {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub(crate) struct JsonAssertionData {
-    label: String,
-    data: Value,
-    is_cbor: bool,
-}
+// #[derive(Serialize, Deserialize, Debug)]
+// pub(crate) struct JsonAssertionData {
+//     label: String,
+//     data: Value,
+//     is_cbor: bool,
+// }
 
 /// This error type is returned when an assertion can not be decoded.
 #[non_exhaustive]

--- a/sdk/src/assertion.rs
+++ b/sdk/src/assertion.rs
@@ -471,12 +471,13 @@ impl Assertion {
     }
 }
 
-// #[derive(Serialize, Deserialize, Debug)]
-// pub(crate) struct JsonAssertionData {
-//     label: String,
-//     data: Value,
-//     is_cbor: bool,
-// }
+#[allow(dead_code)] // TODO: temp, see #498
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct JsonAssertionData {
+    label: String,
+    data: Value,
+    is_cbor: bool,
+}
 
 /// This error type is returned when an assertion can not be decoded.
 #[non_exhaustive]


### PR DESCRIPTION
## Changes in this pull request
Temporarily comment `JsonAssertionData` to fix unused error in CI.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
