### PR TITLE
feat: Change the definition of `Signer.raw_signer()` to return an `Option` defaulting to `None`

### DIFF
--- a/cawg_identity/src/builder/identity_assertion_signer.rs
+++ b/cawg_identity/src/builder/identity_assertion_signer.rs
@@ -162,8 +162,8 @@ impl AsyncSigner for IdentityAssertionSigner {
             .map(|r| r.map_err(|e| e.into()))
     }
 
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        Box::new(&*self.signer)
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        Some(Box::new(&*self.signer))
     }
 
     fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {

--- a/cli/src/callback_signer.rs
+++ b/cli/src/callback_signer.rs
@@ -18,10 +18,6 @@ use std::{
 
 use anyhow::{bail, Context};
 use c2pa::{Error, Signer, SigningAlg};
-use c2pa_crypto::{
-    raw_signature::{RawSigner, RawSignerError},
-    time_stamp::TimeStampProvider,
-};
 
 use crate::signer::SignConfig;
 
@@ -185,53 +181,6 @@ impl Signer for CallbackSigner<'_> {
     }
 
     fn time_authority_url(&self) -> Option<String> {
-        self.config.tsa_url.clone()
-    }
-
-    fn raw_signer(&self) -> Box<&dyn RawSigner> {
-        Box::new(self)
-    }
-}
-
-impl RawSigner for CallbackSigner<'_> {
-    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, RawSignerError> {
-        self.callback.sign(data).map_err(|e| {
-            eprintln!("Unable to embed signature into asset. {}", e);
-            RawSignerError::InternalError(e.to_string())
-        })
-    }
-
-    fn alg(&self) -> SigningAlg {
-        self.config.alg
-    }
-
-    fn cert_chain(&self) -> Result<Vec<Vec<u8>>, RawSignerError> {
-        let cert_contents = std::fs::read(&self.config.sign_cert_path)?;
-
-        let mut pems = pem::parse_many(cert_contents).map_err(|_| Error::CoseInvalidCert)?;
-        // [pem::parse_many] returns an empty vector if you supply invalid contents, like json, for example.
-        // Check here if the pems vector is empty.
-        if pems.is_empty() {
-            return Err(RawSignerError::InvalidSigningCredentials(
-                "no certificates provided".to_string(),
-            ));
-        }
-
-        let sign_cert = pems
-            .drain(..)
-            .map(|p| p.into_contents())
-            .collect::<Vec<Vec<u8>>>();
-
-        Ok(sign_cert)
-    }
-
-    fn reserve_size(&self) -> usize {
-        self.config.reserve_size
-    }
-}
-
-impl TimeStampProvider for CallbackSigner<'_> {
-    fn time_stamp_service_url(&self) -> Option<String> {
         self.config.tsa_url.clone()
     }
 }

--- a/sdk/src/callback_signer.rs
+++ b/sdk/src/callback_signer.rs
@@ -18,8 +18,8 @@
 
 use async_trait::async_trait;
 use c2pa_crypto::{
-    raw_signature::{AsyncRawSigner, RawSigner, RawSignerError, SigningAlg},
-    time_stamp::{AsyncTimeStampProvider, TimeStampProvider},
+    raw_signature::{AsyncRawSigner, RawSignerError, SigningAlg},
+    time_stamp::AsyncTimeStampProvider,
 };
 
 use crate::{AsyncSigner, Error, Result, Signer};
@@ -160,38 +160,6 @@ impl Signer for CallbackSigner {
     }
 
     fn time_authority_url(&self) -> Option<String> {
-        self.tsa_url.clone()
-    }
-
-    fn raw_signer(&self) -> Box<&dyn RawSigner> {
-        Box::new(self)
-    }
-}
-
-impl RawSigner for CallbackSigner {
-    // TO DISCUSS WITH GAVIN: Perhaps we could make CallbackSigner's API return c2pa_crypto::Result<..., RawSignerError> instead?
-    fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
-        (self.callback)(self.context, data)
-            .map_err(|e| RawSignerError::InternalError(e.to_string()))
-    }
-
-    fn alg(&self) -> SigningAlg {
-        self.alg
-    }
-
-    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-        let pems = pem::parse_many(&self.certs)
-            .map_err(|e| RawSignerError::InvalidSigningCredentials(e.to_string()))?;
-        Ok(pems.into_iter().map(|p| p.into_contents()).collect())
-    }
-
-    fn reserve_size(&self) -> usize {
-        self.reserve_size
-    }
-}
-
-impl TimeStampProvider for CallbackSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
         self.tsa_url.clone()
     }
 }

--- a/sdk/src/callback_signer.rs
+++ b/sdk/src/callback_signer.rs
@@ -17,10 +17,7 @@
 //! using a callback and public signing certificates.
 
 use async_trait::async_trait;
-use c2pa_crypto::{
-    raw_signature::{AsyncRawSigner, RawSignerError, SigningAlg},
-    time_stamp::AsyncTimeStampProvider,
-};
+use c2pa_crypto::raw_signature::SigningAlg;
 
 use crate::{AsyncSigner, Error, Result, Signer};
 
@@ -191,39 +188,5 @@ impl AsyncSigner for CallbackSigner {
     #[cfg(target_arch = "wasm32")]
     async fn send_timestamp_request(&self, _message: &[u8]) -> Option<Result<Vec<u8>>> {
         None
-    }
-
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        Box::new(self)
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl AsyncRawSigner for CallbackSigner {
-    // TO DISCUSS WITH GAVIN: Perhaps we could make CallbackSigner's API return c2pa_crypto::Result<..., RawSignerError> instead?
-    async fn sign(&self, data: Vec<u8>) -> std::result::Result<Vec<u8>, RawSignerError> {
-        (self.callback)(self.context, &data)
-            .map_err(|e| RawSignerError::InternalError(e.to_string()))
-    }
-
-    fn alg(&self) -> SigningAlg {
-        self.alg
-    }
-
-    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-        let pems = pem::parse_many(&self.certs)
-            .map_err(|e| RawSignerError::InvalidSigningCredentials(e.to_string()))?;
-        Ok(pems.into_iter().map(|p| p.into_contents()).collect())
-    }
-
-    fn reserve_size(&self) -> usize {
-        self.reserve_size
-    }
-}
-
-impl AsyncTimeStampProvider for CallbackSigner {
-    fn time_stamp_service_url(&self) -> Option<String> {
-        self.tsa_url.clone()
     }
 }

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -204,7 +204,8 @@ impl<'a> TimeStampProvider for SignerWrapper<'a> {
 
 struct AsyncSignerWrapper<'a>(&'a dyn AsyncSigner);
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<'a> AsyncRawSigner for AsyncSignerWrapper<'a> {
     async fn sign(&self, data: Vec<u8>) -> std::result::Result<Vec<u8>, RawSignerError> {
         Ok(self.0.sign(data).await?)
@@ -227,7 +228,8 @@ impl<'a> AsyncRawSigner for AsyncSignerWrapper<'a> {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<'a> AsyncTimeStampProvider for AsyncSignerWrapper<'a> {
     fn time_stamp_service_url(&self) -> Option<String> {
         self.0.time_authority_url()

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -154,7 +154,7 @@ fn signing_cert_valid(signing_cert: &[u8]) -> Result<()> {
 
 struct SignerWrapper<'a>(&'a dyn Signer);
 
-impl<'a> RawSigner for SignerWrapper<'a> {
+impl RawSigner for SignerWrapper<'_> {
     fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
         Ok(self.0.sign(data)?)
     }
@@ -176,7 +176,7 @@ impl<'a> RawSigner for SignerWrapper<'a> {
     }
 }
 
-impl<'a> TimeStampProvider for SignerWrapper<'a> {
+impl TimeStampProvider for SignerWrapper<'_> {
     fn time_stamp_service_url(&self) -> Option<String> {
         self.0.time_authority_url()
     }
@@ -206,7 +206,7 @@ struct AsyncSignerWrapper<'a>(&'a dyn AsyncSigner);
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<'a> AsyncRawSigner for AsyncSignerWrapper<'a> {
+impl AsyncRawSigner for AsyncSignerWrapper<'_> {
     async fn sign(&self, data: Vec<u8>) -> std::result::Result<Vec<u8>, RawSignerError> {
         Ok(self.0.sign(data).await?)
     }
@@ -230,7 +230,7 @@ impl<'a> AsyncRawSigner for AsyncSignerWrapper<'a> {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<'a> AsyncTimeStampProvider for AsyncSignerWrapper<'a> {
+impl AsyncTimeStampProvider for AsyncSignerWrapper<'_> {
     fn time_stamp_service_url(&self) -> Option<String> {
         self.0.time_authority_url()
     }

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -239,57 +239,6 @@ pub mod tests {
             fn ocsp_val(&self) -> Option<Vec<u8>> {
                 Some(self.ocsp_rsp.clone())
             }
-
-            fn raw_signer(&self) -> Box<&dyn RawSigner> {
-                Box::new(self)
-            }
-        }
-
-        impl RawSigner for OcspSigner {
-            fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
-                self.raw_signer.sign(data)
-            }
-
-            fn alg(&self) -> SigningAlg {
-                self.raw_signer.alg()
-            }
-
-            fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-                self.raw_signer.cert_chain()
-            }
-
-            fn reserve_size(&self) -> usize {
-                self.raw_signer.reserve_size()
-            }
-
-            fn ocsp_response(&self) -> Option<Vec<u8>> {
-                eprintln!("THE ONE I WANTED @ 287");
-                Some(self.ocsp_rsp.clone())
-            }
-        }
-
-        impl TimeStampProvider for OcspSigner {
-            fn time_stamp_service_url(&self) -> Option<String> {
-                self.raw_signer.time_stamp_service_url()
-            }
-
-            fn time_stamp_request_headers(&self) -> Option<Vec<(String, String)>> {
-                self.raw_signer.time_stamp_request_headers()
-            }
-
-            fn time_stamp_request_body(
-                &self,
-                message: &[u8],
-            ) -> std::result::Result<Vec<u8>, TimeStampError> {
-                self.raw_signer.time_stamp_request_body(message)
-            }
-
-            fn send_time_stamp_request(
-                &self,
-                message: &[u8],
-            ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
-                self.raw_signer.send_time_stamp_request(message)
-            }
         }
 
         let ocsp_signer = OcspSigner {
@@ -298,12 +247,9 @@ pub mod tests {
         };
 
         // sign and staple
-        let cose_bytes = crate::cose_sign::sign_claim(
-            &claim_bytes,
-            &ocsp_signer,
-            RawSigner::reserve_size(&ocsp_signer),
-        )
-        .unwrap();
+        let cose_bytes =
+            crate::cose_sign::sign_claim(&claim_bytes, &ocsp_signer, ocsp_signer.reserve_size())
+                .unwrap();
 
         let cose_sign1 = parse_cose_sign1(&cose_bytes, &claim_bytes, &mut validation_log).unwrap();
         let ocsp_stapled = get_ocsp_der(&cose_sign1).unwrap();

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -101,7 +101,8 @@ pub trait Signer {
     /// If this struct also implements or wraps [`RawSigner`], it should
     /// return a reference to that trait implementation.
     ///
-    /// If this function returns `None` (the default behavior), a temporary wrapper will be constructed for it.
+    /// If this function returns `None` (the default behavior), a temporary
+    /// wrapper will be constructed for it.
     ///
     /// NOTE: Due to limitations in some of the FFI tooling that we use to bridge
     /// c2pa-rs to other languages, we can not make [`RawSigner`] a supertrait of
@@ -225,15 +226,20 @@ pub trait AsyncSigner: Sync {
         Vec::new()
     }
 
-    /// This struct must also implement [`AsyncRawSigner`]. Return a reference
-    /// to that trait implementation.
+    /// If this struct also implements or wraps [`AsyncRawSigner`], it should
+    /// return a reference to that trait implementation.
+    ///
+    /// If this function returns `None` (the default behavior), a temporary
+    /// wrapper will be constructed for it when needed.
     ///
     /// NOTE: Due to limitations in some of the FFI tooling that we use to bridge
     /// c2pa-rs to other languages, we can not make [`AsyncRawSigner`] a supertrait
     /// of this trait. This API is a workaround for that limitation.
     ///
     /// [`AsyncRawSigner`]: c2pa_crypto::raw_signature::AsyncRawSigner
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner>;
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        None
+    }
 }
 
 /// The `AsyncSigner` trait generates a cryptographic signature over a byte array.
@@ -307,15 +313,20 @@ pub trait AsyncSigner {
         Vec::new()
     }
 
-    /// This struct must also implement [`AsyncRawSigner`]. Return a reference
-    /// to that trait implementation.
+    /// If this struct also implements or wraps [`AsyncRawSigner`], it should
+    /// return a reference to that trait implementation.
+    ///
+    /// If this function returns `None` (the default behavior), a temporary
+    /// wrapper will be constructed for it when needed.
     ///
     /// NOTE: Due to limitations in some of the FFI tooling that we use to bridge
     /// c2pa-rs to other languages, we can not make [`AsyncRawSigner`] a supertrait
     /// of this trait. This API is a workaround for that limitation.
     ///
     /// [`AsyncRawSigner`]: c2pa_crypto::raw_signature::AsyncRawSigner
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner>;
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        None
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -481,7 +492,7 @@ impl AsyncSigner for Box<dyn AsyncSigner + Send + Sync> {
         (**self).dynamic_assertions()
     }
 
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
         (**self).async_raw_signer()
     }
 }
@@ -533,7 +544,7 @@ impl AsyncSigner for Box<dyn AsyncSigner> {
         (**self).dynamic_assertions()
     }
 
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
         (**self).async_raw_signer()
     }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -5922,7 +5922,6 @@ pub mod tests {
     #[cfg(feature = "openssl_sign")]
     async fn test_dynamic_assertions() {
         use async_trait::async_trait;
-        use c2pa_crypto::raw_signature::AsyncRawSigner;
 
         #[derive(Serialize)]
         struct TestAssertion {
@@ -6006,10 +6005,6 @@ pub mod tests {
             // Returns our dynamic assertion here.
             fn dynamic_assertions(&self) -> Vec<Box<dyn crate::DynamicAssertion>> {
                 vec![Box::new(TestDynamicAssertion {})]
-            }
-
-            fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-                self.0.async_raw_signer()
             }
         }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3620,10 +3620,7 @@ pub mod tests {
 
     use std::io::Write;
 
-    use c2pa_crypto::{
-        raw_signature::{RawSigner, RawSignerError, SigningAlg},
-        time_stamp::TimeStampProvider,
-    };
+    use c2pa_crypto::raw_signature::SigningAlg;
     use c2pa_status_tracker::StatusTracker;
     use memchr::memmem;
     use serde::Serialize;
@@ -3864,31 +3861,7 @@ pub mod tests {
         fn reserve_size(&self) -> usize {
             42
         }
-
-        fn raw_signer(&self) -> Box<&dyn RawSigner> {
-            Box::new(self)
-        }
     }
-
-    impl RawSigner for BadSigner {
-        fn sign(&self, _data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
-            Ok(b"not a valid signature".to_vec())
-        }
-
-        fn alg(&self) -> SigningAlg {
-            SigningAlg::Ps256
-        }
-
-        fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-            Ok(Vec::new())
-        }
-
-        fn reserve_size(&self) -> usize {
-            42
-        }
-    }
-
-    impl TimeStampProvider for BadSigner {}
 
     #[test]
     #[cfg(feature = "file_io")]

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -25,8 +25,8 @@ use async_trait::async_trait;
 use c2pa_crypto::cose::TimeStampStorage;
 use c2pa_crypto::{
     cose::CertificateTrustPolicy,
-    raw_signature::{AsyncRawSigner, RawSigner, RawSignerError, SigningAlg},
-    time_stamp::{AsyncTimeStampProvider, TimeStampError, TimeStampProvider},
+    raw_signature::{AsyncRawSigner, RawSignerError, SigningAlg},
+    time_stamp::{AsyncTimeStampProvider, TimeStampError},
 };
 use tempfile::TempDir;
 
@@ -315,37 +315,6 @@ impl crate::Signer for TestGoodSigner {
     }
 
     fn send_timestamp_request(&self, _message: &[u8]) -> Option<crate::error::Result<Vec<u8>>> {
-        Some(Ok(Vec::new()))
-    }
-
-    fn raw_signer(&self) -> Box<&dyn RawSigner> {
-        Box::new(self)
-    }
-}
-
-impl RawSigner for TestGoodSigner {
-    fn sign(&self, _data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
-        Ok(b"not a valid signature".to_vec())
-    }
-
-    fn alg(&self) -> SigningAlg {
-        SigningAlg::Ps256
-    }
-
-    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-        Ok(Vec::new())
-    }
-
-    fn reserve_size(&self) -> usize {
-        1024
-    }
-}
-
-impl TimeStampProvider for TestGoodSigner {
-    fn send_time_stamp_request(
-        &self,
-        _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
         Some(Ok(Vec::new()))
     }
 }

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -346,41 +346,6 @@ impl AsyncSigner for AsyncTestGoodSigner {
     ) -> Option<crate::error::Result<Vec<u8>>> {
         Some(Ok(Vec::new()))
     }
-
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        Box::new(self)
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl AsyncRawSigner for AsyncTestGoodSigner {
-    async fn sign(&self, _data: Vec<u8>) -> std::result::Result<Vec<u8>, RawSignerError> {
-        Ok(b"not a valid signature".to_vec())
-    }
-
-    fn alg(&self) -> SigningAlg {
-        SigningAlg::Ps256
-    }
-
-    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-        Ok(Vec::new())
-    }
-
-    fn reserve_size(&self) -> usize {
-        1024
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl AsyncTimeStampProvider for AsyncTestGoodSigner {
-    async fn send_time_stamp_request(
-        &self,
-        _message: &[u8],
-    ) -> Option<std::result::Result<Vec<u8>, TimeStampError>> {
-        Some(Ok(Vec::new()))
-    }
 }
 
 struct TempRemoteSigner {}
@@ -504,10 +469,6 @@ impl AsyncSigner for WebCryptoSigner {
     async fn send_timestamp_request(&self, _: &[u8]) -> Option<Result<Vec<u8>>> {
         None
     }
-
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        unreachable!();
-    }
 }
 
 /// Create a [`RemoteSigner`] instance that can be used for testing purposes.
@@ -564,10 +525,6 @@ impl AsyncSigner for TempAsyncRemoteSigner {
         _message: &[u8],
     ) -> Option<crate::error::Result<Vec<u8>>> {
         Some(Ok(Vec::new()))
-    }
-
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        Box::new(self)
     }
 }
 

--- a/sdk/src/utils/test_signer.rs
+++ b/sdk/src/utils/test_signer.rs
@@ -142,7 +142,7 @@ impl AsyncSigner for AsyncRawSignerWrapper {
             .map(|r| r.map_err(|e| e.into()))
     }
 
-    fn async_raw_signer(&self) -> Box<&dyn AsyncRawSigner> {
-        Box::new(&*self.0)
+    fn async_raw_signer(&self) -> Option<Box<&dyn AsyncRawSigner>> {
+        Some(Box::new(&*self.0))
     }
 }


### PR DESCRIPTION
Removes the need for each `Signer` implementation to also provide `RawSigner` and `TimeStampProvider` implementations.
