### PR TITLE
chore: Additional exports to enable easy unit tests writing

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -38,6 +38,7 @@ json_schema = ["dep:schemars", "c2pa-crypto/json_schema"]
 pdf = ["dep:lopdf"]
 v1_api = []
 unstable_api = []
+cawg_identity = []
 
 # The diagnostics feature is unsupported and might be removed.
 # It enables some low-overhead timing features used in our development cycle.

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -140,6 +140,8 @@ pub use reader::{Reader, ValidationState};
 pub use resource_store::{ResourceRef, ResourceStore};
 pub use signer::{AsyncSigner, RemoteSigner, Signer};
 pub use utils::mime::format_from_path;
+#[cfg(feature = "cawg_identity")]
+pub use cawg_identity::{IdentityAssertion, IcaSignatureVerifier};
 
 // Internal modules
 pub(crate) mod assertion;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -140,8 +140,8 @@ pub use reader::{Reader, ValidationState};
 pub use resource_store::{ResourceRef, ResourceStore};
 pub use signer::{AsyncSigner, RemoteSigner, Signer};
 pub use utils::mime::format_from_path;
-#[cfg(feature = "cawg_identity")]
-pub use cawg_identity::{IdentityAssertion, IcaSignatureVerifier};
+// #[cfg(feature = "cawg_identity")]
+// pub use cawg_identity::{IdentityAssertion, IcaSignatureVerifier, SignerPayload};
 
 // Internal modules
 pub(crate) mod assertion;


### PR DESCRIPTION
## Changes in this pull request
Additional exports to enable easy unit tests writing, based on code from https://github.com/contentauth/c2pa-rs/blob/main/cawg_identity/src/tests/claim_aggregation/interop.rs.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
