### PR TITLE
feat(cawg-identity): Add `IdentityAssertionReport`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ version = "0.5.0"
 
 [[package]]
 name = "c2patool"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cawg_identity/src/identity_assertion/assertion.rs
+++ b/cawg_identity/src/identity_assertion/assertion.rs
@@ -63,6 +63,21 @@ impl IdentityAssertion {
             .map(|a| a.to_assertion())
     }
 
+    /// Create an [`IdentityAssertionReport`] from this `IdentityAssertion`.
+    ///
+    /// This will [`validate`] the assertion and then render the result as
+    /// an [`IdentityAssertionReport`] that describes the decoded content of
+    /// the identity assertion.
+    ///
+    /// [`validate`]: Self::validate
+    pub async fn to_report<SV: SignatureVerifier>(
+        &self,
+        manifest: &Manifest,
+        verifier: &SV,
+    ) -> IdentityAssertionReport {
+        todo!("validate and render as report");
+    }
+
     /// Using the provided [`SignatureVerifier`], check the validity of this
     /// identity assertion.
     ///

--- a/cawg_identity/src/identity_assertion/mod.rs
+++ b/cawg_identity/src/identity_assertion/mod.rs
@@ -12,6 +12,7 @@
 // each license.
 
 pub(crate) mod assertion;
+pub(crate) mod report;
 pub(crate) mod signature_verifier;
 pub(crate) mod signer_payload;
 pub(crate) mod validation_error;

--- a/cawg_identity/src/identity_assertion/report.rs
+++ b/cawg_identity/src/identity_assertion/report.rs
@@ -1,0 +1,33 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+
+use crate::{builder::CredentialHolder, identity_assertion::signer_payload::SignerPayload};
+
+/// This struct represents the validated content of an identity assertion.
+///
+/// It is created by calling [`IdentityAssertion::to_report`], which will
+/// validate the content of the assertion and decode the content
+#[derive(Debug, Serialize)]
+pub struct IdentityAssertionReport {
+    #[serde(flatten)]
+    pub(crate) signer_payload: SignerPayload,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) named_actor: Option<Box<dyn CredentialHolder>>,
+    // ^^ TO DO: Replace CredentialHolder with another type
+    // that is guaranteed to be Serializable.
+}


### PR DESCRIPTION
Intended for use in various tools that require a JSON description of an identity assertion, including its validated/decoded content.