### PR TITLE
Export `AssertionDefinition` and `ActionTemplate` in public API

### DIFF
--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -14,7 +14,7 @@
 //! Assertion helpers to build, validate, and parse assertions.
 
 mod actions;
-pub use actions::{c2pa_action, Action, Actions, SoftwareAgent};
+pub use actions::{c2pa_action, Action, ActionTemplate, Actions, SoftwareAgent};
 
 mod bmff_hash;
 pub use bmff_hash::{BmffHash, BmffMerkleMap, DataMap, ExclusionsMap, SubsetMap};

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -112,7 +112,7 @@ pub mod wasm;
 #[cfg(feature = "v1_api")]
 pub use asset_io::{CAIRead, CAIReadWrite};
 #[cfg(feature = "unstable_api")]
-pub use builder::{Builder, ManifestDefinition};
+pub use builder::{AssertionDefinition, Builder, ManifestDefinition};
 pub use callback_signer::{CallbackFunc, CallbackSigner};
 pub use claim_generator_info::ClaimGeneratorInfo;
 pub use error::{Error, Result};


### PR DESCRIPTION
## Changes in this pull request
Export `AssertionDefinition` + `ActionTemplate` in public API.

<img width="565" alt="image" src="https://github.com/user-attachments/assets/183e9421-8037-4ac3-9b46-6ce13fcee3a4">

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
