### PR TITLE
feat: Make `AsyncRawSignatureValidator` available on all platforms

### DIFF
--- a/internal/crypto/src/raw_signature/mod.rs
+++ b/internal/crypto/src/raw_signature/mod.rs
@@ -23,6 +23,6 @@ pub(crate) mod oids;
 
 mod validator;
 pub use validator::{
-    validator_for_sig_and_hash_algs, validator_for_signing_alg, RawSignatureValidationError,
-    RawSignatureValidator,
+    async_validator_for_signing_alg, validator_for_sig_and_hash_algs, validator_for_signing_alg,
+    AsyncRawSignatureValidator, RawSignatureValidationError, RawSignatureValidator,
 };

--- a/internal/crypto/src/raw_signature/validator.rs
+++ b/internal/crypto/src/raw_signature/validator.rs
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use async_trait::async_trait;
 use bcder::Oid;
 use thiserror::Error;
 
@@ -27,6 +28,31 @@ pub trait RawSignatureValidator {
     /// Return `true` if the signature `sig` is valid for the raw content `data`
     /// and the public key `public_key`.
     fn validate(
+        &self,
+        sig: &[u8],
+        data: &[u8],
+        public_key: &[u8],
+    ) -> Result<(), RawSignatureValidationError>;
+}
+
+/// An `AsyncRawSignatureValidator` implementation checks a signature encoded
+/// using a specific signature algorithm and a private/public key pair.
+///
+/// IMPORTANT: This signature is typically embedded in a wrapper provided by
+/// another signature mechanism. In the C2PA ecosystem, this wrapper is
+/// typically COSE, but `AsyncRawSignatureValidator` does not implement COSE.
+///
+/// The WASM implementation of `c2pa-crypto` also implements
+/// [`RawSignatureValidator`] (the synchronous version), but some encryption
+/// algorithms are not fully supported. When possible, it's preferable to use
+/// this implementation.
+///
+/// [`RawSignatureValidator`]: crate::raw_signature::RawSignatureValidator
+#[async_trait(?Send)]
+pub trait AsyncRawSignatureValidator {
+    /// Return `true` if the signature `sig` is valid for the raw content `data`
+    /// and the public key `public_key`.
+    async fn validate_async(
         &self,
         sig: &[u8],
         data: &[u8],
@@ -52,6 +78,26 @@ pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignature
 
     let _ = alg; // this value will be unused in this case
     None
+}
+
+/// Return a built-in signature validator for the requested signature
+/// algorithm.
+///
+/// Which validators are available may vary depending on the platform and
+/// which crate features were enabled.
+pub fn async_validator_for_signing_alg(
+    alg: SigningAlg,
+) -> Option<Box<dyn AsyncRawSignatureValidator>> {
+    #[cfg(target_arch = "wasm32")]
+    if let Some(validator) = crate::webcrypto::async_validator_for_signing_alg(alg) {
+        return Some(validator);
+    }
+
+    let Some(validator) = validator_for_signing_alg(alg) else {
+        return None;
+    };
+
+    Some(Box::new(AsyncValidatorAdapter(validator)))
 }
 
 /// Return a built-in signature validator for the requested signature
@@ -163,5 +209,19 @@ impl From<crate::webcrypto::WasmCryptoError> for RawSignatureValidationError {
                 Self::InternalError("WASM crypto unavailable")
             }
         }
+    }
+}
+
+struct AsyncValidatorAdapter(Box<dyn RawSignatureValidator>);
+
+#[async_trait(?Send)]
+impl AsyncRawSignatureValidator for AsyncValidatorAdapter {
+    async fn validate_async(
+        &self,
+        sig: &[u8],
+        data: &[u8],
+        public_key: &[u8],
+    ) -> Result<(), RawSignatureValidationError> {
+        self.0.validate(sig, data, public_key)
     }
 }

--- a/internal/crypto/src/raw_signature/validator.rs
+++ b/internal/crypto/src/raw_signature/validator.rs
@@ -93,11 +93,9 @@ pub fn async_validator_for_signing_alg(
         return Some(validator);
     }
 
-    let Some(validator) = validator_for_signing_alg(alg) else {
-        return None;
-    };
-
-    Some(Box::new(AsyncValidatorAdapter(validator)))
+    Some(Box::new(AsyncValidatorAdapter(validator_for_signing_alg(
+        alg,
+    )?)))
 }
 
 /// Return a built-in signature validator for the requested signature

--- a/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
@@ -18,8 +18,8 @@ use wasm_bindgen_futures::JsFuture;
 use web_sys::CryptoKey;
 
 use crate::{
-    raw_signature::RawSignatureValidationError,
-    webcrypto::{AsyncRawSignatureValidator, WindowOrWorker},
+    raw_signature::{AsyncRawSignatureValidator, RawSignatureValidationError},
+    webcrypto::WindowOrWorker,
 };
 
 /// An `EcdsaValidator` can validate raw signatures with one of the ECDSA

--- a/internal/crypto/src/webcrypto/async_validators/ed25519_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/ed25519_validator.rs
@@ -13,9 +13,8 @@
 
 use async_trait::async_trait;
 
-use crate::{
-    raw_signature::{RawSignatureValidationError, RawSignatureValidator},
-    webcrypto::AsyncRawSignatureValidator,
+use crate::raw_signature::{
+    AsyncRawSignatureValidator, RawSignatureValidationError, RawSignatureValidator,
 };
 
 /// An `Ed25519Validator` can validate raw signatures with the Ed25519 signature

--- a/internal/crypto/src/webcrypto/async_validators/mod.rs
+++ b/internal/crypto/src/webcrypto/async_validators/mod.rs
@@ -11,38 +11,12 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use async_trait::async_trait;
 use bcder::Oid;
 
 use crate::{
-    raw_signature::{oids::*, RawSignatureValidationError},
+    raw_signature::{oids::*, AsyncRawSignatureValidator},
     SigningAlg,
 };
-
-/// An `AsyncRawSignatureValidator` implementation checks a signature encoded
-/// using a specific signature algorithm and a private/public key pair.
-///
-/// IMPORTANT: This signature is typically embedded in a wrapper provided by
-/// another signature mechanism. In the C2PA ecosystem, this wrapper is
-/// typically COSE, but `AsyncRawSignatureValidator` does not implement COSE.
-///
-/// The WASM implementation of `c2pa-crypto` also implements
-/// [`RawSignatureValidator`] (the synchronous version), but some encryption
-/// algorithms are not fully supported. When possible, it's preferable to use
-/// this implementation.
-///
-/// [`RawSignatureValidator`]: crate::raw_signature::RawSignatureValidator
-#[async_trait(?Send)]
-pub trait AsyncRawSignatureValidator {
-    /// Return `true` if the signature `sig` is valid for the raw content `data`
-    /// and the public key `public_key`.
-    async fn validate_async(
-        &self,
-        sig: &[u8],
-        data: &[u8],
-        public_key: &[u8],
-    ) -> Result<(), RawSignatureValidationError>;
-}
 
 /// Return an async validator for the given signing algorithm.
 pub fn async_validator_for_signing_alg(

--- a/internal/crypto/src/webcrypto/async_validators/rsa_legacy_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/rsa_legacy_validator.rs
@@ -13,9 +13,8 @@
 
 use async_trait::async_trait;
 
-use crate::{
-    raw_signature::{RawSignatureValidationError, RawSignatureValidator},
-    webcrypto::AsyncRawSignatureValidator,
+use crate::raw_signature::{
+    AsyncRawSignatureValidator, RawSignatureValidationError, RawSignatureValidator,
 };
 
 /// An `RsaLegacyValidator` can validate raw signatures with an RSA signature

--- a/internal/crypto/src/webcrypto/async_validators/rsa_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/rsa_validator.rs
@@ -13,9 +13,8 @@
 
 use async_trait::async_trait;
 
-use crate::{
-    raw_signature::{RawSignatureValidationError, RawSignatureValidator},
-    webcrypto::AsyncRawSignatureValidator,
+use crate::raw_signature::{
+    AsyncRawSignatureValidator, RawSignatureValidationError, RawSignatureValidator,
 };
 
 /// An `RsaValidator` can validate raw signatures with one of the RSA-PSS

--- a/internal/crypto/src/webcrypto/mod.rs
+++ b/internal/crypto/src/webcrypto/mod.rs
@@ -22,7 +22,6 @@
 pub(crate) mod async_validators;
 pub use async_validators::{
     async_validator_for_sig_and_hash_algs, async_validator_for_signing_alg,
-    AsyncRawSignatureValidator,
 };
 
 pub(crate) mod check_certificate_trust;


### PR DESCRIPTION
(When OpenSSL is used, it's just a wrapper around the synchronous code path.)
