### PR TITLE
DO NOT MERGE: Test case for rust-lang/rustfmt#6427

### DIFF
--- a/internal/crypto/rustc-ice-2024-12-30T18_44_36-52351.txt
+++ b/internal/crypto/rustc-ice-2024-12-30T18_44_36-52351.txt
@@ -1,0 +1,31 @@
+thread 'main' panicked at src/tools/rustfmt/src/comment.rs:503:29:
+byte index 4 is out of bounds of `> >`
+stack backtrace:
+   0:        0x10f0680f0 - std::backtrace::Backtrace::create::ha751bce222e5ae16
+   1:        0x10d2f6acc - std[17a8e917c6ec07a8]::panicking::update_hook::<alloc[48cb1b81ffafecc]::boxed::Box<rustc_driver_impl[ad5d86c5e6d345f]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10f082eb0 - std::panicking::rust_panic_with_hook::he198aa85ff28153f
+   3:        0x10f082a1c - std::panicking::begin_panic_handler::{{closure}}::h4073917fa0e6d1d3
+   4:        0x10f080610 - std::sys::backtrace::__rust_end_short_backtrace::h09e7e14c9bd67923
+   5:        0x10f0826e0 - _rust_begin_unwind
+   6:        0x1117506cc - core::panicking::panic_fmt::h3c70e330423a8a1d
+   7:        0x10c8a4430 - core::str::slice_error_fail_rt::h14d858b97a4525ec
+   8:        0x111750bd0 - core::str::slice_error_fail::h51812382ee2b7c98
+   9:        0x102f2f09c - rustfmt_nightly[4afb4d3298affb73]::comment::rewrite_comment_inner
+  10:        0x102f2abe0 - rustfmt_nightly[4afb4d3298affb73]::comment::identify_comment
+  11:        0x102f20dc4 - <[rustc_ast[9e0ec498d228abde]::ast::Attribute] as rustfmt_nightly[4afb4d3298affb73]::rewrite::Rewrite>::rewrite_result
+  12:        0x102fb04f0 - <rustfmt_nightly[4afb4d3298affb73]::visitor::FmtVisitor>::visit_attrs
+  13:        0x102fa5990 - <rustfmt_nightly[4afb4d3298affb73]::visitor::FmtVisitor>::visit_item
+  14:        0x102f8d6ac - <rustfmt_nightly[4afb4d3298affb73]::visitor::FmtVisitor>::visit_items_with_reordering
+  15:        0x102fb1520 - <rustfmt_nightly[4afb4d3298affb73]::visitor::FmtVisitor>::format_separate_mod
+  16:        0x102e5b84c - <scoped_tls[96d12b8eb3754116]::ScopedKey<rustc_span[35582937fc5d27f5]::SessionGlobals>>::with::<<rustfmt_nightly[4afb4d3298affb73]::Session<std[17a8e917c6ec07a8]::io::stdio::Stdout>>::format_input_inner::{closure#0}, core[4f329069540e35fb]::result::Result<rustfmt_nightly[4afb4d3298affb73]::FormatReport, rustfmt_nightly[4afb4d3298affb73]::ErrorKind>>
+  17:        0x102e72298 - rustfmt[8cd2b3af7b1ec055]::format_and_emit_report::<std[17a8e917c6ec07a8]::io::stdio::Stdout>
+  18:        0x102e701ec - rustfmt[8cd2b3af7b1ec055]::execute
+  19:        0x102e6d0c8 - rustfmt[8cd2b3af7b1ec055]::main
+  20:        0x102e63970 - std[17a8e917c6ec07a8]::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
+  21:        0x102e63d48 - std[17a8e917c6ec07a8]::rt::lang_start::<()>::{closure#0}
+  22:        0x10f065ac4 - std::rt::lang_start_internal::h2bf1499861d71f0a
+  23:        0x102e73230 - _main
+
+
+rustc version: 1.85.0-nightly (14ee63a3c 2024-12-29)
+platform: aarch64-apple-darwin

--- a/internal/crypto/src/cose/error.rs
+++ b/internal/crypto/src/cose/error.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 use crate::{
     cose::{CertificateProfileError, CertificateTrustError},
-    raw_signature::RawSignatureValidationError,
+    raw_signature::{RawSignatureValidationError, RawSignerError},
     time_stamp::TimeStampError,
 };
 
@@ -66,7 +66,15 @@ pub enum CoseError {
     #[error(transparent)]
     CertificateTrustError(#[from] CertificateTrustError),
 
-    /// An error was occurred when interpreting the underlying raw signature.
+    /// The box size provided for the signature is too small.
+    #[error("the signature box is too small")]
+    BoxSizeTooSmall,
+
+    /// An error occurred when generating the underlying raw signature.
+    #[error(transparent)]
+    RawSignerError(#[from] RawSignerError),
+
+    /// An error occurred when interpreting the underlying raw signature.
     #[error(transparent)]
     RawSignatureValidationError(#[from] RawSignatureValidationError),
 

--- a/internal/crypto/src/cose/mod.rs
+++ b/internal/crypto/src/cose/mod.rs
@@ -29,6 +29,9 @@ pub use error::CoseError;
 mod ocsp;
 pub use ocsp::{check_ocsp_status, check_ocsp_status_async, OcspFetchPolicy};
 
+mod sign;
+pub use sign::{sign, sign_async};
+
 mod sign1;
 pub use sign1::{cert_chain_from_sign1, parse_cose_sign1, signing_alg_from_sign1};
 

--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -1,0 +1,269 @@
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use async_generic::async_generic;
+use ciborium::value::Value;
+use coset::{
+    iana::{self, EnumI64},
+    CoseSign1, CoseSign1Builder, Header, HeaderBuilder, Label, ProtectedHeader,
+    TaggedCborSerializable,
+};
+
+use crate::{
+    cose::{add_sigtst_header, add_sigtst_header_async, CoseError},
+    p1363::{der_to_p1363, parse_ec_der_sig},
+    raw_signature::{AsyncRawSigner, RawSigner},
+    SigningAlg,
+};
+
+/// Given an arbitrary block of data and a [`RawSigner`] or [`AsyncRawSigner`]
+/// instance, generate a COSE signature for that block of data.
+///
+/// Returns a byte vector that is a `Cose_Sign1` data structure.
+///
+/// From [§14.5, X.509 Certificates] of the C2PA Technical Specification:
+///
+/// > X.509 Certificates are stored as defined by [RFC 9360] (CBOR Object
+/// > Signing and Encryption (COSE): Header Parameters for Carrying and
+/// > Referencing X.509 Certificates). For convenience, the definition of
+/// > x5chain is copied below.
+/// >
+/// > ...
+/// >
+/// >> `x5chain`: This header parameter contains an ordered array of X.509
+/// certificates. The certificates are to be ordered starting with the
+/// certificate containing the end-entity key followed by the certificate that
+/// signed it, and so on. There is no requirement for the entire chain to be
+/// present in the element if there is reason to believe that the relying party
+/// already has, or can locate, the missing certificates. This means that the
+/// relying party is still required to do path building but that a candidate
+/// path is proposed in this header parameter. >>
+/// >> The trust mechanism MUST process any certificates in this parameter as
+/// untrusted input. The presence of a self-signed certificate in the parameter
+/// MUST NOT cause the update of the set of trust anchors without some
+/// out-of-band confirmation. As the contents of this header parameter are
+/// untrusted input, the header parameter can be in either the protected or
+/// unprotected header bucket. Sending the header parameter in the unprotected
+/// header bucket allows an intermediary to remove or add certificates. >>
+/// >> The end-entity certificate MUST be integrity protected by COSE. This can,
+/// for example, be done by sending the header parameter in the protected
+/// header, sending an `x5chain` in the unprotected header combined with an
+/// `x5t` in the protected header, or including the end-entity certificate in
+/// the `external_aad`. >>
+/// >> This header parameter allows for a single X.509 certificate or a chain of
+/// X.509 certificates to be carried in the message. >>
+/// >> * If a single certificate is conveyed, it is placed in a CBOR byte
+/// string. >> * If multiple certificates are conveyed, a CBOR array of byte
+/// strings is used, with each certificate being in its own byte string.
+///
+/// [§14.5, X.509 Certificates]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#x509_certificates
+/// [RFC 9360]: https://datatracker.ietf.org/doc/html/rfc9360
+#[async_generic(async_signature(
+    signer: &dyn AsyncRawSigner,
+    data: &[u8],
+    box_size: usize
+))]
+pub fn sign(signer: &dyn RawSigner, data: &[u8], box_size: usize) -> Result<Vec<u8>, CoseError> {
+    let alg = signer.alg();
+
+    let (protected_header, unprotected_header) = if _sync {
+        build_headers(signer, data, alg)?
+    } else {
+        build_headers_async(signer, data, alg).await?
+    };
+
+    // We don't use the additional data header.
+    let aad: &[u8; 0] = b"";
+
+    let sign1_builder = CoseSign1Builder::new()
+        .protected(protected_header)
+        .unprotected(unprotected_header)
+        .payload(data.to_vec());
+
+    let mut sign1 = sign1_builder.build();
+
+    let tbs = coset::sig_structure_data(
+        coset::SignatureContext::CoseSign1,
+        sign1.protected.clone(),
+        None,
+        aad,
+        sign1.payload.as_ref().unwrap_or(&vec![]),
+    );
+
+    let signature = if _sync {
+        signer.sign(&tbs)?
+    } else {
+        signer.sign(tbs).await?
+    };
+
+    // Fix up signatures that may be in the wrong format.
+    sign1.signature = match alg {
+        SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
+            if parse_ec_der_sig(&signature).is_ok() {
+                // Fix up DER signature to be in P1363 format.
+                der_to_p1363(&signature, alg)?
+            } else {
+                signature
+            }
+        }
+        _ => signature,
+    };
+
+    // The payload is provided elsewhere, so we don't need to repeat it in the
+    // `Cose_Sign1` structure.
+    sign1.payload = None;
+    Ok(pad_cose_sig(&mut sign1, box_size)?)
+}
+
+#[async_generic(async_signature(signer: &dyn AsyncRawSigner, data: &[u8], alg: SigningAlg))]
+fn build_headers(
+    signer: &dyn RawSigner,
+    data: &[u8],
+    alg: SigningAlg,
+) -> Result<(Header, Header), CoseError> {
+    let mut protected_h = match alg {
+        SigningAlg::Ps256 => HeaderBuilder::new().algorithm(iana::Algorithm::PS256),
+        SigningAlg::Ps384 => HeaderBuilder::new().algorithm(iana::Algorithm::PS384),
+        SigningAlg::Ps512 => HeaderBuilder::new().algorithm(iana::Algorithm::PS512),
+        SigningAlg::Es256 => HeaderBuilder::new().algorithm(iana::Algorithm::ES256),
+        SigningAlg::Es384 => HeaderBuilder::new().algorithm(iana::Algorithm::ES384),
+        SigningAlg::Es512 => HeaderBuilder::new().algorithm(iana::Algorithm::ES512),
+        SigningAlg::Ed25519 => HeaderBuilder::new().algorithm(iana::Algorithm::EdDSA),
+    };
+
+    let ocsp_val = if _sync {
+        signer.ocsp_response()
+    } else {
+        signer.ocsp_response().await
+    };
+
+    dbg!(&ocsp_val);
+
+    let certs = signer.cert_chain()?;
+
+    let sc_der_array_or_bytes = match certs.len() {
+        1 => Value::Bytes(certs[0].clone()),
+        _ => Value::Array(certs.into_iter().map(|cert| Value::Bytes(cert)).collect()),
+    };
+
+    // Add certs to protected header.
+    protected_h = protected_h.value(
+        iana::HeaderParameter::X5Chain.to_i64(),
+        sc_der_array_or_bytes.clone(),
+    );
+
+    let protected_header = protected_h.build();
+    let ph2 = ProtectedHeader {
+        original_data: None,
+        header: protected_header.clone(),
+    };
+
+    let unprotected_h = HeaderBuilder::new();
+
+    let mut unprotected_h = if _sync {
+        add_sigtst_header(signer, data, &ph2, unprotected_h)?
+    } else {
+        add_sigtst_header_async(signer, data, &ph2, unprotected_h).await?
+    };
+
+    // Set the OCSP responder response if available.
+    if let Some(ocsp) = ocsp_val {
+        let mut ocsp_vec: Vec<Value> = Vec::new();
+        let mut r_vals: Vec<(Value, Value)> = vec![];
+
+        ocsp_vec.push(Value::Bytes(ocsp));
+        r_vals.push((Value::Text("ocspVals".to_string()), Value::Array(ocsp_vec)));
+
+        unprotected_h = unprotected_h.text_value("rVals".to_string(), Value::Map(r_vals));
+    }
+
+    // Build complete header
+    Ok((protected_header, unprotected_h.build()))
+}
+
+const PAD: &str = "pad";
+const PAD2: &str = "pad2";
+const PAD_OFFSET: usize = 7;
+
+// Pad the CoseSign1 structure with zeroes to match the reserved box size. There
+// are some values lengths that are impossible to hit with a single padding so
+// when that happens a second padding is added to change the remaining needed
+// padding. The default initial guess works for almost all sizes, without the
+// need for additional loops.
+fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>, CoseError> {
+    let mut sign1_clone = sign1.clone();
+
+    let cur_vec = sign1_clone
+        .to_tagged_vec()
+        .map_err(|e| CoseError::CborGenerationError(e.to_string()))?;
+
+    let cur_size = cur_vec.len();
+    if cur_size == end_size {
+        return Ok(cur_vec);
+    }
+
+    // check for box too small and matched size
+    if cur_size + PAD_OFFSET > end_size {
+        return Err(CoseError::BoxSizeTooSmall);
+    }
+
+    // Start close to desired end size, accounting for label.
+    let mut padding_found = false;
+    let mut last_pad = 0;
+    let mut target_guess = end_size - cur_size - PAD_OFFSET;
+
+    loop {
+        sign1_clone = sign1.clone();
+
+        // Replace padding with new estimate.
+        for header_pair in &mut sign1_clone.unprotected.rest {
+            if header_pair.0 == Label::Text("pad".to_string()) {
+                if let Value::Bytes(b) = &header_pair.1 {
+                    last_pad = b.len();
+                }
+                header_pair.1 = Value::Bytes(vec![0u8; target_guess]);
+                padding_found = true;
+                break;
+            }
+        }
+
+        // If there was no padding, add it and try again.
+        if !padding_found {
+            sign1_clone.unprotected.rest.push((
+                Label::Text(PAD.to_string()),
+                Value::Bytes(vec![0u8; target_guess]),
+            ));
+            return pad_cose_sig(&mut sign1_clone, end_size);
+        }
+
+        // Get current CBOR vec to see if we reached target size.
+        let new_cbor = sign1_clone
+            .to_tagged_vec()
+            .map_err(|e| CoseError::CborGenerationError(e.to_string()))?;
+
+        match new_cbor.len() < end_size {
+            true => target_guess += 1,
+            false if new_cbor.len() == end_size => return Ok(new_cbor),
+            false => break,
+            // ^^ We could not match end_size in a single pad so break and add a second.
+        }
+    }
+
+    // If we reach here, we need a new second padding object to hit exact size.
+    sign1.unprotected.rest.push((
+        Label::Text(PAD2.to_string()),
+        Value::Bytes(vec![0u8; last_pad - 10]),
+    ));
+
+    pad_cose_sig(sign1, end_size)
+}

--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -36,35 +36,20 @@ use crate::{
 /// > X.509 Certificates are stored as defined by [RFC 9360] (CBOR Object
 /// > Signing and Encryption (COSE): Header Parameters for Carrying and
 /// > Referencing X.509 Certificates). For convenience, the definition of
-/// > x5chain is copied below.
+/// > `x5chain` is copied below.
 /// >
 /// > ...
 /// >
-/// >> `x5chain`: This header parameter contains an ordered array of X.509
-/// certificates. The certificates are to be ordered starting with the
-/// certificate containing the end-entity key followed by the certificate that
-/// signed it, and so on. There is no requirement for the entire chain to be
-/// present in the element if there is reason to believe that the relying party
-/// already has, or can locate, the missing certificates. This means that the
-/// relying party is still required to do path building but that a candidate
-/// path is proposed in this header parameter. >>
-/// >> The trust mechanism MUST process any certificates in this parameter as
-/// untrusted input. The presence of a self-signed certificate in the parameter
-/// MUST NOT cause the update of the set of trust anchors without some
-/// out-of-band confirmation. As the contents of this header parameter are
-/// untrusted input, the header parameter can be in either the protected or
-/// unprotected header bucket. Sending the header parameter in the unprotected
-/// header bucket allows an intermediary to remove or add certificates. >>
-/// >> The end-entity certificate MUST be integrity protected by COSE. This can,
-/// for example, be done by sending the header parameter in the protected
-/// header, sending an `x5chain` in the unprotected header combined with an
-/// `x5t` in the protected header, or including the end-entity certificate in
-/// the `external_aad`. >>
-/// >> This header parameter allows for a single X.509 certificate or a chain of
-/// X.509 certificates to be carried in the message. >>
-/// >> * If a single certificate is conveyed, it is placed in a CBOR byte
-/// string. >> * If multiple certificates are conveyed, a CBOR array of byte
-/// strings is used, with each certificate being in its own byte string.
+/// > > `x5chain`: This header parameter contains an ordered array of X.509 certificates. The certificates are to be ordered starting with the certificate containing the end-entity key followed by the certificate that signed it, and so on. There is no requirement for the entire chain to be present in the element if there is reason to believe that the relying party already has, or can locate, the missing certificates. This means that the relying party is still required to do path building but that a candidate path is proposed in this header parameter.
+/// > >
+/// > > The trust mechanism MUST process any certificates in this parameter as untrusted input. The presence of a self-signed certificate in the parameter MUST NOT cause the update of the set of trust anchors without some out-of-band confirmation. As the contents of this header parameter are untrusted input, the header parameter can be in either the protected or unprotected header bucket. Sending the header parameter in the unprotected header bucket allows an intermediary to remove or add certificates.
+/// > >
+/// > > The end-entity certificate MUST be integrity protected by COSE. This can, for example, be done by sending the header parameter in the protected header, sending an `x5chain` in the unprotected header combined with an `x5t` in the protected header, or including the end-entity certificate in the `external_aad`.
+/// > >
+/// > > This header parameter allows for a single X.509 certificate or a chain of X.509 certificates to be carried in the message.
+/// > >
+/// > > * If a single certificate is conveyed, it is placed in a CBOR byte string.
+/// > > * If multiple certificates are conveyed, a CBOR array of byte strings is used, with each certificate being in its own byte string.
 ///
 /// [§14.5, X.509 Certificates]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#x509_certificates
 /// [RFC 9360]: https://datatracker.ietf.org/doc/html/rfc9360

--- a/internal/crypto/src/cose/sigtst.rs
+++ b/internal/crypto/src/cose/sigtst.rs
@@ -19,9 +19,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     asn1::rfc3161::TstInfo,
     cose::CoseError,
-    time_stamp::{
-        verify_time_stamp, verify_time_stamp_async, AsyncTimeStampProvider, TimeStampProvider,
-    },
+    raw_signature::{AsyncRawSigner, RawSigner},
+    time_stamp::{verify_time_stamp, verify_time_stamp_async},
 };
 
 /// Given a COSE signature, retrieve the `sigTst` header from it and validate
@@ -142,13 +141,13 @@ impl TstContainer {
 /// timestamp for that block of data.
 #[async_generic(
     async_signature(
-        ts_provider: &dyn AsyncTimeStampProvider,
+        ts_provider: &dyn AsyncRawSigner,
         data: &[u8],
         p_header: &ProtectedHeader,
         mut header_builder: HeaderBuilder,
     ))]
 pub fn add_sigtst_header(
-    ts_provider: &dyn TimeStampProvider,
+    ts_provider: &dyn RawSigner,
     data: &[u8],
     p_header: &ProtectedHeader,
     mut header_builder: HeaderBuilder,

--- a/internal/crypto/src/cose/sigtst.rs
+++ b/internal/crypto/src/cose/sigtst.rs
@@ -139,6 +139,9 @@ impl TstContainer {
 /// Given a COSE [`ProtectedHeader`] and an arbitrary block of data, use the
 /// provided [`TimeStampProvider`] or [`AsyncTimeStampProvider`] to request a
 /// timestamp for that block of data.
+/// 
+/// [`TimeStampProvider`]: crate::time_stamp::TimeStampProvider
+/// [`AsyncTimeStampProvider`]: crate::time_stamp::AsyncTimeStampProvider
 #[async_generic(
     async_signature(
         ts_provider: &dyn AsyncRawSigner,

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -16,21 +16,8 @@
 #![deny(missing_docs)]
 
 use async_generic::async_generic;
-use c2pa_crypto::{
-    cose::{
-        add_sigtst_header, add_sigtst_header_async, check_certificate_profile,
-        CertificateTrustPolicy,
-    },
-    p1363::parse_ec_der_sig,
-    SigningAlg,
-};
+use c2pa_crypto::cose::{check_certificate_profile, sign, sign_async, CertificateTrustPolicy};
 use c2pa_status_tracker::OneShotStatusTracker;
-use ciborium::value::Value;
-use coset::{
-    iana::{self, EnumI64},
-    CoseSign1, CoseSign1Builder, Header, HeaderBuilder, Label, ProtectedHeader,
-    TaggedCborSerializable,
-};
 
 use crate::{
     claim::Claim, cose_validator::verify_cose, settings::get_settings_value, AsyncSigner, Error,
@@ -98,6 +85,41 @@ pub fn sign_claim(claim_bytes: &[u8], signer: &dyn Signer, box_size: usize) -> R
     }
 }
 
+/// Returns signed Cose_Sign1 bytes for `data`.
+/// The Cose_Sign1 will be signed with the algorithm from [`Signer`].
+#[async_generic(async_signature(
+    signer: &dyn AsyncSigner,
+    data: &[u8],
+    box_size: usize
+))]
+pub(crate) fn cose_sign(signer: &dyn Signer, data: &[u8], box_size: usize) -> Result<Vec<u8>> {
+    // Make sure the signing cert is valid.
+    let certs = signer.certs()?;
+    if let Some(signing_cert) = certs.first() {
+        signing_cert_valid(signing_cert)?;
+    } else {
+        return Err(Error::CoseNoCerts);
+    }
+
+    let signer = if _sync {
+        signer.raw_signer()
+    } else {
+        signer.async_raw_signer()
+    };
+
+    let Some(signer) = signer else {
+        return Err(Error::InternalError(
+            "Signer does not implement RawSigner".to_string(),
+        ));
+    };
+
+    if _sync {
+        Ok(sign(*signer, data, box_size)?)
+    } else {
+        Ok(sign_async(*signer, data, box_size).await?)
+    }
+}
+
 fn signing_cert_valid(signing_cert: &[u8]) -> Result<()> {
     // make sure signer certs are valid
     let mut cose_log = OneShotStatusTracker::default();
@@ -114,303 +136,6 @@ fn signing_cert_valid(signing_cert: &[u8]) -> Result<()> {
         &mut cose_log,
         None,
     )?)
-}
-
-/// Returns signed Cose_Sign1 bytes for `data`.
-/// The Cose_Sign1 will be signed with the algorithm from [`Signer`].
-#[async_generic(async_signature(
-    signer: &dyn AsyncSigner,
-    data: &[u8],
-    box_size: usize
-))]
-pub(crate) fn cose_sign(signer: &dyn Signer, data: &[u8], box_size: usize) -> Result<Vec<u8>> {
-    // 13.2.1. X.509 Certificates
-    //
-    // X.509 Certificates are stored in a header named x5chain draft-ietf-cose-x509.
-    // The value is a CBOR array of byte strings, each of which contains the certificate
-    // encoded as ASN.1 distinguished encoding rules (DER). This array must contain at
-    // least one element. The first element of the array must be the certificate of
-    // the signer, and the subjectPublicKeyInfo element of the certificate will be the
-    // public key used to validate the signature. The Validity member of the TBSCertificate
-    // sequence provides the time validity period of the certificate.
-
-    /*
-       This header parameter allows for a single X.509 certificate or a
-       chain of X.509 certificates to be carried in the message.
-
-       *  If a single certificate is conveyed, it is placed in a CBOR
-           byte string.
-
-       *  If multiple certificates are conveyed, a CBOR array of byte
-           strings is used, with each certificate being in its own byte
-           string.
-    */
-
-    // make sure the signing cert is valid
-    let certs = signer.certs()?;
-    if let Some(signing_cert) = certs.first() {
-        signing_cert_valid(signing_cert)?;
-    } else {
-        return Err(Error::CoseNoCerts);
-    }
-
-    let alg = signer.alg();
-
-    // build complete header
-    let (protected_header, unprotected_header) = if _sync {
-        build_headers(signer, data, alg)?
-    } else {
-        build_headers_async(signer, data, alg).await?
-    };
-
-    let aad: &[u8; 0] = b""; // no additional data required here
-
-    let sign1_builder = CoseSign1Builder::new()
-        .protected(protected_header)
-        .unprotected(unprotected_header)
-        .payload(data.to_vec());
-
-    let mut sign1 = sign1_builder.build();
-
-    let tbs = coset::sig_structure_data(
-        coset::SignatureContext::CoseSign1,
-        sign1.protected.clone(),
-        None,
-        aad,
-        sign1.payload.as_ref().unwrap_or(&vec![]),
-    );
-
-    let signature = if _sync {
-        signer.sign(&tbs)?
-    } else {
-        signer.sign(tbs).await?
-    };
-
-    // fix up signatures that may be in the wrong format
-    sign1.signature = match alg {
-        SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
-            if parse_ec_der_sig(&signature).is_ok() {
-                // fix up DER signature to be in P1363 format
-                der_to_p1363(&signature, alg)?
-            } else {
-                signature
-            }
-        }
-        _ => signature,
-    };
-
-    sign1.payload = None; // clear the payload since it is known
-
-    let c2pa_sig_data = pad_cose_sig(&mut sign1, box_size)?;
-
-    // println!("sig: {}", Hexlify(&c2pa_sig_data));
-
-    Ok(c2pa_sig_data)
-}
-
-fn der_to_p1363(data: &[u8], alg: SigningAlg) -> Result<Vec<u8>> {
-    // P1363 format: r | s
-
-    let (_, p) = parse_ec_der_sig(data).map_err(|_err| Error::InvalidEcdsaSignature)?;
-
-    let mut r = extfmt::Hexlify(p.r).to_string();
-    let mut s = extfmt::Hexlify(p.s).to_string();
-
-    let sig_len: usize = match alg {
-        SigningAlg::Es256 => 64,
-        SigningAlg::Es384 => 96,
-        SigningAlg::Es512 => 132,
-        _ => return Err(Error::UnsupportedType),
-    };
-
-    // pad or truncate as needed
-    let rp = if r.len() > sig_len {
-        // truncate
-        let offset = r.len() - sig_len;
-        &r[offset..r.len()]
-    } else {
-        // pad
-        while r.len() != sig_len {
-            r.insert(0, '0');
-        }
-        r.as_ref()
-    };
-
-    let sp = if s.len() > sig_len {
-        // truncate
-        let offset = s.len() - sig_len;
-        &s[offset..s.len()]
-    } else {
-        // pad
-        while s.len() != sig_len {
-            s.insert(0, '0');
-        }
-        s.as_ref()
-    };
-
-    if rp.len() != sig_len || rp.len() != sp.len() {
-        return Err(Error::InvalidEcdsaSignature);
-    }
-
-    // merge r and s strings
-    let mut new_sig = rp.to_string();
-    new_sig.push_str(sp);
-
-    // convert back from hex string to byte array
-    (0..new_sig.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&new_sig[i..i + 2], 16).map_err(|_err| Error::InvalidEcdsaSignature)
-        })
-        .collect()
-}
-
-#[async_generic(async_signature(signer: &dyn AsyncSigner, data: &[u8], alg: SigningAlg))]
-fn build_headers(signer: &dyn Signer, data: &[u8], alg: SigningAlg) -> Result<(Header, Header)> {
-    let mut protected_h = match alg {
-        SigningAlg::Ps256 => HeaderBuilder::new().algorithm(iana::Algorithm::PS256),
-        SigningAlg::Ps384 => HeaderBuilder::new().algorithm(iana::Algorithm::PS384),
-        SigningAlg::Ps512 => HeaderBuilder::new().algorithm(iana::Algorithm::PS512),
-        SigningAlg::Es256 => HeaderBuilder::new().algorithm(iana::Algorithm::ES256),
-        SigningAlg::Es384 => HeaderBuilder::new().algorithm(iana::Algorithm::ES384),
-        SigningAlg::Es512 => HeaderBuilder::new().algorithm(iana::Algorithm::ES512),
-        SigningAlg::Ed25519 => HeaderBuilder::new().algorithm(iana::Algorithm::EdDSA),
-    };
-
-    let certs = signer.certs()?;
-
-    let ocsp_val = if _sync {
-        signer.ocsp_val()
-    } else {
-        signer.ocsp_val().await
-    };
-
-    let sc_der_array_or_bytes = match certs.len() {
-        1 => Value::Bytes(certs[0].clone()), // single cert
-        _ => {
-            let mut sc_der_array: Vec<Value> = Vec::new();
-            for cert in certs {
-                sc_der_array.push(Value::Bytes(cert));
-            }
-            Value::Array(sc_der_array) // provide vec of certs when required
-        }
-    };
-
-    // add certs to protected header (spec 1.3 now requires integer 33(X5Chain) in favor of string "x5chain" going forward)
-    protected_h = protected_h.value(
-        iana::HeaderParameter::X5Chain.to_i64(),
-        sc_der_array_or_bytes.clone(),
-    );
-
-    let protected_header = protected_h.build();
-    let ph2 = ProtectedHeader {
-        original_data: None,
-        header: protected_header.clone(),
-    };
-
-    let unprotected_h = HeaderBuilder::new();
-
-    let mut unprotected_h = if _sync {
-        if let Some(tsp) = signer.time_stamp_provider() {
-            add_sigtst_header(*tsp, data, &ph2, unprotected_h)?
-        } else {
-            unprotected_h
-        }
-    } else {
-        if let Some(tsp) = signer.async_time_stamp_provider() {
-            add_sigtst_header_async(*tsp, data, &ph2, unprotected_h).await?
-        } else {
-            unprotected_h
-        }
-    };
-
-    // set the ocsp responder response if available
-    if let Some(ocsp) = ocsp_val {
-        let mut ocsp_vec: Vec<Value> = Vec::new();
-        let mut r_vals: Vec<(Value, Value)> = vec![];
-
-        ocsp_vec.push(Value::Bytes(ocsp));
-        r_vals.push((Value::Text("ocspVals".to_string()), Value::Array(ocsp_vec)));
-
-        unprotected_h = unprotected_h.text_value("rVals".to_string(), Value::Map(r_vals));
-    }
-
-    // build complete header
-    let unprotected_header = unprotected_h.build();
-
-    Ok((protected_header, unprotected_header))
-}
-
-const PAD: &str = "pad";
-const PAD2: &str = "pad2";
-const PAD_OFFSET: usize = 7;
-
-// Pad the CoseSign1 structure with 0s to match the reserved box size.
-// There are some values lengths that are impossible to hit with a single padding so
-// when that happens a second padding is added to change the remaining needed padding.
-// The default initial guess works for almost all sizes, without the need for additional loops.
-fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>> {
-    let mut sign1_clone = sign1.clone();
-    let cur_vec = sign1_clone
-        .to_tagged_vec()
-        .map_err(|_e| Error::CoseSignature)?;
-    let cur_size = cur_vec.len();
-
-    if cur_size == end_size {
-        return Ok(cur_vec);
-    }
-
-    // check for box too small and matched size
-    if cur_size + PAD_OFFSET > end_size {
-        return Err(Error::CoseSigboxTooSmall);
-    }
-
-    let mut padding_found = false;
-    let mut last_pad = 0;
-    let mut target_guess = end_size - cur_size - PAD_OFFSET; // start close to desired end_size accounting for label
-    loop {
-        // clone to use
-        sign1_clone = sign1.clone();
-
-        // replace padding with new estimate
-        for header_pair in &mut sign1_clone.unprotected.rest {
-            if header_pair.0 == Label::Text("pad".to_string()) {
-                if let Value::Bytes(b) = &header_pair.1 {
-                    last_pad = b.len();
-                }
-                header_pair.1 = Value::Bytes(vec![0u8; target_guess]);
-                padding_found = true;
-                break;
-            }
-        }
-
-        // if there was no padding add it and call again
-        if !padding_found {
-            sign1_clone.unprotected.rest.push((
-                Label::Text(PAD.to_string()),
-                Value::Bytes(vec![0u8; target_guess]),
-            ));
-            return pad_cose_sig(&mut sign1_clone, end_size);
-        }
-
-        // get current cbor vec to size if we reached target size
-        let new_cbor = sign1_clone
-            .to_tagged_vec()
-            .map_err(|_e| Error::CoseSignature)?;
-
-        match new_cbor.len() < end_size {
-            true => target_guess += 1,
-            false if new_cbor.len() == end_size => return Ok(new_cbor),
-            false => break, // we could not match end_size in a single pad so break and add a second
-        }
-    }
-
-    // if we reach here we need a new second padding object to hit exact size
-    sign1.unprotected.rest.push((
-        Label::Text(PAD2.to_string()),
-        Value::Bytes(vec![0u8; last_pad - 10]),
-    ));
-    pad_cose_sig(sign1, end_size)
 }
 
 #[cfg(test)]

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -214,8 +214,9 @@ pub mod tests {
     #[test]
     #[cfg(feature = "openssl_sign")]
     fn test_stapled_ocsp() {
-        use c2pa_crypto::raw_signature::{
-            signer_from_cert_chain_and_private_key, RawSigner, RawSignerError,
+        use c2pa_crypto::{
+            raw_signature::{signer_from_cert_chain_and_private_key, RawSigner, RawSignerError},
+            time_stamp::{TimeStampError, TimeStampProvider},
         };
 
         let mut validation_log = DetailedStatusTracker::default();
@@ -229,19 +230,19 @@ pub mod tests {
         let pem_key = include_bytes!("../tests/fixtures/certs/ps256.pem").to_vec();
         let ocsp_rsp_data = include_bytes!("../tests/fixtures/ocsp_good.data");
 
-        let signer =
+        let raw_signer =
             signer_from_cert_chain_and_private_key(&sign_cert, &pem_key, SigningAlg::Ps256, None)
                 .unwrap();
 
         // create a test signer that supports stapling
         struct OcspSigner {
-            pub signer: Box<dyn crate::Signer>,
+            pub raw_signer: Box<dyn RawSigner>,
             pub ocsp_rsp: Vec<u8>,
         }
 
         impl crate::Signer for OcspSigner {
             fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
-                self.signer.sign(data)
+                Ok(self.raw_signer.sign(&data)?)
             }
 
             fn alg(&self) -> SigningAlg {
@@ -249,27 +250,82 @@ pub mod tests {
             }
 
             fn certs(&self) -> Result<Vec<Vec<u8>>> {
-                self.signer.certs()
+                Ok(self.raw_signer.cert_chain()?)
             }
 
             fn reserve_size(&self) -> usize {
-                self.signer.reserve_size()
+                self.raw_signer.reserve_size()
             }
 
             fn ocsp_val(&self) -> Option<Vec<u8>> {
                 Some(self.ocsp_rsp.clone())
             }
+
+            fn raw_signer(&self) -> Option<Box<&dyn c2pa_crypto::raw_signature::RawSigner>> {
+                eprintln!("RS AS SELF:265");
+                Some(Box::new(self))
+            }
+        }
+
+        impl RawSigner for OcspSigner {
+            fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
+                self.raw_signer.sign(data)
+            }
+
+            fn alg(&self) -> SigningAlg {
+                self.raw_signer.alg()
+            }
+
+            fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
+                self.raw_signer.cert_chain()
+            }
+
+            fn reserve_size(&self) -> usize {
+                self.raw_signer.reserve_size()
+            }
+
+            fn ocsp_response(&self) -> Option<Vec<u8>> {
+                eprintln!("THE ONE I WANTED @ 287");
+                Some(self.ocsp_rsp.clone())
+            }
+        }
+
+        impl TimeStampProvider for OcspSigner {
+            fn time_stamp_service_url(&self) -> Option<String> {
+                self.raw_signer.time_stamp_service_url()
+            }
+
+            fn time_stamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+                self.raw_signer.time_stamp_request_headers()
+            }
+
+            fn time_stamp_request_body(
+                &self,
+                message: &[u8],
+            ) -> std::result::Result<Vec<u8>, TimeStampError> {
+                self.raw_signer.time_stamp_request_body(message)
+            }
+
+            fn send_time_stamp_request(
+                &self,
+                message: &[u8],
+            ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
+                self.raw_signer.send_time_stamp_request(message)
+            }
         }
 
         let ocsp_signer = OcspSigner {
-            signer: Box::new(crate::signer::RawSignerWrapper(signer)),
+            raw_signer,
             ocsp_rsp: ocsp_rsp_data.to_vec(),
         };
 
         // sign and staple
-        let cose_bytes =
-            crate::cose_sign::sign_claim(&claim_bytes, &ocsp_signer, ocsp_signer.reserve_size())
-                .unwrap();
+        let cose_bytes = crate::cose_sign::sign_claim(
+            &claim_bytes,
+            &ocsp_signer,
+            RawSigner::reserve_size(&ocsp_signer),
+        )
+        .unwrap();
 
         let cose_sign1 = parse_cose_sign1(&cose_bytes, &claim_bytes, &mut validation_log).unwrap();
         let ocsp_stapled = get_ocsp_der(&cose_sign1).unwrap();

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -13,7 +13,7 @@
 
 // #![deny(missing_docs)] (we'll turn this on once fully documented)
 
-use c2pa_crypto::cose::CoseError;
+use c2pa_crypto::{cose::CoseError, raw_signature::RawSignerError, time_stamp::TimeStampError};
 use thiserror::Error;
 
 /// `Error` enumerates errors returned by most C2PA toolkit operations.
@@ -358,8 +358,44 @@ impl From<CoseError> for Error {
             CoseError::TimeStampError(e) => e.into(),
             CoseError::CertificateProfileError(e) => e.into(),
             CoseError::CertificateTrustError(e) => e.into(),
+            CoseError::BoxSizeTooSmall => Self::CoseSigboxTooSmall,
+            CoseError::RawSignerError(e) => e.into(),
             CoseError::RawSignatureValidationError(e) => e.into(),
             CoseError::InternalError(e) => Self::InternalError(e),
         }
+    }
+}
+
+impl From<Error> for CoseError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::CoseX5ChainMissing => Self::MissingSigningCertificateChain,
+            Error::CoseVerifier => Self::MultipleSigningCertificateChains,
+            Error::NotFound => Self::NoTimeStampToken,
+            Error::CoseSignatureAlgorithmNotSupported => Self::UnsupportedSigningAlgorithm,
+            Error::InvalidEcdsaSignature => Self::InvalidEcdsaSignature,
+            Error::CoseTimeStampGeneration => Self::CborGenerationError(err.to_string()),
+            Error::TimeStampError(e) => Self::TimeStampError(e),
+            Error::CertificateProfileError(e) => Self::CertificateProfileError(e),
+            Error::CertificateTrustError(e) => Self::CertificateTrustError(e),
+            Error::CoseSigboxTooSmall => Self::BoxSizeTooSmall,
+            Error::RawSignerError(e) => Self::RawSignerError(e),
+            Error::RawSignatureValidationError(e) => Self::RawSignatureValidationError(e),
+            _ => Self::InternalError(err.to_string()),
+        }
+    }
+}
+
+impl From<Error> for RawSignerError {
+    fn from(err: Error) -> Self {
+        // See if better mappings exist, but I doubt it.
+        Self::InternalError(err.to_string())
+    }
+}
+
+impl From<Error> for TimeStampError {
+    fn from(err: Error) -> Self {
+        // See if better mappings exist, but I doubt it.
+        Self::InternalError(err.to_string())
     }
 }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -13,8 +13,8 @@
 
 use async_trait::async_trait;
 use c2pa_crypto::{
-    raw_signature::RawSigner,
-    time_stamp::{AsyncTimeStampProvider, TimeStampProvider},
+    raw_signature::{AsyncRawSigner, RawSigner, RawSignerError},
+    time_stamp::{TimeStampError, TimeStampProvider},
     SigningAlg,
 };
 
@@ -99,10 +99,10 @@ pub trait Signer {
         Vec::new()
     }
 
-    /// If this struct also implements [`TimeStampProvider`], return a reference to that struct.
+    /// If this struct also implements [`RawSigner`] (which it should), return a reference to that struct.
     ///
-    /// [`TimeStampProvider`]: c2pa_crypto::time_stamp::TimeStampProvider
-    fn time_stamp_provider(&self) -> Option<Box<&dyn TimeStampProvider>> {
+    /// [`RawSigner`]: c2pa_crypto::time_stamp::RawSigner
+    fn raw_signer(&self) -> Option<Box<&dyn RawSigner>> {
         None
     }
 }
@@ -219,10 +219,10 @@ pub trait AsyncSigner: Sync {
         Vec::new()
     }
 
-    /// If this struct also implements [`AsyncTimeStampProvider`], return a reference to that struct.
+    /// If this struct also implements [`AsyncRawSigner`] (which it should), return a reference to that struct.
     ///
-    /// [`AsyncTimeStampProvider`]: c2pa_crypto::time_stamp::AsyncTimeStampProvider
-    fn async_time_stamp_provider(&self) -> Option<Box<&dyn AsyncTimeStampProvider>> {
+    /// [`AsyncRawSigner`]: c2pa_crypto::time_stamp::AsyncRawSigner
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
         None
     }
 }
@@ -298,10 +298,10 @@ pub trait AsyncSigner {
         Vec::new()
     }
 
-    /// If this struct also implements [`AsyncTimeStampProvider`], return a reference to that struct.
+    /// If this struct also implements [`AsyncRawSigner`] (which it should), return a reference to that struct.
     ///
-    /// [`AsyncTimeStampProvider`]: c2pa_crypto::time_stamp::AsyncTimeStampProvider
-    fn async_time_stamp_provider<'a>(&'a self) -> Option<Box<&'a dyn AsyncTimeStampProvider>> {
+    /// [`AsyncRawSigner`]: c2pa_crypto::time_stamp::AsyncRawSigner
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
         None
     }
 }
@@ -368,8 +368,57 @@ impl Signer for Box<dyn Signer> {
         (**self).send_timestamp_request(message)
     }
 
-    fn time_stamp_provider(&self) -> Option<Box<&dyn TimeStampProvider>> {
-        (**self).time_stamp_provider()
+    fn raw_signer(&self) -> Option<Box<&dyn RawSigner>> {
+        (**self).raw_signer()
+    }
+}
+
+impl RawSigner for Box<dyn Signer> {
+    fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
+        Ok(self.as_ref().sign(data)?)
+    }
+
+    fn alg(&self) -> SigningAlg {
+        self.as_ref().alg()
+    }
+
+    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
+        Ok(self.as_ref().certs()?)
+    }
+
+    fn reserve_size(&self) -> usize {
+        self.as_ref().reserve_size()
+    }
+
+    fn ocsp_response(&self) -> Option<Vec<u8>> {
+        eprintln!("HUH, A DIFFERENT I WANTED @ 397");
+        self.as_ref().ocsp_val()
+    }
+}
+
+impl TimeStampProvider for Box<dyn Signer> {
+    fn time_stamp_service_url(&self) -> Option<String> {
+        self.as_ref().time_authority_url()
+    }
+
+    fn time_stamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+        self.as_ref().timestamp_request_headers()
+    }
+
+    fn time_stamp_request_body(
+        &self,
+        message: &[u8],
+    ) -> std::result::Result<Vec<u8>, TimeStampError> {
+        Ok(self.as_ref().sign(message)?)
+    }
+
+    fn send_time_stamp_request(
+        &self,
+        message: &[u8],
+    ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
+        self.as_ref()
+            .send_timestamp_request(message)
+            .map(|r| Ok(r?))
     }
 }
 
@@ -419,6 +468,10 @@ impl AsyncSigner for Box<dyn AsyncSigner + Send + Sync> {
     fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
         (**self).dynamic_assertions()
     }
+
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        (**self).async_raw_signer()
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -467,6 +520,10 @@ impl AsyncSigner for Box<dyn AsyncSigner> {
     fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
         (**self).dynamic_assertions()
     }
+
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        (**self).async_raw_signer()
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -511,5 +568,9 @@ impl Signer for RawSignerWrapper {
         self.0
             .send_time_stamp_request(message)
             .map(|r| r.map_err(|e| e.into()))
+    }
+
+    fn raw_signer(&self) -> Option<Box<&dyn RawSigner>> {
+        Some(Box::new(&*self.0))
     }
 }

--- a/sdk/src/utils/test_signer.rs
+++ b/sdk/src/utils/test_signer.rs
@@ -143,4 +143,8 @@ impl AsyncSigner for AsyncRawSignerWrapper {
             .await
             .map(|r| r.map_err(|e| e.into()))
     }
+
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        Some(Box::new(&*self.0))
+    }
 }


### PR DESCRIPTION
This code causes rustfmt nightly (as of 2024-12-30) to panic. Log attached.
    
IMPORTANT: The log states the rustfmt version is from 2024-11-16, but I have run `rustup update nightly` with the following result:
    
```
$ rustup update nightly
info: syncing channel updates for 'nightly-aarch64-apple-darwin'

nightly-aarch64-apple-darwin unchanged - rustc 1.85.0-nightly (14ee63a3c 2024-12-29)

info: checking for self-update
```