### PR TITLE
fix: Bring `claim_v2` changes from #707 into `c2pa_crypto`

### DIFF
--- a/internal/crypto/src/cose/mod.rs
+++ b/internal/crypto/src/cose/mod.rs
@@ -42,5 +42,8 @@ pub use sigtst::{
     TstToken,
 };
 
+mod time_stamp_storage;
+pub use time_stamp_storage::TimeStampStorage;
+
 mod verifier;
 pub use verifier::Verifier;

--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -20,7 +20,7 @@ use coset::{
 };
 
 use crate::{
-    cose::{add_sigtst_header, add_sigtst_header_async, CoseError},
+    cose::{add_sigtst_header, add_sigtst_header_async, CoseError, TimeStampStorage},
     p1363::{der_to_p1363, parse_ec_der_sig},
     raw_signature::{AsyncRawSigner, RawSigner},
     SigningAlg,
@@ -76,9 +76,15 @@ use crate::{
 #[async_generic(async_signature(
     signer: &dyn AsyncRawSigner,
     data: &[u8],
-    box_size: usize
+    box_size: usize,
+    _time_stamp_storage: TimeStampStorage
 ))]
-pub fn sign(signer: &dyn RawSigner, data: &[u8], box_size: usize) -> Result<Vec<u8>, CoseError> {
+pub fn sign(
+    signer: &dyn RawSigner,
+    data: &[u8],
+    box_size: usize,
+    _time_stamp_storage: TimeStampStorage,
+) -> Result<Vec<u8>, CoseError> {
     let alg = signer.alg();
 
     let (protected_header, unprotected_header) = if _sync {

--- a/internal/crypto/src/cose/sigtst.rs
+++ b/internal/crypto/src/cose/sigtst.rs
@@ -231,10 +231,7 @@ fn make_cose_timestamp(ts_data: &[u8]) -> TstContainer {
 // Return timeStampToken used by sigTst2.
 fn timestamptoken_from_timestamprsp(ts: &[u8]) -> Option<Vec<u8>> {
     let ts_resp = TimeStampResponse(
-        Constructed::decode(ts, bcder::Mode::Der, |cons| {
-            TimeStampResp::take_from(cons)
-        })
-        .ok()?,
+        Constructed::decode(ts, bcder::Mode::Der, |cons| TimeStampResp::take_from(cons)).ok()?,
     );
 
     let tst = ts_resp.0.time_stamp_token?;

--- a/internal/crypto/src/cose/sigtst.rs
+++ b/internal/crypto/src/cose/sigtst.rs
@@ -231,7 +231,7 @@ fn make_cose_timestamp(ts_data: &[u8]) -> TstContainer {
 // Return timeStampToken used by sigTst2.
 fn timestamptoken_from_timestamprsp(ts: &[u8]) -> Option<Vec<u8>> {
     let ts_resp = TimeStampResponse(
-        Constructed::decode(ts, bcder::Mode::Der, |cons| TimeStampResp::take_from(cons)).ok()?,
+        Constructed::decode(ts, bcder::Mode::Der, TimeStampResp::take_from).ok()?,
     );
 
     let tst = ts_resp.0.time_stamp_token?;

--- a/internal/crypto/src/cose/sigtst.rs
+++ b/internal/crypto/src/cose/sigtst.rs
@@ -231,7 +231,7 @@ fn make_cose_timestamp(ts_data: &[u8]) -> TstContainer {
 // Return timeStampToken used by sigTst2.
 fn timestamptoken_from_timestamprsp(ts: &[u8]) -> Option<Vec<u8>> {
     let ts_resp = TimeStampResponse(
-        Constructed::decode(ts.as_ref(), bcder::Mode::Der, |cons| {
+        Constructed::decode(ts, bcder::Mode::Der, |cons| {
             TimeStampResp::take_from(cons)
         })
         .ok()?,

--- a/internal/crypto/src/cose/time_stamp_storage.rs
+++ b/internal/crypto/src/cose/time_stamp_storage.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+/// The `TimeStampStorage` parameter defines how [RFC 3161] time stamps are to
+/// be stored in a COSE signature.
+///
+/// This is as defined in [§10.3.2.5.4, Storing the time-stamp], of version 2.1
+/// of the C2PA Technical Specification.
+///
+/// [§10.3.2.5.4, Storing the time-stamp]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_storing_the_time_stamp
+#[allow(non_camel_case_types)] // We choose to match the exact header names as used in the C2PA specification.
+pub enum TimeStampStorage {
+    /// v1 time-stamps _(deprecated)_ are stored in a COSE unprotected header
+    /// whose label is the string `sigTst`. If present, the value of this header
+    /// shall be a `tstContainer` defined by [Example 2, “CDDL for
+    /// `tstContainer`”]. The content of the `TimeStampResp` structure received
+    /// in reply from the TSA shall be stored as the value of the `val property
+    /// of an element of `tstTokens`.
+    ///
+    /// [Example 2, “CDDL for `tstContainer`”]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#tstContainer-CDDL
+    V1_sigTst,
+
+    /// v2 time-stamps shall be stored in a COSE unprotected header whose label
+    /// is the string `sigTst2`. When present, the value of this header shall be
+    /// a `tstContainer` defined by [Example 2, “CDDL for `tstContainer`”]. The
+    /// content of value of the `timeStampToken` field of the `TimeStampResp`
+    /// structure received in reply from the TSA shall be stored as the value of
+    /// the `val` property of an element of `tstTokens`.
+    ///
+    /// **NOTE:** A v2 time-stamp is equivalent to the "CTT" model of [COSE
+    /// Header parameter for RFC 3161 Time-Stamp Tokens Draft]. It requires that
+    /// the complete signature structure be completed prior to time-stamping,
+    /// thus enabling the time-stamp to serve as a countersignature on the
+    /// entire signature structure, including the actual certificate.
+    ///
+    /// [Example 2, “CDDL for `tstContainer`”]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#tstContainer-CDDL
+    /// [COSE Header parameter for RFC 3161 Time-Stamp Tokens Draft]: https://datatracker.ietf.org/doc/draft-ietf-cose-tsa-tst-header-parameter/
+    V2_sigTst2_CTT,
+}

--- a/internal/crypto/src/cose/time_stamp_storage.rs
+++ b/internal/crypto/src/cose/time_stamp_storage.rs
@@ -19,6 +19,7 @@
 ///
 /// [§10.3.2.5.4, Storing the time-stamp]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_storing_the_time_stamp
 #[allow(non_camel_case_types)] // We choose to match the exact header names as used in the C2PA specification.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TimeStampStorage {
     /// v1 time-stamps _(deprecated)_ are stored in a COSE unprotected header
     /// whose label is the string `sigTst`. If present, the value of this header

--- a/internal/crypto/src/cose/verifier.rs
+++ b/internal/crypto/src/cose/verifier.rs
@@ -88,17 +88,7 @@ impl Verifier<'_> {
         } else {
             validate_cose_tst_info_async(&sign1, data).await
         };
-
-        if _sync {
-            self.verify_profile(&sign1, &tst_info_res, validation_log)?;
-            self.verify_trust(&sign1, &tst_info_res, validation_log)?;
-        } else {
-            self.verify_profile_async(&sign1, &tst_info_res, validation_log)
-                .await?;
-            self.verify_trust_async(&sign1, &tst_info_res, validation_log)
-                .await?;
-        }
-
+        
         match alg {
             SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
                 if parse_ec_der_sig(&sign1.signature).is_ok() {
@@ -113,6 +103,16 @@ impl Verifier<'_> {
             }
             _ => (),
         }
+
+        if _sync {
+            self.verify_profile(&sign1, &tst_info_res, validation_log)?;
+            self.verify_trust(&sign1, &tst_info_res, validation_log)?;
+        } else {
+            self.verify_profile_async(&sign1, &tst_info_res, validation_log)
+                .await?;
+            self.verify_trust_async(&sign1, &tst_info_res, validation_log)
+                .await?;
+        }    
 
         // Reconstruct payload and additional data as it should have been at time of
         // signing.

--- a/internal/crypto/src/cose/verifier.rs
+++ b/internal/crypto/src/cose/verifier.rs
@@ -88,7 +88,7 @@ impl Verifier<'_> {
         } else {
             validate_cose_tst_info_async(&sign1, data).await
         };
-        
+
         match alg {
             SigningAlg::Es256 | SigningAlg::Es384 | SigningAlg::Es512 => {
                 if parse_ec_der_sig(&sign1.signature).is_ok() {
@@ -112,7 +112,7 @@ impl Verifier<'_> {
                 .await?;
             self.verify_trust_async(&sign1, &tst_info_res, validation_log)
                 .await?;
-        }    
+        }
 
         // Reconstruct payload and additional data as it should have been at time of
         // signing.

--- a/internal/crypto/src/openssl/check_certificate_trust.rs
+++ b/internal/crypto/src/openssl/check_certificate_trust.rs
@@ -38,7 +38,10 @@ pub(crate) fn check_certificate_trust(
     let cert = X509::from_der(cert_der)?;
 
     let mut builder = openssl::x509::store::X509StoreBuilder::new()?;
+    builder.set_flags(X509VerifyFlags::X509_STRICT)?;
+
     let mut verify_param = openssl::x509::verify::X509VerifyParam::new()?;
+    verify_param.set_flags(X509VerifyFlags::X509_STRICT)?;
 
     if let Some(st) = signing_time_epoch {
         verify_param.set_time(st);

--- a/internal/crypto/src/time_stamp/mod.rs
+++ b/internal/crypto/src/time_stamp/mod.rs
@@ -27,7 +27,7 @@ mod provider;
 pub use provider::{default_rfc3161_message, AsyncTimeStampProvider, TimeStampProvider};
 
 mod response;
-pub(crate) use response::TimeStampResponse;
+pub(crate) use response::{ContentInfo, TimeStampResponse};
 
 mod verify;
 /// TEMPORARILY PUBLIC while refactoring

--- a/internal/crypto/src/time_stamp/mod.rs
+++ b/internal/crypto/src/time_stamp/mod.rs
@@ -27,6 +27,7 @@ mod provider;
 pub use provider::{default_rfc3161_message, AsyncTimeStampProvider, TimeStampProvider};
 
 mod response;
+pub(crate) use response::TimeStampResponse;
 
 mod verify;
 /// TEMPORARILY PUBLIC while refactoring

--- a/internal/crypto/src/time_stamp/response.rs
+++ b/internal/crypto/src/time_stamp/response.rs
@@ -89,11 +89,11 @@ impl TimeStampResponse {
 }
 
 #[derive(AsnType, Clone, Debug, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct ContentInfo {
-    content_type: rasn::types::ObjectIdentifier,
+pub(crate) struct ContentInfo {
+    pub(crate) content_type: rasn::types::ObjectIdentifier,
 
     #[rasn(tag(explicit(0)))]
-    content: rasn::types::Any,
+    pub(crate) content: rasn::types::Any,
 }
 
 /// TO REVIEW: Does this need to be public after refactoring?

--- a/internal/crypto/src/time_stamp/response.rs
+++ b/internal/crypto/src/time_stamp/response.rs
@@ -14,8 +14,6 @@
 use bcder::decode::Constructed;
 use rasn::{AsnType, Decode, Decoder, Encode, Encoder};
 
-#[cfg(not(target_arch = "wasm32"))]
-use crate::asn1::rfc3161::PkiStatus;
 use crate::{
     asn1::{
         rfc3161::{TimeStampResp, TimeStampToken, TstInfo, OID_CONTENT_TYPE_TST_INFO},
@@ -24,10 +22,8 @@ use crate::{
     time_stamp::TimeStampError,
 };
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct TimeStampResponse(pub TimeStampResp);
 
-#[cfg(not(target_arch = "wasm32"))]
 impl std::ops::Deref for TimeStampResponse {
     type Target = TimeStampResp;
 
@@ -36,16 +32,19 @@ impl std::ops::Deref for TimeStampResponse {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl TimeStampResponse {
     /// Return `true` if the request was successful.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn is_success(&self) -> bool {
+        use crate::asn1::rfc3161::PkiStatus;
+
         matches!(
             self.0.status.status,
             PkiStatus::Granted | PkiStatus::GrantedWithMods
         )
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn signed_data(&self) -> Result<Option<SignedData>, TimeStampError> {
         if let Some(token) = &self.0.time_stamp_token {
             if token.content_type == OID_ID_SIGNED_DATA {
@@ -66,6 +65,7 @@ impl TimeStampResponse {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn tst_info(&self) -> Result<Option<TstInfo>, TimeStampError> {
         if let Some(signed_data) = self.signed_data()? {
             if signed_data.content_info.content_type == OID_CONTENT_TYPE_TST_INFO {

--- a/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
@@ -71,9 +71,7 @@ impl AsyncRawSignatureValidator for EcdsaValidator {
 
         let crypto_key: CryptoKey = JsFuture::from(promise)
             .await
-            .map_err(|_err| {
-                RawSignatureValidationError::InternalError("invalid ECDSA key")
-            })?
+            .map_err(|_err| RawSignatureValidationError::InternalError("invalid ECDSA key"))?
             .into();
 
         let algorithm = EcdsaParams(hash).as_js_object().map_err(|_err| {

--- a/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
+++ b/internal/crypto/src/webcrypto/async_validators/ecdsa_validator.rs
@@ -72,7 +72,7 @@ impl AsyncRawSignatureValidator for EcdsaValidator {
         let crypto_key: CryptoKey = JsFuture::from(promise)
             .await
             .map_err(|_err| {
-                RawSignatureValidationError::InternalError("unable to create CryptoKey promise")
+                RawSignatureValidationError::InternalError("invalid ECDSA key")
             })?
             .into();
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -24,7 +24,7 @@ use std::{
 use async_generic::async_generic;
 use async_recursion::async_recursion;
 use c2pa_crypto::{
-    cose::{parse_cose_sign1, CertificateTrustPolicy},
+    cose::{parse_cose_sign1, CertificateTrustPolicy, TimeStampStorage},
     hash::sha256,
 };
 use c2pa_status_tracker::{log_item, DetailedStatusTracker, OneShotStatusTracker, StatusTracker};
@@ -494,7 +494,8 @@ impl Store {
                 // Let the signer do all the COSE processing and return the structured COSE data.
                 return signer.sign(&claim_bytes); // do not verify remote signers (we never did)
             } else {
-                cose_sign(signer, &claim_bytes, box_size)
+                // TEMPORARY: Assume V1 until we plumb things through further.
+                cose_sign(signer, &claim_bytes, box_size, TimeStampStorage::V1_sigTst)
             }
         } else {
             if signer.direct_cose_handling() {
@@ -502,7 +503,8 @@ impl Store {
                 return signer.sign(claim_bytes.clone()).await;
             // do not verify remote signers (we never did)
             } else {
-                cose_sign_async(signer, &claim_bytes, box_size).await
+                // TEMPORARY: Assume V1 until we plumb things through further.
+                cose_sign_async(signer, &claim_bytes, box_size, TimeStampStorage::V1_sigTst).await
             }
         };
         match result {

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -452,7 +452,14 @@ impl crate::signer::RemoteSigner for TempRemoteSigner {
         {
             let signer = crate::wasm::RsaWasmSignerAsync::new();
 
-            crate::cose_sign::cose_sign_async(&signer, claim_bytes, self.reserve_size()).await
+            // TEMPORARY: Assume V1 until we plumb more through.
+            crate::cose_sign::cose_sign_async(
+                &signer,
+                claim_bytes,
+                self.reserve_size(),
+                TimeStampStorage::V1_sigTst,
+            )
+            .await
         }
     }
 

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -22,7 +22,7 @@ use std::{
 
 use async_trait::async_trait;
 use c2pa_crypto::{
-    cose::CertificateTrustPolicy,
+    cose::{CertificateTrustPolicy, TimeStampStorage},
     raw_signature::{AsyncRawSigner, RawSigner, RawSignerError},
     time_stamp::{AsyncTimeStampProvider, TimeStampError, TimeStampProvider},
     SigningAlg,
@@ -424,7 +424,14 @@ impl crate::signer::RemoteSigner for TempRemoteSigner {
             let signer = crate::utils::test_signer::async_test_signer(SigningAlg::Ps256);
 
             // this would happen on some remote server
-            crate::cose_sign::cose_sign_async(&signer, claim_bytes, self.reserve_size()).await
+            // TEMPORARY: Assume v1 until we plumb things through further.
+            crate::cose_sign::cose_sign_async(
+                &signer,
+                claim_bytes,
+                self.reserve_size(),
+                TimeStampStorage::V1_sigTst,
+            )
+            .await
         }
         #[cfg(not(any(
             target_arch = "wasm32",
@@ -581,10 +588,12 @@ impl AsyncSigner for TempAsyncRemoteSigner {
             let signer = crate::utils::test_signer::async_test_signer(SigningAlg::Ps256);
 
             // this would happen on some remote server
+            // TEMPORARY: Assume V1 until we plumb through further.
             crate::cose_sign::cose_sign_async(
                 &signer,
                 &claim_bytes,
                 AsyncSigner::reserve_size(self),
+                TimeStampStorage::V1_sigTst,
             )
             .await
         }
@@ -592,10 +601,12 @@ impl AsyncSigner for TempAsyncRemoteSigner {
         #[cfg(target_arch = "wasm32")]
         {
             let signer = crate::wasm::rsa_wasm_signer::RsaWasmSignerAsync::new();
+            // TEMPORARY: Assume V1 until we plumb through further.
             crate::cose_sign::cose_sign_async(
                 &signer,
                 &claim_bytes,
                 AsyncRawSigner::reserve_size(self),
+                TimeStampStorage::V1_sigTst,
             )
             .await
         }


### PR DESCRIPTION
Review #707 for changes that should be incorporated into `c2pa_crypto` crate.

The biggest change is the introduction of the `TimeStampStorage` enum, which can select V1 (now deprecated) or V2 (new as of C2PA 2.x) handling of `sigTst` or `sigTst2` time stamp headers.