### PR TITLE
using send_bytes instead of send to ensure Content-Length header is sent

### DIFF
--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -133,8 +133,6 @@ fn time_stamp_request_http(
         .encode_ref()
         .write_encoded(bcder::Mode::Der, &mut body)?;
 
-    let body_reader = std::io::Cursor::new(body);
-
     let mut req = ureq::post(url);
 
     if let Some(headers) = headers {
@@ -145,7 +143,7 @@ fn time_stamp_request_http(
 
     let response = req
         .set("Content-Type", HTTP_CONTENT_TYPE_REQUEST)
-        .send(body_reader)
+        .send_bytes(&body)
         .map_err(|_err| Error::CoseTimeStampGeneration)?;
 
     if response.status() == 200 && response.content_type() == HTTP_CONTENT_TYPE_RESPONSE {


### PR DESCRIPTION


## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x ] This PR represents a single feature, fix, or change.
- [ x] All applicable changes have been documented.
- [ x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
