### PR TITLE
Make data_types field optional when serializing data-box-map

### DIFF
--- a/sdk/src/assertions/metadata.rs
+++ b/sdk/src/assertions/metadata.rs
@@ -290,6 +290,7 @@ pub struct DataBox {
     pub format: String,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_types: Option<Vec<AssetType>>,
 }
 


### PR DESCRIPTION
## Changes in this pull request
Fix for issue: https://github.com/contentauth/c2pa-rs/issues/504.  Incorrect serialization caused hash mismatch

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
