### PR TITLE
fix: Write absolute urls to manifest store resource references.

### DIFF
--- a/make_test_images/src/compare_manifests.rs
+++ b/make_test_images/src/compare_manifests.rs
@@ -183,7 +183,10 @@ fn compare_json_values(
                 || path.ends_with(".instanceId")
                 || path.ends_with(".time")
                 || path.contains(".hash")
-                || val1.is_string() && val2.is_string() && val1.to_string().contains(":urn:uuid:"))
+                || val1.is_string()
+                    && val2.is_string()
+                    && (val1.to_string().contains(":urn:uuid:")
+                        || val2.to_string().contains(":urn:uuid:")))
             {
                 if val2.is_null() {
                     issues.push(format!("Missing {}: {}", path, val1));

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1595,4 +1595,205 @@ mod tests {
             "image/jpeg",
         );
     }
+
+    #[cfg(feature = "file_io")]
+    const MANIFEST_JSON: &str = r#"{
+        "claim_generator": "test",
+        "claim_generator_info": [
+            {
+                "name": "test",
+                "version": "1.0",
+                "icon": {
+                    "format": "image/svg+xml",
+                    "identifier": "sample1.svg"
+                }
+            }
+        ],
+        "metadata": [
+            {
+                "dateTime": "1985-04-12T23:20:50.52Z",
+                "my_metadata": "some custom response"
+            }
+        ],
+        "format" : "image/jpeg",
+        "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "IMG_0003.jpg"
+        },
+        "assertions": [
+            {
+                "label": "c2pa.actions.v2",
+                "data": {
+                    "actions": [
+                        {
+                            "action": "c2pa.opened",
+                            "instanceId": "xmp.iid:7b57930e-2f23-47fc-affe-0400d70b738d",
+                            "parameters": {
+                                "description": "import"
+                            },
+                            "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia",
+                            "softwareAgent": {
+                                "name": "TestApp",
+                                "version": "1.0",
+                                "icon": {
+                                    "format": "image/svg+xml",
+                                    "identifier": "sample1.svg"
+                                },
+                                "something": "else"
+                            },
+                            "changes": [
+                                {
+                                    "region" : [
+                                        {
+                                            "type" : "temporal",
+                                            "time" : {}
+                                        }
+                                    ],
+                                    "description": "lip synced area"
+                                }
+                            ]
+                        }
+                    ],
+                    "templates": [
+                        {
+                            "action": "c2pa.opened",
+                            "softwareAgent": {
+                                "name": "TestApp",
+                                "version": "1.0",
+                                "icon": {
+                                    "format": "image/svg+xml",
+                                    "identifier": "sample1.svg"
+                                },
+                                "something": "else"
+                            },
+                            "icon": {
+                                "format": "image/svg+xml",
+                                "identifier": "sample1.svg"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "ingredients": [{
+            "title": "A.jpg",
+            "format": "image/jpeg",
+            "document_id": "xmp.did:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+            "relationship": "parentOf",
+            "thumbnail": {
+                "format": "image/png",
+                "identifier": "exp-test1.png"
+            }
+        },
+        {
+            "title": "prompt",
+            "format": "text/plain",
+            "relationship": "inputTo",
+            "data": {
+                "format": "text/plain",
+                "identifier": "prompt.txt",
+                "data_types": [
+                    {
+                    "type": "c2pa.types.generator.prompt"
+                    }
+                ]
+            }
+        },
+        {
+            "title": "Custom AI Model",
+            "format": "application/octet-stream",
+            "relationship": "inputTo",
+            "data_types": [
+                {
+                    "type": "c2pa.types.model"
+                }
+            ]
+          }
+        ]
+    }"#;
+
+    #[test]
+    #[cfg(feature = "openssl_sign")]
+    /// tests and illustrates how to add assets to a non-file based manifest by using a stream
+    fn from_json_with_stream_full_resources() {
+        use crate::assertions::Relationship;
+
+        let mut builder = Builder::from_json(MANIFEST_JSON).unwrap();
+        // add binary resources to manifest and ingredients giving matching the identifiers given in JSON
+        builder
+            .add_resource("IMG_0003.jpg", Cursor::new(b"jpeg data"))
+            .unwrap()
+            .add_resource("sample1.svg", Cursor::new(b"svg data"))
+            .expect("add resource")
+            .add_resource("exp-test1.png", Cursor::new(b"png data"))
+            .expect("add_resource")
+            .add_resource("prompt.txt", Cursor::new(b"pirate with bird on shoulder"))
+            .expect("add_resource");
+
+        //println!("{builder}");
+
+        let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg");
+        // convert buffer to cursor with Read/Write/Seek capability
+        let mut input = Cursor::new(image.to_vec());
+
+        let signer = temp_signer();
+        // Embed a manifest using the signer.
+        let mut output = Cursor::new(Vec::new());
+        builder
+            .sign(signer.as_ref(), "jpeg", &mut input, &mut output)
+            .expect("builder sign");
+
+        output.set_position(0);
+        let reader = Reader::from_stream("jpeg", &mut output).expect("from_bytes");
+        println!("reader = {reader}");
+        let m = reader.active_manifest().unwrap();
+
+        //println!("after = {m}");
+
+        assert!(m.thumbnail().is_some());
+        assert!(m.thumbnail_ref().is_some());
+        assert_eq!(m.thumbnail_ref().unwrap().format, "image/jpeg");
+        let id = m.thumbnail_ref().unwrap().identifier.as_str();
+        let mut thumbnail_data = Cursor::new(Vec::new());
+        reader.resource_to_stream(id, &mut thumbnail_data).unwrap();
+        assert_eq!(thumbnail_data.into_inner(), b"jpeg data");
+
+        assert_eq!(m.ingredients().len(), 3);
+        // Validate a prompt ingredient (with data field)
+        let prompt = &m.ingredients()[1];
+        assert_eq!(prompt.title(), "prompt");
+        assert_eq!(prompt.relationship(), &Relationship::InputTo);
+        assert!(prompt.data_ref().is_some());
+        assert_eq!(prompt.data_ref().unwrap().format, "text/plain");
+        let id = prompt.data_ref().unwrap().identifier.as_str();
+        let mut prompt_data = Cursor::new(Vec::new());
+        reader.resource_to_stream(id, &mut prompt_data).unwrap();
+        assert_eq!(prompt_data.into_inner(), b"pirate with bird on shoulder");
+
+        // Validate a custom AI model ingredient.
+        assert_eq!(m.ingredients()[2].title(), "Custom AI Model");
+        assert_eq!(m.ingredients()[2].relationship(), &Relationship::InputTo);
+        assert_eq!(
+            m.ingredients()[2].data_types().unwrap()[0].asset_type,
+            "c2pa.types.model"
+        );
+
+        // validate the claim_generator_info
+        let cgi = m.claim_generator_info.as_ref().unwrap();
+        assert_eq!(cgi[0].name, "test");
+        assert_eq!(cgi[0].version.as_ref().unwrap(), "1.0");
+        match cgi[0].icon().unwrap() {
+            crate::resource_store::UriOrResource::ResourceRef(resource) => {
+                assert_eq!(resource.format, "image/svg+xml");
+                let mut icon_data = Cursor::new(Vec::new());
+                reader
+                    .resource_to_stream(&resource.identifier, &mut icon_data)
+                    .unwrap();
+                assert_eq!(icon_data.into_inner(), b"svg data");
+            }
+            _ => unreachable!(),
+        }
+
+        // println!("{manifest_store}");
+    }
 }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -34,7 +34,7 @@ use crate::{
     error::{Error, Result},
     hashed_uri::HashedUri,
     ingredient::Ingredient,
-    jumbf,
+    jumbf::labels::{assertion_label_from_uri, to_absolute_uri, to_assertion_uri},
     manifest_assertion::ManifestAssertion,
     resource_store::{mime_from_uri, skip_serializing_resources, ResourceRef, ResourceStore},
     salt::DefaultSalt,
@@ -576,7 +576,7 @@ impl Manifest {
 
         manifest.redactions = claim.redactions().map(|rs| {
             rs.iter()
-                .filter_map(|r| jumbf::labels::assertion_label_from_uri(r))
+                .filter_map(|r| assertion_label_from_uri(r))
                 .collect()
         });
 
@@ -591,14 +591,14 @@ impl Manifest {
             .iter()
             .map(|h| {
                 let alg = h.alg().or_else(|| Some(claim.alg().to_string()));
-                HashedUri::new(h.url(), alg, &h.hash())
+                let url = to_absolute_uri(claim.label(), &h.url());
+                HashedUri::new(url, alg, &h.hash())
             })
             .collect();
 
         for assertion in claim.assertions() {
-            let claim_assertion = store.get_claim_assertion_from_uri(
-                &jumbf::labels::to_absolute_uri(claim.label(), &assertion.url()),
-            )?;
+            let claim_assertion = store
+                .get_claim_assertion_from_uri(&to_absolute_uri(claim.label(), &assertion.url()))?;
             let assertion = claim_assertion.assertion();
             let label = claim_assertion.label();
             let base_label = assertion.label();
@@ -649,7 +649,7 @@ impl Manifest {
                 }
                 base if base.starts_with(labels::INGREDIENT) => {
                     // note that we use the original label here, not the base label
-                    let assertion_uri = jumbf::labels::to_assertion_uri(claim.label(), &label);
+                    let assertion_uri = to_assertion_uri(claim.label(), &label);
                     let ingredient = Ingredient::from_ingredient_uri(
                         store,
                         manifest_label,
@@ -664,8 +664,8 @@ impl Manifest {
                 }
                 label if label.starts_with(labels::CLAIM_THUMBNAIL) => {
                     let thumbnail = Thumbnail::from_assertion(assertion)?;
-                    let id = jumbf::labels::to_assertion_uri(claim.label(), label);
-                    let id = jumbf::labels::to_relative_uri(&id);
+                    let id = to_assertion_uri(claim.label(), label);
+                    //let id = jumbf::labels::to_relative_uri(&id);
                     manifest.thumbnail = Some(manifest.resources.add_uri(
                         &id,
                         &thumbnail.content_type,

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -302,3 +302,21 @@ fn test_reader_from_file_nested_errors() -> Result<()> {
     assert_eq!(reader.manifest_store.manifests().len(), 3);
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "file_io")]
+#[allow(clippy::unwrap_used)]
+/// Test that the reader can validate a file with nested assertion errors
+fn test_reader_nested_resource() -> Result<()> {
+    let reader = Reader::from_file("tests/fixtures/CACAE-uri-CA.jpg")?;
+    println!("{reader}");
+    assert_eq!(reader.validation_status(), None);
+    assert_eq!(reader.manifest_store.manifests().len(), 3);
+    let manifest = reader.active_manifest().unwrap();
+    let ingredient = manifest.ingredients().iter().next().unwrap();
+    let uri = ingredient.thumbnail_ref().unwrap().identifier.clone();
+    let mut stream = std::io::Cursor::new(Vec::new());
+    let bytes_written = reader.resource_to_stream(&uri, &mut stream)?;
+    assert_eq!(bytes_written, 41810);
+    Ok(())
+}

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -32,7 +32,7 @@ use crate::{
     assertions::{labels, AssetType},
     claim::Claim,
     hashed_uri::HashedUri,
-    jumbf::labels::assertion_label_from_uri,
+    jumbf::labels::{assertion_label_from_uri, to_absolute_uri},
     Error, Result,
 };
 
@@ -75,8 +75,9 @@ impl UriOrResource {
             UriOrResource::ResourceRef(r) => Ok(UriOrResource::ResourceRef(r.clone())),
             UriOrResource::HashedUri(h) => {
                 let data_box = claim.get_databox(h).ok_or(Error::MissingDataBox)?;
+                let url = to_absolute_uri(claim.label(), &h.url());
                 let resource_ref =
-                    resources.add_with(&h.url(), &data_box.format, data_box.data.clone())?;
+                    resources.add_with(&url, &data_box.format, data_box.data.clone())?;
                 Ok(UriOrResource::ResourceRef(resource_ref))
             }
         }

--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -194,8 +194,7 @@ pub fn status_for_store(
                             if let Some(url) = &status.url {
                                 if url.starts_with("self#jumbf") {
                                     // Some are just labels (i.e. "Cose_Sign1")
-                                    status.url =
-                                        Some(dbg!(jumbf::labels::to_absolute_uri(&label, url)));
+                                    status.url = Some(jumbf::labels::to_absolute_uri(&label, url));
                                 }
                             }
                         }

--- a/sdk/tests/common/compare_readers.rs
+++ b/sdk/tests/common/compare_readers.rs
@@ -165,6 +165,7 @@ fn compare_json_values(
         (val1, val2) if val1 != val2 => {
             if !(path.ends_with(".instance_id")
                 || path.ends_with(".instanceId")
+                || path.ends_with(".identifier")
                 || path.ends_with(".time")
                 || path.contains(".hash")
                 || path.contains("claim_generator")  // changes with every version (todo: get more specific)

--- a/sdk/tests/known_good/C.json
+++ b/sdk/tests/known_good/C.json
@@ -18,7 +18,7 @@
       "instance_id": "xmp:iid:22704d84-c37f-4733-a207-56c4c2e67b1a",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg"
+        "identifier": "self#jumbf=/c2pa/contentauth:urn:uuid:b2b1f7fa-b119-4de1-9c0d-c97fbea3f2c3/c2pa.assertions/c2pa.thumbnail.claim.jpeg"
       },
       "ingredients": [],
       "assertions": [

--- a/sdk/tests/known_good/CA.json
+++ b/sdk/tests/known_good/CA.json
@@ -18,7 +18,7 @@
       "instance_id": "xmp:iid:ba572347-db0e-4619-b6eb-d38e487da238",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg"
+        "identifier": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg"
       },
       "ingredients": [
         {

--- a/sdk/tests/known_good/XCA.json
+++ b/sdk/tests/known_good/XCA.json
@@ -18,7 +18,7 @@
       "instance_id": "xmp:iid:ba572347-db0e-4619-b6eb-d38e487da238",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg"
+        "identifier": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg"
       },
       "ingredients": [
         {


### PR DESCRIPTION
Write absolute urls to manifest store resource references
Also match on either an absolute or relative reference. This allows Reader.resource_to_stream to read resources from nested manifests. Updates tests to ignore relative/absolute changes in urls. Adds from_json_with_stream_full_resources() Builder unit test.


