### PR TITLE
fix: Add temporary exemption for `instant` crate (no longer maintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,8 @@ yanked = "deny"
 
 ignore = [
   "RUSTSEC-2021-0127", # serde_cbor
-  "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
+  "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104),
+  "RUSTSEC-2024-0384", # instant (https://github.com/contentauth/c2pa-rs/issues/663)
 ]
 
 [bans]


### PR DESCRIPTION
We should replace `instant` with `web_time` as called for in #663.

This is a temporary exemption for [RUSTSEC-2024-0384](https://rustsec.org/advisories/RUSTSEC-2024-0384).