### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ version = "0.3.0"
 
 [[package]]
 name = "c2patool"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.2.0...cawg-identity-v0.2.1)
+_18 January 2025_
+
+### Fixed
+
+* Add support for WASM to CAWG SDK (#861)
+
 ## [0.2.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.1.1...cawg-identity-v0.2.0)
 _16 January 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.2.0"
+version = "0.2.1"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.11.1](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.11.0...c2patool-v0.11.1)
+_18 January 2025_
+
+### Fixed
+
+* Upload a distinct SBOM per platform (#856)
+
 ## [0.11.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.10.2...c2patool-v0.11.0)
 _16 January 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.11.0"
+version = "0.11.1"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `c2patool`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.2.1](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.2.0...cawg-identity-v0.2.1)

_18 January 2025_

### Fixed

* Add support for WASM to CAWG SDK (#861)
</blockquote>

## `c2patool`
<blockquote>

## [0.11.1](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.11.0...c2patool-v0.11.1)

_18 January 2025_

### Fixed

* Upload a distinct SBOM per platform (#856)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).