### PR TITLE
(IGNORE) Clarify use of unstable_api feature flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ The library supports several common C2PA [assertions](https://c2pa.org/specifica
 
 This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
 
+### New API
+
+The library has a new API in development that will eventually replace the existing methods of reading and writing C2PA data. Ultimately, it will support all language bindings and build environments.  To use this API, enable the `unstable_api` feature; for example:
+
+```
+c2pa = {version="0.33.1", features=["unstable_api"]}
+```
+
+The new API focuses on streaming I/O and supports the following structs:
+- [Builder](https://docs.rs/c2pa/latest/c2pa/struct.Builder.html)
+- [Reader](https://docs.rs/c2pa/latest/c2pa/struct.Reader.html)
+- [ManifestDefinition](https://docs.rs/c2pa/latest/c2pa/struct.ManifestDefinition.html)
+
+For some informal development and ussage notes, see [2024_API_NOTES.md](https://github.com/contentauth/c2pa-rs/blob/main/2024_API_NOTES.md).
+
 ### Contributions and feedback
 
 We welcome contributions to this project.  For information on contributing, providing feedback, and about ongoing work, see [Contributing](https://github.com/contentauth/c2pa-js/blob/main/CONTRIBUTING.md).

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,7 +19,7 @@
 //! This library supports reading, creating and embedding C2PA data
 //! with a variety of asset types.
 //!
-//! Some functionality requires you to enable specific crate features, 
+//! Some functionality requires you to enable specific crate features,
 //! as noted in the documentation.
 //!
 //! The library has a new experimental Builder/Reader API that will eventually replace

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -26,11 +26,11 @@
 //! c2pa = {version="0.32.0", features=["file_io"]}
 //! ```
 //!
-//! We have a new experimental Builder/Reader API that will eventually replace
+//! The library has a new experimental Builder/Reader API that will eventually replace
 //! the existing methods of reading and writing C2PA data.
 //! The new API focuses on stream support and can do more with fewer methods.
 //! It will be supported in all language bindings and build environments.
-//! To try these out, you need to enable the `unstable_api` feature, for example:
+//! To use the new API, you must enable the `unstable_api` feature, for example:
 //!
 //! ```text
 //! c2pa = {version="0.32.0", features=["unstable_api"]}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,20 +19,26 @@
 //! This library supports reading, creating and embedding C2PA data
 //! with a variety of asset types.
 //!
-//! We have a new experimental Builder/Reader API that will eventually replace
-//! the existing methods of reading and writing C2PA data.
-//! The new API focuses on stream support and can do more with fewer methods.
-//! It will be supported in all language bindings and build environments.
-//! To try these out, you need to enable the `unstable_api` feature.
-//!
-//! To read with file based methods, you must add the `file_io` dependency to your Cargo.toml.
+//! To read with file-based methods, you must add the `file_io` dependency to your Cargo.toml.
 //! For example:
 //!
 //! ```text
 //! c2pa = {version="0.32.0", features=["file_io"]}
 //! ```
 //!
+//! We have a new experimental Builder/Reader API that will eventually replace
+//! the existing methods of reading and writing C2PA data.
+//! The new API focuses on stream support and can do more with fewer methods.
+//! It will be supported in all language bindings and build environments.
+//! To try these out, you need to enable the `unstable_api` feature, for example:
+//!
+//! ```text
+//! c2pa = {version="0.32.0", features=["unstable_api"]}
+//! ```
+//!
 //! # Example: Reading a ManifestStore
+//!
+//! This example requires the `unstable_api` feature to be enabled.
 //!
 //! ```
 //! # use c2pa::Result;
@@ -54,6 +60,8 @@
 //! ```
 //!
 //! # Example: Adding a Manifest to a file
+//!
+//! This example requires the `unstable_api` feature to be enabled.
 //!
 //! ```
 //! # use c2pa::Result;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -19,12 +19,8 @@
 //! This library supports reading, creating and embedding C2PA data
 //! with a variety of asset types.
 //!
-//! To read with file-based methods, you must add the `file_io` dependency to your Cargo.toml.
-//! For example:
-//!
-//! ```text
-//! c2pa = {version="0.32.0", features=["file_io"]}
-//! ```
+//! Some functionality requires you to enable specific crate features, 
+//! as noted in the documentation.
 //!
 //! The library has a new experimental Builder/Reader API that will eventually replace
 //! the existing methods of reading and writing C2PA data.


### PR DESCRIPTION
Clarify use of unstable_api feature flag in README and examples. 