### PR TITLE
feat: Add `Builder::from_manifest_def`

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -231,6 +231,13 @@ impl AsRef<Builder> for Builder {
 }
 
 impl Builder {
+    pub fn from_manifest_def(manifest_def: ManifestDefinition) -> Self {
+        Self {
+            definition: manifest_def,
+            ..Default::default()
+        }
+    }
+
     /// Creates a new builder from a JSON [`ManifestDefinition`] string.
     ///
     /// # Arguments
@@ -974,6 +981,22 @@ mod tests {
                 .into_owned(),
             b"12345"
         );
+    }
+
+    #[test]
+    fn test_from_manifest_def() {
+        let manifest_def = ManifestDefinition {
+            vendor: Some("test".to_string()),
+            title: Some("Test_Manifest".to_string()),
+            format: "image/tiff".to_string(),
+            instance_id: "1234".to_string(),
+            ..Default::default()
+        };
+        let builder = Builder::from_manifest_def(manifest_def);
+        assert_eq!(builder.definition.vendor, Some("test".to_string()));
+        assert_eq!(builder.definition.title, Some("Test_Manifest".to_string()));
+        assert_eq!(builder.definition.format, "image/tiff".to_string());
+        assert_eq!(builder.definition.instance_id, "1234".to_string());
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request
Adds `Builder::from_manifest_def` to construct a `Builder` from a `ManifestDefinition`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
