### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.41.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.40.0...c2pa-v0.41.0)
+_08 January 2025_
+
+### Added
+
+* Remove writing of native camera RAW formats from SDK (#814)
+* Review `c2pa-crypto` crate API (#813)
+* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
+* Move COSE signing into `c2pa_crypto` crate (#807)
+* Move COSE timestamp generation into `c2pa_crypto` (#803)
+* Move COSE signature verification into `c2pa_crypto` (#801)
+* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
+* Introduce `c2pa_crypto::cose::Verifier` (#797)
+* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
+* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
+* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
+* Move COSE OCSP support into c2pa-crypto (#793)
+* Move `verify_trust` into `c2pa_crypto` (#784)
+* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
+* Bump MSRV to 1.81.0 (#781)
+
+### Fixed
+
+* Update img-parts for jpeg segment underflow fix (#806)
+* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
+* Improve usage of `#[cfg]` directives (#783)
+* OOB read attempt in jpeg_io asset handler in get_cai_segments function (#719)
+* Prevent negative length value for SVG object locations (#766)
+* JPEG `write_cai` OOB insertion (#762)
+* Add support XMP in SVG (#771)
+* Possible overflow for TIFF (#760)
+* Resolve new Clippy issues (#776)
+
+### Updated dependencies
+
+* Bump jfifdump from 0.5.1 to 0.6.0 (#785)
+* Bump serde-wasm-bindgen from 0.5.0 to 0.6.5 (#786)
+* Bump thiserror from 2.0.6 to 2.0.8 (#787)
+* Bump rasn from 0.18.0 to 0.22.0 (#727)
+* Bump thiserror from 1.0.69 to 2.0.6 (#770)
+
 ## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)
 _12 December 2024_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
@@ -212,7 +212,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -224,7 +224,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -307,7 +307,7 @@ checksum = "ddf3728566eefa873833159754f5732fb0951d3649e6e5b891cc70d56dd41673"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -377,7 +377,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "futures-lite",
  "rustix",
  "tracing",
@@ -391,7 +391,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -448,13 +448,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -628,9 +628,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -661,7 +661,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
  "sha2",
  "spki",
  "tempfile",
- "thiserror 2.0.8",
+ "thiserror 2.0.9",
  "tokio",
  "treeline",
  "ureq",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -776,7 +776,7 @@ dependencies = [
  "sha1",
  "sha2",
  "spki",
- "thiserror 2.0.8",
+ "thiserror 2.0.9",
  "ureq",
  "url",
  "wasm-bindgen",
@@ -790,11 +790,11 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "c2patool"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "c2pa-crypto",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "shlex",
 ]
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -915,14 +915,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1073,18 +1073,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1157,7 +1157,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1187,7 +1187,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1198,7 +1198,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1250,7 +1250,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1300,7 +1300,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1416,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1461,9 +1461,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1476,7 +1476,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -1646,7 +1646,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1710,9 +1710,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-timers"
@@ -1919,7 +1919,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "lazy_static",
  "levenshtein",
  "log",
@@ -1940,9 +1940,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1963,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1983,13 +1983,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2006,7 +2006,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2025,7 +2025,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2171,7 +2171,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2409,9 +2409,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -2437,9 +2437,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2538,9 +2538,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2580,7 +2580,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2713,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -2758,7 +2758,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.8",
+ "thiserror 2.0.9",
  "ucd-trie",
 ]
 
@@ -2933,7 +2933,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2974,9 +2974,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3030,9 +3030,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.15"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -3092,9 +3092,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -3106,15 +3106,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -3140,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
@@ -3156,9 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3205,7 +3205,7 @@ version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
 dependencies = [
- "zerocopy 0.8.13",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -3229,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "rasn"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593394cad523914fcac9296bdb69701ad308589b3ea1e16d37b6f0c3cfad075"
+checksum = "9c1d1ed06b066a36d0492d65daaa5f40b7101c24a1228e0af2709712ef1a86e1"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
@@ -3251,34 +3251,34 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c367bf1b9a9bc34d40b9c140b52d26b585d0c7755b18496ba061f50639082"
+checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
 dependencies = [
  "proc-macro2",
  "rasn-derive-impl",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "rasn-derive-impl"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a321099d2f0f08f0afb90e68a16015abea210d4734f7faf6b3497f29feb46a35"
+checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
 dependencies = [
  "either",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "uuid",
 ]
 
 [[package]]
 name = "rasn-ocsp"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8804910bee097437b7df967160127e250e59b4d497b450c89328cd796ee1f8"
+checksum = "5cf2cbdf7f5e46d9a4ae4f0cac4bf578b748ccf39e369e7511a94b6f106a8a9e"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -3286,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-pkix"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884db2ae0da3a7239daaec802df74f3431062f85651c511e6c40b35a30282b82"
+checksum = "2645f907b8c01fa266c9855d8effd38b63896574a66bbce3114682b30de5d6f1"
 dependencies = [
  "rasn",
 ]
@@ -3364,9 +3364,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3378,7 +3378,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -3398,6 +3398,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3521,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3558,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -3575,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -3624,7 +3625,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3668,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3678,15 +3679,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3732,13 +3733,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3749,14 +3750,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -3798,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3816,14 +3817,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3924,7 +3925,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4003,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4029,7 +4030,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4061,12 +4062,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4085,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -4100,11 +4102,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.8",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -4115,18 +4117,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4181,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4199,13 +4201,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4276,6 +4278,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,7 +4331,7 @@ checksum = "d856e22ead1fb79b9fc3cec63300086f680924f2f7b0e2701f6835a28b9c4425"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4494,7 +4517,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -4529,7 +4552,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4562,7 +4585,7 @@ checksum = "54171416ce73aa0b9c377b51cc3cb542becee1cd678204812e8392e5b0e4a031"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4754,9 +4777,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -4837,7 +4860,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -4853,11 +4876,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
 dependencies = [
- "zerocopy-derive 0.8.13",
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -4868,18 +4891,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4899,7 +4922,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -4928,14 +4951,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -4943,7 +4966,7 @@ dependencies = [
  "displaydoc",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.8",
+ "thiserror 2.0.9",
 ]
 
 [[package]]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.1...cawg-identity-v0.2.0)
+_08 January 2025_
+
+### Added
+
+* *(cawg_identity)* Define `CredentialHolder` trait (#821)
+* *(cawg_identity)* Add `SignerPayload` struct (#817)
+* Bump MSRV to 1.81.0 (#781)
+
 ## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.0...cawg-identity-v0.1.1)
 _24 October 2024_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.1.1"
+version = "0.2.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1.78"
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
 ciborium = "0.2.2"
 hex-literal = "0.4.1"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,21 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.11.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.2...c2patool-v0.11.0)
+_08 January 2025_
+
+### Added
+
+* Move COSE signing into `c2pa_crypto` crate (#807)
+
+### Documented
+
+* Post move cleanup (#778)
+
+### Fixed
+
+* Fix: Obscure glob error message for missing files
+
 ## [0.10.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.1...c2patool-v0.10.2)
 _12 December 2024_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "c2patool"
 default-run = "c2patool"
 
-version = "0.10.2"
+version = "0.11.0"
 
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
@@ -24,14 +24,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.40.0", features = [
+c2pa = { path = "../sdk", version = "0.41.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
 	"unstable_api",
 ] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,38 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.2.0...c2pa-crypto-v0.3.0)
+_08 January 2025_
+
+### Added
+
+* Review `c2pa-crypto` crate API (#813)
+* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
+* Move COSE signing into `c2pa_crypto` crate (#807)
+* Move COSE timestamp generation into `c2pa_crypto` (#803)
+* Move COSE signature verification into `c2pa_crypto` (#801)
+* Make `AsyncRawSignatureValidator` available on all platforms (#800)
+* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
+* Introduce `c2pa_crypto::cose::Verifier` (#797)
+* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
+* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
+* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
+* Move COSE OCSP support into c2pa-crypto (#793)
+* Move `verify_trust` into `c2pa_crypto` (#784)
+* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
+* Bump MSRV to 1.81.0 (#781)
+
+### Fixed
+
+* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
+* Improve usage of `#[cfg]` directives (#783)
+
+### Updated dependencies
+
+* Bump thiserror from 2.0.6 to 2.0.8 (#787)
+* Bump rasn from 0.18.0 to 0.22.0 (#727)
+* Bump thiserror from 1.0.69 to 2.0.6 (#770)
+
 ## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)
 _12 December 2024_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -40,7 +40,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.2.0" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.3.0" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 coset = "0.3.1"

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.2.0...c2pa-status-tracker-v0.3.0)
+_08 January 2025_
+
+### Added
+
+* Bump MSRV to 1.81.0 (#781)
+
 ## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.1.0...c2pa-status-tracker-v0.2.0)
 _11 December 2024_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.40.0"
+version = "0.41.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -76,8 +76,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.2.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.3.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",
     "wasmbind",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `c2pa-status-tracker`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `c2patool`: 0.10.2 -> 0.11.0
* `c2pa`: 0.40.0 -> 0.41.0 (⚠️ API breaking changes)

### ⚠️ `cawg-identity` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function cawg_identity::does_nothing_yet, previously in file /tmp/.tmpj5WzE5/cawg-identity/src/lib.rs:2
```

### ⚠️ `c2pa-crypto` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa_crypto::ocsp::OcspError, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/ocsp/mod.rs:268
  enum c2pa_crypto::asn1::rfc5652::RevocationInfoChoice, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1138
  enum c2pa_crypto::asn1::rfc5652::OriginatorIdentifierOrKey, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:917
  enum c2pa_crypto::asn1::rfc3161::PkiFailureInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:293
  enum c2pa_crypto::asn1::rfc5652::RecipientIdentifier, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:884
  enum c2pa_crypto::asn1::rfc3281::AttCertVersion, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:82
  enum c2pa_crypto::asn1::rfc3281::AttCertIssuer, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:145
  enum c2pa_crypto::asn1::rfc5652::CertificateChoices, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1168
  enum c2pa_crypto::asn1::rfc3161::PkiStatus, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:230
  enum c2pa_crypto::asn1::rfc5652::CmsVersion, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1317
  enum c2pa_crypto::asn1::rfc3281::DigestedObjectType, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:107
  enum c2pa_crypto::asn1::rfc5652::KeyAgreeRecipientIdentifier, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:960
  enum c2pa_crypto::asn1::rfc5652::Time, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1387
  enum c2pa_crypto::asn1::rfc5652::SigningTime, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1387
  enum c2pa_crypto::asn1::rfc5652::SignerIdentifier, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:590
  enum c2pa_crypto::SigningAlg, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/signing_alg.rs:31
  enum c2pa_crypto::asn1::rfc5652::RecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:849

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant CoseError:MissingSigningCertificateChain in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:30
  variant CoseError:MultipleSigningCertificateChains in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:34
  variant CoseError:UnsupportedSigningAlgorithm in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:42
  variant CoseError:InvalidEcdsaSignature in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:46
  variant CoseError:CborGenerationError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:54
  variant CoseError:CertificateProfileError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:63
  variant CoseError:CertificateTrustError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:67
  variant CoseError:BoxSizeTooSmall in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:71
  variant CoseError:RawSignerError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:75
  variant CoseError:RawSignatureValidationError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:79
  variant CoseError:InternalError in /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/cose/error.rs:84

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa_crypto::ocsp::fetch_ocsp_response, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/ocsp/fetch.rs:32
  function c2pa_crypto::cose::parse_and_validate_sigtst_async, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/cose/sigtst.rs:31
  function c2pa_crypto::raw_signature::validator_for_sig_and_hash_algs, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/raw_signature/validator.rs:65
  function c2pa_crypto::time_stamp::verify_time_stamp_async, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/time_stamp/verify.rs:44
  function c2pa_crypto::p1363::parse_ec_der_sig, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/p1363.rs:25
  function c2pa_crypto::time_stamp::verify_time_stamp, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/time_stamp/verify.rs:44
  function c2pa_crypto::hash::sha1, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/hash.rs:17
  function c2pa_crypto::cose::parse_and_validate_sigtst, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/cose/sigtst.rs:31
  function c2pa_crypto::cose::cose_countersign_data, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/cose/sigtst.rs:61

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  OcspResponse::from_der_checked, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/ocsp/mod.rs:53

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/module_missing.ron

Failed in:
  mod c2pa_crypto::asn1, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/mod.rs:5
  mod c2pa_crypto::asn1::rfc3161, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:5
  mod c2pa_crypto::asn1::rfc5652, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:5
  mod c2pa_crypto::asn1::rfc4210, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc4210.rs:5
  mod c2pa_crypto::asn1::rfc3281, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:5
  mod c2pa_crypto::p1363, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/p1363.rs:14

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  OID_AUTHENTICATED_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:62
  OID_COUNTER_SIGNATURE in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:82
  OID_SIGNING_TIME in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:77
  OID_DIGESTED_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:52
  OID_ENVELOPE_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:47
  OID_ID_SIGNED_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:42
  OID_TIME_STAMP_TOKEN in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:30
  OID_CONTENT_TYPE_TST_INFO in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:25
  OID_CONTENT_TYPE in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:67
  OID_MESSAGE_DIGEST in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:72
  OID_ENCRYPTED_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:57
  OID_ID_DATA in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:37

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct c2pa_crypto::asn1::rfc3281::Holder, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:100
  struct c2pa_crypto::asn1::rfc5652::OtherCertificateFormat, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1232
  struct c2pa_crypto::asn1::rfc5652::KekRecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:992
  struct c2pa_crypto::asn1::rfc5652::SignedAttributesDer, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:713
  struct c2pa_crypto::asn1::rfc5652::KeyTransRecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:869
  struct c2pa_crypto::asn1::rfc5652::OriginatorInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:812
  struct c2pa_crypto::asn1::rfc3281::IssuerSerial, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:177
  struct c2pa_crypto::asn1::rfc5652::AuthenticatedData, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1088
  struct c2pa_crypto::asn1::rfc5652::PasswordRecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1025
  struct c2pa_crypto::asn1::rfc3161::MessageImprint, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:102
  struct c2pa_crypto::asn1::rfc5652::IssuerAndSerialNumber, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1285
  struct c2pa_crypto::asn1::rfc3281::AttCertValidityPeriod, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:191
  struct c2pa_crypto::asn1::rfc3161::TstInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:380
  struct c2pa_crypto::asn1::rfc5652::EncryptedContentInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:828
  struct c2pa_crypto::asn1::rfc5652::OriginatorPublicKey, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:931
  struct c2pa_crypto::ValidationInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/validation_info.rs:23
  struct c2pa_crypto::asn1::rfc5652::RecipientKeyIdentifier, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:974
  struct c2pa_crypto::p1363::EcSigComps, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/p1363.rs:42
  struct c2pa_crypto::asn1::rfc5652::UnsignedAttributes, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:745
  struct c2pa_crypto::asn1::rfc3161::PkiStatusInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:174
  struct c2pa_crypto::asn1::rfc5652::RecipientEncryptedKey, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:947
  struct c2pa_crypto::asn1::rfc5652::SignerInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:370
  struct c2pa_crypto::asn1::rfc5652::CounterSignature, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:370
  struct c2pa_crypto::asn1::rfc4210::PkiFreeText, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc4210.rs:21
  struct c2pa_crypto::asn1::rfc3161::TimeStampResp, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:135
  struct c2pa_crypto::asn1::rfc5652::KeyAgreeRecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:900
  struct c2pa_crypto::asn1::rfc5652::KekIdentifier, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1008
  struct c2pa_crypto::asn1::rfc5652::OtherKeyAttribute, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1367
  struct c2pa_crypto::asn1::rfc5652::EncryptedData, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1067
  struct c2pa_crypto::asn1::rfc5652::EnvelopedData, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:796
  struct c2pa_crypto::asn1::rfc3281::AttributeCertificate, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:25
  struct c2pa_crypto::asn1::rfc5652::AttributeCertificateV2, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:25
  struct c2pa_crypto::asn1::rfc3161::Accuracy, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:454
  struct c2pa_crypto::asn1::rfc3281::V2Form, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:163
  struct c2pa_crypto::cose::TstToken, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/cose/sigtst.rs:77
  struct c2pa_crypto::asn1::rfc5652::CertificateSet, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1245
  struct c2pa_crypto::asn1::rfc5652::RevocationInfoChoices, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1122
  struct c2pa_crypto::asn1::rfc5652::DigestAlgorithmIdentifiers, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:227
  struct c2pa_crypto::asn1::rfc3161::TimeStampReq, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3161.rs:46
  struct c2pa_crypto::asn1::rfc5652::DigestedData, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1049
  struct c2pa_crypto::asn1::rfc5652::EncapsulatedContentInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:311
  struct c2pa_crypto::asn1::rfc3281::AttributeCertificateInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:63
  struct c2pa_crypto::UnknownAlgorithmError, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/signing_alg.rs:95
  struct c2pa_crypto::asn1::rfc3281::Attribute, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:206
  struct c2pa_crypto::asn1::rfc5652::SignedData, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:151
  struct c2pa_crypto::asn1::rfc5652::SignedAttributes, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:633
  struct c2pa_crypto::asn1::rfc5652::OtherRevocationInfoFormat, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1151
  struct c2pa_crypto::asn1::rfc3161::TimeStampToken, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:92
  struct c2pa_crypto::asn1::rfc5652::ContentInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:92
  struct c2pa_crypto::asn1::rfc5652::SignerInfos, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:269
  struct c2pa_crypto::asn1::rfc3281::ObjectDigestInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc3281.rs:128
  struct c2pa_crypto::asn1::rfc5652::OtherRecipientInfo, previously in file /tmp/.tmpj5WzE5/c2pa-crypto/src/asn1/rfc5652.rs:1033

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait c2pa_crypto::time_stamp::AsyncTimeStampProvider gained Sync in file /tmp/.tmpQvzUW2/c2pa-rs/internal/crypto/src/time_stamp/provider.rs:78
```

### ⚠️ `c2pa` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::OpenSslError, previously in file /tmp/.tmpj5WzE5/c2pa/src/error.rs:290

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_added.ron

Failed in:
  trait method c2pa::AsyncSigner::async_raw_signer in file /tmp/.tmpQvzUW2/c2pa-rs/sdk/src/signer.rs:232
  trait method c2pa::Signer::raw_signer in file /tmp/.tmpQvzUW2/c2pa-rs/sdk/src/signer.rs:109
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.1...cawg-identity-v0.2.0)

_08 January 2025_

### Added

* *(cawg_identity)* Define `CredentialHolder` trait (#821)
* *(cawg_identity)* Add `SignerPayload` struct (#817)
* Bump MSRV to 1.81.0 (#781)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.2.0...c2pa-crypto-v0.3.0)

_08 January 2025_

### Added

* Review `c2pa-crypto` crate API (#813)
* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
* Move COSE signing into `c2pa_crypto` crate (#807)
* Move COSE timestamp generation into `c2pa_crypto` (#803)
* Move COSE signature verification into `c2pa_crypto` (#801)
* Make `AsyncRawSignatureValidator` available on all platforms (#800)
* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
* Introduce `c2pa_crypto::cose::Verifier` (#797)
* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
* Move COSE OCSP support into c2pa-crypto (#793)
* Move `verify_trust` into `c2pa_crypto` (#784)
* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
* Bump MSRV to 1.81.0 (#781)

### Fixed

* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
* Improve usage of `#[cfg]` directives (#783)

### Updated dependencies

* Bump thiserror from 2.0.6 to 2.0.8 (#787)
* Bump rasn from 0.18.0 to 0.22.0 (#727)
* Bump thiserror from 1.0.69 to 2.0.6 (#770)
</blockquote>

## `c2pa-status-tracker`
<blockquote>

## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.2.0...c2pa-status-tracker-v0.3.0)

_08 January 2025_

### Added

* Bump MSRV to 1.81.0 (#781)
</blockquote>

## `c2patool`
<blockquote>

## [0.11.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.2...c2patool-v0.11.0)

_08 January 2025_

### Added

* Move COSE signing into `c2pa_crypto` crate (#807)

### Documented

* Post move cleanup (#778)

### Fixed

* Fix: Obscure glob error message for missing files
</blockquote>

## `c2pa`
<blockquote>

## [0.41.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.40.0...c2pa-v0.41.0)

_08 January 2025_

### Added

* Remove writing of native camera RAW formats from SDK (#814)
* Review `c2pa-crypto` crate API (#813)
* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
* Move COSE signing into `c2pa_crypto` crate (#807)
* Move COSE timestamp generation into `c2pa_crypto` (#803)
* Move COSE signature verification into `c2pa_crypto` (#801)
* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
* Introduce `c2pa_crypto::cose::Verifier` (#797)
* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
* Move COSE OCSP support into c2pa-crypto (#793)
* Move `verify_trust` into `c2pa_crypto` (#784)
* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
* Bump MSRV to 1.81.0 (#781)

### Fixed

* Update img-parts for jpeg segment underflow fix (#806)
* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
* Improve usage of `#[cfg]` directives (#783)
* OOB read attempt in jpeg_io asset handler in get_cai_segments function (#719)
* Prevent negative length value for SVG object locations (#766)
* JPEG `write_cai` OOB insertion (#762)
* Add support XMP in SVG (#771)
* Possible overflow for TIFF (#760)
* Resolve new Clippy issues (#776)

### Updated dependencies

* Bump jfifdump from 0.5.1 to 0.6.0 (#785)
* Bump serde-wasm-bindgen from 0.5.0 to 0.6.5 (#786)
* Bump thiserror from 2.0.6 to 2.0.8 (#787)
* Bump rasn from 0.18.0 to 0.22.0 (#727)
* Bump thiserror from 1.0.69 to 2.0.6 (#770)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).