### PR TITLE
Report OCSP revocation and update status in SignatureInfo

### DIFF
--- a/sdk/examples/v2show.rs
+++ b/sdk/examples/v2show.rs
@@ -57,6 +57,7 @@ fn main() -> Result<()> {
             Err(e) => Err(e),
         }?;
         println!("{reader}");
+        //println!("\n\n{:#?}", reader);
     } else {
         println!("Prints a manifest report (requires a file path argument)")
     }

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -965,6 +965,8 @@ pub(crate) async fn verify_cose_async(
     th: &dyn TrustHandlerConfig,
     validation_log: &mut impl StatusTracker,
 ) -> Result<ValidationInfo> {
+    let oscp_info = check_ocsp_status_async(&cose_bytes, &data, th, validation_log).await?;
+
     let mut sign1 = get_cose_sign1(&cose_bytes, &data, validation_log)?;
 
     let alg = match get_signing_alg(&sign1) {
@@ -1090,6 +1092,11 @@ pub(crate) async fn verify_cose_async(
 
         // return cert chain
         result.cert_chain = dump_cert_chain(&get_sign_certs(&sign1)?)?;
+
+        // return revocation status and update info
+        result.revocation_date = oscp_info.revoked_at;
+
+        result.ocsp_next_update = Some(oscp_info.next_update);
     }
 
     Ok(result)
@@ -1100,12 +1107,19 @@ pub(crate) async fn verify_cose_async(
 pub(crate) fn get_signing_info(
     cose_bytes: &[u8],
     data: &[u8],
+    th: &dyn TrustHandlerConfig,
     validation_log: &mut impl StatusTracker,
 ) -> ValidationInfo {
     let mut date = None;
     let mut issuer_org = None;
     let mut alg: Option<SigningAlg> = None;
     let mut cert_serial_number = None;
+
+    let (revocation_date, ocsp_next_update) =
+        match check_ocsp_status(cose_bytes, data, th, validation_log) {
+            Ok(oscp_info) => (oscp_info.revoked_at, Some(oscp_info.next_update)),
+            Err(_) => (None, None),
+        };
 
     let sign1 = match get_cose_sign1(cose_bytes, data, validation_log) {
         Ok(sign1) => {
@@ -1148,7 +1162,8 @@ pub(crate) fn get_signing_info(
         validated: false,
         cert_chain: certs,
         cert_serial_number,
-        revocation_status: None,
+        revocation_date,
+        ocsp_next_update,
     }
 }
 
@@ -1166,6 +1181,9 @@ pub(crate) fn verify_cose(
     th: &dyn TrustHandlerConfig,
     validation_log: &mut impl StatusTracker,
 ) -> Result<ValidationInfo> {
+    // check certificate revocation
+    let oscp_info = check_ocsp_status(cose_bytes, data, th, validation_log)?;
+
     let sign1 = get_cose_sign1(cose_bytes, data, validation_log)?;
 
     let alg = match get_signing_alg(&sign1) {
@@ -1275,7 +1293,9 @@ pub(crate) fn verify_cose(
             // return cert chain
             result.cert_chain = dump_cert_chain(&certs)?;
 
-            result.revocation_status = Some(true);
+            result.revocation_date = oscp_info.revoked_at;
+
+            result.ocsp_next_update = Some(oscp_info.next_update);
         }
         // Note: not adding validation_log entry here since caller will supply claim specific info to log
         Ok(())

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -701,9 +701,9 @@ impl Manifest {
 
         // get verified signing info
         let si = if _sync {
-            claim.signature_info()
+            claim.signature_info(store.trust_handler())
         } else {
-            claim.signature_info_async().await
+            claim.signature_info_async(store.trust_handler()).await
         };
 
         manifest.signature_info = match si {
@@ -714,7 +714,8 @@ impl Manifest {
                 cert_serial_number: signature_info.cert_serial_number.map(|s| s.to_string()),
                 cert_chain: String::from_utf8(signature_info.cert_chain)
                     .map_err(|_e| Error::CoseInvalidCert)?,
-                revocation_status: signature_info.revocation_status,
+                revocation_date: signature_info.revocation_date.map(|d| d.to_rfc3339()),
+                ocsp_next_update: signature_info.ocsp_next_update.map(|d| d.to_rfc3339()),
             }),
             None => None,
         };
@@ -1480,17 +1481,21 @@ pub struct SignatureInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time: Option<String>,
 
-    /// Revocation status of the certificate.
+    // The date the certificate was revoked.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revocation_status: Option<bool>,
+    pub revocation_date: Option<String>,
+
+    // The date the OCSP response should be updated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocsp_next_update: Option<String>,
 
     /// The cert chain for this claim.
     #[serde(skip)] // don't serialize this, let someone ask for it
-    cert_chain: String,
+    pub cert_chain: String,
 }
 
 impl SignatureInfo {
-    // returns the cert chain for this signature
+    /// Returns the cert chain for this signature.
     pub fn cert_chain(&self) -> &str {
         &self.cert_chain
     }

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -241,6 +241,14 @@ impl Reader {
         self.manifest_store.to_string()
     }
 
+    /// Get the manifest store as a Detailed JSON string
+    pub fn detailed_json(&self) -> Result<String> {
+        Ok(format!(
+            "{}",
+            ManifestStoreReport::from_store(self.manifest_store.store())?
+        ))
+    }
+
     /// Get the [`ValidationStatus`] array of the manifest store if it exists.
     /// Call this method to check for validation errors.
     ///
@@ -443,8 +451,20 @@ fn test_reader_nested_resource() -> Result<()> {
 /// Test that the reader can validate a file with nested assertion errors
 fn test_reader_to_folder() -> Result<()> {
     let reader = Reader::from_file("tests/fixtures/CACAE-uri-CA.jpg")?;
-    println!("{reader}");
+    //println!("{reader}");
     assert_eq!(reader.validation_status(), None);
     reader.to_folder("../target/reader_folder")?;
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "file_io")]
+#[allow(clippy::unwrap_used)]
+fn test_reader_detailed_json() -> Result<()> {
+    let reader = Reader::from_file("tests/fixtures/XCA.jpg")?;
+    assert!(reader.validation_status().is_some());
+    let detailed_json = reader.detailed_json().unwrap();
+    //println!("{}", detailed_json);
+    assert!(detailed_json.contains("assertion_store"));
     Ok(())
 }

--- a/sdk/src/validator.rs
+++ b/sdk/src/validator.rs
@@ -26,7 +26,8 @@ pub struct ValidationInfo {
     pub issuer_org: Option<String>,
     pub validated: bool,     // claim signature is valid
     pub cert_chain: Vec<u8>, // certificate chain used to validate signature
-    pub revocation_status: Option<bool>,
+    pub revocation_date: Option<DateTime<Utc>>,
+    pub ocsp_next_update: Option<DateTime<Utc>>,
 }
 
 /// Trait to support validating a signature against the provided data

--- a/sdk/tests/common/compare_readers.rs
+++ b/sdk/tests/common/compare_readers.rs
@@ -167,6 +167,7 @@ fn compare_json_values(
                 || path.ends_with(".instanceId")
                 || path.ends_with(".identifier")
                 || path.ends_with(".time")
+                || path.contains(".ocsp_next_update")
                 || path.contains(".hash")
                 || path.contains("claim_generator")  // changes with every version (todo: get more specific)
                 || val1.is_string() && val2.is_string() && val1.to_string().contains("urn:uuid:"))

--- a/sdk/tests/known_good/C.json
+++ b/sdk/tests/known_good/C.json
@@ -56,7 +56,8 @@
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2024-08-06T21:53:37+00:00"
+        "time": "2024-08-06T21:53:37+00:00",
+        "ocsp_next_update": "2024-11-20T00:15:54.189494+00:00"
       },
       "label": "contentauth:urn:uuid:b2b1f7fa-b119-4de1-9c0d-c97fbea3f2c3"
     }

--- a/sdk/tests/known_good/CA.json
+++ b/sdk/tests/known_good/CA.json
@@ -76,7 +76,8 @@
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2024-08-06T21:53:37+00:00"
+        "time": "2024-08-06T21:53:37+00:00",
+        "ocsp_next_update": "2024-11-20T00:15:54.189494+00:00"
       },
       "label": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf"
     }

--- a/sdk/tests/known_good/CA_test.json
+++ b/sdk/tests/known_good/CA_test.json
@@ -41,7 +41,8 @@
       "signature_info": {
         "alg": "Ed25519",
         "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "638838410810235485828984295321338730070538954823"
+        "cert_serial_number": "638838410810235485828984295321338730070538954823",
+        "ocsp_next_update": "2024-11-20T00:15:54.189494+00:00"
       },
       "label": "urn:uuid:b6eb5aed-cc20-469f-b23a-88eb3b43775b"
     }

--- a/sdk/tests/known_good/XCA.json
+++ b/sdk/tests/known_good/XCA.json
@@ -76,7 +76,8 @@
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2024-08-06T21:53:37+00:00"
+        "time": "2024-08-06T21:53:37+00:00",
+        "ocsp_next_update": "2024-11-20T00:15:54.189494+00:00"
       },
       "label": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf"
     }


### PR DESCRIPTION
Add functionality to report OCSP revocation status and update information in the `SignatureInfo` structure. Introduce a new method `Reader.detailed_json()` for enhanced JSON output. Remove the obsolete `revocation_status` field and replace it with `revocation_date` and `ocsp_next_update`.