### PR TITLE
fix: requires "StatusTracker" to implement "Send"

### DIFF
--- a/sdk/src/status_tracker.rs
+++ b/sdk/src/status_tracker.rs
@@ -69,7 +69,7 @@ impl LogItem {
     }
 }
 
-pub trait StatusTracker {
+pub trait StatusTracker: Send {
     // should we stop on the first error
     fn stop_on_error(&self) -> bool;
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1382,7 +1382,8 @@ impl Store {
     }
 
     // wake the ingredients and validate
-    #[async_recursion(?Send)]
+    #[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
     async fn ingredient_checks_async(
         store: &Store,
         claim: &Claim,
@@ -1428,7 +1429,7 @@ impl Store {
                     }
 
                     let check_ingredient_trust: bool =
-                        crate::settings::get_settings_value("verify.check_ingredient_trust")?;
+                        get_settings_value("verify.check_ingredient_trust")?;
 
                     // verify the ingredient claim
                     Claim::verify_claim_async(


### PR DESCRIPTION
## Changes in this pull request
This PR requires `StatusTracker` implementations to implement the `Send` trait. This is required because c2pa-node is calling the function 
`Ingredient::from_manifest_and_asset_bytes_async`, which eventually calls `Store::ingredient_checks_async` in c2pa-rs. 

Marking the `Store::ingredient_checks_async` as not `Sync` with the `#[async_recursion(?Send)]` macro is preventing calls to `Store::ingredient_checks_async` with Tokio via the `tokio::spawn` function call. 

Another approach to this may be to only mark the `Store::ingredient_checks_async` 's status tracker argument, and all of its callers in c2pa-rs as `Send`. Something like this: `&mut (impl StatusTracker + Send)`. 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
