### PR TITLE
fix: Bump coset requirement to 0.3.8

### DIFF
--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -52,7 +52,7 @@ c2pa-status-tracker = { path = "../status-tracker", version = "0.3.0" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }
-coset = "0.3.1"
+coset = "0.3.8"
 der = { version = "0.7.9", optional = true }
 ed25519-dalek = { version = "2.1.1", features = ["alloc", "digest", "pem", "pkcs8"], optional = true }
 getrandom = { version = "0.2.7", features = ["js"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -91,7 +91,7 @@ config = { version = "0.14.0", default-features = false, features = [
     "ini",
 ] }
 conv = "0.3.3"
-coset = "0.3.1"
+coset = "0.3.8"
 extfmt = "0.1.1"
 ed25519-dalek = "2.1.1"
 quick-xml = "0.37.1"


### PR DESCRIPTION
Needed because c2pa-crypto refers to the `tbs_data` method which was made public in 0.3.8.