### PR TITLE
fix: Make sure RSTn segment names are including in the data box hashes list

### DIFF
--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -941,7 +941,18 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
 
                 box_maps.push(bm);
             }
-            jfifdump::SegmentKind::Rst(_r) => (),
+            jfifdump::SegmentKind::Rst(r) => {
+                let bm = BoxMap {
+                    names: vec![format!("RST{}", r.nr)],
+                    alg: None,
+                    hash: ByteBuf::from(Vec::new()),
+                    pad: ByteBuf::from(Vec::new()),
+                    range_start: seg.position,
+                    range_len: 0,
+                };
+
+                box_maps.push(bm);
+            }
             jfifdump::SegmentKind::Comment(_) => {
                 let bm = BoxMap {
                     names: vec!["COM".to_string()],


### PR DESCRIPTION
## Changes in this pull request
RSTn segments were not being including in the list of box hash names.  This PR makes sure that are including in the list

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
