### PR TITLE
fix: Harden SDK against attempting buffers that are too large

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -293,6 +293,12 @@ pub enum Error {
 
     #[error("prerelease content detected")]
     PrereleaseError,
+
+    #[error("insufficient memory space for operation")]
+    InsufficientMemory,
+
+    #[error("parameters our of range")]
+    OutOfRange,
 }
 
 /// A specialized `Result` type for C2PA toolkit operations.

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -297,7 +297,7 @@ pub enum Error {
     #[error("insufficient memory space for operation")]
     InsufficientMemory,
 
-    #[error("parameters our of range")]
+    #[error("parameters out of range")]
     OutOfRange,
 }
 


### PR DESCRIPTION
## Changes in this pull request
vec! will panic if the requested size is beyond the available memory limits.  This PR makes sure that user supplied values use a safer way to allocate than vec!.  It also adds a safe single line implementation of the common pattern:

let mut data = vec![0u8; data_len];
reader.read_exact(&mut data)?;

changes to:

let data = reader.read_to_vec(data_len)?;

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
