### PR TITLE
fix: Remove `c2pa::Signer` dependency on `c2pa_crypto::TimeStampProvider`

### DIFF
--- a/internal/crypto/src/time_stamp/mod.rs
+++ b/internal/crypto/src/time_stamp/mod.rs
@@ -20,9 +20,11 @@ pub use error::TimeStampError;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod http_request;
+#[cfg(not(target_arch = "wasm32"))]
+pub use http_request::{default_rfc3161_request, default_rfc3161_request_async};
 
 mod provider;
-pub use provider::{AsyncTimeStampProvider, TimeStampProvider};
+pub use provider::{default_rfc3161_message, AsyncTimeStampProvider, TimeStampProvider};
 
 mod response;
 

--- a/internal/crypto/src/time_stamp/provider.rs
+++ b/internal/crypto/src/time_stamp/provider.rs
@@ -125,7 +125,10 @@ pub trait AsyncTimeStampProvider {
     }
 }
 
-fn default_rfc3161_message(data: &[u8]) -> Result<Vec<u8>, TimeStampError> {
+/// Create an [RFC 3161] time stamp request message for a given piece of data.
+///
+/// [RFC 3161]: https://datatracker.ietf.org/doc/html/rfc3161
+pub fn default_rfc3161_message(data: &[u8]) -> Result<Vec<u8>, TimeStampError> {
     let request = time_stamp_message_http(data, DigestAlgorithm::Sha256)?;
 
     let mut body = Vec::<u8>::new();

--- a/sdk/src/callback_signer.rs
+++ b/sdk/src/callback_signer.rs
@@ -190,10 +190,7 @@ impl AsyncSigner for CallbackSigner {
     }
 
     #[cfg(target_arch = "wasm32")]
-    async fn send_timestamp_request(
-        &self,
-        _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {
+    async fn send_timestamp_request(&self, _message: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }
 }

--- a/sdk/src/callback_signer.rs
+++ b/sdk/src/callback_signer.rs
@@ -156,16 +156,13 @@ impl Signer for CallbackSigner {
     fn reserve_size(&self) -> usize {
         self.reserve_size
     }
-}
 
-impl TimeStampProvider for CallbackSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
+    fn time_authority_url(&self) -> Option<String> {
         self.tsa_url.clone()
     }
 }
 
 use async_trait::async_trait;
-use c2pa_crypto::time_stamp::{AsyncTimeStampProvider, TimeStampProvider};
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -187,16 +184,13 @@ impl AsyncSigner for CallbackSigner {
     fn reserve_size(&self) -> usize {
         self.reserve_size
     }
-}
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl AsyncTimeStampProvider for CallbackSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
+    fn time_authority_url(&self) -> Option<String> {
         self.tsa_url.clone()
     }
 
     #[cfg(target_arch = "wasm32")]
-    async fn send_time_stamp_request(
+    async fn send_timestamp_request(
         &self,
         _message: &[u8],
     ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -358,8 +358,6 @@ fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>> {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use c2pa_crypto::time_stamp::{TimeStampError, TimeStampProvider};
-
     use super::sign_claim;
     use crate::{claim::Claim, utils::test::temp_signer};
 
@@ -428,13 +426,8 @@ mod tests {
         fn reserve_size(&self) -> usize {
             1024
         }
-    }
 
-    impl TimeStampProvider for BogusSigner {
-        fn send_time_stamp_request(
-            &self,
-            _message: &[u8],
-        ) -> Option<Result<Vec<u8>, TimeStampError>> {
+        fn send_timestamp_request(&self, _message: &[u8]) -> Option<crate::error::Result<Vec<u8>>> {
             Some(Ok(Vec::new()))
         }
     }

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -1504,8 +1504,6 @@ pub mod tests {
             }
         }
 
-        impl c2pa_crypto::time_stamp::TimeStampProvider for OcspSigner {}
-
         let ocsp_signer = OcspSigner {
             signer: Box::new(signer),
             ocsp_rsp: ocsp_rsp_data.to_vec(),

--- a/sdk/src/openssl/ec_signer.rs
+++ b/sdk/src/openssl/ec_signer.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use c2pa_crypto::{openssl::OpenSslMutex, time_stamp::TimeStampProvider, SigningAlg};
+use c2pa_crypto::{openssl::OpenSslMutex, SigningAlg};
 use openssl::{
     ec::EcKey,
     hash::MessageDigest,
@@ -107,14 +107,12 @@ impl Signer for EcSigner {
         Ok(certs)
     }
 
+    fn time_authority_url(&self) -> Option<String> {
+        self.tsa_url.clone()
+    }
+
     fn reserve_size(&self) -> usize {
         1024 + self.certs_size + self.timestamp_size // the Cose_Sign1 contains complete certs and timestamps so account for size
-    }
-}
-
-impl TimeStampProvider for EcSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        self.tsa_url.clone()
     }
 }
 

--- a/sdk/src/openssl/ed_signer.rs
+++ b/sdk/src/openssl/ed_signer.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use c2pa_crypto::{openssl::OpenSslMutex, time_stamp::TimeStampProvider, SigningAlg};
+use c2pa_crypto::{openssl::OpenSslMutex, SigningAlg};
 use openssl::{
     pkey::{PKey, Private},
     x509::X509,
@@ -97,14 +97,12 @@ impl Signer for EdSigner {
         Ok(certs)
     }
 
+    fn time_authority_url(&self) -> Option<String> {
+        self.tsa_url.clone()
+    }
+
     fn reserve_size(&self) -> usize {
         1024 + self.certs_size + self.timestamp_size // the Cose_Sign1 contains complete certs and timestamps so account for size
-    }
-}
-
-impl TimeStampProvider for EdSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        self.tsa_url.clone()
     }
 }
 

--- a/sdk/src/openssl/temp_signer_async.rs
+++ b/sdk/src/openssl/temp_signer_async.rs
@@ -60,7 +60,7 @@ impl AsyncSignerAdapter {
             alg,
             certs: signer.certs().unwrap_or_default(),
             reserve_size: signer.reserve_size(),
-            tsa_url: signer.time_stamp_service_url(),
+            tsa_url: signer.time_authority_url(),
             ocsp_val: signer.ocsp_val(),
         }
     }
@@ -91,16 +91,11 @@ impl crate::AsyncSigner for AsyncSignerAdapter {
         self.reserve_size
     }
 
+    fn time_authority_url(&self) -> Option<String> {
+        self.tsa_url.clone()
+    }
+
     async fn ocsp_val(&self) -> Option<Vec<u8>> {
         self.ocsp_val.clone()
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "openssl_sign")]
-#[async_trait::async_trait]
-impl c2pa_crypto::time_stamp::AsyncTimeStampProvider for AsyncSignerAdapter {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        self.tsa_url.clone()
     }
 }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -11,16 +11,15 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use c2pa_crypto::{
-    time_stamp::{AsyncTimeStampProvider, TimeStampError, TimeStampProvider},
-    SigningAlg,
-};
+use async_trait::async_trait;
+use c2pa_crypto::SigningAlg;
 
 use crate::{DynamicAssertion, Result};
+
 /// The `Signer` trait generates a cryptographic signature over a byte array.
 ///
 /// This trait exists to allow the signature mechanism to be extended.
-pub trait Signer: TimeStampProvider {
+pub trait Signer {
     /// Returns a new byte array which is a signature over the original.
     fn sign(&self, data: &[u8]) -> Result<Vec<u8>>;
 
@@ -34,6 +33,45 @@ pub trait Signer: TimeStampProvider {
     /// Signing will fail if the result of the `sign` function is larger
     /// than this value.
     fn reserve_size(&self) -> usize;
+
+    /// URL for time authority to time stamp the signature
+    fn time_authority_url(&self) -> Option<String> {
+        None
+    }
+
+    /// Additional request headers to pass to the time stamp authority.
+    ///
+    /// IMPORTANT: You should not include the "Content-type" header here.
+    /// That is provided by default.
+    fn timestamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+        None
+    }
+
+    fn timestamp_request_body(&self, message: &[u8]) -> Result<Vec<u8>> {
+        c2pa_crypto::time_stamp::default_rfc3161_message(message).map_err(|e| e.into())
+    }
+
+    /// Request RFC 3161 timestamp to be included in the manifest data
+    /// structure.
+    ///
+    /// `message` is a preliminary hash of the claim
+    ///
+    /// The default implementation will send the request to the URL
+    /// provided by [`Self::time_authority_url()`], if any.
+    #[allow(unused)] // message not used on WASM
+    fn send_timestamp_request(&self, message: &[u8]) -> Option<Result<Vec<u8>>> {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(url) = self.time_authority_url() {
+            if let Ok(body) = self.timestamp_request_body(message) {
+                let headers: Option<Vec<(String, String)>> = self.timestamp_request_headers();
+                return Some(
+                    c2pa_crypto::time_stamp::default_rfc3161_request(&url, headers, &body, message)
+                        .map_err(|e| e.into()),
+                );
+            }
+        }
+        None
+    }
 
     /// OCSP response for the signing cert if available
     /// This is the only C2PA supported cert revocation method.
@@ -85,16 +123,15 @@ pub(crate) trait ConfigurableSigner: Signer + Sized {
     ) -> Result<Self>;
 }
 
-use async_trait::async_trait;
-
 /// The `AsyncSigner` trait generates a cryptographic signature over a byte array.
 ///
 /// This trait exists to allow the signature mechanism to be extended.
 ///
 /// Use this when the implementation is asynchronous.
 #[cfg(not(target_arch = "wasm32"))]
-#[async_trait]
-pub trait AsyncSigner: Sync + AsyncTimeStampProvider {
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait AsyncSigner: Sync {
     /// Returns a new byte array which is a signature over the original.
     async fn sign(&self, data: Vec<u8>) -> Result<Vec<u8>>;
 
@@ -109,44 +146,47 @@ pub trait AsyncSigner: Sync + AsyncTimeStampProvider {
     /// than this value.
     fn reserve_size(&self) -> usize;
 
-    /// OCSP response for the signing cert if available
-    /// This is the only C2PA supported cert revocation method.
-    /// By pre-querying the value for a your signing cert the value can
-    /// be cached taking pressure off of the CA (recommended by C2PA spec)
-    async fn ocsp_val(&self) -> Option<Vec<u8>> {
+    /// URL for time authority to time stamp the signature
+    fn time_authority_url(&self) -> Option<String> {
         None
     }
 
-    /// If this returns true the sign function is responsible for for direct handling of the COSE structure.
+    /// Additional request headers to pass to the time stamp authority.
     ///
-    /// This is useful for cases where the signer needs to handle the COSE structure directly.
-    /// Not recommended for general use.
-    fn direct_cose_handling(&self) -> bool {
-        false
+    /// IMPORTANT: You should not include the "Content-type" header here.
+    /// That is provided by default.
+    fn timestamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+        None
     }
 
-    /// Returns a list of dynamic assertions that should be included in the manifest.
-    fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
-        Vec::new()
+    fn timestamp_request_body(&self, message: &[u8]) -> Result<Vec<u8>> {
+        c2pa_crypto::time_stamp::default_rfc3161_message(message).map_err(|e| e.into())
     }
-}
 
-#[cfg(target_arch = "wasm32")]
-#[async_trait(?Send)]
-pub trait AsyncSigner: AsyncTimeStampProvider {
-    /// Returns a new byte array which is a signature over the original.
-    async fn sign(&self, data: Vec<u8>) -> Result<Vec<u8>>;
-
-    /// Returns the algorithm of the Signer.
-    fn alg(&self) -> SigningAlg;
-
-    /// Returns the certificates as a Vec containing a Vec of DER bytes for each certificate.
-    fn certs(&self) -> Result<Vec<Vec<u8>>>;
-
-    /// Returns the size in bytes of the largest possible expected signature.
-    /// Signing will fail if the result of the `sign` function is larger
-    /// than this value.
-    fn reserve_size(&self) -> usize;
+    /// Request RFC 3161 timestamp to be included in the manifest data
+    /// structure.
+    ///
+    /// `message` is a preliminary hash of the claim
+    ///
+    /// The default implementation will send the request to the URL
+    /// provided by [`Self::time_authority_url()`], if any.
+    async fn send_timestamp_request(&self, message: &[u8]) -> Option<Result<Vec<u8>>> {
+        // NOTE: This is currently synchronous, but may become
+        // async in the future.
+        if let Some(url) = self.time_authority_url() {
+            if let Ok(body) = self.timestamp_request_body(message) {
+                let headers: Option<Vec<(String, String)>> = self.timestamp_request_headers();
+                return Some(
+                    c2pa_crypto::time_stamp::default_rfc3161_request_async(
+                        &url, headers, &body, message,
+                    )
+                    .await
+                    .map_err(|e| e.into()),
+                );
+            }
+        }
+        None
+    }
 
     /// OCSP response for the signing cert if available
     /// This is the only C2PA supported cert revocation method.
@@ -214,29 +254,5 @@ impl Signer for Box<dyn Signer + Send + Sync> {
 
     fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
         (**self).dynamic_assertions()
-    }
-}
-
-impl TimeStampProvider for Box<dyn Signer + Send + Sync> {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        (**self).time_stamp_service_url()
-    }
-
-    fn time_stamp_request_headers(&self) -> Option<Vec<(String, String)>> {
-        (**self).time_stamp_request_headers()
-    }
-
-    fn time_stamp_request_body(
-        &self,
-        message: &[u8],
-    ) -> std::result::Result<Vec<u8>, TimeStampError> {
-        (**self).time_stamp_request_body(message)
-    }
-
-    fn send_time_stamp_request(
-        &self,
-        message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
-        (**self).send_time_stamp_request(message)
     }
 }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -70,6 +70,7 @@ pub trait Signer {
                 );
             }
         }
+
         None
     }
 
@@ -128,8 +129,8 @@ pub(crate) trait ConfigurableSigner: Signer + Sized {
 /// This trait exists to allow the signature mechanism to be extended.
 ///
 /// Use this when the implementation is asynchronous.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
 pub trait AsyncSigner: Sync {
     /// Returns a new byte array which is a signature over the original.
     async fn sign(&self, data: Vec<u8>) -> Result<Vec<u8>>;
@@ -184,6 +185,79 @@ pub trait AsyncSigner: Sync {
                 );
             }
         }
+
+        None
+    }
+
+    /// OCSP response for the signing cert if available
+    /// This is the only C2PA supported cert revocation method.
+    /// By pre-querying the value for a your signing cert the value can
+    /// be cached taking pressure off of the CA (recommended by C2PA spec)
+    async fn ocsp_val(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    /// If this returns true the sign function is responsible for for direct handling of the COSE structure.
+    ///
+    /// This is useful for cases where the signer needs to handle the COSE structure directly.
+    /// Not recommended for general use.
+    fn direct_cose_handling(&self) -> bool {
+        false
+    }
+
+    /// Returns a list of dynamic assertions that should be included in the manifest.
+    fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
+        Vec::new()
+    }
+}
+
+/// The `AsyncSigner` trait generates a cryptographic signature over a byte array.
+///
+/// This trait exists to allow the signature mechanism to be extended.
+///
+/// Use this when the implementation is asynchronous.
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+pub trait AsyncSigner {
+    /// Returns a new byte array which is a signature over the original.
+    async fn sign(&self, data: Vec<u8>) -> Result<Vec<u8>>;
+
+    /// Returns the algorithm of the Signer.
+    fn alg(&self) -> SigningAlg;
+
+    /// Returns the certificates as a Vec containing a Vec of DER bytes for each certificate.
+    fn certs(&self) -> Result<Vec<Vec<u8>>>;
+
+    /// Returns the size in bytes of the largest possible expected signature.
+    /// Signing will fail if the result of the `sign` function is larger
+    /// than this value.
+    fn reserve_size(&self) -> usize;
+
+    /// URL for time authority to time stamp the signature
+    fn time_authority_url(&self) -> Option<String> {
+        None
+    }
+
+    /// Additional request headers to pass to the time stamp authority.
+    ///
+    /// IMPORTANT: You should not include the "Content-type" header here.
+    /// That is provided by default.
+    fn timestamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+        None
+    }
+
+    fn timestamp_request_body(&self, message: &[u8]) -> Result<Vec<u8>> {
+        c2pa_crypto::time_stamp::default_rfc3161_message(message).map_err(|e| e.into())
+    }
+
+    /// Request RFC 3161 timestamp to be included in the manifest data
+    /// structure.
+    ///
+    /// `message` is a preliminary hash of the claim
+    ///
+    /// The default implementation will send the request to the URL
+    /// provided by [`Self::time_authority_url()`], if any.
+    async fn send_timestamp_request(&self, _message: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }
 

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -128,7 +128,6 @@ pub(crate) trait ConfigurableSigner: Signer + Sized {
 /// This trait exists to allow the signature mechanism to be extended.
 ///
 /// Use this when the implementation is asynchronous.
-#[cfg(not(target_arch = "wasm32"))]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AsyncSigner: Sync {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3868,8 +3868,6 @@ pub mod tests {
         }
     }
 
-    impl c2pa_crypto::time_stamp::TimeStampProvider for BadSigner {}
-
     #[test]
     #[cfg(feature = "file_io")]
     fn test_detects_unverifiable_signature() {
@@ -5975,7 +5973,7 @@ pub mod tests {
                     alg: signer.alg(),
                     certs: signer.certs().unwrap_or_default(),
                     reserve_size: signer.reserve_size(),
-                    tsa_url: signer.time_stamp_service_url(),
+                    tsa_url: signer.time_authority_url(),
                     ocsp_val: signer.ocsp_val(),
                 }
             }
@@ -6004,6 +6002,10 @@ pub mod tests {
                 self.reserve_size
             }
 
+            fn time_authority_url(&self) -> Option<String> {
+                self.tsa_url.clone()
+            }
+
             async fn ocsp_val(&self) -> Option<Vec<u8>> {
                 self.ocsp_val.clone()
             }
@@ -6011,13 +6013,6 @@ pub mod tests {
             // Returns our dynamic assertion here.
             fn dynamic_assertions(&self) -> Vec<Box<dyn crate::DynamicAssertion>> {
                 vec![Box::new(TestDynamicAssertion {})]
-            }
-        }
-
-        #[async_trait::async_trait]
-        impl c2pa_crypto::time_stamp::AsyncTimeStampProvider for DynamicSigner {
-            fn time_stamp_service_url(&self) -> Option<String> {
-                self.tsa_url.clone()
             }
         }
 

--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -50,11 +50,11 @@ pub(crate) fn cose_timestamp_countersign(
 fn timestamp_data(signer: &dyn Signer, data: &[u8]) -> Option<Result<Vec<u8>>> {
     if _sync {
         signer
-            .send_time_stamp_request(data)
+            .send_timestamp_request(data)
             .map(|r| r.map_err(|e| e.into()))
     } else {
         signer
-            .send_time_stamp_request(data)
+            .send_timestamp_request(data)
             .await
             .map(|r| r.map_err(|e| e.into()))
         // TO DO: Fix bug in async_generic. This .await

--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -49,14 +49,9 @@ pub(crate) fn cose_timestamp_countersign(
 #[async_generic(async_signature(signer: &dyn AsyncSigner, data: &[u8]))]
 fn timestamp_data(signer: &dyn Signer, data: &[u8]) -> Option<Result<Vec<u8>>> {
     if _sync {
-        signer
-            .send_timestamp_request(data)
-            .map(|r| r.map_err(|e| e.into()))
+        signer.send_timestamp_request(data)
     } else {
-        signer
-            .send_timestamp_request(data)
-            .await
-            .map(|r| r.map_err(|e| e.into()))
+        signer.send_timestamp_request(data).await
         // TO DO: Fix bug in async_generic. This .await
         // should be automatically removed.
     }

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -301,13 +301,8 @@ impl crate::Signer for TestGoodSigner {
     fn reserve_size(&self) -> usize {
         1024
     }
-}
 
-impl c2pa_crypto::time_stamp::TimeStampProvider for TestGoodSigner {
-    fn send_time_stamp_request(
-        &self,
-        _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {
+    fn send_timestamp_request(&self, _message: &[u8]) -> Option<crate::error::Result<Vec<u8>>> {
         Some(Ok(Vec::new()))
     }
 }
@@ -332,15 +327,11 @@ impl crate::AsyncSigner for AsyncTestGoodSigner {
     fn reserve_size(&self) -> usize {
         1024
     }
-}
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl c2pa_crypto::time_stamp::AsyncTimeStampProvider for AsyncTestGoodSigner {
-    async fn send_time_stamp_request(
+    async fn send_timestamp_request(
         &self,
         _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {
+    ) -> Option<crate::error::Result<Vec<u8>>> {
         Some(Ok(Vec::new()))
     }
 }
@@ -622,15 +613,11 @@ impl crate::signer::AsyncSigner for TempAsyncRemoteSigner {
     fn reserve_size(&self) -> usize {
         10000
     }
-}
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl c2pa_crypto::time_stamp::AsyncTimeStampProvider for TempAsyncRemoteSigner {
-    async fn send_time_stamp_request(
+    async fn send_timestamp_request(
         &self,
         _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {
+    ) -> Option<crate::error::Result<Vec<u8>>> {
         Some(Ok(Vec::new()))
     }
 }

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -537,15 +537,8 @@ impl crate::signer::AsyncSigner for WebCryptoSigner {
     fn reserve_size(&self) -> usize {
         10000
     }
-}
 
-#[cfg(target_arch = "wasm32")]
-#[async_trait::async_trait(?Send)]
-impl c2pa_crypto::time_stamp::AsyncTimeStampProvider for WebCryptoSigner {
-    async fn send_time_stamp_request(
-        &self,
-        _: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, c2pa_crypto::time_stamp::TimeStampError>> {
+    async fn send_timestamp_request(&self, _: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }
 }

--- a/sdk/src/wasm/rsa_wasm_signer.rs
+++ b/sdk/src/wasm/rsa_wasm_signer.rs
@@ -14,10 +14,7 @@
 use core::str;
 
 use async_trait::async_trait;
-use c2pa_crypto::{
-    time_stamp::{AsyncTimeStampProvider, TimeStampError, TimeStampProvider},
-    SigningAlg,
-};
+use c2pa_crypto::SigningAlg;
 use rsa::{
     pkcs8::DecodePrivateKey,
     pss::SigningKey,
@@ -277,7 +274,7 @@ impl RsaWasmSignerAsync {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[async_trait(?Send)]
 impl AsyncSigner for RsaWasmSignerAsync {
     async fn sign(&self, data: Vec<u8>) -> Result<Vec<u8>> {
         self.signer.sign(&data)
@@ -295,10 +292,7 @@ impl AsyncSigner for RsaWasmSignerAsync {
         self.signer.reserve_size()
     }
 
-    async fn send_timestamp_request(
-        &self,
-        _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
+    async fn send_timestamp_request(&self, _message: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }
 }

--- a/sdk/src/wasm/rsa_wasm_signer.rs
+++ b/sdk/src/wasm/rsa_wasm_signer.rs
@@ -115,14 +115,12 @@ impl Signer for RsaWasmSigner {
         self.alg
     }
 
+    fn time_authority_url(&self) -> Option<String> {
+        self.tsa_url.clone()
+    }
+
     fn ocsp_val(&self) -> Option<Vec<u8>> {
         None
-    }
-}
-
-impl TimeStampProvider for RsaWasmSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        self.tsa_url.clone()
     }
 }
 
@@ -296,11 +294,8 @@ impl AsyncSigner for RsaWasmSignerAsync {
     fn reserve_size(&self) -> usize {
         self.signer.reserve_size()
     }
-}
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl AsyncTimeStampProvider for RsaWasmSignerAsync {
-    async fn send_time_stamp_request(
+    async fn send_timestamp_request(
         &self,
         _message: &[u8],
     ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {


### PR DESCRIPTION
This causes problems with Python bindings that can't be addressed.
