### PR TITLE
Fix GIF `remove_cai_store_from_stream` behavior

### DIFF
--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -148,7 +148,11 @@ impl CAIWriter for GifIO {
             Some(block_marker) => {
                 self.remove_block(input_stream, output_stream, &block_marker.into())
             }
-            None => Err(Error::JumbfNotFound),
+            None => {
+                input_stream.rewind()?;
+                io::copy(input_stream, output_stream)?;
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes in this pull request
GIF should copy the entire input stream to the output if no c2pa block was found when calling `remove_cai_store_from_stream`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
