### PR TITLE
export_schema: add unstable_api feature

### DIFF
--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.74.0"
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", features = ["json_schema"] }
+c2pa = { path = "../sdk", features = ["json_schema", "unstable_api"] }
 schemars = "0.8.21"
 serde_json = "1.0.117"


### PR DESCRIPTION
This is needed for
```
cargo install --git https://github.com/contentauth/c2pa-rs export_schema
```
to work, otherwise you get this error:
```
error[E0432]: unresolved import `c2pa::ManifestDefinition`
   --> export_schema/src/main.rs:4:32
    |
4   | use c2pa::{settings::Settings, ManifestDefinition, ManifestStore};
    |                                ^^^^^^^^^^^^^^^^^^
    |                                |
    |                                no `ManifestDefinition` in the root
    |                                help: a similar name exists in the module: `ManifestAssertion`
    |
note: found an item that was configured out
   --> /home/iameli/.cargo/git/checkouts/c2pa-rs-6dcfbef940eef094/345e24b/sdk/src/lib.rs:119:49
    |
119 | pub use builder::{AssertionDefinition, Builder, ManifestDefinition};
    |                                                 ^^^^^^^^^^^^^^^^^^
    = note: the item is gated behind the `unstable_api` feature

For more information about this error, try `rustc --explain E0432`.
error: could not compile `export_schema` (bin "export_schema") due to 1 previous error
```

And the `cargo install` method is a useful way to pull down the schema definitions into other language repositories, like the Go one I'm working on.
