### PR TITLE
fix: Fixed a typo in ManifestDefinition docstring

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -62,7 +62,7 @@ pub struct ManifestDefinition {
     /// This is typically Internet domain name for the vendor (i.e. `adobe`)
     pub vendor: Option<String>,
 
-    /// Clam Generator Info is always required with at least one entry
+    /// Claim Generator Info is always required with at least one entry
     #[serde(default = "default_claim_generator_info")]
     pub claim_generator_info: Vec<ClaimGeneratorInfo>,
 


### PR DESCRIPTION
## Changes in this pull request
Fixed a typo in a docstring, from ClamDefinition to ClaimDefinition

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
