### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.45.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.45.0...c2pa-v0.45.1)
+_31 January 2025_
+
+### Fixed
+
+* Remove dependency on SubtleCrypto (#881)
+
 ## [0.45.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.44.0...c2pa-v0.45.0)
 _30 January 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c2pa"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -4988,9 +4988,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -27,8 +27,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.45.0", features = ["openssl"] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
+c2pa = { path = "../sdk", version = "0.45.1", features = ["openssl"] }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.1" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.4.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,13 +22,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.45.0", features = [
+c2pa = { path = "../sdk", version = "0.45.1", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf"
 ] }
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.1" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.6.0...c2pa-crypto-v0.6.1)
+_31 January 2025_
+
+### Fixed
+
+* Remove dependency on SubtleCrypto (#881)
+
 ## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.5.0...c2pa-crypto-v0.6.0)
 _29 January 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.6.0"
+version = "0.6.1"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.45.0"
+version = "0.45.1"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -72,7 +72,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.6.1" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.4.0" }
 chrono = { version = "0.4.39", default-features = false, features = [
     "serde",


### PR DESCRIPTION
## 🤖 New release
* `c2pa`: 0.45.0 -> 0.45.1 (✓ API compatible changes)
* `c2pa-crypto`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`
<blockquote>

## [0.45.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.45.0...c2pa-v0.45.1)

_31 January 2025_

### Fixed

* Remove dependency on SubtleCrypto (#881)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.6.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.6.0...c2pa-crypto-v0.6.1)

_31 January 2025_

### Fixed

* Remove dependency on SubtleCrypto (#881)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).