### PR TITLE
fix: Correct usage of `#[cfg]` directives

### DIFF
--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.76.0"
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", features = ["json_schema", "unstable_api"] }
+c2pa = { path = "../sdk", default-features = false, features = ["json_schema", "unstable_api"] }
 schemars = "0.8.21"
 serde_json = "1.0.117"

--- a/internal/crypto/src/lib.rs
+++ b/internal/crypto/src/lib.rs
@@ -26,11 +26,11 @@ pub(crate) mod internal;
 
 pub mod ocsp;
 
-#[cfg(all(feature = "openssl", not(target_arch = "wasm32")))]
-pub mod openssl;
-
 #[cfg(all(feature = "openssl", target_arch = "wasm32"))]
 compile_error!("OpenSSL feature is not compatible with WASM platform");
+
+#[cfg(feature = "openssl")]
+pub mod openssl;
 
 pub mod raw_signature;
 

--- a/internal/crypto/src/raw_signature/validator.rs
+++ b/internal/crypto/src/raw_signature/validator.rs
@@ -50,6 +50,7 @@ pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignature
         return Some(validator);
     }
 
+    let _ = alg; // mark as used if none are enabled
     None
 }
 

--- a/internal/crypto/src/tests/raw_signature/mod.rs
+++ b/internal/crypto/src/tests/raw_signature/mod.rs
@@ -11,4 +11,5 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#[cfg(any(target_arch = "wasm32", feature = "openssl"))]
 mod validator;

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -6,14 +6,13 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.76.0"
 
+[[bin]]
+name = "make_test_images"
+required-features = ["default"]
+
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", default-features = false, features = [
-	"file_io",
-	"openssl_sign",
-	"unstable_api",
-	"file_io",
-] }
+c2pa = { path = "../sdk", default-features = false, features = ["unstable_api"] }
 env_logger = "0.11"
 log = "0.4.8"
 image = { version = "0.25.2", default-features = false, features = [
@@ -26,3 +25,7 @@ regex = "1.5.6"
 serde = "1.0.197"
 serde_json = { version = "1.0.117", features = ["preserve_order"] }
 tempfile = "3.10.1"
+
+[features]
+# prevents these features from being always enabled in the workspace
+default = ["c2pa/openssl_sign", "c2pa/file_io"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -163,7 +163,7 @@ web-sys = { version = "0.3.58", features = [
 [dev-dependencies]
 anyhow = "1.0.40"
 mockall = "0.11.2"
-c2pa = { path = ".", features = [
+c2pa = { path = ".", default-features = false, features = [
     "unstable_api",
 ] } # allow integration tests to use the new API
 glob = "0.3.1"

--- a/sdk/examples/client/main.rs
+++ b/sdk/examples/client/main.rs
@@ -15,10 +15,10 @@ use anyhow::Result;
 // This example is not designed to work with a wasm build
 // so we provide this shell to avoid testing errors
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 mod client;
 fn main() -> Result<()> {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     client::main()?;
     Ok(())
 }

--- a/sdk/examples/data_hash.rs
+++ b/sdk/examples/data_hash.rs
@@ -20,13 +20,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(feature = "openssl_sign")]
+use c2pa::create_signer;
+
 #[cfg(not(target_arch = "wasm32"))]
 use c2pa::{
     assertions::{
         c2pa_action, labels::*, Action, Actions, CreativeWork, DataHash, Exif, SchemaDotOrgPerson,
     },
-    create_signer, hash_stream_by_alg, Builder, ClaimGeneratorInfo, HashRange, Ingredient, Reader,
-    Relationship, Result,
+    hash_stream_by_alg, Builder, ClaimGeneratorInfo, HashRange, Ingredient, Reader, Relationship,
+    Result,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use c2pa_crypto::SigningAlg;
@@ -34,16 +37,16 @@ use c2pa_crypto::SigningAlg;
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("DataHash demo");
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
     user_data_hash_with_sdk_hashing()?;
     println!("Done with SDK hashing1");
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
     user_data_hash_with_user_hashing()?;
     println!("Done with SDK hashing2");
     Ok(())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "file_io")]
 fn builder_from_source<S: AsRef<Path>>(source: S) -> Result<Builder> {
     let mut parent = Ingredient::from_file(source.as_ref())?;
     parent.set_relationship(Relationship::ParentOf);
@@ -86,7 +89,7 @@ fn builder_from_source<S: AsRef<Path>>(source: S) -> Result<Builder> {
     Ok(builder)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "openssl_sign", feature = "file_io"))]
 fn user_data_hash_with_sdk_hashing() -> Result<()> {
     // You will often implement your own Signer trait to perform on device signing
     let signcert_path = "sdk/tests/fixtures/certs/es256.pub";
@@ -146,7 +149,7 @@ fn user_data_hash_with_sdk_hashing() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "openssl_sign", feature = "file_io"))]
 fn user_data_hash_with_user_hashing() -> Result<()> {
     // You will often implement your own Signer trait to perform on device signing
     let signcert_path = "sdk/tests/fixtures/certs/es256.pub";

--- a/sdk/examples/show.rs
+++ b/sdk/examples/show.rs
@@ -15,7 +15,7 @@
 use anyhow::Result;
 use c2pa::Reader;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 {

--- a/sdk/examples/v2api.rs
+++ b/sdk/examples/v2api.rs
@@ -175,6 +175,7 @@ mod tests {
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
     async fn test_v2_api() -> Result<()> {
         main()
     }

--- a/sdk/examples/v2show.rs
+++ b/sdk/examples/v2show.rs
@@ -14,12 +14,12 @@
 //! Example App that generates a manifest store listing for a given file
 
 use anyhow::Result;
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(not(feature = "openssl"), target_arch = "wasm32"))]
 fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "openssl", not(target_arch = "wasm32")))]
 fn main() -> Result<()> {
     use std::io::Read;
 

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1258,7 +1258,7 @@ pub mod tests {
     //use super::*;
     use crate::utils::test::fixture_path;
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     #[test]
     fn test_fragemented_mp4() {
         use crate::{

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1853,8 +1853,7 @@ pub mod tests {
     use super::*;
     use crate::utils::test::{fixture_path, temp_dir_path};
 
-    #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(feature = "file_io")]
+    #[cfg(all(feature = "openssl", feature = "file_io"))]
     #[test]
     fn test_read_mp4() {
         use c2pa_status_tracker::DetailedStatusTracker;

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1261,6 +1261,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     fn test_builder_sign() {
         #[derive(Serialize, Deserialize)]
         struct TestAssertion {
@@ -1421,6 +1422,7 @@ mod tests {
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     async fn test_builder_remote_sign() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);
@@ -1458,7 +1460,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl_sign")]
     fn test_builder_remote_url() {
         let mut source = Cursor::new(TEST_IMAGE_CLEAN);
         let mut dest = Cursor::new(Vec::new());
@@ -1492,6 +1494,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     fn test_builder_data_hashed_embeddable() {
         const CLOUD_IMAGE: &[u8] = include_bytes!("../tests/fixtures/cloud.jpg");
         let mut input_stream = Cursor::new(CLOUD_IMAGE);
@@ -1552,6 +1555,7 @@ mod tests {
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(any(target_arch = "wasm32", all(feature = "openssl_sign", feature = "file_io")))]
     async fn test_builder_box_hashed_embeddable() {
         use crate::asset_io::{CAIWriter, HashBlockObjectType};
         const BOX_HASH_IMAGE: &[u8] = include_bytes!("../tests/fixtures/boxhash.jpg");
@@ -1655,7 +1659,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "openssl_sign")]
     const MANIFEST_JSON: &str = r#"{
         "claim_generator": "test",
         "claim_generator_info": [

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1980,7 +1980,7 @@ impl Claim {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 #[cfg(test)]
 pub mod tests {
     #![allow(clippy::expect_used)]

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -362,6 +362,7 @@ mod tests {
     use crate::{claim::Claim, utils::test::temp_signer};
 
     #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     fn test_sign_claim() {
         let mut claim = Claim::new("extern_sign_test", Some("contentauth"));
         claim.build().unwrap();
@@ -376,8 +377,7 @@ mod tests {
         assert_eq!(cose_sign1.len(), box_size);
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(feature = "openssl")]
+    #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
     #[actix::test]
     async fn test_sign_claim_async() {
         use crate::{

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -869,7 +869,7 @@ fn check_trust(
             verify_trust(th, chain_der, cert_der, signing_time_epoc)
         }
 
-        #[cfg(all(not(feature = "openssl"), not(target_arch = "wasm32")))]
+        #[cfg(not(any(feature = "openssl", target_arch = "wasm32")))]
         {
             Err(Error::NotImplemented(
                 "no trust handler for this feature".to_string(),
@@ -1380,7 +1380,7 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg(feature = "openssl_sign")]
+    #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
     fn test_cert_algorithms() {
         let cert_dir = crate::utils::test::fixture_path("certs");
         let th = crate::openssl::OpenSSLTrustHandlerConfig::new();

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1517,6 +1517,7 @@ mod tests {
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
     async fn test_stream_async_jpg() {
         let image_bytes = include_bytes!("../tests/fixtures/CA.jpg");
         let title = "Test Image";
@@ -1536,12 +1537,18 @@ mod tests {
             &"ingredient_from_memory_async:".into(),
             &ingredient.to_string().into(),
         );
-        assert!(ingredient.validation_status().is_none());
+        assert_eq!(None, ingredient.validation_status());
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    #[test]
+    #[cfg_attr(
+        any(
+            target_arch = "wasm32",
+            not(feature = "openssl")
+        ),
+        ignore
+    )]
     // Note this does not work from wasm32, due to validation issues
-    #[cfg(not(target_arch = "wasm32"))]
     fn test_stream_jpg() {
         let image_bytes = include_bytes!("../tests/fixtures/CA.jpg");
         let title = "Test Image";
@@ -1554,11 +1561,12 @@ mod tests {
         assert_eq!(ingredient.format(), format);
         assert!(ingredient.manifest_data().is_some());
         assert!(ingredient.metadata().is_none());
-        assert!(ingredient.validation_status().is_none());
+        assert_eq!(None, ingredient.validation_status());
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
     async fn test_stream_ogp() {
         let image_bytes = include_bytes!("../tests/fixtures/XCA.jpg");
         let title = "XCA.jpg";
@@ -1583,8 +1591,8 @@ mod tests {
     }
 
     #[allow(dead_code)]
-    #[cfg_attr(not(any(target_arch = "wasm32", feature = "file_io")), actix::test)]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
+    #[cfg_attr(not(all(feature = "openssl", feature = "fetch_remote_manifests")), ignore)]
     async fn test_jpg_cloud_from_memory() {
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
@@ -1597,7 +1605,7 @@ mod tests {
         assert!(ingredient.provenance().is_some());
         assert!(ingredient.provenance().unwrap().starts_with("https:"));
         assert!(ingredient.manifest_data().is_some());
-        assert!(ingredient.validation_status().is_none());
+        assert_eq!(None, ingredient.validation_status());
     }
 
     #[allow(dead_code)]
@@ -1624,6 +1632,7 @@ mod tests {
 
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
     async fn test_jpg_cloud_from_memory_and_manifest() {
         let asset_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let manifest_bytes = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");
@@ -1640,7 +1649,7 @@ mod tests {
             &"ingredient_from_memory_async:".into(),
             &ingredient.to_string().into(),
         );
-        assert!(ingredient.validation_status().is_none());
+        assert_eq!(None, ingredient.validation_status());
         assert!(ingredient.manifest_data().is_some());
         assert!(ingredient.provenance().is_some());
     }
@@ -1838,7 +1847,7 @@ mod tests_file_io {
         let ap = fixture_path("CIE-sig-CA.jpg");
         let ingredient = Ingredient::from_file(ap).expect("from_file");
         // println!("ingredient = {ingredient}");
-        assert!(ingredient.validation_status().is_none());
+        assert_eq!(None, ingredient.validation_status());
         assert!(ingredient.manifest_data().is_some());
     }
 

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1983,6 +1983,7 @@ pub(crate) mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[allow(deprecated)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     async fn test_embed_jpeg_stream_wasm() {
         use crate::assertions::User;
         let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg");
@@ -2023,6 +2024,7 @@ pub(crate) mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[allow(deprecated)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     async fn test_embed_png_stream_wasm() {
         use crate::assertions::User;
         let image = include_bytes!("../tests/fixtures/libpng-test.png");
@@ -2056,6 +2058,7 @@ pub(crate) mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[allow(deprecated)]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     async fn test_embed_webp_stream_wasm() {
         use crate::assertions::User;
         let image = include_bytes!("../tests/fixtures/mars.webp");
@@ -2087,6 +2090,7 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl_sign")), ignore)]
     fn test_embed_stream() {
         use crate::assertions::User;
         let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg");
@@ -2122,9 +2126,9 @@ pub(crate) mod tests {
         //println!("{manifest_store}");main
     }
 
-    #[cfg(any(target_arch = "wasm32", feature = "openssl_sign"))]
     #[cfg_attr(feature = "openssl_sign", actix::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(any(target_arch = "wasm32", all(feature = "openssl_sign", feature = "file_io")))]
     async fn test_embed_from_memory_async() {
         use crate::{assertions::User, utils::test::temp_async_signer};
         let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg");
@@ -2252,7 +2256,7 @@ pub(crate) mod tests {
         assert_eq!(image.into_owned(), thumb_data);
     }
 
-    #[cfg(feature = "file_io")]
+    #[cfg(feature = "openssl_sign")]
     const MANIFEST_JSON: &str = r#"{
         "claim_generator": "test",
         "claim_generator_info": [

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -580,7 +580,10 @@ impl std::fmt::Display for ManifestStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(target_arch = "wasm32", feature = "openssl")
+))]
 mod tests {
     #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]

--- a/sdk/src/openssl/mod.rs
+++ b/sdk/src/openssl/mod.rs
@@ -43,7 +43,7 @@ pub(crate) mod temp_signer_async;
 use openssl::x509::X509;
 #[cfg(test)]
 #[allow(unused_imports)]
-#[cfg(feature = "openssl")]
+#[cfg(feature = "openssl_sign")]
 pub(crate) use temp_signer_async::AsyncSignerAdapter;
 
 #[cfg(feature = "openssl")]

--- a/sdk/src/openssl/openssl_trust_handler.rs
+++ b/sdk/src/openssl/openssl_trust_handler.rs
@@ -295,6 +295,7 @@ pub(crate) fn verify_trust(
 }
 
 #[cfg(test)]
+#[cfg(feature = "file_io")]
 pub mod tests {
     #![allow(clippy::expect_used)]
     #![allow(clippy::panic)]

--- a/sdk/src/openssl/temp_signer_async.rs
+++ b/sdk/src/openssl/temp_signer_async.rs
@@ -22,7 +22,7 @@
 #[cfg(feature = "openssl_sign")]
 use c2pa_crypto::SigningAlg;
 
-#[cfg(feature = "openssl_sign")]
+#[cfg(all(feature = "openssl_sign", feature = "file_io"))]
 fn get_local_signer(alg: SigningAlg) -> Box<dyn crate::Signer> {
     let cert_dir = crate::utils::test::fixture_path("certs");
 
@@ -51,7 +51,7 @@ pub struct AsyncSignerAdapter {
     ocsp_val: Option<Vec<u8>>,
 }
 
-#[cfg(feature = "openssl_sign")]
+#[cfg(all(feature = "openssl_sign", feature = "file_io"))]
 impl AsyncSignerAdapter {
     pub fn new(alg: SigningAlg) -> Self {
         let signer = get_local_signer(alg);
@@ -67,7 +67,7 @@ impl AsyncSignerAdapter {
 }
 
 #[cfg(test)]
-#[cfg(feature = "openssl_sign")]
+#[cfg(all(feature = "openssl_sign", feature = "file_io"))]
 #[async_trait::async_trait]
 impl crate::AsyncSigner for AsyncSignerAdapter {
     async fn sign(&self, data: Vec<u8>) -> crate::error::Result<Vec<u8>> {

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -56,7 +56,7 @@ pub trait Signer {
     ///
     /// The default implementation will send the request to the URL
     /// provided by [`Self::time_authority_url()`], if any.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     fn send_timestamp_request(&self, message: &[u8]) -> Option<Result<Vec<u8>>> {
         if let Some(url) = self.time_authority_url() {
             if let Ok(body) = self.timestamp_request_body(message) {
@@ -68,7 +68,7 @@ pub trait Signer {
         }
         None
     }
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(not(feature = "openssl"))]
     fn send_timestamp_request(&self, _message: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -130,9 +130,9 @@ impl Store {
             label: label.to_string(),
             #[cfg(feature = "openssl")]
             trust_handler: Box::new(crate::openssl::OpenSSLTrustHandlerConfig::new()),
-            #[cfg(all(not(feature = "openssl"), target_arch = "wasm32"))]
+            #[cfg(target_arch = "wasm32")]
             trust_handler: Box::new(crate::wasm::WebTrustHandlerConfig::new()),
-            #[cfg(all(not(feature = "openssl"), not(target_arch = "wasm32")))]
+            #[cfg(not(any(feature = "openssl", target_arch = "wasm32")))]
             trust_handler: Box::new(crate::trust_handler::TrustPassThrough::new()),
             provenance_path: None,
             //dynamic_assertions: Vec::new(),

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -362,9 +362,9 @@ pub(crate) fn temp_signer() -> Box<dyn Signer> {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", feature = "openssl_sign"))]
+#[cfg(any(target_arch = "wasm32", all(feature = "openssl_sign", feature = "file_io")))]
 pub fn temp_async_signer() -> Box<dyn crate::signer::AsyncSigner> {
-    #[cfg(feature = "openssl_sign")]
+    #[cfg(not(target_arch = "wasm32"))]
     {
         Box::new(AsyncSignerAdapter::new(SigningAlg::Es256))
     }
@@ -410,7 +410,7 @@ struct TempRemoteSigner {}
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl crate::signer::RemoteSigner for TempRemoteSigner {
     async fn sign_remote(&self, claim_bytes: &[u8]) -> crate::error::Result<Vec<u8>> {
-        #[cfg(feature = "openssl_sign")]
+        #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
         {
             let signer =
                 crate::openssl::temp_signer_async::AsyncSignerAdapter::new(SigningAlg::Ps256);
@@ -418,7 +418,7 @@ impl crate::signer::RemoteSigner for TempRemoteSigner {
             // this would happen on some remote server
             crate::cose_sign::cose_sign_async(&signer, claim_bytes, self.reserve_size()).await
         }
-        #[cfg(all(not(feature = "openssl"), not(target_arch = "wasm32")))]
+        #[cfg(not(any(target_arch = "wasm32", all(feature = "openssl_sign", feature = "file_io"))))]
         {
             use std::io::{Seek, Write};
 
@@ -561,7 +561,7 @@ struct TempAsyncRemoteSigner {
 impl crate::signer::AsyncSigner for TempAsyncRemoteSigner {
     // this will not be called but requires an implementation
     async fn sign(&self, claim_bytes: Vec<u8>) -> Result<Vec<u8>> {
-        #[cfg(feature = "openssl_sign")]
+        #[cfg(all(feature = "openssl_sign", feature = "file_io"))]
         {
             let signer =
                 crate::openssl::temp_signer_async::AsyncSignerAdapter::new(SigningAlg::Ps256);
@@ -575,7 +575,7 @@ impl crate::signer::AsyncSigner for TempAsyncRemoteSigner {
             crate::cose_sign::cose_sign_async(&signer, &claim_bytes, self.reserve_size()).await
         }
 
-        #[cfg(all(not(feature = "openssl"), not(target_arch = "wasm32")))]
+        #[cfg(not(any(target_arch = "wasm32", all(feature = "openssl_sign", feature = "file_io"))))]
         {
             use std::io::{Seek, Write};
 

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -19,6 +19,7 @@ mod common;
 use common::{compare_stream_to_known_good, fixtures_path, test_signer};
 
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_builder_ca_jpg() -> Result<()> {
     let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
     let mut builder = Builder::from_json(&manifest_def)?;
@@ -42,6 +43,7 @@ fn test_builder_ca_jpg() -> Result<()> {
 
 // Source: https://github.com/contentauth/c2pa-rs/issues/530
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_builder_riff() -> Result<()> {
     let manifest_def = include_str!("fixtures/simple_manifest.json");
     let mut source = Cursor::new(include_bytes!("fixtures/sample1.wav"));
@@ -119,6 +121,7 @@ fn test_builder_fragmented() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_builder_remote_url_no_embed() -> Result<()> {
     let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
     let mut builder = Builder::from_json(&manifest_def)?;

--- a/sdk/tests/test_reader.rs
+++ b/sdk/tests/test_reader.rs
@@ -32,6 +32,7 @@ fn test_reader_no_jumbf() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_reader_ca_jpg() -> Result<()> {
     let (format, mut stream) = fixture_stream("CA.jpg")?;
     let reader = Reader::from_stream(&format, &mut stream)?;
@@ -39,6 +40,7 @@ fn test_reader_ca_jpg() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_reader_c_jpg() -> Result<()> {
     let (format, mut stream) = fixture_stream("C.jpg")?;
     let reader = Reader::from_stream(&format, &mut stream)?;
@@ -46,6 +48,7 @@ fn test_reader_c_jpg() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
 fn test_reader_xca_jpg() -> Result<()> {
     let (format, mut stream) = fixture_stream("XCA.jpg")?;
     let reader = Reader::from_stream(&format, &mut stream)?;

--- a/sdk/tests/v2_api_integration.rs
+++ b/sdk/tests/v2_api_integration.rs
@@ -108,6 +108,7 @@ mod integration_v2 {
     }
 
     #[test]
+    #[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
     fn test_v2_integration() -> Result<()> {
         let title = "CA.jpg";
         let format = "image/jpeg";


### PR DESCRIPTION
The `make_test_images` crate enables the `file_io` and `openssl`, which means that when `cargo test --all-targets` is used, these features will always be enabled. That made mistakes in applying `cfg(feature = "openssl")` undetectable in tests, and the flags indeed weren't quite correct.

In need to run the SDK in a sandbox that can't have any `file_io`, and I'll probably need to disable `openssl` too, so I need these combinations of features to work.

`v1_api` is not possible to disable — too much code relies on `CAIRead` and `ManifestStore`. I haven't tried fixing that feature flag, since you'll probably going to remove it soon anyway. Once `v1_api` is fixed, `cargo hack --each-feature --no-dev-deps check` works.

I haven't tried to remove unused `use` imports, since they're harmless, and hiding them exactly when needed would require a lot of extra `#[cfg]`s.