### PR TITLE
feat: Remove writing of native camera RAW formats from SDK

### DIFF
--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -68,6 +68,16 @@ static SUPPORTED_TYPES: [&str; 10] = [
     "image/x-nikon-nef",
 ];
 
+// Writing native formats is beyond the scope of the SDK.
+static SUPPORTED_WRITER_TYPES: [&str; 6] = [
+    "tif",
+    "tiff",
+    "image/tiff",
+    "dng",
+    "image/dng",
+    "image/x-adobe-dng",
+];
+
 // The type of an IFD entry
 #[derive(Debug, PartialEq)]
 enum IFDEntryType {
@@ -1414,7 +1424,11 @@ impl AssetIO for TiffIO {
     }
 
     fn get_writer(&self, asset_type: &str) -> Option<Box<dyn CAIWriter>> {
-        Some(Box::new(TiffIO::new(asset_type)))
+        if SUPPORTED_WRITER_TYPES.contains(&asset_type) {
+            Some(Box::new(TiffIO::new(asset_type)))
+        } else {
+            None
+        }
     }
 
     fn remote_ref_writer_ref(&self) -> Option<&dyn RemoteRefEmbed> {

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -421,6 +421,10 @@ pub mod tests {
                 assert!(get_caiwriter_handler(supported_type).is_some());
             }
         }
+
+        // Writing native formats is beyond the scope of the SDK.
+        assert!(get_caiwriter_handler("nef").is_none());
+        assert!(get_caiwriter_handler("arw").is_none());
     }
 
     #[test]

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -421,10 +421,28 @@ pub mod tests {
                 assert!(get_caiwriter_handler(supported_type).is_some());
             }
         }
+    }
 
+    #[test]
+    fn test_get_writer_tiff() {
+        let h = TiffIO::new("");
         // Writing native formats is beyond the scope of the SDK.
-        assert!(get_caiwriter_handler("nef").is_none());
-        assert!(get_caiwriter_handler("arw").is_none());
+        // Only the following are supported.
+        let supported_tiff_types: [&str; 6] = [
+            "tif",
+            "tiff",
+            "image/tiff",
+            "dng",
+            "image/dng",
+            "image/x-adobe-dng",
+        ];
+        for tiff_type in h.supported_types() {
+            if supported_tiff_types.contains(tiff_type) {
+                assert!(get_caiwriter_handler(tiff_type).is_some());
+            } else {
+                assert!(get_caiwriter_handler(tiff_type).is_none());
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request
Writers of native formats cannot be easily tested and are beyond the scope of the SDK.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
