### PR TITLE
chore: Install `cargo udeps` directly rather than using action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,7 @@ jobs:
 
       - name: Run cargo-udeps
         run: |
-          ./.github/temp-bin/cargo-udeps --all-targets --all-features
+          mv ./.github/temp-bin/cargo-udeps /home/runner/.cargo/bin/cargo-udeps
+          cargo udeps --all-targets --all-features
           # NOTE: Using pre-built binary as a workaround for
           # https://github.com/aig787/cargo-udeps-action/issues/6.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
-        with:
-          version: latest
-          args: --all-targets --all-features
+        run: |
+          cargo install cargo-udeps --locked
+          cargo +nightly udeps --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,14 +432,8 @@ jobs:
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Run cargo-udeps (build and archive)
+      - name: Run cargo-udeps
         run: |
-          cargo +nightly install cargo-udeps --locked
-          mkdir ./.github/temp-bin
-          cp `which cargo-udeps` ./.github/temp-bin/cargo-udeps
-          # cargo +nightly udeps --all-targets --all-features
-
-      - name: Write back 
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit-message: "Save copy of built cargo-udeps tool"
+          ./.github/temp-bin/cargo-udeps --all-targets --all-features
+          # NOTE: Using pre-built binary as a workaround for
+          # https://github.com/aig787/cargo-udeps-action/issues/6.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,8 +429,8 @@ jobs:
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Run cargo-udeps
+      - name: Run cargo-udeps (build and archive)
         run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo +nightly binstall cargo-udeps --locked
-          cargo +nightly udeps --all-targets --all-features
+          cargo +nightly install cargo-udeps --locked
+          which cargo-udeps
+          # cargo +nightly udeps --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,5 +431,6 @@ jobs:
 
       - name: Run cargo-udeps
         run: |
-          cargo install cargo-udeps --locked
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo +nightly binstall cargo-udeps --locked
           cargo +nightly udeps --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -432,5 +435,10 @@ jobs:
       - name: Run cargo-udeps (build and archive)
         run: |
           cargo +nightly install cargo-udeps --locked
-          which cargo-udeps
+          cp `which cargo-udeps` ./.github/temp-bin/cargo-udeps
           # cargo +nightly udeps --all-targets --all-features
+
+      - name: Write back 
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit-message: "Save copy of built cargo-udeps tool"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,7 @@ jobs:
       - name: Run cargo-udeps (build and archive)
         run: |
           cargo +nightly install cargo-udeps --locked
+          mkdir ./.github/temp-bin
           cp `which cargo-udeps` ./.github/temp-bin/cargo-udeps
           # cargo +nightly udeps --all-targets --all-features
 


### PR DESCRIPTION
The `cargo-udeps-action` has not been updated in more than a year and no longer operates on GitHub's Ubuntu runner.
