### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.44.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.43.0...c2pa-v0.44.0)
+_29 January 2025_
+
+### Added
+
+* Allow synchronous DynamicAssertion (#889)
+* Claim v2 (#707)
+
 ## [0.43.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.42.0...c2pa-v0.43.0)
 _24 January 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
@@ -711,7 +711,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -734,7 +734,7 @@ dependencies = [
  "coset",
  "ed25519-dalek",
  "extfmt",
- "getrandom",
+ "getrandom 0.2.15",
  "glob",
  "hex",
  "hex-literal",
@@ -755,7 +755,7 @@ dependencies = [
  "quick-xml",
  "rand",
  "rand_chacha",
- "rand_core 0.9.0-beta.1",
+ "rand_core 0.9.0",
  "range-set",
  "rasn",
  "rasn-ocsp",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -810,7 +810,7 @@ dependencies = [
  "der",
  "ecdsa",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "js-sys",
  "nom",
@@ -844,11 +844,11 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "c2patool"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1100,7 +1100,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1808,8 +1808,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2010,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -2079,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2105,7 +2117,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2123,7 +2135,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2142,7 +2154,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2698,7 +2710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2755,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -2913,9 +2925,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3398,7 +3410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand",
  "ring 0.17.8",
  "rustc-hash",
@@ -3467,14 +3479,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.0-beta.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "zerocopy 0.8.14",
 ]
@@ -3605,7 +3617,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3655,7 +3667,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -3728,7 +3740,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -3847,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -3873,9 +3885,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -4040,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",
@@ -4378,13 +4390,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4697,9 +4709,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-xid"
@@ -4776,7 +4788,7 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
  "wasm-bindgen",
 ]
@@ -4832,6 +4844,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5117,11 +5138,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.4.0...cawg-identity-v0.5.0)
+_29 January 2025_
+
+### Added
+
+* Allow synchronous DynamicAssertion (#889)
+* Claim v2 (#707)
+* X.509 support for CAWG identity SDK (#880)
+
 ## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.3.0...cawg-identity-v0.4.0)
 _24 January 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.4.0"
+version = "0.5.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -27,9 +27,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.43.0", features = ["openssl"] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.3.0" }
+c2pa = { path = "../sdk", version = "0.44.0", features = ["openssl"] }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.4.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.12.0...c2patool-v0.13.0)
+_29 January 2025_
+
+### Added
+
+* Claim v2 (#707)
+
 ## [0.12.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.11.1...c2patool-v0.12.0)
 _22 January 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.12.0"
+version = "0.13.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,13 +22,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.43.0", features = [
+c2pa = { path = "../sdk", version = "0.44.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf"
 ] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.5.0...c2pa-crypto-v0.6.0)
+_29 January 2025_
+
+### Added
+
+* Claim v2 (#707)
+
 ## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.4.0...c2pa-crypto-v0.5.0)
 _24 January 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.5.0"
+version = "0.6.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -48,7 +48,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.3.0" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.4.0" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.3.0...c2pa-status-tracker-v0.4.0)
+_29 January 2025_
+
+### Added
+
+* Claim v2 (#707)
+
 ## [0.3.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.2.0...c2pa-status-tracker-v0.3.0)
 _16 January 2025_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.3.0"
+version = "0.4.0"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.43.0"
+version = "0.44.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -72,8 +72,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.5.0" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.3.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.4.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",
     "wasmbind",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)
* `c2pa`: 0.43.0 -> 0.44.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `c2pa-status-tracker`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)
* `c2patool`: 0.12.0 -> 0.13.0

### ⚠️ `cawg-identity` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant IdentityBuilderError:CredentialError in /tmp/.tmpV5rF74/c2pa-rs/cawg_identity/src/builder/error.rs:31
  variant IdentityBuilderError:SignerError in /tmp/.tmpV5rF74/c2pa-rs/cawg_identity/src/builder/error.rs:35

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant IdentityBuilderError::RawSignerError, previously in file /tmp/.tmpj1EYx7/cawg-identity/src/builder/error.rs:32
```

### ⚠️ `c2pa` breaking changes

```
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant Error::AssertionEncoding in /tmp/.tmpV5rF74/c2pa-rs/sdk/src/error.rs:38
```

### ⚠️ `c2pa-status-tracker` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LogItem.ingredient_uri in /tmp/.tmpV5rF74/c2pa-rs/internal/status-tracker/src/log.rs:106
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.4.0...cawg-identity-v0.5.0)

_29 January 2025_

### Added

* Allow synchronous DynamicAssertion (#889)
* Claim v2 (#707)
* X.509 support for CAWG identity SDK (#880)
</blockquote>

## `c2pa`
<blockquote>

## [0.44.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.43.0...c2pa-v0.44.0)

_29 January 2025_

### Added

* Allow synchronous DynamicAssertion (#889)
* Claim v2 (#707)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.5.0...c2pa-crypto-v0.6.0)

_29 January 2025_

### Added

* Claim v2 (#707)
</blockquote>

## `c2pa-status-tracker`
<blockquote>

## [0.4.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.3.0...c2pa-status-tracker-v0.4.0)

_29 January 2025_

### Added

* Claim v2 (#707)
</blockquote>

## `c2patool`
<blockquote>

## [0.13.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.12.0...c2patool-v0.13.0)

_29 January 2025_

### Added

* Claim v2 (#707)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).