### PR TITLE
fix: Make alg enum exhaustive

### DIFF
--- a/cawg_identity/src/tests/fixtures/test_credentials.rs
+++ b/cawg_identity/src/tests/fixtures/test_credentials.rs
@@ -49,7 +49,5 @@ pub(crate) fn cert_chain_and_private_key_for_alg(alg: SigningAlg) -> (Vec<u8>, V
             include_bytes!("../../../../sdk/tests/fixtures/certs/ed25519.pub").to_vec(),
             include_bytes!("../../../../sdk/tests/fixtures/certs/ed25519.pem").to_vec(),
         ),
-
-        _ => unimplemented!("Unknown SigningAlg variant {alg:#?}"),
     }
 }

--- a/internal/crypto/src/raw_signature/signing_alg.rs
+++ b/internal/crypto/src/raw_signature/signing_alg.rs
@@ -28,7 +28,6 @@ use serde::{Deserialize, Serialize};
 /// [§13.2, “Digital Signatures”]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_digital_signatures
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
-#[non_exhaustive]
 pub enum SigningAlg {
     /// ECDSA with SHA-256
     Es256,

--- a/sdk/src/utils/test_signer.rs
+++ b/sdk/src/utils/test_signer.rs
@@ -87,8 +87,6 @@ fn cert_chain_and_private_key_for_alg(alg: SigningAlg) -> (Vec<u8>, Vec<u8>) {
             include_bytes!("../../tests/fixtures/certs/ed25519.pub").to_vec(),
             include_bytes!("../../tests/fixtures/certs/ed25519.pem").to_vec(),
         ),
-
-        _ => unimplemented!("Unknown SigningAlg variant {alg:#?}"),
     }
 }
 


### PR DESCRIPTION
## Changes in this pull request
Make alg enum exhaustive, so it can be understood by other tools too.
Build issue this fixes: https://github.com/contentauth/c2pa-python/pull/82
Also reported in https://github.com/mozilla/uniffi-rs/issues/2414

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
