### PR TITLE
Update crate to fix bad certificate dump content

### DIFF
--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.40"
 c2pa = { path = "../sdk", default-features = false, features = [
 	"openssl",
 	"unstable_api",
+	"file_io",
 ] }
 env_logger = "0.11"
 log = "0.4.8"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -124,7 +124,7 @@ treeline = "0.1.0"
 url = "2.2.2, <2.5.1"  # Can't use 2.5.1 or newer until new license is reviewed.
 uuid = { version = "1.7.0", features = ["serde", "v4", "js"] }
 x509-parser = "0.15.1"
-x509-certificate = "0.19.0"
+x509-certificate = "0.21.1"
 zip = { version = "0.6.6", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -140,7 +140,7 @@ openssl = { version = "0.10.61", features = ["vendored"], optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "1.0.0", features = ["color"] }
 ed25519-dalek = "2.1.1"
-getrandom = { version = "0.2.7", features = ["js"] }
+getrandom = { version = "0.2.15", features = ["js"] }
 # We need to use the `inaccurate` flag here to ensure usage of the JavaScript Date API
 # to handle certificate timestamp checking correctly.
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -73,7 +73,7 @@ bcder = "0.7.3"
 bytes = "1.6.1"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-chrono = { version = "0.4.27", default-features = false, features = [
+chrono = { version = "0.4.38", default-features = false, features = [
 	"serde",
 	"wasmbind",
 ] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,10 +70,10 @@ async-trait = { version = "0.1.77" }
 atree = "0.5.2"
 base64 = "0.21.2"
 bcder = "0.7.3"
-bytes = "1.6.1"
+bytes = "1.4.0"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-chrono = { version = "0.4.33", default-features = false, features = [
+chrono = { version = "0.4.27", default-features = false, features = [
 	"serde",
 	"wasmbind",
 ] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -73,7 +73,7 @@ bcder = "0.7.3"
 bytes = "1.6.1"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-chrono = { version = "0.4.38", default-features = false, features = [
+chrono = { version = "0.4.33", default-features = false, features = [
 	"serde",
 	"wasmbind",
 ] }
@@ -125,7 +125,7 @@ treeline = "0.1.0"
 url = "2.2.2, <2.5.1"                                               # Can't use 2.5.1 or newer until new license is reviewed.
 uuid = { version = "1.7.0", features = ["serde", "v4", "js"] }
 x509-parser = "0.15.1"
-x509-certificate = "0.23.1"
+x509-certificate = "0.21.0"
 zip = { version = "0.6.6", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -140,7 +140,7 @@ openssl = { version = "0.10.61", features = ["vendored"], optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "1.0.0", features = ["color"] }
 ed25519-dalek = "2.1.1"
-getrandom = { version = "0.2.15", features = ["js"] }
+getrandom = { version = "0.2.7", features = ["js"] }
 # We need to use the `inaccurate` flag here to ensure usage of the JavaScript Date API
 # to handle certificate timestamp checking correctly.
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -70,7 +70,7 @@ async-trait = { version = "0.1.77" }
 atree = "0.5.2"
 base64 = "0.21.2"
 bcder = "0.7.3"
-bytes = "1.4.0"
+bytes = "1.6.1"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
 chrono = { version = "0.4.27", default-features = false, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -124,7 +124,7 @@ treeline = "0.1.0"
 url = "2.2.2, <2.5.1"  # Can't use 2.5.1 or newer until new license is reviewed.
 uuid = { version = "1.7.0", features = ["serde", "v4", "js"] }
 x509-parser = "0.15.1"
-x509-certificate = "0.21.1"
+x509-certificate = "0.23.1"
 zip = { version = "0.6.6", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2274,11 +2274,11 @@ impl BoxReader {
                 sbox.add_data_box(next_box);
             }
 
-            // if our current position is past the size, bail out...
-            if let Ok(p) = current_pos(reader) {
-                if p >= dest_pos {
-                    found = false;
-                }
+            // Error out if box reads past specified box len
+            match current_pos(reader).map_err(|_| JumbfParseError::InvalidBoxRange)? {
+                p if p == dest_pos => found = false,
+                p if p > dest_pos => return Err(JumbfParseError::InvalidJumbBox),
+                _ => continue,
             }
         }
 
@@ -2700,31 +2700,30 @@ pub mod tests {
     }
 
     // ANCHOR: DescriptionBox Reader
-    /*
-     #[test]
-     fn desc_box_reader() {
-         const JUMD_DESC: &str =
-             "000000256A756D62000000216A756D646332706100110010800000AA00389B7103633270612E763100";
-         let buffer = hex::decode(JUMD_DESC).expect("decode failed");
-         let mut buf_reader = Cursor::new(buffer);
+    #[test]
+    fn desc_box_reader() {
+        const JUMD_DESC: &str =
+            "000000226A756D620000001E6A756D646332706100110010800000AA00389B71036332706100";
+        let buffer = hex::decode(JUMD_DESC).expect("decode failed");
+        let mut buf_reader = Cursor::new(buffer);
 
-         let jumb_header = BoxReader::read_header(&mut buf_reader).unwrap();
-         assert_eq!(jumb_header.size, 0x25);
-         assert_eq!(jumb_header.name, BoxType::JumbBox);
+        let jumb_header = BoxReader::read_header(&mut buf_reader).unwrap();
+        assert_eq!(jumb_header.size, 0x22);
+        assert_eq!(jumb_header.name, BoxType::Jumb);
 
-         let jumd_header = BoxReader::read_header(&mut buf_reader).unwrap();
-         assert_eq!(jumd_header.size, 0x21);
-         assert_eq!(jumd_header.name, BoxType::JumdBox);
+        let jumd_header = BoxReader::read_header(&mut buf_reader).unwrap();
+        assert_eq!(jumd_header.size, 0x1e);
+        assert_eq!(jumd_header.name, BoxType::Jumd);
 
-         let desc_box = BoxReader::read_desc_box(&mut buf_reader, jumd_header.size).unwrap();
-         assert_eq!(desc_box.label(), labels::MANIFEST_STORE);
-         assert_eq!(desc_box.uuid(), "6332706100110010800000AA00389B71");
-     }
-    */
+        let desc_box = BoxReader::read_desc_box(&mut buf_reader, jumd_header.size).unwrap();
+        assert_eq!(desc_box.label(), labels::MANIFEST_STORE);
+        assert_eq!(desc_box.uuid(), "6332706100110010800000AA00389B71");
+    }
+
     // ANCHOR: JSON Content Box Reader
     #[test]
     fn json_box_reader() {
-        const JSON_BOX: &str ="0000005a6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
+        const JSON_BOX: &str ="0000005b6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
 
         let buffer = hex::decode(JSON_BOX).expect("decode failed");
         let mut buf_reader = Cursor::new(buffer);
@@ -2738,6 +2737,15 @@ pub mod tests {
         let json_box = super_box.data_box_as_json_box(0).unwrap();
         assert_eq!(json_box.box_uuid(), JUMBF_JSON_UUID);
         assert_eq!(json_box.json().len(), 30);
+    }
+
+    #[test]
+    fn test_bad_box_size() {
+        const JSON_BOX: &str ="0000005a6a756d620000002d6a756d646a736f6e00110010800000aa00389b7103633270612e6c6f636174696f6e2e62726f616400000000266a736f6e7b20226c6f636174696f6e223a202253616e204672616e636973636f227d";
+
+        let buffer = hex::decode(JSON_BOX).expect("decode failed");
+        let mut buf_reader = Cursor::new(buffer);
+        assert!(BoxReader::read_super_box(&mut buf_reader).is_err());
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Changes in this pull request
Fix issue reported in https://github.com/contentauth/c2patool/issues/173. This was caused by bug in x509_certificate crate

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
