### PR TITLE
feat: Add support for DynamicAssertions in JSON format

### DIFF
--- a/cawg_identity/src/builder/identity_assertion_builder.rs
+++ b/cawg_identity/src/builder/identity_assertion_builder.rs
@@ -12,7 +12,7 @@
 // each license.
 
 use async_trait::async_trait;
-use c2pa::{AsyncDynamicAssertion, DynamicAssertion, PreliminaryClaim};
+use c2pa::{AsyncDynamicAssertion, DynamicAssertion, DynamicAssertionContent, PreliminaryClaim};
 use serde_bytes::ByteBuf;
 
 use super::{CredentialHolder, IdentityBuilderError};
@@ -50,8 +50,8 @@ impl DynamicAssertion for IdentityAssertionBuilder {
         "cawg.identity".to_string()
     }
 
-    fn reserve_size(&self) -> usize {
-        self.credential_holder.reserve_size()
+    fn reserve_size(&self) -> c2pa::Result<usize> {
+        Ok(self.credential_holder.reserve_size())
         // TO DO: Credential holder will state reserve size for signature.
         // Add additional size for CBOR wrapper outside signature.
     }
@@ -61,7 +61,7 @@ impl DynamicAssertion for IdentityAssertionBuilder {
         _label: &str,
         size: Option<usize>,
         claim: &PreliminaryClaim,
-    ) -> c2pa::Result<Vec<u8>> {
+    ) -> c2pa::Result<DynamicAssertionContent> {
         // TO DO: Better filter for referenced assertions.
         // For now, just require hard binding.
 
@@ -120,8 +120,8 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
         "cawg.identity".to_string()
     }
 
-    fn reserve_size(&self) -> usize {
-        self.credential_holder.reserve_size()
+    fn reserve_size(&self) -> c2pa::Result<usize> {
+        Ok(self.credential_holder.reserve_size())
         // TO DO: Credential holder will state reserve size for signature.
         // Add additional size for CBOR wrapper outside signature.
     }
@@ -131,7 +131,7 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
         _label: &str,
         size: Option<usize>,
         claim: &PreliminaryClaim,
-    ) -> c2pa::Result<Vec<u8>> {
+    ) -> c2pa::Result<DynamicAssertionContent> {
         // TO DO: Better filter for referenced assertions.
         // For now, just require hard binding.
 
@@ -158,7 +158,7 @@ fn finalize_identity_assertion(
     signer_payload: SignerPayload,
     size: Option<usize>,
     signature_result: Result<Vec<u8>, IdentityBuilderError>,
-) -> c2pa::Result<Vec<u8>> {
+) -> c2pa::Result<DynamicAssertionContent> {
     // TO DO: Think through how errors map into c2pa::Error.
     let signature = signature_result.map_err(|e| c2pa::Error::BadParam(e.to_string()))?;
 
@@ -202,5 +202,5 @@ fn finalize_identity_assertion(
         assert_eq!(assertion_size, assertion_cbor.len());
     }
 
-    Ok(assertion_cbor)
+    Ok(DynamicAssertionContent::Cbor(assertion_cbor))
 }

--- a/sdk/src/dynamic_assertion.rs
+++ b/sdk/src/dynamic_assertion.rs
@@ -23,8 +23,10 @@ use crate::{hashed_uri::HashedUri, Result};
 pub enum DynamicAssertionContent {
     /// The assertion is a CBOR-encoded binary blob.
     Cbor(Vec<u8>),
-    /// The assertion is a JSON-encoded Strings.
+
+    /// The assertion is a JSON-encoded string.
     Json(String),
+
     /// The assertion is a binary blob with a content type.
     Binary(String, Vec<u8>),
 }

--- a/sdk/src/dynamic_assertion.rs
+++ b/sdk/src/dynamic_assertion.rs
@@ -19,6 +19,16 @@ use async_trait::async_trait;
 
 use crate::{hashed_uri::HashedUri, Result};
 
+/// The type of content that can be returned by a [`DynamicAssertion`] content call.
+pub enum DynamicAssertionContent {
+    /// The assertion is a CBOR-encoded binary blob.
+    Cbor(Vec<u8>),
+    /// The assertion is a JSON-encoded Strings.
+    Json(String),
+    /// The assertion is a binary blob with a content type.
+    Binary(String, Vec<u8>),
+}
+
 /// A `DynamicAssertion` is an assertion that has the ability to adjust
 /// its content based on other assertions within the overall [`Manifest`].
 ///
@@ -41,7 +51,7 @@ pub trait DynamicAssertion {
     /// assertion).
     ///
     /// [`Builder`]: crate::Builder
-    fn reserve_size(&self) -> usize;
+    fn reserve_size(&self) -> Result<usize>;
 
     /// Return the final assertion content.
     ///
@@ -61,7 +71,7 @@ pub trait DynamicAssertion {
         label: &str,
         size: Option<usize>,
         claim: &PreliminaryClaim,
-    ) -> Result<Vec<u8>>;
+    ) -> Result<DynamicAssertionContent>;
 }
 
 /// An `AsyncDynamicAssertion` is an assertion that has the ability
@@ -89,7 +99,7 @@ pub trait AsyncDynamicAssertion: Sync {
     /// assertion).
     ///
     /// [`Builder`]: crate::Builder
-    fn reserve_size(&self) -> usize;
+    fn reserve_size(&self) -> Result<usize>;
 
     /// Return the final assertion content.
     ///
@@ -109,7 +119,7 @@ pub trait AsyncDynamicAssertion: Sync {
         label: &str,
         size: Option<usize>,
         claim: &PreliminaryClaim,
-    ) -> Result<Vec<u8>>;
+    ) -> Result<DynamicAssertionContent>;
 }
 
 /// An `AsyncDynamicAssertion` is an assertion that has the ability
@@ -137,7 +147,7 @@ pub trait AsyncDynamicAssertion {
     /// assertion).
     ///
     /// [`Builder`]: crate::Builder
-    fn reserve_size(&self) -> usize;
+    fn reserve_size(&self) -> Result<usize>;
 
     /// Return the final assertion content.
     ///
@@ -157,7 +167,7 @@ pub trait AsyncDynamicAssertion {
         label: &str,
         size: Option<usize>,
         claim: &PreliminaryClaim,
-    ) -> Result<Vec<u8>>;
+    ) -> Result<DynamicAssertionContent>;
 }
 
 /// Describes information from the preliminary C2PA Claim that may

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -107,7 +107,9 @@ pub use builder::{Builder, ManifestDefinition};
 pub use c2pa_crypto::raw_signature::SigningAlg;
 pub use callback_signer::{CallbackFunc, CallbackSigner};
 pub use claim_generator_info::ClaimGeneratorInfo;
-pub use dynamic_assertion::{AsyncDynamicAssertion, DynamicAssertion, PreliminaryClaim};
+pub use dynamic_assertion::{
+    AsyncDynamicAssertion, DynamicAssertion, DynamicAssertionContent, PreliminaryClaim,
+};
 pub use error::{Error, Result};
 pub use external_manifest::ManifestPatchCallback;
 pub use hash_utils::{hash_stream_by_alg, HashRange};

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2097,7 +2097,7 @@ impl Store {
                     final_assertions.push(User::new(&label, &data).to_assertion()?);
                 }
                 DynamicAssertionContent::Binary(format, data) => {
-                    // todo:: support for pushing binary assertions here
+                    todo!("Binary dynamic assertions not yet supported");
                 }
             }
         }

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -245,8 +245,8 @@ fn test_dynamic_assertions_builder() -> Result<()> {
         }
     }
 
-    /// This is an signer wrapped around a local temp signer,
-    /// that implements the dynamic assertion trait.
+    /// This is a Signer wrapped around a local temp signer,
+    /// that implements the DynamicAssertion trait.
     struct DynamicSigner(Box<dyn Signer>);
 
     impl DynamicSigner {

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -182,3 +182,129 @@ fn test_builder_embedded_v1_otgp() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(not(any(target_arch = "wasm32", feature = "openssl")), ignore)]
+fn test_dynamic_assertions_builder() -> Result<()> {
+    use c2pa::{
+        // assertions::{CreativeWork, SchemaDotOrgPerson},
+        DynamicAssertion,
+        DynamicAssertionContent,
+        PreliminaryClaim,
+        Signer,
+        SigningAlg,
+    };
+    use serde::Serialize;
+    #[derive(Serialize)]
+    struct TestAssertion {
+        my_tag: String,
+    }
+
+    #[derive(Debug)]
+    struct TestDynamicAssertion {}
+
+    impl DynamicAssertion for TestDynamicAssertion {
+        fn label(&self) -> String {
+            //CreativeWork::LABEL.to_string()
+            "com.mycompany.myassertion".to_string()
+        }
+
+        fn reserve_size(&self) -> Result<usize> {
+            let assertion = TestAssertion {
+                my_tag: "some value I will replace".to_string(),
+            };
+            // let assertion = CreativeWork::new()
+            //     .add_author(SchemaDotOrgPerson::new().set_name("me").unwrap())
+            //     .unwrap();
+            Ok(serde_json::to_string(&assertion)?.len())
+        }
+
+        fn content(
+            &self,
+            _label: &str,
+            _size: Option<usize>,
+            claim: &PreliminaryClaim,
+        ) -> Result<DynamicAssertionContent> {
+            assert!(claim
+                .assertions()
+                .inspect(|a| {
+                    dbg!(a);
+                })
+                .any(|a| a.url().contains("c2pa.hash")));
+
+            // let assertion =
+            //     CreativeWork::new().add_author(SchemaDotOrgPerson::new().set_name("me")?)?;
+
+            let assertion = TestAssertion {
+                my_tag: "some value I will replace".to_string(),
+            };
+
+            Ok(DynamicAssertionContent::Json(serde_json::to_string(
+                &assertion,
+            )?))
+        }
+    }
+
+    /// This is an signer wrapped around a local temp signer,
+    /// that implements the dynamic assertion trait.
+    struct DynamicSigner(Box<dyn Signer>);
+
+    impl DynamicSigner {
+        fn new() -> Self {
+            Self(Box::new(test_signer()))
+        }
+    }
+
+    impl Signer for DynamicSigner {
+        fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
+            self.0.sign(data)
+        }
+
+        fn alg(&self) -> SigningAlg {
+            self.0.alg()
+        }
+
+        fn certs(&self) -> crate::Result<Vec<Vec<u8>>> {
+            self.0.certs()
+        }
+
+        fn reserve_size(&self) -> usize {
+            self.0.reserve_size()
+        }
+
+        fn time_authority_url(&self) -> Option<String> {
+            self.0.time_authority_url()
+        }
+
+        fn ocsp_val(&self) -> Option<Vec<u8>> {
+            self.0.ocsp_val()
+        }
+
+        // Returns our dynamic assertion here.
+        fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
+            vec![Box::new(TestDynamicAssertion {})]
+        }
+    }
+
+    let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
+    let mut builder = Builder::from_json(&manifest_def)?;
+
+    const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
+    let format = "image/jpeg";
+    let mut source = Cursor::new(TEST_IMAGE);
+
+    let mut dest = Cursor::new(Vec::new());
+
+    let signer = DynamicSigner::new();
+    builder.sign(&signer, format, &mut source, &mut dest)?;
+
+    dest.set_position(0);
+
+    let reader = Reader::from_stream(format, &mut dest).unwrap();
+
+    println!("reader: {}", reader);
+
+    assert_ne!(reader.validation_state(), ValidationState::Invalid);
+
+    Ok(())
+}


### PR DESCRIPTION
This allows DynamicAssertions to create JSON formatted assertions. Previously only Cbor formatted assertions were supported.