### PR TITLE
feat: Add `get_provenance_cert_chain` to `Reader`

### DIFF
--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -168,6 +168,11 @@ impl Reader {
         self.manifest_store.to_string()
     }
 
+    /// Return certificate chain for the provenance claim
+    pub fn get_provenance_cert_chain(&self) -> Result<String> {
+        self.manifest_store.store().get_provenance_cert_chain()
+    }
+
     /// Get the [`ValidationStatus`] array of the manifest store if it exists.
     ///
     /// This validation report only includes error statuses on applied to the active manifest.


### PR DESCRIPTION
I found myself needing to inspect the cert chain present in a C2PA asset over in [c2pa-go](https://github.com/aquareum-tv/c2pa-go). This reader interface seemed to be the only piece exposed in the UniFFI bindings, so I added a helper function here. I have no idea if I'm doing it the right way, but it does work.