### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.43.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.42.0...c2pa-v0.43.0)
+_24 January 2025_
+
+### Added
+
+* *(crypto)* Make `box_size` parameter on `c2pa_crypto::cose::sign` an `Option` (#879)
+
+### Fixed
+
+* Bump coset requirement to 0.3.8 (#883)
+* Update id3 crate (#875)
+* Remove `Debug` supertrait from `DynamicAssertion` and `CredentialHolder` traits (#876)
+
 ## [0.42.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.41.1...c2pa-v0.42.0)
 _22 January 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2939,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
@@ -4697,9 +4697,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-xid"

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.3.0...cawg-identity-v0.4.0)
+_24 January 2025_
+
+### Fixed
+
+* Remove `Debug` supertrait from `DynamicAssertion` and `CredentialHolder` traits (#876)
+
 ## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.2.2...cawg-identity-v0.3.0)
 _22 January 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.3.0"
+version = "0.4.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -27,8 +27,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.42.0", features = ["openssl", "unstable_api"] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.4.0" }
+c2pa = { path = "../sdk", version = "0.43.0", features = ["openssl", "unstable_api"] }
+c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,14 +22,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.42.0", features = [
+c2pa = { path = "../sdk", version = "0.43.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
 	"unstable_api",
 ] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.4.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.4.0...c2pa-crypto-v0.5.0)
+_24 January 2025_
+
+### Added
+
+* *(crypto)* Make `box_size` parameter on `c2pa_crypto::cose::sign` an `Option` (#879)
+
+### Fixed
+
+* Bump coset requirement to 0.3.8 (#883)
+
 ## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.3.1...c2pa-crypto-v0.4.0)
 _22 January 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.4.0"
+version = "0.5.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.42.0"
+version = "0.43.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -76,7 +76,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.4.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.3.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)
* `c2pa`: 0.42.0 -> 0.43.0 (✓ API compatible changes)
* `c2pa-crypto`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

### ⚠️ `cawg-identity` breaking changes

```
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type IdentityAssertionBuilder no longer derives Debug, in /tmp/.tmpw62218/c2pa-rs/cawg_identity/src/builder/identity_assertion_builder.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.3.0...cawg-identity-v0.4.0)

_24 January 2025_

### Fixed

* Remove `Debug` supertrait from `DynamicAssertion` and `CredentialHolder` traits (#876)
</blockquote>

## `c2pa`
<blockquote>

## [0.43.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.42.0...c2pa-v0.43.0)

_24 January 2025_

### Added

* *(crypto)* Make `box_size` parameter on `c2pa_crypto::cose::sign` an `Option` (#879)

### Fixed

* Bump coset requirement to 0.3.8 (#883)
* Update id3 crate (#875)
* Remove `Debug` supertrait from `DynamicAssertion` and `CredentialHolder` traits (#876)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.4.0...c2pa-crypto-v0.5.0)

_24 January 2025_

### Added

* *(crypto)* Make `box_size` parameter on `c2pa_crypto::cose::sign` an `Option` (#879)

### Fixed

* Bump coset requirement to 0.3.8 (#883)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).