### PR TITLE
fix: Use older version of x509-certificate for wasm32-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
  "memchr",
  "mockall",
  "mp4",
- "pem",
+ "pem 3.0.4",
  "png_pong",
  "quick-xml",
  "rand",
@@ -787,7 +787,8 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "wstd",
- "x509-certificate",
+ "x509-certificate 0.21.0",
+ "x509-certificate 0.23.1",
  "x509-parser",
  "zip",
 ]
@@ -827,7 +828,6 @@ dependencies = [
  "rasn",
  "rasn-ocsp",
  "rasn-pkix",
- "ring",
  "rsa",
  "schemars",
  "serde",
@@ -844,7 +844,8 @@ dependencies = [
  "web-sys",
  "web-time",
  "wstd",
- "x509-certificate",
+ "x509-certificate 0.21.0",
+ "x509-certificate 0.23.1",
  "x509-parser",
 ]
 
@@ -868,7 +869,7 @@ dependencies = [
  "log",
  "mockall",
  "openssl",
- "pem",
+ "pem 3.0.4",
  "predicates",
  "reqwest",
  "serde",
@@ -2550,7 +2551,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3076,6 +3077,16 @@ dependencies = [
 
 [[package]]
 name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
+name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
@@ -3411,7 +3422,7 @@ dependencies = [
  "bytes",
  "getrandom",
  "rand",
- "ring",
+ "ring 0.17.9",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -3718,6 +3729,21 @@ checksum = "3c601484456988d75017d86700d3743b949c21cdc7399f940c75e34680d185c5"
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
@@ -3726,7 +3752,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3824,7 +3850,7 @@ checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.9",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3855,9 +3881,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
+ "ring 0.17.9",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4217,6 +4243,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4697,6 +4729,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5172,6 +5210,24 @@ dependencies = [
 
 [[package]]
 name = "x509-certificate"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5d27c90840e84503cf44364de338794d5d5680bdd1da6272d13f80b0769ee0"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem 2.0.1",
+ "ring 0.16.20",
+ "signature",
+ "spki",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "x509-certificate"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
@@ -5181,8 +5237,8 @@ dependencies = [
  "chrono",
  "der",
  "hex",
- "pem",
- "ring",
+ "pem 3.0.4",
+ "ring 0.17.9",
  "signature",
  "spki",
  "thiserror 1.0.69",

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -78,7 +78,6 @@ sha2 = "0.10.6"
 spki = { version = "0.7.3", optional = true }
 thiserror = "2.0.8"
 web-time = "1.1"
-x509-certificate = "0.23.1"
 x509-parser = "0.16.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -99,6 +98,9 @@ version = "0.4.39"
 default-features = false
 features = ["now"]
 
+[target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies]
+x509-certificate = "0.23.1"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait = "0.1.77"
 const-oid = "0.9.6"
@@ -110,9 +112,9 @@ rsa = { version = "0.9.7", features = ["pem", "sha2"] }
 spki = "0.7.3"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+x509-certificate = "0.21.0"
 getrandom = { version = "0.2.7", features = ["js"] }
 js-sys = "0.3.58"
-ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"]}
 wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "0.4.31"
 web-sys = { version = "0.3.58", features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -121,7 +121,6 @@ thiserror = "2.0.8"
 treeline = "0.1.0"
 url = "2.5.3"
 uuid = { version = "=1.12.0", features = ["serde", "v4"] }
-x509-certificate = "0.23.1"
 x509-parser = "0.16.0"
 zip = { version = "2.2.1", default-features = false }
 
@@ -136,6 +135,7 @@ tempfile = { version = "3.15", features = ["nightly"] }
 ureq = "2.4.0"
 
 [target.'cfg(any(target_os = "wasi", not(target_arch = "wasm32")))'.dependencies]
+x509-certificate = "0.23.1"
 image = { version = "0.24.7", default-features = false, features = [
     "jpeg",
     "png",
@@ -165,6 +165,7 @@ web-sys = { version = "0.3.58", features = [
     "Window",
     "WorkerGlobalScope",
 ] }
+x509-certificate = "0.21.0"
 
 [dev-dependencies]
 anyhow = "1.0.40"


### PR DESCRIPTION
## Changes in this pull request
x509-certificate v0.22.0 uses a newer version of ring (0.17.5) which cannot be built by Xcode on Mac Silicon for wasm32-unknown-unknown.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
