### PR TITLE
fix: JPEG `write_cai` OOB insertion

### DIFF
--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -321,7 +321,7 @@ impl CAIWriter for JpegIO {
             if seg <= jpeg.segments().len() {
                 jpeg.segments_mut().insert(seg, app11_segment); // we put this in the beginning...
             } else {
-                return Err(Error::InvalidAsset("JPEG JUMPF segment error".to_owned()));
+                return Err(Error::InvalidAsset("JPEG JUMBF segment error".to_owned()));
             }
         }
 


### PR DESCRIPTION
## Changes in this pull request
Malformed jpeg may lead to insertion of CAI data at invalid index

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
