### PR TITLE
feat(crypto): Make `box_size` parameter on `c2pa_crypto::cose::sign` an `Option`

### DIFF
--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -76,13 +76,13 @@ use crate::{
 #[async_generic(async_signature(
     signer: &dyn AsyncRawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage
 ))]
 pub fn sign(
     signer: &dyn RawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage,
 ) -> Result<Vec<u8>, CoseError> {
     if _sync {
@@ -101,13 +101,13 @@ pub fn sign(
 #[async_generic(async_signature(
     signer: &dyn AsyncRawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage
 ))]
 pub fn sign_v1(
     signer: &dyn RawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage,
 ) -> Result<Vec<u8>, CoseError> {
     let alg = signer.alg();
@@ -171,13 +171,13 @@ pub fn sign_v1(
 #[async_generic(async_signature(
     signer: &dyn AsyncRawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage
 ))]
 pub fn sign_v2(
     signer: &dyn RawSigner,
     data: &[u8],
-    box_size: usize,
+    box_size: Option<usize>,
     tss: TimeStampStorage,
 ) -> Result<Vec<u8>, CoseError> {
     let alg = signer.alg();
@@ -283,7 +283,7 @@ fn build_protected_header(
     Ok(ph2)
 }
 
-#[async_generic(async_signature(signer: &dyn AsyncRawSigner, data: &[u8], p_header: &ProtectedHeader,     tss: TimeStampStorage,))]
+#[async_generic(async_signature(signer: &dyn AsyncRawSigner, data: &[u8], p_header: &ProtectedHeader, tss: TimeStampStorage,))]
 fn build_unprotected_header(
     signer: &dyn RawSigner,
     data: &[u8],
@@ -332,12 +332,16 @@ const PAD_OFFSET: usize = 7;
 // when that happens a second padding is added to change the remaining needed
 // padding. The default initial guess works for almost all sizes, without the
 // need for additional loops.
-fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>, CoseError> {
+fn pad_cose_sig(sign1: &mut CoseSign1, end_size: Option<usize>) -> Result<Vec<u8>, CoseError> {
     let mut sign1_clone = sign1.clone();
 
     let cur_vec = sign1_clone
         .to_tagged_vec()
         .map_err(|e| CoseError::CborGenerationError(e.to_string()))?;
+
+    let Some(end_size) = end_size else {
+        return Ok(cur_vec);
+    };
 
     let cur_size = cur_vec.len();
     if cur_size == end_size {
@@ -375,7 +379,7 @@ fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>, CoseE
                 Label::Text(PAD.to_string()),
                 Value::Bytes(vec![0u8; target_guess]),
             ));
-            return pad_cose_sig(&mut sign1_clone, end_size);
+            return pad_cose_sig(&mut sign1_clone, Some(end_size));
         }
 
         // Get current CBOR vec to see if we reached target size.
@@ -397,5 +401,5 @@ fn pad_cose_sig(sign1: &mut CoseSign1, end_size: usize) -> Result<Vec<u8>, CoseE
         Value::Bytes(vec![0u8; last_pad - 10]),
     ));
 
-    pad_cose_sig(sign1, end_size)
+    pad_cose_sig(sign1, Some(end_size))
 }

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -115,20 +115,20 @@ pub(crate) fn cose_sign(
 
     if _sync {
         match signer.raw_signer() {
-            Some(raw_signer) => Ok(sign(*raw_signer, data, box_size, time_stamp_storage)?),
+            Some(raw_signer) => Ok(sign(*raw_signer, data, Some(box_size), time_stamp_storage)?),
             None => {
                 let wrapper = SignerWrapper(signer);
-                Ok(sign(&wrapper, data, box_size, time_stamp_storage)?)
+                Ok(sign(&wrapper, data, Some(box_size), time_stamp_storage)?)
             }
         }
     } else {
         match signer.async_raw_signer() {
             Some(raw_signer) => {
-                Ok(sign_async(*raw_signer, data, box_size, time_stamp_storage).await?)
+                Ok(sign_async(*raw_signer, data, Some(box_size), time_stamp_storage).await?)
             }
             None => {
                 let wrapper = AsyncSignerWrapper(signer);
-                Ok(sign_async(&wrapper, data, box_size, time_stamp_storage).await?)
+                Ok(sign_async(&wrapper, data, Some(box_size), time_stamp_storage).await?)
             }
         }
     }


### PR DESCRIPTION
Signing via CAWG identity SDK for X.509 credentials does the padding at a different stage so I need to disable it here.
