### PR TITLE
fix(cawg_identity): No-op change to trigger re-release of cawg-identity crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ version = "0.5.0"
 
 [[package]]
 name = "c2patool"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cawg_identity/src/internal/debug_byte_slice.rs
+++ b/cawg_identity/src/internal/debug_byte_slice.rs
@@ -11,8 +11,6 @@
 // specific language governing permissions and limitations under
 // each license.
 
-#![allow(unused)] // TEMPORARY while updating ...
-
 use std::fmt::{Debug, Error, Formatter};
 
 pub(crate) struct DebugByteSlice<'a>(pub(crate) &'a [u8]);


### PR DESCRIPTION
Workaround for https://github.com/release-plz/release-plz/issues/2034.
