### PR TITLE
feat: Adds validation_state to the json reports from the Reader

### DIFF
--- a/cawg_identity/src/identity_assertion/assertion.rs
+++ b/cawg_identity/src/identity_assertion/assertion.rs
@@ -161,8 +161,8 @@ impl IdentityAssertion {
     ///
     /// [`ManifestStore`]: c2pa::ManifestStore
     #[cfg(feature = "v1_api")]
-    pub async fn summarize_manifest_store<SV: SignatureVerifier>(
-        store: &c2pa::ManifestStore,
+    pub async fn summarize_reader<SV: SignatureVerifier>(
+        reader: &c2pa::Reader,
         verifier: &SV,
     ) -> impl Serialize {
         // NOTE: We can't write this using .map(...).collect() because there are async
@@ -174,7 +174,7 @@ impl IdentityAssertion {
             >,
         > = BTreeMap::new();
 
-        for (id, manifest) in store.manifests() {
+        for (id, manifest) in reader.manifests() {
             let report = Self::summarize_all_impl(manifest, verifier).await;
             reports.insert(id.clone(), report);
         }

--- a/cawg_identity/src/identity_assertion/assertion.rs
+++ b/cawg_identity/src/identity_assertion/assertion.rs
@@ -161,8 +161,8 @@ impl IdentityAssertion {
     ///
     /// [`ManifestStore`]: c2pa::ManifestStore
     #[cfg(feature = "v1_api")]
-    pub async fn summarize_reader<SV: SignatureVerifier>(
-        reader: &c2pa::Reader,
+    pub async fn summarize_manifest_store<SV: SignatureVerifier>(
+        store: &c2pa::ManifestStore,
         verifier: &SV,
     ) -> impl Serialize {
         // NOTE: We can't write this using .map(...).collect() because there are async
@@ -174,7 +174,7 @@ impl IdentityAssertion {
             >,
         > = BTreeMap::new();
 
-        for (id, manifest) in reader.manifests() {
+        for (id, manifest) in store.manifests() {
             let report = Self::summarize_all_impl(manifest, verifier).await;
             reports.insert(id.clone(), report);
         }
@@ -200,13 +200,9 @@ impl IdentityAssertion {
             >,
         > = BTreeMap::new();
 
-        for manifest in reader.iter_manifests() {
+        for (id, manifest) in reader.manifests() {
             let report = Self::summarize_all_impl(manifest, verifier).await;
-
-            // TO DO: What to do if manifest doesn't have a label?
-            if let Some(label) = manifest.label() {
-                reports.insert(label.to_owned(), report);
-            }
+            reports.insert(id.clone(), report);
         }
 
         IdentityAssertionsForManifestStore::<

--- a/make_test_images/src/compare_manifests.rs
+++ b/make_test_images/src/compare_manifests.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::{fs, path::Path};
 
-use c2pa::{Error, Reader as ManifestStore, Result};
+use c2pa::{Error, Reader, Result};
 
 /// Compares all the files in two directories and returns a list of issues
 pub fn compare_folders<P: AsRef<Path>, Q: AsRef<Path>>(folder1: P, folder2: Q) -> Result<()> {
@@ -79,17 +79,16 @@ pub fn compare_image_manifests<P: AsRef<Path>, Q: AsRef<Path>>(
 ) -> Result<Vec<String>> {
     let manifest_store1 = match m1.as_ref().extension() {
         Some(ext) if ext == "json" => {
-            ManifestStore::from_json(&fs::read_to_string(m1)?)
+            Reader::from_json(&fs::read_to_string(m1)?)
             //serde_json::from_str(&fs::read_to_string(m1)?).map_err(Error::JsonError)
         }
-        _ => ManifestStore::from_file(m1.as_ref()),
+        _ => Reader::from_file(m1.as_ref()),
     };
     let manifest_store2 = match m2.as_ref().extension() {
-        Some(ext) if ext == "json" => ManifestStore::from_json(&fs::read_to_string(m2)?),
-        _ => ManifestStore::from_file(m2.as_ref()),
+        Some(ext) if ext == "json" => Reader::from_json(&fs::read_to_string(m2)?),
+        _ => Reader::from_file(m2.as_ref()),
     };
-    // let manifest_store1 = ManifestStore::from_file(m1);
-    // let manifest_store2 = ManifestStore::from_file(m2);
+
     match (manifest_store1, manifest_store2) {
         (Ok(manifest_store1), Ok(manifest_store2)) => {
             compare_manifests(&manifest_store1, &manifest_store2)
@@ -102,8 +101,8 @@ pub fn compare_image_manifests<P: AsRef<Path>, Q: AsRef<Path>>(
 
 /// Compares two manifest stores and returns a list of issues.
 pub fn compare_manifests(
-    manifest_store1: &ManifestStore,
-    manifest_store2: &ManifestStore,
+    manifest_store1: &Reader,
+    manifest_store2: &Reader,
 ) -> Result<Vec<String>> {
     // first we need to gather all the manifests in the order they are first seen recursively
     let mut labels1 = Vec::new();
@@ -136,11 +135,7 @@ pub fn compare_manifests(
 }
 
 // creates list of manifests in the order they are first seen from the active manifest
-fn gather_manifests(
-    manifest_store: &ManifestStore,
-    manifest_label: &str,
-    labels: &mut Vec<String>,
-) {
+fn gather_manifests(manifest_store: &Reader, manifest_label: &str, labels: &mut Vec<String>) {
     if !labels.contains(&manifest_label.to_string()) {
         labels.push(manifest_label.to_string());
     }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1469,7 +1469,7 @@ mod tests {
             .add("thumbnail.jpg", TEST_THUMBNAIL.to_vec())
             .unwrap();
 
-        // sign the ManifestStoreBuilder and write it to the output stream
+        // sign the Builder and write it to the output stream
         let signer = crate::utils::test::temp_async_remote_signer();
         builder
             .sign_async(signer.as_ref(), format, &mut source, &mut dest)
@@ -1504,7 +1504,7 @@ mod tests {
             .add_resource("thumbnail.jpg", Cursor::new(TEST_THUMBNAIL))
             .unwrap();
 
-        // sign the ManifestStoreBuilder and write it to the output stream
+        // sign the Builder and write it to the output stream
         let signer = test_signer(SigningAlg::Ps256);
         let manifest_data = builder
             .sign(signer.as_ref(), "image/jpeg", &mut source, &mut dest)
@@ -1669,7 +1669,7 @@ mod tests {
         zipped.rewind().unwrap();
         let mut builder = Builder::from_archive(&mut zipped).unwrap();
 
-        // sign the ManifestStoreBuilder and write it to the output stream
+        // sign the Builder and write it to the output stream
         let signer = test_signer(SigningAlg::Ps256);
         let _manifest_data = builder
             .sign(signer.as_ref(), "image/jpeg", &mut source, &mut dest)
@@ -1855,6 +1855,7 @@ mod tests {
             .expect("builder sign");
 
         output.set_position(0);
+        println!("output len: {}", output.get_ref().len());
         let reader = Reader::from_stream("jpeg", &mut output).expect("from_bytes");
         println!("reader = {reader}");
         let m = reader.active_manifest().unwrap();

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -81,6 +81,7 @@ static _V2_SPEC_DEPRECATED_ASSERTIONS: [&str; 4] = [
 // Enum to encapsulate the data type of the source asset.  This simplifies
 // having different implementations for functions as a single entry point can be
 // used to handle different data types.
+#[allow(dead_code)] // Bytes and third param in StreamFragment not used without v1_api feature
 pub enum ClaimAssetData<'a> {
     #[cfg(feature = "file_io")]
     Path(&'a Path),

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -45,7 +45,7 @@ use crate::{
     store::Store,
     utils::xmp_inmemory_utils::XmpInfo,
     validation_results::ValidationResults,
-    validation_status::{self, validation_results_for_store, ValidationStatus},
+    validation_status::{self, ValidationStatus},
 };
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -589,7 +589,7 @@ impl Ingredient {
         match result {
             Ok(store) => {
                 // generate validation results from the store
-                let validation_results = validation_results_for_store(&store, validation_log);
+                let validation_results = ValidationResults::from_store(&store, validation_log);
 
                 if let Some(claim) = store.provenance_claim() {
                     // if the parent claim is valid and has a thumbnail, use it

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -282,7 +282,7 @@ pub fn load_jumbf_from_file<P: AsRef<Path>>(in_path: P) -> Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "file_io")]
+#[cfg(all(feature = "v1_api", feature = "file_io"))]
 pub(crate) fn object_locations(in_path: &Path) -> Result<Vec<HashObjectPositions>> {
     let ext = get_file_extension(in_path).ok_or(Error::UnsupportedType)?;
 

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -329,14 +329,13 @@ where
     }
 }
 
-#[cfg(feature = "file_io")]
 /// removes the C2PA JUMBF from an asset
 /// Note: Use with caution since this deletes C2PA data
 /// It is useful when creating remote manifests from embedded manifests
 ///
 /// path - path to file to be updated
 /// returns Unsupported type or errors from remove_cai_store
-#[allow(dead_code)]
+#[cfg(feature = "file_io")]
 pub fn remove_jumbf_from_file<P: AsRef<Path>>(path: P) -> Result<()> {
     let ext = get_file_extension(path.as_ref()).ok_or(Error::UnsupportedType)?;
     match get_assetio_handler(&ext) {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -148,6 +148,7 @@ pub(crate) mod jumbf;
 
 pub(crate) mod manifest;
 pub(crate) mod manifest_assertion;
+#[cfg(feature = "v1_api")]
 pub(crate) mod manifest_store;
 pub(crate) mod manifest_store_report;
 #[allow(dead_code)]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -121,6 +121,7 @@ pub use manifest::{Manifest, SignatureInfo};
 pub use manifest_assertion::{ManifestAssertion, ManifestAssertionKind};
 #[cfg(feature = "v1_api")]
 pub use manifest_store::ManifestStore;
+#[cfg(feature = "v1_api")]
 pub use manifest_store_report::ManifestStoreReport;
 pub use reader::Reader;
 pub use resource_store::{ResourceRef, ResourceStore};

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -30,7 +30,7 @@ use crate::{
     jumbf::labels::{manifest_label_from_uri, to_absolute_uri, to_relative_uri},
     store::Store,
     validation_results::ValidationResults,
-    validation_status::{validation_results_for_store, ValidationStatus},
+    validation_status::ValidationStatus,
     Error, Manifest, Result,
 };
 
@@ -183,7 +183,7 @@ impl ManifestStore {
         validation_log: &impl StatusTracker,
         #[cfg(feature = "file_io")] resource_path: Option<&Path>,
     ) -> ManifestStore {
-        let mut validation_results = validation_results_for_store(&store, validation_log);
+        let mut validation_results = ValidationResults::from_store(&store, validation_log);
 
         let mut manifest_store = ManifestStore::new();
         manifest_store.active_manifest = store.provenance_label();
@@ -220,7 +220,7 @@ impl ManifestStore {
         validation_log: &impl StatusTracker,
         #[cfg(feature = "file_io")] resource_path: Option<&Path>,
     ) -> ManifestStore {
-        let mut validation_results = validation_results_for_store(&store, validation_log);
+        let mut validation_results = ValidationResults::from_store(&store, validation_log);
 
         let mut manifest_store = ManifestStore::new();
         manifest_store.active_manifest = store.provenance_label();
@@ -250,10 +250,6 @@ impl ManifestStore {
         manifest_store.validation_results = Some(validation_results);
 
         manifest_store
-    }
-
-    pub(crate) fn store(&self) -> &Store {
-        &self.store
     }
 
     /// Creates a new Manifest Store from a Manifest

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -268,7 +268,6 @@ impl ManifestStore {
     }
 
     /// Generate a Store from a format string and bytes.
-    #[cfg(feature = "v1_api")]
     #[deprecated(since = "0.38.0", note = "Please use Reader::from_stream() instead")]
     #[cfg(feature = "v1_api")]
     #[async_generic]

--- a/sdk/src/manifest_store_report.rs
+++ b/sdk/src/manifest_store_report.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 
 use crate::{
     assertion::AssertionData, claim::Claim, store::Store, validation_results::ValidationResults,
-    validation_status::ValidationStatus, Result,
+    validation_status::ValidationStatus, Result, ValidationState,
 };
 
 /// Low level JSON based representation of Manifest Store - used for debugging
@@ -39,6 +39,7 @@ pub struct ManifestStoreReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     validation_status: Option<Vec<ValidationStatus>>,
     pub(crate) validation_results: Option<ValidationResults>,
+    pub(crate) validation_state: Option<ValidationState>,
 }
 
 impl ManifestStoreReport {
@@ -54,7 +55,18 @@ impl ManifestStoreReport {
             manifests,
             validation_status: None,
             validation_results: None,
+            validation_state: None,
         })
+    }
+
+    pub(crate) fn from_store_with_results(
+        store: &Store,
+        validation_results: &ValidationResults,
+    ) -> Result<Self> {
+        let mut report = Self::from_store(store)?;
+        report.validation_results = Some(validation_results.clone());
+        report.validation_state = Some(validation_results.validation_state());
+        Ok(report)
     }
 
     /// Prints tree view of manifest store

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -33,11 +33,12 @@ use crate::{
     claim::ClaimAssetData,
     error::{Error, Result},
     jumbf::labels::{manifest_label_from_uri, to_absolute_uri, to_relative_uri},
+    manifest_store_report::ManifestStoreReport,
     settings::get_settings_value,
     store::Store,
     validation_results::{ValidationResults, ValidationState},
     validation_status::ValidationStatus,
-    Manifest, ManifestStoreReport,
+    Manifest,
 };
 
 /// A reader for the manifest store.

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -16,20 +16,23 @@
 
 #[cfg(feature = "file_io")]
 use std::fs::{read, File};
-use std::io::{Read, Seek, Write};
+use std::{
+    collections::HashMap,
+    io::{Read, Seek, Write},
+};
 
 use async_generic::async_generic;
+use c2pa_crypto::base64;
 use c2pa_status_tracker::DetailedStatusTracker;
 #[cfg(feature = "json_schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
-#[cfg(feature = "file_io")]
-use crate::error::Error;
 use crate::{
     claim::ClaimAssetData,
-    error::Result,
-    manifest_store::ManifestStore,
+    error::{Error, Result},
+    jumbf::labels::{manifest_label_from_uri, to_absolute_uri, to_relative_uri},
     settings::get_settings_value,
     store::Store,
     validation_results::{ValidationResults, ValidationState},
@@ -38,10 +41,28 @@ use crate::{
 };
 
 /// A reader for the manifest store.
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct Reader {
-    pub(crate) manifest_store: ManifestStore,
+    /// A label for the active (most recent) manifest in the store
+    active_manifest: Option<String>,
+
+    /// A HashMap of Manifests
+    manifests: HashMap<String, Manifest>,
+
+    /// ValidationStatus generated when loading the ManifestStore from an asset
+    validation_status: Option<Vec<ValidationStatus>>,
+
+    /// ValidationStatus generated when loading the ManifestStore from an asset
+    validation_results: Option<ValidationResults>,
+
+    /// The validation state of the manifest store
+    validation_state: Option<ValidationState>,
+
+    #[serde(skip)]
+    /// We keep this around so we can generate a detailed report if needed
+    store: Store,
 }
 
 impl Reader {
@@ -65,16 +86,13 @@ impl Reader {
     /// ```
     #[async_generic()]
     pub fn from_stream(format: &str, mut stream: impl Read + Seek + Send) -> Result<Reader> {
-        let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
-        #[allow(deprecated)]
-        let reader = if _sync {
-            ManifestStore::from_stream(format, &mut stream, verify)
+        let manifest_bytes = Store::load_jumbf_from_stream(format, &mut stream)?;
+
+        if _sync {
+            Self::from_manifest_data_and_stream(&manifest_bytes, format, &mut stream)
         } else {
-            ManifestStore::from_stream_async(format, &mut stream, verify).await
-        }?;
-        Ok(Reader {
-            manifest_store: reader,
-        })
+            Self::from_manifest_data_and_stream_async(&manifest_bytes, format, &mut stream).await
+        }
     }
 
     #[cfg(feature = "file_io")]
@@ -135,8 +153,7 @@ impl Reader {
     /// # WARNING
     /// This function is intended for use in testing. Don't use it in an implementation.
     pub fn from_json(json: &str) -> Result<Reader> {
-        let manifest_store = serde_json::from_str(json)?;
-        Ok(Reader { manifest_store })
+        serde_json::from_str(json).map_err(crate::Error::JsonError)
     }
 
     /// Create a manifest store [`Reader`] from existing `c2pa_data` and a stream.
@@ -163,28 +180,16 @@ impl Reader {
 
         let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
 
-        if _sync {
-            if verify {
-                Store::verify_store(
-                    &store,
-                    &mut ClaimAssetData::Stream(&mut stream, format),
-                    &mut validation_log,
-                )?;
-            }
-        } else {
-            if verify {
-                Store::verify_store_async(
-                    &store,
-                    &mut ClaimAssetData::Stream(&mut stream, format),
-                    &mut validation_log,
-                )
-                .await?;
-            }
+        if verify {
+            let mut asset_data = ClaimAssetData::Stream(&mut stream, format);
+            if _sync {
+                Store::verify_store(&store, &mut asset_data, &mut validation_log)
+            } else {
+                Store::verify_store_async(&store, &mut asset_data, &mut validation_log).await
+            }?;
         }
 
-        Ok(Reader {
-            manifest_store: ManifestStore::from_store(store, &validation_log),
-        })
+        Ok(Self::from_store(store, &validation_log))
     }
 
     /// Create a [`Reader`] from an initial segment and a fragment stream.
@@ -213,17 +218,13 @@ impl Reader {
         if verify {
             let mut fragment = ClaimAssetData::StreamFragment(&mut stream, &mut fragment, format);
             if _sync {
-                // verify store and claims
                 Store::verify_store(&store, &mut fragment, &mut validation_log)
             } else {
-                // verify store and claims
                 Store::verify_store_async(&store, &mut fragment, &mut validation_log).await
             }?;
         };
 
-        Ok(Self {
-            manifest_store: ManifestStore::from_store(store, &validation_log),
-        })
+        Ok(Self::from_store(store, &validation_log))
     }
 
     #[cfg(feature = "file_io")]
@@ -235,15 +236,70 @@ impl Reader {
         fragments: &Vec<std::path::PathBuf>,
     ) -> Result<Reader> {
         let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
-        #[allow(deprecated)]
-        Ok(Reader {
-            manifest_store: ManifestStore::from_fragments(path, fragments, verify)?,
-        })
+
+        let mut validation_log = DetailedStatusTracker::default();
+
+        let asset_type = crate::jumbf_io::get_supported_file_extension(path.as_ref())
+            .ok_or(crate::Error::UnsupportedType)?;
+
+        let mut init_segment = std::fs::File::open(path.as_ref())?;
+
+        match Store::load_from_file_and_fragments(
+            &asset_type,
+            &mut init_segment,
+            fragments,
+            verify,
+            &mut validation_log,
+        ) {
+            Ok(store) => Ok(Self::from_store(store, &validation_log)),
+            Err(e) => Err(e),
+        }
     }
 
     /// Get the manifest store as a JSON string
     pub fn json(&self) -> String {
-        self.manifest_store.to_string()
+        let mut json = serde_json::to_string_pretty(self).unwrap_or_default();
+
+        fn omit_tag(mut json: String, tag: &str) -> String {
+            while let Some(index) = json.find(&format!("\"{tag}\": [")) {
+                if let Some(idx2) = json[index..].find(']') {
+                    json = format!(
+                        "{}\"{}\": \"<omitted>\"{}",
+                        &json[..index],
+                        tag,
+                        &json[index + idx2 + 1..]
+                    );
+                }
+            }
+            json
+        }
+
+        // Make a base64 hash from Vec<u8> values.
+        fn b64_tag(mut json: String, tag: &str) -> String {
+            while let Some(index) = json.find(&format!("\"{tag}\": [")) {
+                if let Some(idx2) = json[index..].find(']') {
+                    let idx3 = json[index..].find('[').unwrap_or_default();
+
+                    let bytes: Vec<u8> =
+                        serde_json::from_slice(json[index + idx3..index + idx2 + 1].as_bytes())
+                            .unwrap_or_default();
+
+                    json = format!(
+                        "{}\"{}\": \"{}\"{}",
+                        &json[..index],
+                        tag,
+                        base64::encode(&bytes),
+                        &json[index + idx2 + 1..]
+                    );
+                }
+            }
+
+            json
+        }
+
+        json = b64_tag(json, "hash");
+        json = omit_tag(json, "pad");
+        json
     }
 
     /// Get the [`ValidationStatus`] array of the manifest store if it exists.
@@ -260,7 +316,7 @@ impl Reader {
     /// let status = reader.validation_status();
     /// ```
     pub fn validation_status(&self) -> Option<&[ValidationStatus]> {
-        self.manifest_store.validation_status()
+        self.validation_status.as_deref()
     }
 
     /// Get the [`ValidationResults`] map of an asset if it exists.
@@ -281,12 +337,12 @@ impl Reader {
     /// let status = reader.validation_results();
     /// ```
     pub fn validation_results(&self) -> Option<&ValidationResults> {
-        self.manifest_store.validation_results()
+        self.validation_results.as_ref()
     }
 
     /// Get the [`ValidationState`] of the manifest store.
     pub fn validation_state(&self) -> ValidationState {
-        if let Some(validation_results) = self.manifest_store.validation_results() {
+        if let Some(validation_results) = self.validation_results() {
             return validation_results.validation_state();
         }
 
@@ -319,24 +375,33 @@ impl Reader {
 
     /// Return the active [`Manifest`], or `None` if there's no active manifest.
     pub fn active_manifest(&self) -> Option<&Manifest> {
-        self.manifest_store.get_active()
+        if let Some(label) = self.active_manifest.as_ref() {
+            self.manifests.get(label)
+        } else {
+            None
+        }
     }
 
     /// Return the active [`Manifest`], or `None` if there's no active manifest.
     pub fn active_label(&self) -> Option<&str> {
-        self.manifest_store.active_label()
+        self.active_manifest.as_deref()
     }
 
     /// Returns an iterator over a collection of [`Manifest`] structs.
     pub fn iter_manifests(&self) -> impl Iterator<Item = &Manifest> + '_ {
-        self.manifest_store.manifests().values()
+        self.manifests.values()
+    }
+
+    /// Returns a reference to the [`Manifest`] collection.
+    pub fn manifests(&self) -> &HashMap<String, Manifest> {
+        &self.manifests
     }
 
     /// Given a label, return the associated [`Manifest`], if it exists.
     /// # Arguments
     /// * `label` - The label of the requested [`Manifest`].
     pub fn get_manifest(&self, label: &str) -> Option<&Manifest> {
-        self.manifest_store.get(label)
+        self.manifests.get(label)
     }
 
     /// Write a resource identified by URI to the given stream.
@@ -362,11 +427,48 @@ impl Reader {
     pub fn resource_to_stream(
         &self,
         uri: &str,
-        mut stream: impl Write + Read + Seek + Send,
+        stream: impl Write + Read + Seek + Send,
     ) -> Result<usize> {
-        self.manifest_store
-            .get_resource(uri, &mut stream)
-            .map(|size| size as usize)
+        // get the manifest referenced by the uri, or the active one if None
+        // add logic to search for local or absolute uri identifiers
+        let (manifest, label) = match manifest_label_from_uri(uri) {
+            Some(label) => (self.manifests.get(&label), label),
+            None => (
+                self.active_manifest(),
+                self.active_label().unwrap_or_default().to_string(),
+            ),
+        };
+        let relative_uri = to_relative_uri(uri);
+        let absolute_uri = to_absolute_uri(&label, uri);
+
+        if let Some(manifest) = manifest {
+            let find_resource = |uri: &str| -> Result<&crate::ResourceStore> {
+                let mut resources = manifest.resources();
+                if !resources.exists(uri) {
+                    // also search ingredients resources to support Reader model
+                    for ingredient in manifest.ingredients() {
+                        if ingredient.resources().exists(uri) {
+                            resources = ingredient.resources();
+                            return Ok(resources);
+                        }
+                    }
+                } else {
+                    return Ok(resources);
+                }
+                Err(Error::ResourceNotFound(uri.to_owned()))
+            };
+            let result = find_resource(&relative_uri);
+            match result {
+                Ok(resource) => resource.write_stream(&relative_uri, stream),
+                Err(_) => match find_resource(&absolute_uri) {
+                    Ok(resource) => resource.write_stream(&absolute_uri, stream),
+                    Err(e) => Err(e),
+                },
+            }
+        } else {
+            Err(Error::ResourceNotFound(uri.to_owned()))
+        }
+        .map(|size| size as usize)
     }
 
     /// Convert a URI to a file path. (todo: move this to utils)
@@ -406,7 +508,7 @@ impl Reader {
     pub fn to_folder<P: AsRef<std::path::Path>>(&self, path: P) -> Result<()> {
         std::fs::create_dir_all(&path)?;
         std::fs::write(path.as_ref().join("manifest.json"), self.json())?;
-        for manifest in self.manifest_store.manifests().values() {
+        for manifest in self.manifests.values() {
             let resources = manifest.resources();
             for (uri, data) in resources.resources() {
                 let id_path = Self::uri_to_path(uri, manifest.label().unwrap_or("unknown"));
@@ -420,13 +522,72 @@ impl Reader {
         }
         Ok(())
     }
+
+    #[async_generic()]
+    fn from_store(store: Store, validation_log: &DetailedStatusTracker) -> Self {
+        let mut validation_results = ValidationResults::from_store(&store, validation_log);
+
+        let active_manifest = store.provenance_label();
+        let mut manifests = HashMap::new();
+
+        for claim in store.claims() {
+            let manifest_label = claim.label();
+            let result = if _sync {
+                #[cfg(feature = "file_io")]
+                {
+                    Manifest::from_store(&store, manifest_label, None)
+                }
+                #[cfg(not(feature = "file_io"))]
+                Manifest::from_store(&store, manifest_label)
+            } else {
+                #[cfg(feature = "file_io")]
+                {
+                    Manifest::from_store_async(&store, manifest_label, None).await
+                }
+                #[cfg(not(feature = "file_io"))]
+                Manifest::from_store_async(&store, manifest_label).await
+            };
+            match result {
+                Ok(manifest) => {
+                    manifests.insert(manifest_label.to_owned(), manifest);
+                }
+                Err(e) => {
+                    validation_results.add_status(manifest_label, ValidationStatus::from_error(&e));
+                }
+            };
+        }
+
+        let validation_state = validation_results.validation_state();
+        Self {
+            active_manifest,
+            manifests,
+            validation_status: validation_results.validation_errors(),
+            validation_results: Some(validation_results),
+            validation_state: Some(validation_state),
+            store,
+        }
+    }
 }
 
 impl Default for Reader {
     fn default() -> Self {
         Self {
-            manifest_store: ManifestStore::new(),
+            active_manifest: None,
+            manifests: HashMap::<String, Manifest>::new(),
+            validation_status: None,
+            validation_results: None,
+            validation_state: None,
+            store: Store::new(),
         }
+    }
+}
+
+/// Convert the Reader to a JSON value.
+impl TryInto<serde_json::Value> for Reader {
+    type Error = Error;
+
+    fn try_into(self) -> Result<serde_json::Value> {
+        serde_json::to_value(self).map_err(Error::JsonError)
     }
 }
 
@@ -440,9 +601,11 @@ impl std::fmt::Display for Reader {
 /// Prints the full debug details of the manifest data.
 impl std::fmt::Debug for Reader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut report = ManifestStoreReport::from_store(self.manifest_store.store())
-            .map_err(|_| std::fmt::Error)?;
-        report.validation_results = self.manifest_store.validation_results().cloned();
+        let report = match self.validation_results() {
+            Some(results) => ManifestStoreReport::from_store_with_results(&self.store, results),
+            None => ManifestStoreReport::from_store(&self.store),
+        }
+        .map_err(|_| std::fmt::Error)?;
         f.write_str(&report.to_string())
     }
 }
@@ -496,7 +659,7 @@ pub mod tests {
         println!("{reader}");
         assert_eq!(reader.validation_status(), None);
         assert_eq!(reader.validation_state(), ValidationState::Valid);
-        assert_eq!(reader.manifest_store.manifests().len(), 3);
+        assert_eq!(reader.manifests.len(), 3);
         Ok(())
     }
 
@@ -506,7 +669,7 @@ pub mod tests {
         let reader =
             Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
         assert_eq!(reader.validation_status(), None);
-        assert_eq!(reader.manifest_store.manifests().len(), 3);
+        assert_eq!(reader.manifests.len(), 3);
         let manifest = reader.active_manifest().unwrap();
         let ingredient = manifest.ingredients().iter().next().unwrap();
         let uri = ingredient.thumbnail_ref().unwrap().identifier.clone();

--- a/sdk/tests/common/compare_readers.rs
+++ b/sdk/tests/common/compare_readers.rs
@@ -124,14 +124,14 @@ pub fn compare_readers(reader1: &Reader, reader2: &Reader) -> Result<Vec<String>
 }
 
 // creates list of manifests in the order they are first seen from the active manifest
-fn gather_manifests(manifest_store: &Reader, manifest_label: &str, labels: &mut Vec<String>) {
+fn gather_manifests(reader: &Reader, manifest_label: &str, labels: &mut Vec<String>) {
     if !labels.contains(&manifest_label.to_string()) {
         labels.push(manifest_label.to_string());
     }
-    if let Some(manifest) = manifest_store.get_manifest(manifest_label) {
+    if let Some(manifest) = reader.get_manifest(manifest_label) {
         for ingredient in manifest.ingredients() {
             if let Some(label) = ingredient.active_manifest() {
-                gather_manifests(manifest_store, label, labels);
+                gather_manifests(reader, label, labels);
             }
         }
     }

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -18,7 +18,9 @@ use c2pa::{
 };
 
 mod common;
-use common::{compare_stream_to_known_good, fixtures_path, test_signer};
+#[cfg(all(feature = "add_thumbnails", feature = "file_io"))]
+use common::compare_stream_to_known_good;
+use common::{fixtures_path, test_signer};
 
 #[test]
 #[cfg(all(feature = "add_thumbnails", feature = "file_io"))]


### PR DESCRIPTION
This is also a cleanup of the new API, removing ManifestStore, ManifestStoreReport, and Store from the public API unless the v1_api feature is used.
These are steps toward a version 1.0 SDK.