### PR TITLE
Make sure reading past end of JUMBF box is an error

### DIFF
--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2712,7 +2712,7 @@ pub mod tests {
         assert_eq!(jumb_header.name, BoxType::Jumb);
 
         let jumd_header = BoxReader::read_header(&mut buf_reader).unwrap();
-        assert_eq!(jumd_header.size, 0x1E);
+        assert_eq!(jumd_header.size, 0x1e);
         assert_eq!(jumd_header.name, BoxType::Jumd);
 
         let desc_box = BoxReader::read_desc_box(&mut buf_reader, jumd_header.size).unwrap();

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2700,27 +2700,25 @@ pub mod tests {
     }
 
     // ANCHOR: DescriptionBox Reader
-    /*
-     #[test]
-     fn desc_box_reader() {
-         const JUMD_DESC: &str =
-             "000000256A756D62000000216A756D646332706100110010800000AA00389B7103633270612E763100";
-         let buffer = hex::decode(JUMD_DESC).expect("decode failed");
-         let mut buf_reader = Cursor::new(buffer);
+    #[test]
+    fn desc_box_reader() {
+        const JUMD_DESC: &str =
+            "000000226A756D620000001E6A756D646332706100110010800000AA00389B71036332706100";
+        let buffer = hex::decode(JUMD_DESC).expect("decode failed");
+        let mut buf_reader = Cursor::new(buffer);
 
-         let jumb_header = BoxReader::read_header(&mut buf_reader).unwrap();
-         assert_eq!(jumb_header.size, 0x25);
-         assert_eq!(jumb_header.name, BoxType::JumbBox);
+        let jumb_header = BoxReader::read_header(&mut buf_reader).unwrap();
+        assert_eq!(jumb_header.size, 0x22);
+        assert_eq!(jumb_header.name, BoxType::Jumb);
 
-         let jumd_header = BoxReader::read_header(&mut buf_reader).unwrap();
-         assert_eq!(jumd_header.size, 0x21);
-         assert_eq!(jumd_header.name, BoxType::JumdBox);
+        let jumd_header = BoxReader::read_header(&mut buf_reader).unwrap();
+        assert_eq!(jumd_header.size, 0x1E);
+        assert_eq!(jumd_header.name, BoxType::Jumd);
 
-         let desc_box = BoxReader::read_desc_box(&mut buf_reader, jumd_header.size).unwrap();
-         assert_eq!(desc_box.label(), labels::MANIFEST_STORE);
-         assert_eq!(desc_box.uuid(), "6332706100110010800000AA00389B71");
-     }
-    */
+        let desc_box = BoxReader::read_desc_box(&mut buf_reader, jumd_header.size).unwrap();
+        assert_eq!(desc_box.label(), labels::MANIFEST_STORE);
+        assert_eq!(desc_box.uuid(), "6332706100110010800000AA00389B71");
+    }
 
     // ANCHOR: JSON Content Box Reader
     #[test]

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2274,11 +2274,11 @@ impl BoxReader {
                 sbox.add_data_box(next_box);
             }
 
-            // if our current position is past the size, bail out...
-            if let Ok(p) = current_pos(reader) {
-                if p >= dest_pos {
-                    found = false;
-                }
+            // Error out if box reads past specified box len
+            match current_pos(reader).map_err(|_| JumbfParseError::InvalidBoxRange)? {
+                p if p == dest_pos => found = false,
+                p if p > dest_pos => return Err(JumbfParseError::InvalidJumbBox),
+                _ => continue,
             }
         }
 
@@ -2721,10 +2721,11 @@ pub mod tests {
          assert_eq!(desc_box.uuid(), "6332706100110010800000AA00389B71");
      }
     */
+
     // ANCHOR: JSON Content Box Reader
     #[test]
     fn json_box_reader() {
-        const JSON_BOX: &str ="0000005a6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
+        const JSON_BOX: &str ="0000005b6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
 
         let buffer = hex::decode(JSON_BOX).expect("decode failed");
         let mut buf_reader = Cursor::new(buffer);
@@ -2738,6 +2739,15 @@ pub mod tests {
         let json_box = super_box.data_box_as_json_box(0).unwrap();
         assert_eq!(json_box.box_uuid(), JUMBF_JSON_UUID);
         assert_eq!(json_box.json().len(), 30);
+    }
+
+    #[test]
+    fn test_bad_box_size() {
+        const JSON_BOX: &str ="0000005a6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
+
+        let buffer = hex::decode(JSON_BOX).expect("decode failed");
+        let mut buf_reader = Cursor::new(buffer);
+        assert!(BoxReader::read_super_box(&mut buf_reader).is_err());
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Changes in this pull request
Fix for issue: https://github.com/contentauth/c2pa-rs/issues/515 where reading past a JUMBF box size was not considered an error.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
