### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)
+_11 December 2024_
+
+### Added
+
+* Add `RawSigner` trait to `c2pa-crypto` (derived from `c2pa::Signer`) (#716)
+* Move time stamp code into c2pa-crypto (#696)
+* Adds ValidationState support (#701)
+* Introduce `DynamicAssertion` trait (#566)
+
+### Fixed
+
+* Verbose assertions for `is_none()` (#704)
+* Remove `c2pa::Signer` dependency on `c2pa_crypto::TimeStampProvider` (#718)
+* Add support for MP3 without ID3 header (#652)
+* Treat Unicode-3.0 license as approved; unpin related dependencies (#693)
+* Remote manifest fetch test was not using full path (#675)
+* Fix #624 (edge cases when combining the box hashes) (#625)
+* For Issue 672, Callback is unsound (#674)
+* For Issue 672, Callback is unsound
+* Support "remote_manifest_fetch" verify setting (#667)
+
+### Updated dependencies
+
+* Bump chrono from 0.4.38 to 0.4.39 (#763)
+* Bump asn1-rs from 0.5.2 to 0.6.2 (#724)
+* Bump mockall requirement from 0.11.2 to 0.13.1 in /sdk (#685)
+* Update zip requirement from 0.6.6 to 2.2.1 in /sdk (#698)
+
 ## [0.39.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.38.0...c2pa-v0.39.0)
 _13 November 2024_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+Note that this changelog is for the primary `c2pa` crate; there are several other projects hosted within this repo and they each have their own changelog.
+
 ## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)
 _11 December 2024_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _11 December 2024_
 * Treat Unicode-3.0 license as approved; unpin related dependencies (#693)
 * Remote manifest fetch test was not using full path (#675)
 * Fix #624 (edge cases when combining the box hashes) (#625)
-* For Issue 672, Callback is unsound (#674)
+* Fix #672, Callback is unsound (#674)
 * Support "remote_manifest_fetch" verify setting (#667)
 
 ### Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ _11 December 2024_
 * Remote manifest fetch test was not using full path (#675)
 * Fix #624 (edge cases when combining the box hashes) (#625)
 * For Issue 672, Callback is unsound (#674)
-* For Issue 672, Callback is unsound
 * Support "remote_manifest_fetch" verify setting (#667)
 
 ### Updated dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -661,7 +661,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "actix",
  "async-generic",
@@ -794,7 +794,7 @@ version = "0.1.0"
 
 [[package]]
 name = "c2patool"
-version = "0.9.12"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -824,9 +824,9 @@ version = "0.1.1"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "shlex",
 ]
@@ -1501,15 +1501,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
@@ -2328,9 +2328,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "konst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65f00fb3910881e52bf0850ae2a82aea411488a557e1c02820ceaa60963dce3"
+checksum = "298ddf99f06a97c1ecd0e910932662b7842855046234b0d0376d35d93add087f"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -2370,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599c1232f55c72c7fc378335a3efe1c878c92720838c8e6a4fd87784ef7764de"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
 dependencies = [
  "typewit",
 ]
@@ -2434,9 +2434,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -2929,20 +2929,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2950,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2963,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
@@ -3055,9 +3055,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.14"
+version = "0.17.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
+checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -3230,7 +3230,7 @@ version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
 dependencies = [
- "zerocopy 0.8.12",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -3332,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3538,22 +3538,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
@@ -3701,9 +3701,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4248,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4349,9 +4349,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typewit"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51dbd25812f740f45e2a9769f84711982e000483b13b73a8a1852e092abac8c"
+checksum = "cb77c29baba9e4d3a6182d51fa75e3215c7fd1dab8f4ea9d107c716878e55fc0"
 dependencies = [
  "typewit_proc_macros",
 ]
@@ -4400,9 +4400,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3193f92e105038f98ae68af40c008e3c94f2f046926e0f95e6c835dc6459bac8"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -4508,9 +4508,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4519,13 +4519,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4534,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4547,9 +4546,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4557,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4570,19 +4569,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d919bb60ebcecb9160afee6c71b43a58a4f0517a2de0054cd050d02cec08201"
+checksum = "c61d44563646eb934577f2772656c7ad5e9c90fac78aa8013d776fcdaf24625d"
 dependencies = [
  "js-sys",
  "minicov",
- "once_cell",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4591,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
+checksum = "54171416ce73aa0b9c377b51cc3cb542becee1cd678204812e8392e5b0e4a031"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4602,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4888,11 +4886,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e031087b26520ba76806365896f191416ce84873ed6c6910a9ab5fe0f98f8ed3"
+checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
 dependencies = [
- "zerocopy-derive 0.8.12",
+ "zerocopy-derive 0.8.13",
 ]
 
 [[package]]
@@ -4908,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568244125ba0fc91ae949b97f2852f82cb1a65c3327bd68e6edadd29e67cca26"
+checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,26 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.9.12...c2patool-v0.10.0)
+_11 December 2024_
+
+### Added
+
+* Updates c2patool to use only the new Builder/Reader API (contentauth/c2patool#297)
+
+### Documented
+
+* Update Contributing guide, misc minor edits (contentauth/c2patool#296)
+
+### Other
+
+* Move profile settings to workspace Cargo.toml
+* Fix README links
+* Update repository link in cli/Cargo.toml
+* Fix formatting of cli/CHANGELOG.md
+* Merge branch 'c2patool-main' into c2patool-merge
+* Enlarged description of c2pa command-line behavior (contentauth/c2patool[#285](https://github.com/contentauth/c2pa-rs/pull/285))
+
 ## 0.9.12
 _18 October 2024_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "c2patool"
 default-run = "c2patool"
 
-version = "0.9.12"
+version = "0.10.0"
 
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
@@ -20,7 +20,7 @@ repository = "https://github.com/contentauth/c2pa-rs/tree/main/cli"
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.39.0", features = [
+c2pa = { path = "../sdk", version = "0.40.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)
+_11 December 2024_
+
+### Added
+
+* Add `RawSigner` trait to `c2pa-crypto` (derived from `c2pa::Signer`) (#716)
+* Move time stamp code into c2pa-crypto (#696)
+
+### Fixed
+
+* Verbose assertions for `is_none()` (#704)
+* Remove `c2pa::Signer` dependency on `c2pa_crypto::TimeStampProvider` (#718)
+* Treat Unicode-3.0 license as approved; unpin related dependencies (#693)
+
+### Updated dependencies
+
+* Bump chrono from 0.4.38 to 0.4.39 (#763)
+
 ## [0.1.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.1...c2pa-crypto-v0.1.2)
 _24 October 2024_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.1.2"
+version = "0.2.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.39.0"
+version = "0.40.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -72,7 +72,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.1.2" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.1.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",


### PR DESCRIPTION
## 🤖 New release
* `c2patool`: 0.9.12 -> 0.10.0
* `c2pa`: 0.39.0 -> 0.40.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.1.2 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `c2pa` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa::SigningAlg, previously in file /tmp/.tmpJVDJUk/c2pa/src/signing_alg.rs:31

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature psxxx_ocsp_stapling_experimental in the package's Cargo.toml
  feature openssl_ffi_mutex in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa::validation_status::is_success, previously in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:510

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  ASSERTION_SELF_REDACTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:417
  ASSERTION_BMFFHASH_MATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:263
  ASSERTION_CBOR_INVALID in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:432
  INGREDIENT_HASHEDURI_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:309
  CLAIM_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:282
  CLAIM_MULTIPLE in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:287
  ASSERTION_UNDECLARED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:401
  ASSERTION_DATAHASH_MATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:257
  SIGNING_CREDENTIAL_INVALID in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:357
  ASSERTION_NOT_REDACTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:412
  TIMESTAMP_TRUSTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:245
  TIMESTAMP_OUTSIDE_VALIDITY in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:383
  MANIFEST_UPDATE_WRONG_PARENTS in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:347
  SIGNING_CREDENTIAL_TRUSTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:240
  ASSERTION_INACCESSIBLE in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:406
  GENERAL_ERROR in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:491
  ASSERTION_CLOUD_DATA_HARD_BINDING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:473
  TIMESTAMP_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:372
  CLAIM_SIGNATURE_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:321
  ALGORITHM_UNSUPPORTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:486
  MANIFEST_MULTIPLE_PARENTS in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:335
  CLAIM_SIGNATURE_VALIDATED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:235
  ASSERTION_JSON_INVALID in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:427
  ACTION_ASSERTION_REDACTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:444
  ACTION_ASSERTION_INGREDIENT_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:438
  ASSERTION_BOXHASH_UNKNOWN in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:468
  HARD_BINDINGS_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:292
  ASSERTION_BOXHASH_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:462
  ASSERTION_HASHEDURI_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:389
  CLAIM_REQUIRED_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:297
  ASSERTION_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:395
  SIGNING_CREDENTIAL_UNTRUSTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:352
  SIGNING_CREDENTIAL_EXPIRED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:367
  SIGNING_CREDENTIAL_REVOKED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:362
  TIMESTAMP_UNTRUSTED in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:377
  ASSERTION_CLOUD_DATA_ACTIONS in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:479
  ASSERTION_DATAHASH_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:450
  MANIFEST_INACCESSIBLE in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:329
  ASSERTION_REQUIRED_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:422
  ASSERTION_BMFFHASH_MISMATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:456
  ASSERTION_ACCESSIBLE in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:275
  ASSERTION_BOXHASH_MATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:269
  CLAIM_CBOR_INVALID in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:302
  MANIFEST_UPDATE_INVALID in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:341
  CLAIM_SIGNATURE_MISSING in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:315
  ASSERTION_HASHEDURI_MATCH in file /tmp/.tmpJVDJUk/c2pa/src/validation_status.rs:251
```

### ⚠️ `c2pa-crypto` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa_crypto::does_nothing_yet, previously in file /tmp/.tmpJVDJUk/c2pa-crypto/src/lib.rs:2
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2patool`
<blockquote>

## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.9.12...c2patool-v0.10.0)

_11 December 2024_

### Added

* Updates c2patool to use only the new Builder/Reader API (contentauth/c2patool#297)

### Documented

* Update Contributing guide, misc minor edits (contentauth/c2patool#296)

### Other

* Move profile settings to workspace Cargo.toml
* Fix README links
* Update repository link in cli/Cargo.toml
* Fix formatting of cli/CHANGELOG.md
* Merge branch 'c2patool-main' into c2patool-merge
* Enlarged description of c2pa command-line behavior (contentauth/c2patool[#285](https://github.com/contentauth/c2pa-rs/pull/285))
</blockquote>

## `c2pa`
<blockquote>

## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)

_11 December 2024_

### Added

* Add `RawSigner` trait to `c2pa-crypto` (derived from `c2pa::Signer`) (#716)
* Move time stamp code into c2pa-crypto (#696)
* Adds ValidationState support (#701)
* Introduce `DynamicAssertion` trait (#566)

### Fixed

* Verbose assertions for `is_none()` (#704)
* Remove `c2pa::Signer` dependency on `c2pa_crypto::TimeStampProvider` (#718)
* Add support for MP3 without ID3 header (#652)
* Treat Unicode-3.0 license as approved; unpin related dependencies (#693)
* Remote manifest fetch test was not using full path (#675)
* Fix #624 (edge cases when combining the box hashes) (#625)
* For Issue 672, Callback is unsound (#674)
* For Issue 672, Callback is unsound
* Support "remote_manifest_fetch" verify setting (#667)

### Updated dependencies

* Bump chrono from 0.4.38 to 0.4.39 (#763)
* Bump asn1-rs from 0.5.2 to 0.6.2 (#724)
* Bump mockall requirement from 0.11.2 to 0.13.1 in /sdk (#685)
* Update zip requirement from 0.6.6 to 2.2.1 in /sdk (#698)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)

_11 December 2024_

### Added

* Add `RawSigner` trait to `c2pa-crypto` (derived from `c2pa::Signer`) (#716)
* Move time stamp code into c2pa-crypto (#696)

### Fixed

* Verbose assertions for `is_none()` (#704)
* Remove `c2pa::Signer` dependency on `c2pa_crypto::TimeStampProvider` (#718)
* Treat Unicode-3.0 license as approved; unpin related dependencies (#693)

### Updated dependencies

* Bump chrono from 0.4.38 to 0.4.39 (#763)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).