### PR TITLE
chore: release v0.1.1

### DIFF
--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.0...cawg-identity-v0.1.1)
+_24 October 2024_
+
+### Fixed
+
+* Tweak changelog format
+
 ## [0.1.0](https://github.com/contentauth/c2pa-rs/releases/tag/cawg-identity-v0.1.0)
 _24 October 2024_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.1.0"
+version = "0.1.1"
 description = "Implementation of CAWG identity assertion specification"
 authors = [
     "Eric Scouten <scouten@adobe.com>",

--- a/crypto/CHANGELOG.md
+++ b/crypto/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.0...c2pa-crypto-v0.1.1)
+_24 October 2024_
+
+### Fixed
+
+* Tweak changelog format
+
 ## [0.1.0](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-crypto-v0.1.0)
 _24 October 2024_
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.1.0"
+version = "0.1.1"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `c2pa-crypto`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.0...cawg-identity-v0.1.1)

_24 October 2024_

### Fixed

* Tweak changelog format
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.0...c2pa-crypto-v0.1.1)

_24 October 2024_

### Fixed

* Tweak changelog format
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).