### PR TITLE
EC signature DER support

### DIFF
--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -183,6 +183,7 @@ pub(crate) fn cose_sign(signer: &dyn Signer, data: &[u8], box_size: usize) -> Re
         signer.sign(tbs).await?
     };
 
+    // fix up signatures that may be in the wrong format
     sign1.signature = match alg {
         SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
             if parse_ec_der_sig(&signature).is_ok() {

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -1073,13 +1073,9 @@ pub(crate) async fn verify_cose_async(
 
     // check signature format
     if let Err(e) = check_sig(&sign1.signature, alg) {
-        let log_item = log_item!(
-            "Cose_Sign1",
-            "unsupported signature format",
-            "verify_cose"
-        )
-        .error(Error::CoseSignatureAlgorithmNotSupported)
-        .validation_status(validation_status::SIGNING_CREDENTIAL_INVALID);
+        let log_item = log_item!("Cose_Sign1", "unsupported signature format", "verify_cose")
+            .error(Error::CoseSignatureAlgorithmNotSupported)
+            .validation_status(validation_status::SIGNING_CREDENTIAL_INVALID);
 
         validation_log.log(log_item, Some(e))?;
 
@@ -1277,13 +1273,9 @@ pub(crate) fn verify_cose(
 
     // check signature format
     if let Err(e) = check_sig(&sign1.signature, alg) {
-        let log_item = log_item!(
-            "Cose_Sign1",
-            "unsupported signature format",
-            "verify_cose"
-        )
-        .error(Error::CoseSignatureAlgorithmNotSupported)
-        .validation_status(validation_status::SIGNING_CREDENTIAL_INVALID);
+        let log_item = log_item!("Cose_Sign1", "unsupported signature format", "verify_cose")
+            .error(Error::CoseSignatureAlgorithmNotSupported)
+            .validation_status(validation_status::SIGNING_CREDENTIAL_INVALID);
 
         validation_log.log(log_item, Some(e))?;
 

--- a/sdk/src/openssl/ec_signer.rs
+++ b/sdk/src/openssl/ec_signer.rs
@@ -17,15 +17,12 @@ use openssl::{
     pkey::{PKey, Private},
     x509::X509,
 };
-use x509_parser::der_parser::{
-    self,
-    der::{parse_der_integer, parse_der_sequence_defined_g},
-};
 
 use super::check_chain_order;
 use crate::{
     error::{Error, Result},
     signer::ConfigurableSigner,
+    utils::sig_utils::der_to_p1363,
     Signer, SigningAlg,
 };
 
@@ -116,93 +113,6 @@ impl Signer for EcSigner {
     fn reserve_size(&self) -> usize {
         1024 + self.certs_size + self.timestamp_size // the Cose_Sign1 contains complete certs and timestamps so account for size
     }
-}
-
-// C2PA use P1363 format for EC signatures so we must
-// convert from ASN.1 DER to IEEE P1363 format to verify.
-struct ECSigComps<'a> {
-    r: &'a [u8],
-    s: &'a [u8],
-}
-
-fn parse_ec_sig(data: &[u8]) -> der_parser::error::BerResult<ECSigComps> {
-    // IMPORTANT: OpenSslMutex::acquire() should have been called by calling fn.
-    // Please don't make this pub or pub(crate) without finding a way to ensure
-    // that precondition.
-
-    parse_der_sequence_defined_g(|content: &[u8], _| {
-        let (rem1, r) = parse_der_integer(content)?;
-        let (_rem2, s) = parse_der_integer(rem1)?;
-
-        Ok((
-            data,
-            ECSigComps {
-                r: r.as_slice()?,
-                s: s.as_slice()?,
-            },
-        ))
-    })(data)
-}
-
-fn der_to_p1363(data: &[u8], alg: SigningAlg) -> Result<Vec<u8>> {
-    // IMPORTANT: OpenSslMutex::acquire() should have been called by calling fn.
-    // Please don't make this pub or pub(crate) without finding a way to ensure
-    // that precondition.
-
-    // P1363 format: r | s
-
-    let (_, p) = parse_ec_sig(data).map_err(|_err| Error::InvalidEcdsaSignature)?;
-
-    let mut r = extfmt::Hexlify(p.r).to_string();
-    let mut s = extfmt::Hexlify(p.s).to_string();
-
-    let sig_len: usize = match alg {
-        SigningAlg::Es256 => 64,
-        SigningAlg::Es384 => 96,
-        SigningAlg::Es512 => 132,
-        _ => return Err(Error::UnsupportedType),
-    };
-
-    // pad or truncate as needed
-    let rp = if r.len() > sig_len {
-        // truncate
-        let offset = r.len() - sig_len;
-        &r[offset..r.len()]
-    } else {
-        // pad
-        while r.len() != sig_len {
-            r.insert(0, '0');
-        }
-        r.as_ref()
-    };
-
-    let sp = if s.len() > sig_len {
-        // truncate
-        let offset = s.len() - sig_len;
-        &s[offset..s.len()]
-    } else {
-        // pad
-        while s.len() != sig_len {
-            s.insert(0, '0');
-        }
-        s.as_ref()
-    };
-
-    if rp.len() != sig_len || rp.len() != sp.len() {
-        return Err(Error::InvalidEcdsaSignature);
-    }
-
-    // merge r and s strings
-    let mut new_sig = rp.to_string();
-    new_sig.push_str(sp);
-
-    // convert back from hex string to byte array
-    (0..new_sig.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&new_sig[i..i + 2], 16).map_err(|_err| Error::InvalidEcdsaSignature)
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod merkle;
 pub(crate) mod mime;
 #[allow(dead_code)] // for wasm build
 pub(crate) mod patch;
+pub(crate) mod sig_utils;
 #[cfg(feature = "add_thumbnails")]
 pub(crate) mod thumbnail;
 pub(crate) mod time_it;

--- a/sdk/src/utils/sig_utils.rs
+++ b/sdk/src/utils/sig_utils.rs
@@ -1,0 +1,95 @@
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use x509_parser::der_parser::{self, der::parse_der_integer};
+
+use crate::{Error, Result, SigningAlg};
+
+// C2PA use P1363 format for EC signatures so we must
+// convert from ASN.1 DER to IEEE P1363 format to verify.
+pub(crate) struct ECSigComps<'a> {
+    r: &'a [u8],
+    s: &'a [u8],
+}
+
+pub(crate) fn parse_ec_der_sig(data: &[u8]) -> der_parser::error::BerResult<ECSigComps> {
+    x509_parser::der_parser::der::parse_der_sequence_defined_g(|content: &[u8], _| {
+        let (rem1, r) = parse_der_integer(content)?;
+        let (_rem2, s) = parse_der_integer(rem1)?;
+
+        Ok((
+            data,
+            ECSigComps {
+                r: r.as_slice()?,
+                s: s.as_slice()?,
+            },
+        ))
+    })(data)
+}
+
+pub(crate) fn der_to_p1363(data: &[u8], alg: SigningAlg) -> Result<Vec<u8>> {
+    // P1363 format: r | s
+
+    let (_, p) = parse_ec_der_sig(data).map_err(|_err| Error::InvalidEcdsaSignature)?;
+
+    let mut r = extfmt::Hexlify(p.r).to_string();
+    let mut s = extfmt::Hexlify(p.s).to_string();
+
+    let sig_len: usize = match alg {
+        SigningAlg::Es256 => 64,
+        SigningAlg::Es384 => 96,
+        SigningAlg::Es512 => 132,
+        _ => return Err(Error::UnsupportedType),
+    };
+
+    // pad or truncate as needed
+    let rp = if r.len() > sig_len {
+        // truncate
+        let offset = r.len() - sig_len;
+        &r[offset..r.len()]
+    } else {
+        // pad
+        while r.len() != sig_len {
+            r.insert(0, '0');
+        }
+        r.as_ref()
+    };
+
+    let sp = if s.len() > sig_len {
+        // truncate
+        let offset = s.len() - sig_len;
+        &s[offset..s.len()]
+    } else {
+        // pad
+        while s.len() != sig_len {
+            s.insert(0, '0');
+        }
+        s.as_ref()
+    };
+
+    if rp.len() != sig_len || rp.len() != sp.len() {
+        return Err(Error::InvalidEcdsaSignature);
+    }
+
+    // merge r and s strings
+    let mut new_sig = rp.to_string();
+    new_sig.push_str(sp);
+
+    // convert back from hex string to byte array
+    (0..new_sig.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&new_sig[i..i + 2], 16).map_err(|_err| Error::InvalidEcdsaSignature)
+        })
+        .collect()
+}


### PR DESCRIPTION
## Changes in this pull request
If an external signer returns an EC signature in DER format convert it.
During validation return an error when we encounter an EC signature in the wrong format.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
