### PR TITLE
Set GIF data hash and box hash placeholder box len to >0

### DIFF
--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -125,12 +125,11 @@ impl CAIWriter for GifIO {
                     },
                     HashObjectPositions {
                         offset: end_preamble_pos,
-                        // Size doesn't matter for placeholder block.
-                        length: 0,
+                        length: 1, // Need at least size 1.
                         htype: HashBlockObjectType::Cai,
                     },
                     HashObjectPositions {
-                        offset: end_preamble_pos,
+                        offset: end_preamble_pos + 1,
                         length: usize::try_from(input_stream.seek(SeekFrom::End(0))?)?
                             - end_preamble_pos,
                         htype: HashBlockObjectType::Other,
@@ -259,7 +258,7 @@ impl AssetBoxHash for GifIO {
                                             ApplicationExtension::new_c2pa(&[])?,
                                         ),
                                         start: marker.start,
-                                        // Size doesn't matter for placeholder block.
+                                        // TODO: should this size be >1?
                                         len: 0,
                                     }
                                     .to_box_map()?,

--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -1340,15 +1340,15 @@ mod tests {
             obj_locations.get(1),
             Some(&HashObjectPositions {
                 offset: 781,
-                length: 0,
+                length: 1,
                 htype: HashBlockObjectType::Cai,
             })
         );
         assert_eq!(
             obj_locations.get(2),
             Some(&HashObjectPositions {
-                offset: 781,
-                length: 739692,
+                offset: 782,
+                length: SAMPLE1.len() - 781,
                 htype: HashBlockObjectType::Other,
             })
         );


### PR DESCRIPTION
## Changes in this pull request
Set data box placeholder len to at least 1 for GIF. If not, the code errors [here](https://github.com/contentauth/c2pa-rs/blob/06bad589b7ec0538a76a4ee59bcfe7235495894a/sdk/src/assertions/data_hash.rs#L125) when writing to GIF.

~~TODO: does the placeholder box hash also need a len of at least 1?~~ Yes

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
