### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.45.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.44.0...c2pa-v0.45.0)
+_30 January 2025_
+
+### Added
+
+* *(cawg_identity)* Split `CredentialHolder` into sync and async versions (#891)
+
 ## [0.44.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.43.0...c2pa-v0.44.0)
 _29 January 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3835,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "log",
  "once_cell",
@@ -4609,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -5138,9 +5138,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.5.0...cawg-identity-v0.6.0)
+_30 January 2025_
+
+### Added
+
+* *(cawg_identity)* Split `CredentialHolder` into sync and async versions (#891)
+
 ## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.4.0...cawg-identity-v0.5.0)
 _29 January 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.5.0"
+version = "0.6.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.44.0", features = ["openssl"] }
+c2pa = { path = "../sdk", version = "0.45.0", features = ["openssl"] }
 c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.4.0" }
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.44.0", features = [
+c2pa = { path = "../sdk", version = "0.45.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.44.0"
+version = "0.45.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.5.0 -> 0.6.0 (⚠️ API breaking changes)
* `c2pa`: 0.44.0 -> 0.45.0 (⚠️ API breaking changes)

### ⚠️ `cawg-identity` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type IdentityAssertionBuilder is no longer Send, in /tmp/.tmpvUKcmT/c2pa-rs/cawg_identity/src/builder/identity_assertion_builder.rs:33
  type IdentityAssertionBuilder is no longer Sync, in /tmp/.tmpvUKcmT/c2pa-rs/cawg_identity/src/builder/identity_assertion_builder.rs:33
  type IdentityAssertionSigner is no longer Send, in /tmp/.tmpvUKcmT/c2pa-rs/cawg_identity/src/builder/identity_assertion_signer.rs:26
  type IdentityAssertionSigner is no longer Sync, in /tmp/.tmpvUKcmT/c2pa-rs/cawg_identity/src/builder/identity_assertion_signer.rs:26
```

### ⚠️ `c2pa` breaking changes

```
--- failure trait_method_default_impl_removed: pub trait default method impl removed ---

Description:
A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default
        ref: https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_default_impl_removed.ron

Failed in:
  trait method c2pa::DynamicAssertion::content in file /tmp/.tmpvUKcmT/c2pa-rs/sdk/src/dynamic_assertion.rs:59

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_method_missing.ron

Failed in:
  method content_async of trait DynamicAssertion, previously in file /tmp/.tmpVLxqAj/c2pa/src/dynamic_assertion.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.5.0...cawg-identity-v0.6.0)

_30 January 2025_

### Added

* *(cawg_identity)* Split `CredentialHolder` into sync and async versions (#891)
</blockquote>

## `c2pa`
<blockquote>

## [0.45.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.44.0...c2pa-v0.45.0)

_30 January 2025_

### Added

* *(cawg_identity)* Split `CredentialHolder` into sync and async versions (#891)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).