### PR TITLE
(IGNORE) Re-upgrade async-generic to 1.1

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -65,7 +65,7 @@ crate-type = ["lib"]
 
 [dependencies]
 asn1-rs = "0.5.2"
-async-generic = "0.1.2"
+async-generic = "1.1"
 async-recursion = "1.1.1"
 async-trait = { version = "0.1.77" }
 atree = "0.5.2"


### PR DESCRIPTION
This was (inadvertently?) reverted to an older version in #529.