### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.41.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.40.0...c2pa-v0.41.0)
+_16 January 2025_
+
+### Added
+
+* *(crypto)* Add `rsa` crate support to `rust_native_crypto` feature (#853)
+* *(cawg_identity)* Implement identity assertion validation (#843)
+* Remove writing of native camera RAW formats from SDK (#814)
+* Review `c2pa-crypto` crate API (#813)
+* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
+* Move COSE signing into `c2pa_crypto` crate (#807)
+* Move COSE timestamp generation into `c2pa_crypto` (#803)
+* Move COSE signature verification into `c2pa_crypto` (#801)
+* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
+* Introduce `c2pa_crypto::cose::Verifier` (#797)
+* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
+* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
+* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
+* Move COSE OCSP support into c2pa-crypto (#793)
+* Move `verify_trust` into `c2pa_crypto` (#784)
+* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
+* Bump MSRV to 1.81.0 (#781)
+
+### Fixed
+
+* *(sdk)* Make sure `DynamicAssertion::content` gets a properly populated `PreliminaryClaim` (#842)
+* Switch to from fast_xml to quick_xml (#805)
+* Update img-parts for jpeg segment underflow fix (#806)
+* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
+* Improve usage of `#[cfg]` directives (#783)
+* OOB read attempt in jpeg_io asset handler in get_cai_segments function (#719)
+* Prevent negative length value for SVG object locations (#766)
+* JPEG `write_cai` OOB insertion (#762)
+* Add support XMP in SVG (#771)
+* Possible overflow for TIFF (#760)
+* Resolve new Clippy issues (#776)
+
+### Updated dependencies
+
+* Bump jfifdump from 0.5.1 to 0.6.0 (#785)
+* Bump serde-wasm-bindgen from 0.5.0 to 0.6.5 (#786)
+* Bump thiserror from 2.0.6 to 2.0.8 (#787)
+* Bump rasn from 0.18.0 to 0.22.0 (#727)
+* Bump thiserror from 1.0.69 to 2.0.6 (#770)
+
 ## [0.40.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.39.0...c2pa-v0.40.0)
 _12 December 2024_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _16 January 2025_
 
 ### Fixed
 
-* *(sdk)* Make sure `DynamicAssertion::content` gets a properly populated `PreliminaryClaim` (#842)
+* Make sure `DynamicAssertion::content` gets a properly populated `PreliminaryClaim` (#842)
 * Switch to from fast_xml to quick_xml (#805)
 * Update img-parts for jpeg segment underflow fix (#806)
 * Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -53,7 +53,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -74,7 +74,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -175,19 +175,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
@@ -231,7 +232,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -243,7 +244,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -326,7 +327,7 @@ checksum = "ddf3728566eefa873833159754f5732fb0951d3649e6e5b891cc70d56dd41673"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -369,7 +370,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -396,7 +397,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "futures-lite",
  "rustix",
  "tracing",
@@ -410,7 +411,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -467,13 +468,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -583,9 +584,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -636,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -677,9 +678,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -710,7 +711,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -775,7 +776,7 @@ dependencies = [
  "sha2",
  "spki",
  "tempfile",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "tokio",
  "treeline",
  "ureq",
@@ -792,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -830,7 +831,7 @@ dependencies = [
  "sha1",
  "sha2",
  "spki",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "ureq",
  "url",
  "wasm-bindgen",
@@ -844,11 +845,11 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "c2patool"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -875,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -907,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "shlex",
 ]
@@ -979,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -989,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1001,14 +1002,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1159,18 +1160,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1187,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1243,7 +1244,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1273,7 +1274,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1284,20 +1285,20 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1305,12 +1306,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1367,7 +1368,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1417,7 +1418,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1534,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -1544,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1579,9 +1580,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1594,7 +1595,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
@@ -1663,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -1736,9 +1737,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1755,7 +1756,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1819,9 +1820,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-timers"
@@ -2034,7 +2035,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "lazy_static",
  "levenshtein",
  "log",
@@ -2055,9 +2056,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2078,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2098,13 +2099,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2122,7 +2123,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2141,7 +2142,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2287,7 +2288,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2296,7 +2297,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f4e785f2c700217ee82a1c727c720449421742abd5fcb2f1df04e1244760e9"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "byteorder",
  "flate2",
 ]
@@ -2358,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "img-parts"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfded0de32cc78ecad0061b3c6a263cec6bce298fc1e670a4926b6723664ed87"
+checksum = "6b4e24cfdc6f897b582508e3c382eaf5378076898f80500a80d10d761ae85e90"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2467,9 +2468,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2553,9 +2554,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -2569,7 +2570,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -2581,9 +2582,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2603,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
 ]
@@ -2682,9 +2683,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2724,7 +2725,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2888,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -2916,7 +2917,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2933,7 +2934,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3094,7 +3095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -3118,7 +3119,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3159,9 +3160,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3215,9 +3216,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.15"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -3277,9 +3278,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -3291,15 +3292,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -3340,20 +3341,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -3365,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
 ]
@@ -3385,7 +3386,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -3404,7 +3405,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3426,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3475,7 +3476,7 @@ version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
 dependencies = [
- "zerocopy 0.8.13",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -3505,9 +3506,9 @@ checksum = "d20581732dd76fa913c7dff1a2412b714afe3573e94d41c34719de73337cc8ab"
 
 [[package]]
 name = "rasn"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593394cad523914fcac9296bdb69701ad308589b3ea1e16d37b6f0c3cfad075"
+checksum = "9c1d1ed06b066a36d0492d65daaa5f40b7101c24a1228e0af2709712ef1a86e1"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
@@ -3527,34 +3528,34 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c367bf1b9a9bc34d40b9c140b52d26b585d0c7755b18496ba061f50639082"
+checksum = "7f35fecd68ee4d5850baa37ee4520456bbae761fdd42a7fcb95701c268500a93"
 dependencies = [
  "proc-macro2",
  "rasn-derive-impl",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "rasn-derive-impl"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a321099d2f0f08f0afb90e68a16015abea210d4734f7faf6b3497f29feb46a35"
+checksum = "355eedbab62312d9474e1c2e7963ce5fad99bded7e9abd42ae4f040762a2c5f6"
 dependencies = [
  "either",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "uuid",
 ]
 
 [[package]]
 name = "rasn-ocsp"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8804910bee097437b7df967160127e250e59b4d497b450c89328cd796ee1f8"
+checksum = "5cf2cbdf7f5e46d9a4ae4f0cac4bf578b748ccf39e369e7511a94b6f106a8a9e"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -3562,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-pkix"
-version = "0.22.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884db2ae0da3a7239daaec802df74f3431062f85651c511e6c40b35a30282b82"
+checksum = "2645f907b8c01fa266c9855d8effd38b63896574a66bbce3114682b30de5d6f1"
 dependencies = [
  "rasn",
 ]
@@ -3595,7 +3596,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3640,9 +3641,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3654,7 +3655,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -3678,6 +3679,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3740,7 +3742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "serde",
  "serde_derive",
 ]
@@ -3808,11 +3810,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3821,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -3845,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -3865,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -3914,14 +3916,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3949,7 +3945,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3958,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3968,15 +3964,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -4022,13 +4018,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4039,14 +4035,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -4088,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4106,14 +4102,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4214,7 +4210,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4263,7 +4259,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4282,7 +4278,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2",
- "syn 2.0.90",
+ "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
@@ -4324,9 +4320,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4350,7 +4346,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4359,7 +4355,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4382,12 +4378,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4406,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -4421,11 +4418,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.8",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -4436,18 +4433,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4517,9 +4514,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4535,13 +4532,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4612,6 +4609,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,7 +4662,7 @@ checksum = "d856e22ead1fb79b9fc3cec63300086f680924f2f7b0e2701f6835a28b9c4425"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4754,9 +4772,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
  "serde",
@@ -4817,34 +4835,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4855,9 +4874,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4865,32 +4884,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d44563646eb934577f2772656c7ad5e9c90fac78aa8013d776fcdaf24625d"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
 dependencies = [
  "js-sys",
  "minicov",
- "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -4898,20 +4919,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54171416ce73aa0b9c377b51cc3cb542becee1cd678204812e8392e5b0e4a031"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5096,9 +5117,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -5179,7 +5200,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5195,11 +5216,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
 dependencies = [
- "zerocopy-derive 0.8.13",
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -5210,18 +5231,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5241,7 +5262,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5262,7 +5283,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5284,14 +5305,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -5299,7 +5320,7 @@ dependencies = [
  "displaydoc",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -11,14 +11,14 @@ _16 January 2025_
 
 ### Added
 
-* *(cawg_identity)* Implement identity claims aggregation validator (#846)
-* *(cawg_identity)* Minimal implementation of W3C VC specification (#845)
-* *(cawg_identity)* Implement identity assertion validation (#843)
-* *(cawg_identity)* Add `SignatureVerifier` trait and `ValidationError` enum (#844)
-* *(cawg_identity)* Add `IdentityAssertionBuilder` struct (#840)
-* *(cawg_identity)* Introduce `IdentityAssertionSigner` (#827)
-* *(cawg_identity)* Define `CredentialHolder` trait (#821)
-* *(cawg_identity)* Add `SignerPayload` struct (#817)
+* Implement identity claims aggregation validator (#846)
+* Minimal implementation of W3C VC specification (#845)
+* Implement identity assertion validation (#843)
+* Add `SignatureVerifier` trait and `ValidationError` enum (#844)
+* Add `IdentityAssertionBuilder` struct (#840)
+* Introduce `IdentityAssertionSigner` (#827)
+* Define `CredentialHolder` trait (#821)
+* Add `SignerPayload` struct (#817)
 * Bump MSRV to 1.81.0 (#781)
 
 ## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.0...cawg-identity-v0.1.1)

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.1...cawg-identity-v0.2.0)
+_16 January 2025_
+
+### Added
+
+* *(cawg_identity)* Implement identity claims aggregation validator (#846)
+* *(cawg_identity)* Minimal implementation of W3C VC specification (#845)
+* *(cawg_identity)* Implement identity assertion validation (#843)
+* *(cawg_identity)* Add `SignatureVerifier` trait and `ValidationError` enum (#844)
+* *(cawg_identity)* Add `IdentityAssertionBuilder` struct (#840)
+* *(cawg_identity)* Introduce `IdentityAssertionSigner` (#827)
+* *(cawg_identity)* Define `CredentialHolder` trait (#821)
+* *(cawg_identity)* Add `SignerPayload` struct (#817)
+* Bump MSRV to 1.81.0 (#781)
+
 ## [0.1.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.0...cawg-identity-v0.1.1)
 _24 October 2024_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.1.1"
+version = "0.2.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -27,8 +27,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.40.0", features = ["openssl", "unstable_api"] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
+c2pa = { path = "../sdk", version = "0.41.0", features = ["openssl", "unstable_api"] }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,21 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.11.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.2...c2patool-v0.11.0)
+_16 January 2025_
+
+### Added
+
+* Move COSE signing into `c2pa_crypto` crate (#807)
+
+### Documented
+
+* Post move cleanup (#778)
+
+### Fixed
+
+* Fix: Obscure glob error message for missing files
+
 ## [0.10.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.1...c2patool-v0.10.2)
 _12 December 2024_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "c2patool"
 default-run = "c2patool"
 
-version = "0.10.2"
+version = "0.11.0"
 
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
@@ -24,14 +24,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.40.0", features = [
+c2pa = { path = "../sdk", version = "0.41.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
 	"unstable_api",
 ] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -11,9 +11,8 @@ _16 January 2025_
 
 ### Added
 
-* *(crypto)* Add `rsa` crate support to `rust_native_crypto` feature (#853)
-* *(crypto)* Introduce new (experimental) `rust_native_crypto` feature (#850)
-* *(cawg_identity)* Implement identity assertion validation (#843)
+* Add `rsa` crate support to `rust_native_crypto` feature (#853)
+* Introduce new (experimental) `rust_native_crypto` feature (#850)
 * Review `c2pa-crypto` crate API (#813)
 * Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
 * Move COSE signing into `c2pa_crypto` crate (#807)
@@ -32,7 +31,7 @@ _16 January 2025_
 
 ### Fixed
 
-* *(crypto)* Disable the built-in async validators on non-WASM platforms (#855)
+* Disable the built-in async validators on non-WASM platforms (#855)
 * Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
 * Improve usage of `#[cfg]` directives (#783)
 

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,42 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.2.0...c2pa-crypto-v0.3.0)
+_16 January 2025_
+
+### Added
+
+* *(crypto)* Add `rsa` crate support to `rust_native_crypto` feature (#853)
+* *(crypto)* Introduce new (experimental) `rust_native_crypto` feature (#850)
+* *(cawg_identity)* Implement identity assertion validation (#843)
+* Review `c2pa-crypto` crate API (#813)
+* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
+* Move COSE signing into `c2pa_crypto` crate (#807)
+* Move COSE timestamp generation into `c2pa_crypto` (#803)
+* Move COSE signature verification into `c2pa_crypto` (#801)
+* Make `AsyncRawSignatureValidator` available on all platforms (#800)
+* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
+* Introduce `c2pa_crypto::cose::Verifier` (#797)
+* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
+* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
+* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
+* Move COSE OCSP support into c2pa-crypto (#793)
+* Move `verify_trust` into `c2pa_crypto` (#784)
+* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
+* Bump MSRV to 1.81.0 (#781)
+
+### Fixed
+
+* *(crypto)* Disable the built-in async validators on non-WASM platforms (#855)
+* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
+* Improve usage of `#[cfg]` directives (#783)
+
+### Updated dependencies
+
+* Bump thiserror from 2.0.6 to 2.0.8 (#787)
+* Bump rasn from 0.18.0 to 0.22.0 (#727)
+* Bump thiserror from 1.0.69 to 2.0.6 (#770)
+
 ## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.1.2...c2pa-crypto-v0.2.0)
 _12 December 2024_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -48,7 +48,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.2.0" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.3.0" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }

--- a/internal/crypto/src/tests/raw_signature/async_validators.rs
+++ b/internal/crypto/src/tests/raw_signature/async_validators.rs
@@ -14,8 +14,7 @@
 use wasm_bindgen_test::wasm_bindgen_test;
 
 use crate::raw_signature::{
-    async_validator_for_signing_alg,
-    RawSignatureValidationError, SigningAlg,
+    async_validator_for_signing_alg, RawSignatureValidationError, SigningAlg,
 };
 
 const SAMPLE_DATA: &[u8] = b"some sample content to sign";

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.2.0...c2pa-status-tracker-v0.3.0)
+_16 January 2025_
+
+### Added
+
+* *(cawg_identity)* Implement identity assertion validation (#843)
+* Bump MSRV to 1.81.0 (#781)
+
 ## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.1.0...c2pa-status-tracker-v0.2.0)
 _11 December 2024_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.40.0"
+version = "0.41.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -76,8 +76,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.2.0" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.2.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.3.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.3.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",
     "wasmbind",

--- a/sdk/src/wasm/util.rs
+++ b/sdk/src/wasm/util.rs
@@ -27,7 +27,6 @@ pub mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[wasm_bindgen_test]
     fn test_get_random_values() {
         let len: usize = 32;
         let random1 = get_random_values(len).unwrap();


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)
* `c2pa`: 0.40.0 -> 0.41.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `c2pa-status-tracker`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `c2patool`: 0.10.2 -> 0.11.0

### ⚠️ `cawg-identity` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function cawg_identity::does_nothing_yet, previously in file /tmp/.tmpISCiGd/cawg-identity/src/lib.rs:2
```

### ⚠️ `c2pa` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::OpenSslMutexError, previously in file /tmp/.tmpISCiGd/c2pa/src/error.rs:286
  variant Error::OpenSslError, previously in file /tmp/.tmpISCiGd/c2pa/src/error.rs:290

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_added.ron

Failed in:
  trait method c2pa::AsyncSigner::async_raw_signer in file /tmp/.tmpfwk4cJ/c2pa-rs/sdk/src/signer.rs:232
  trait method c2pa::Signer::raw_signer in file /tmp/.tmpfwk4cJ/c2pa-rs/sdk/src/signer.rs:109
```

### ⚠️ `c2pa-crypto` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa_crypto::SigningAlg, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/signing_alg.rs:31
  enum c2pa_crypto::asn1::rfc5652::CertificateChoices, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1168
  enum c2pa_crypto::asn1::rfc3161::PkiFailureInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:293
  enum c2pa_crypto::asn1::rfc5652::Time, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1387
  enum c2pa_crypto::asn1::rfc5652::SigningTime, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1387
  enum c2pa_crypto::asn1::rfc5652::RecipientIdentifier, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:884
  enum c2pa_crypto::asn1::rfc5652::RecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:849
  enum c2pa_crypto::asn1::rfc5652::RevocationInfoChoice, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1138
  enum c2pa_crypto::openssl::validators::RsaValidator, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/validators/rsa_validator.rs:29
  enum c2pa_crypto::asn1::rfc5652::CmsVersion, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1317
  enum c2pa_crypto::asn1::rfc3281::AttCertIssuer, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:145
  enum c2pa_crypto::asn1::rfc5652::OriginatorIdentifierOrKey, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:917
  enum c2pa_crypto::asn1::rfc3281::DigestedObjectType, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:107
  enum c2pa_crypto::asn1::rfc5652::KeyAgreeRecipientIdentifier, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:960
  enum c2pa_crypto::asn1::rfc5652::SignerIdentifier, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:590
  enum c2pa_crypto::asn1::rfc3281::AttCertVersion, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:82
  enum c2pa_crypto::openssl::validators::EcdsaValidator, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/validators/ecdsa_validator.rs:26
  enum c2pa_crypto::asn1::rfc3161::PkiStatus, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:230
  enum c2pa_crypto::ocsp::OcspError, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/ocsp/mod.rs:268

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant CoseError:MissingSigningCertificateChain in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:30
  variant CoseError:MultipleSigningCertificateChains in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:34
  variant CoseError:UnsupportedSigningAlgorithm in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:42
  variant CoseError:InvalidEcdsaSignature in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:46
  variant CoseError:CborGenerationError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:54
  variant CoseError:CertificateProfileError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:63
  variant CoseError:CertificateTrustError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:67
  variant CoseError:BoxSizeTooSmall in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:71
  variant CoseError:RawSignerError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:75
  variant CoseError:RawSignatureValidationError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:79
  variant CoseError:InternalError in /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/cose/error.rs:84

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant RawSignerError::OpenSslError, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/raw_signature/signer.rs:114
  variant RawSignerError::OpenSslMutexUnavailable, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/raw_signature/signer.rs:119
  variant RawSignatureValidationError::OpenSslError, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/raw_signature/validator.rs:123
  variant RawSignatureValidationError::OpenSslMutexUnavailable, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/raw_signature/validator.rs:128

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature openssl in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa_crypto::hash::sha1, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/hash.rs:17
  function c2pa_crypto::p1363::parse_ec_der_sig, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/p1363.rs:25
  function c2pa_crypto::raw_signature::validator_for_sig_and_hash_algs, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/raw_signature/validator.rs:65
  function c2pa_crypto::openssl::validators::validator_for_signing_alg, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/validators/mod.rs:37
  function c2pa_crypto::time_stamp::verify_time_stamp, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/time_stamp/verify.rs:44
  function c2pa_crypto::cose::cose_countersign_data, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/cose/sigtst.rs:61
  function c2pa_crypto::cose::parse_and_validate_sigtst, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/cose/sigtst.rs:31
  function c2pa_crypto::ocsp::fetch_ocsp_response, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/ocsp/fetch.rs:32
  function c2pa_crypto::time_stamp::verify_time_stamp_async, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/time_stamp/verify.rs:44
  function c2pa_crypto::cose::parse_and_validate_sigtst_async, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/cose/sigtst.rs:31

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  OcspResponse::from_der_checked, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/ocsp/mod.rs:53

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/module_missing.ron

Failed in:
  mod c2pa_crypto::openssl, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/mod.rs:14
  mod c2pa_crypto::p1363, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/p1363.rs:14
  mod c2pa_crypto::asn1::rfc3281, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:5
  mod c2pa_crypto::asn1, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/mod.rs:5
  mod c2pa_crypto::asn1::rfc3161, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:5
  mod c2pa_crypto::asn1::rfc4210, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc4210.rs:5
  mod c2pa_crypto::asn1::rfc5652, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:5
  mod c2pa_crypto::openssl::validators, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/validators/mod.rs:14

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  OID_SIGNING_TIME in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:77
  OID_ID_SIGNED_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:42
  OID_ENVELOPE_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:47
  OID_MESSAGE_DIGEST in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:72
  OID_CONTENT_TYPE_TST_INFO in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:25
  OID_CONTENT_TYPE in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:67
  OID_ID_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:37
  OID_ENCRYPTED_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:57
  OID_AUTHENTICATED_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:62
  OID_DIGESTED_DATA in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:52
  OID_TIME_STAMP_TOKEN in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:30
  OID_COUNTER_SIGNATURE in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:82

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct c2pa_crypto::asn1::rfc3161::Accuracy, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:454
  struct c2pa_crypto::asn1::rfc5652::IssuerAndSerialNumber, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1285
  struct c2pa_crypto::asn1::rfc5652::AuthenticatedData, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1088
  struct c2pa_crypto::cose::TstToken, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/cose/sigtst.rs:77
  struct c2pa_crypto::asn1::rfc5652::RecipientEncryptedKey, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:947
  struct c2pa_crypto::asn1::rfc3281::V2Form, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:163
  struct c2pa_crypto::openssl::OpenSslMutexUnavailable, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/ffi_mutex.rs:71
  struct c2pa_crypto::asn1::rfc3281::ObjectDigestInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:128
  struct c2pa_crypto::asn1::rfc5652::KeyAgreeRecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:900
  struct c2pa_crypto::asn1::rfc3281::Attribute, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:206
  struct c2pa_crypto::p1363::EcSigComps, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/p1363.rs:42
  struct c2pa_crypto::asn1::rfc5652::OtherCertificateFormat, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1232
  struct c2pa_crypto::asn1::rfc5652::UnsignedAttributes, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:745
  struct c2pa_crypto::asn1::rfc3161::TstInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:380
  struct c2pa_crypto::asn1::rfc3161::MessageImprint, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:102
  struct c2pa_crypto::asn1::rfc5652::EnvelopedData, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:796
  struct c2pa_crypto::asn1::rfc5652::SignerInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:370
  struct c2pa_crypto::asn1::rfc5652::CounterSignature, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:370
  struct c2pa_crypto::ValidationInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/validation_info.rs:23
  struct c2pa_crypto::asn1::rfc5652::EncryptedData, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1067
  struct c2pa_crypto::asn1::rfc5652::OtherRevocationInfoFormat, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1151
  struct c2pa_crypto::asn1::rfc5652::SignedAttributesDer, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:713
  struct c2pa_crypto::asn1::rfc5652::SignedAttributes, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:633
  struct c2pa_crypto::asn1::rfc5652::CertificateSet, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1245
  struct c2pa_crypto::asn1::rfc3161::TimeStampResp, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:135
  struct c2pa_crypto::asn1::rfc5652::OtherKeyAttribute, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1367
  struct c2pa_crypto::asn1::rfc5652::OtherRecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1033
  struct c2pa_crypto::asn1::rfc3281::IssuerSerial, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:177
  struct c2pa_crypto::asn1::rfc5652::PasswordRecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1025
  struct c2pa_crypto::asn1::rfc5652::EncapsulatedContentInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:311
  struct c2pa_crypto::asn1::rfc5652::DigestAlgorithmIdentifiers, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:227
  struct c2pa_crypto::asn1::rfc3161::TimeStampReq, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:46
  struct c2pa_crypto::asn1::rfc5652::OriginatorPublicKey, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:931
  struct c2pa_crypto::openssl::validators::Ed25519Validator, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/validators/ed25519_validator.rs:23
  struct c2pa_crypto::asn1::rfc5652::KekRecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:992
  struct c2pa_crypto::asn1::rfc5652::SignedData, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:151
  struct c2pa_crypto::asn1::rfc4210::PkiFreeText, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc4210.rs:21
  struct c2pa_crypto::asn1::rfc5652::RevocationInfoChoices, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1122
  struct c2pa_crypto::asn1::rfc3281::AttCertValidityPeriod, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:191
  struct c2pa_crypto::asn1::rfc3161::PkiStatusInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3161.rs:174
  struct c2pa_crypto::UnknownAlgorithmError, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/signing_alg.rs:95
  struct c2pa_crypto::asn1::rfc5652::KeyTransRecipientInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:869
  struct c2pa_crypto::asn1::rfc5652::KekIdentifier, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1008
  struct c2pa_crypto::asn1::rfc5652::DigestedData, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:1049
  struct c2pa_crypto::asn1::rfc3281::AttributeCertificateInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:63
  struct c2pa_crypto::openssl::OpenSslMutex, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/openssl/ffi_mutex.rs:27
  struct c2pa_crypto::asn1::rfc5652::EncryptedContentInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:828
  struct c2pa_crypto::asn1::rfc3281::Holder, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:100
  struct c2pa_crypto::asn1::rfc5652::SignerInfos, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:269
  struct c2pa_crypto::asn1::rfc5652::OriginatorInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:812
  struct c2pa_crypto::asn1::rfc3281::AttributeCertificate, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:25
  struct c2pa_crypto::asn1::rfc5652::AttributeCertificateV2, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc3281.rs:25
  struct c2pa_crypto::asn1::rfc5652::RecipientKeyIdentifier, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:974
  struct c2pa_crypto::asn1::rfc3161::TimeStampToken, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:92
  struct c2pa_crypto::asn1::rfc5652::ContentInfo, previously in file /tmp/.tmpISCiGd/c2pa-crypto/src/asn1/rfc5652.rs:92

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait c2pa_crypto::time_stamp::AsyncTimeStampProvider gained Sync in file /tmp/.tmpfwk4cJ/c2pa-rs/internal/crypto/src/time_stamp/provider.rs:78
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.1...cawg-identity-v0.2.0)

_16 January 2025_

### Added

* *(cawg_identity)* Implement identity claims aggregation validator (#846)
* *(cawg_identity)* Minimal implementation of W3C VC specification (#845)
* *(cawg_identity)* Implement identity assertion validation (#843)
* *(cawg_identity)* Add `SignatureVerifier` trait and `ValidationError` enum (#844)
* *(cawg_identity)* Add `IdentityAssertionBuilder` struct (#840)
* *(cawg_identity)* Introduce `IdentityAssertionSigner` (#827)
* *(cawg_identity)* Define `CredentialHolder` trait (#821)
* *(cawg_identity)* Add `SignerPayload` struct (#817)
* Bump MSRV to 1.81.0 (#781)
</blockquote>

## `c2pa`
<blockquote>

## [0.41.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.40.0...c2pa-v0.41.0)

_16 January 2025_

### Added

* *(crypto)* Add `rsa` crate support to `rust_native_crypto` feature (#853)
* *(cawg_identity)* Implement identity assertion validation (#843)
* Remove writing of native camera RAW formats from SDK (#814)
* Review `c2pa-crypto` crate API (#813)
* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
* Move COSE signing into `c2pa_crypto` crate (#807)
* Move COSE timestamp generation into `c2pa_crypto` (#803)
* Move COSE signature verification into `c2pa_crypto` (#801)
* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
* Introduce `c2pa_crypto::cose::Verifier` (#797)
* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
* Move COSE OCSP support into c2pa-crypto (#793)
* Move `verify_trust` into `c2pa_crypto` (#784)
* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
* Bump MSRV to 1.81.0 (#781)

### Fixed

* *(sdk)* Make sure `DynamicAssertion::content` gets a properly populated `PreliminaryClaim` (#842)
* Switch to from fast_xml to quick_xml (#805)
* Update img-parts for jpeg segment underflow fix (#806)
* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
* Improve usage of `#[cfg]` directives (#783)
* OOB read attempt in jpeg_io asset handler in get_cai_segments function (#719)
* Prevent negative length value for SVG object locations (#766)
* JPEG `write_cai` OOB insertion (#762)
* Add support XMP in SVG (#771)
* Possible overflow for TIFF (#760)
* Resolve new Clippy issues (#776)

### Updated dependencies

* Bump jfifdump from 0.5.1 to 0.6.0 (#785)
* Bump serde-wasm-bindgen from 0.5.0 to 0.6.5 (#786)
* Bump thiserror from 2.0.6 to 2.0.8 (#787)
* Bump rasn from 0.18.0 to 0.22.0 (#727)
* Bump thiserror from 1.0.69 to 2.0.6 (#770)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.2.0...c2pa-crypto-v0.3.0)

_16 January 2025_

### Added

* *(crypto)* Add `rsa` crate support to `rust_native_crypto` feature (#853)
* *(crypto)* Introduce new (experimental) `rust_native_crypto` feature (#850)
* *(cawg_identity)* Implement identity assertion validation (#843)
* Review `c2pa-crypto` crate API (#813)
* Add new function `c2pa_crypto::cose::signing_time_from_sign1` (#812)
* Move COSE signing into `c2pa_crypto` crate (#807)
* Move COSE timestamp generation into `c2pa_crypto` (#803)
* Move COSE signature verification into `c2pa_crypto` (#801)
* Make `AsyncRawSignatureValidator` available on all platforms (#800)
* Introduce `c2pa_crypto::Verifier::verify_trust` (#798)
* Introduce `c2pa_crypto::cose::Verifier` (#797)
* Consolidate implementations of `cert_chain_from_sign1` in `c2pa_crypto` (#796)
* Move `signing_alg_from_sign1` into `c2pa-crypto` (#795)
* Move `get_cose_sign1` into `c2pa-crypto` crate (#794)
* Move COSE OCSP support into c2pa-crypto (#793)
* Move `verify_trust` into `c2pa_crypto` (#784)
* Introduce `c2pa_crypto::CertificateAcceptancePolicy` (#779)
* Bump MSRV to 1.81.0 (#781)

### Fixed

* *(crypto)* Disable the built-in async validators on non-WASM platforms (#855)
* Bring `claim_v2` changes from #707 into `c2pa_crypto` (#811)
* Improve usage of `#[cfg]` directives (#783)

### Updated dependencies

* Bump thiserror from 2.0.6 to 2.0.8 (#787)
* Bump rasn from 0.18.0 to 0.22.0 (#727)
* Bump thiserror from 1.0.69 to 2.0.6 (#770)
</blockquote>

## `c2pa-status-tracker`
<blockquote>

## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.2.0...c2pa-status-tracker-v0.3.0)

_16 January 2025_

### Added

* *(cawg_identity)* Implement identity assertion validation (#843)
* Bump MSRV to 1.81.0 (#781)
</blockquote>

## `c2patool`
<blockquote>

## [0.11.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.2...c2patool-v0.11.0)

_16 January 2025_

### Added

* Move COSE signing into `c2pa_crypto` crate (#807)

### Documented

* Post move cleanup (#778)

### Fixed

* Fix: Obscure glob error message for missing files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).