### PR TITLE
chore(sdk): Remove `Send` and `Sync` bounds from `DynamicAssertion` on WASM

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1089,7 +1089,7 @@ mod tests {
     use wasm_bindgen_test::*;
 
     use super::*;
-    #[cfg(feature = "openssl_sign")]
+    #[cfg(any(feature = "openssl_sign", target_arch = "wasm32"))]
     use crate::{assertions::BoxHash, asset_handlers::jpeg_io::JpegIO};
     use crate::{
         hash_stream_by_alg,

--- a/sdk/src/dynamic_assertion.rs
+++ b/sdk/src/dynamic_assertion.rs
@@ -15,13 +15,64 @@
 
 use std::{fmt::Debug, slice::Iter};
 
+use async_trait::async_trait;
+
 use crate::{hashed_uri::HashedUri, Result};
 
 /// A `DynamicAssertion` is an assertion that has the ability
 /// to adjust its content based on other assertions within the
-/// overall Manifest.
-#[async_trait::async_trait]
-pub trait DynamicAssertion: Debug + Send + Sync {
+/// overall [`Manifest`].
+///
+/// [`Manifest`]: crate::Manifest
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+pub trait DynamicAssertion: Debug + Sync {
+    /// Return the preferred label for this assertion.
+    ///
+    /// Note that the label may be adjusted in case multiple assertions
+    /// return the same preferred label (i.e. a `_2`, `_3`, etc. suffix
+    /// may be added).
+    fn label(&self) -> String;
+
+    /// Return the expected size of the final assertion content in bytes.
+    ///
+    /// This function will be called by the [`Builder`] API if the hard
+    /// binding assertion in use requires that the assertion size be locked
+    /// down in order to complete file layout (i.e. when using a data hash
+    /// assertion).
+    ///
+    /// [`Builder`]: crate::Builder
+    fn reserve_size(&self) -> usize;
+
+    /// Return the final assertion content.
+    ///
+    /// The `label` parameter will contain the final assigned label for
+    /// this assertion.
+    ///
+    /// If the hard binding assertion requires that the assertion size
+    /// be predicted in advance, then `size` will contain the number of bytes
+    /// specified by a previous call to `reserve_size`. In that case, the
+    /// resulting binary content *MUST* exactly match the specified size;
+    /// otherwise, the overall manifest generation process will fail.
+    ///
+    /// The `claim` structure will contain information about the preliminary
+    /// C2PA claim as known at the time of this call.
+    async fn content(
+        &self,
+        label: &str,
+        size: Option<usize>,
+        claim: &PreliminaryClaim,
+    ) -> Result<Vec<u8>>;
+}
+
+/// A `DynamicAssertion` is an assertion that has the ability
+/// to adjust its content based on other assertions within the
+/// overall [`Manifest`].
+///
+/// [`Manifest`]: crate::Manifest
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+pub trait DynamicAssertion: Debug {
     /// Return the preferred label for this assertion.
     ///
     /// Note that the label may be adjusted in case multiple assertions

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-#[cfg(feature = "openssl_sign")]
+#[cfg(any(feature = "openssl_sign", target_arch = "wasm32"))]
 use c2pa_crypto::cose::TimeStampStorage;
 use c2pa_crypto::{
     cose::CertificateTrustPolicy,

--- a/sdk/src/utils/test_signer.rs
+++ b/sdk/src/utils/test_signer.rs
@@ -31,6 +31,7 @@ pub(crate) fn test_signer(alg: SigningAlg) -> Box<dyn Signer> {
 }
 
 /// Creates an [`AsyncSigner`] instance for testing purposes using test credentials.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 pub(crate) fn async_test_signer(alg: SigningAlg) -> Box<dyn AsyncSigner + Sync + Send> {
     let (cert_chain, private_key) = cert_chain_and_private_key_for_alg(alg);


### PR DESCRIPTION
Also: Fix several WASM platform build issues introduced recently.
