### PR TITLE
fix:  P1363 fix to handle incorrect signers

### DIFF
--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -11,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use asn1_rs::FromDer;
 use async_generic::async_generic;
 use ciborium::value::Value;
 use coset::{
@@ -19,6 +20,7 @@ use coset::{
     TaggedCborSerializable,
 };
 use serde_bytes::ByteBuf;
+use x509_parser::prelude::X509Certificate;
 
 use super::cert_chain_from_sign1;
 use crate::{
@@ -161,7 +163,13 @@ pub fn sign_v1(
                     "bad certificate chain".to_string(),
                 ))?;
 
-                let curve = ec_curve_from_public_key_der(signing_cert).ok_or(
+                let (_, cert) = X509Certificate::from_der(signing_cert).map_err(|_e| {
+                    CoseError::CborGenerationError("incorrect EC signature format".to_string())
+                })?;
+
+                let certificate_public_key = cert.public_key();
+
+                let curve = ec_curve_from_public_key_der(certificate_public_key.raw).ok_or(
                     CoseError::CborGenerationError("incorrect EC signature format".to_string()),
                 )?;
 
@@ -235,7 +243,13 @@ pub fn sign_v2(
                     "bad certificate chain".to_string(),
                 ))?;
 
-                let curve = ec_curve_from_public_key_der(signing_cert).ok_or(
+                let (_, cert) = X509Certificate::from_der(signing_cert).map_err(|_e| {
+                    CoseError::CborGenerationError("incorrect EC signature format".to_string())
+                })?;
+
+                let certificate_public_key = cert.public_key();
+
+                let curve = ec_curve_from_public_key_der(certificate_public_key.raw).ok_or(
                     CoseError::CborGenerationError("incorrect EC signature format".to_string()),
                 )?;
 

--- a/internal/crypto/src/ec_utils.rs
+++ b/internal/crypto/src/ec_utils.rs
@@ -127,6 +127,7 @@ pub(crate) fn der_to_p1363(data: &[u8], sig_len: usize) -> Result<Vec<u8>, RawSi
 }
 
 // Returns supported EcdsaCurve for given public key.
+#[allow(dead_code)]
 pub(crate) fn ec_curve_from_public_key_der(public_key: &[u8]) -> Option<EcdsaCurve> {
     let (_, pk) = SubjectPublicKeyInfo::from_der(public_key).ok()?;
 


### PR DESCRIPTION
## Changes in this pull request
This PR adds support to handle incorrect EC signers with ability to handle arbitrary curves.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
