### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)
+_05 December 2024_
+
+### Added
+
+* Move time stamp code into c2pa-crypto ([#696](https://github.com/contentauth/c2pa-rs/pull/696))
+* Adds ValidationState support ([#701](https://github.com/contentauth/c2pa-rs/pull/701))
+* Introduce `DynamicAssertion` trait ([#566](https://github.com/contentauth/c2pa-rs/pull/566))
+
+### Fixed
+
+* Add support for MP3 without ID3 header ([#652](https://github.com/contentauth/c2pa-rs/pull/652))
+* Treat Unicode-3.0 license as approved; unpin related dependencies ([#693](https://github.com/contentauth/c2pa-rs/pull/693))
+* Remote manifest fetch test was not using full path ([#675](https://github.com/contentauth/c2pa-rs/pull/675))
+* Fix [#624](https://github.com/contentauth/c2pa-rs/pull/624) (edge cases when combining the box hashes) ([#625](https://github.com/contentauth/c2pa-rs/pull/625))
+* For Issue 672, Callback is unsound ([#674](https://github.com/contentauth/c2pa-rs/pull/674))
+* For Issue 672, Callback is unsound
+* Support "remote_manifest_fetch" verify setting ([#667](https://github.com/contentauth/c2pa-rs/pull/667))
+
 ## [0.39.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.38.0...c2pa-v0.39.0)
 _13 November 2024_
 

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)
+_05 December 2024_
+
+### Added
+
+* Move time stamp code into c2pa-crypto ([#696](https://github.com/contentauth/c2pa-rs/pull/696))
+
+### Fixed
+
+* Treat Unicode-3.0 license as approved; unpin related dependencies ([#693](https://github.com/contentauth/c2pa-rs/pull/693))
+
 ## [0.1.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.1...c2pa-crypto-v0.1.2)
 _24 October 2024_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.1.2"
+version = "0.2.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.39.0"
+version = "0.40.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -73,7 +73,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.1.2" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.1.0" }
 chrono = { version = "0.4.38", default-features = false, features = [
     "serde",


### PR DESCRIPTION
## 🤖 New release
* `c2pa`: 0.39.0 -> 0.40.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.1.2 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `c2pa` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa::SigningAlg, previously in file /tmp/.tmpfjkixi/c2pa/src/signing_alg.rs:31

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function c2pa::validation_status::is_success, previously in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:510

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  ASSERTION_INACCESSIBLE in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:406
  ASSERTION_CBOR_INVALID in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:432
  ALGORITHM_UNSUPPORTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:486
  MANIFEST_INACCESSIBLE in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:329
  TIMESTAMP_OUTSIDE_VALIDITY in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:383
  ACTION_ASSERTION_REDACTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:444
  ASSERTION_BMFFHASH_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:456
  CLAIM_SIGNATURE_VALIDATED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:235
  ASSERTION_REQUIRED_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:422
  MANIFEST_MULTIPLE_PARENTS in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:335
  SIGNING_CREDENTIAL_REVOKED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:362
  CLAIM_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:282
  ASSERTION_NOT_REDACTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:412
  GENERAL_ERROR in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:491
  TIMESTAMP_TRUSTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:245
  ASSERTION_BMFFHASH_MATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:263
  HARD_BINDINGS_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:292
  TIMESTAMP_UNTRUSTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:377
  ASSERTION_SELF_REDACTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:417
  CLAIM_SIGNATURE_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:315
  SIGNING_CREDENTIAL_INVALID in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:357
  ASSERTION_CLOUD_DATA_ACTIONS in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:479
  CLAIM_MULTIPLE in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:287
  CLAIM_SIGNATURE_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:321
  TIMESTAMP_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:372
  ASSERTION_BOXHASH_MATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:269
  SIGNING_CREDENTIAL_TRUSTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:240
  CLAIM_CBOR_INVALID in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:302
  ASSERTION_DATAHASH_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:450
  SIGNING_CREDENTIAL_UNTRUSTED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:352
  ASSERTION_DATAHASH_MATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:257
  ASSERTION_HASHEDURI_MATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:251
  ASSERTION_HASHEDURI_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:389
  MANIFEST_UPDATE_WRONG_PARENTS in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:347
  ASSERTION_BOXHASH_UNKNOWN in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:468
  INGREDIENT_HASHEDURI_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:309
  ASSERTION_UNDECLARED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:401
  ASSERTION_BOXHASH_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:462
  CLAIM_REQUIRED_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:297
  MANIFEST_UPDATE_INVALID in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:341
  ASSERTION_MISSING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:395
  SIGNING_CREDENTIAL_EXPIRED in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:367
  ASSERTION_JSON_INVALID in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:427
  ASSERTION_CLOUD_DATA_HARD_BINDING in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:473
  ASSERTION_ACCESSIBLE in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:275
  ACTION_ASSERTION_INGREDIENT_MISMATCH in file /tmp/.tmpfjkixi/c2pa/src/validation_status.rs:438

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait c2pa::Signer gained TimeStampProvider in file /tmp/.tmpkk437k/c2pa-rs/sdk/src/signer.rs:23
  trait c2pa::AsyncSigner gained AsyncTimeStampProvider in file /tmp/.tmpkk437k/c2pa-rs/sdk/src/signer.rs:97

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_missing.ron

Failed in:
  method time_authority_url of trait AsyncSigner, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:143
  method timestamp_request_headers of trait AsyncSigner, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:151
  method timestamp_request_body of trait AsyncSigner, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:155
  method send_timestamp_request of trait AsyncSigner, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:166
  method time_authority_url of trait Signer, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:33
  method timestamp_request_headers of trait Signer, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:41
  method timestamp_request_body of trait Signer, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:45
  method send_timestamp_request of trait Signer, previously in file /tmp/.tmpfjkixi/c2pa/src/signer.rs:57
```

### ⚠️ `c2pa-crypto` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function c2pa_crypto::does_nothing_yet, previously in file /tmp/.tmpfjkixi/c2pa-crypto/src/lib.rs:2
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`
<blockquote>

## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)

_05 December 2024_

### Added

* Move time stamp code into c2pa-crypto ([#696](https://github.com/contentauth/c2pa-rs/pull/696))
* Adds ValidationState support ([#701](https://github.com/contentauth/c2pa-rs/pull/701))
* Introduce `DynamicAssertion` trait ([#566](https://github.com/contentauth/c2pa-rs/pull/566))

### Fixed

* Add support for MP3 without ID3 header ([#652](https://github.com/contentauth/c2pa-rs/pull/652))
* Treat Unicode-3.0 license as approved; unpin related dependencies ([#693](https://github.com/contentauth/c2pa-rs/pull/693))
* Remote manifest fetch test was not using full path ([#675](https://github.com/contentauth/c2pa-rs/pull/675))
* Fix [#624](https://github.com/contentauth/c2pa-rs/pull/624) (edge cases when combining the box hashes) ([#625](https://github.com/contentauth/c2pa-rs/pull/625))
* For Issue 672, Callback is unsound ([#674](https://github.com/contentauth/c2pa-rs/pull/674))
* For Issue 672, Callback is unsound
* Support "remote_manifest_fetch" verify setting ([#667](https://github.com/contentauth/c2pa-rs/pull/667))
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)

_05 December 2024_

### Added

* Move time stamp code into c2pa-crypto ([#696](https://github.com/contentauth/c2pa-rs/pull/696))

### Fixed

* Treat Unicode-3.0 license as approved; unpin related dependencies ([#693](https://github.com/contentauth/c2pa-rs/pull/693))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).