### PR TITLE
feat: Add WASI to c2patool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
           CC: /opt/wasi-sdk/bin/clang
           WASI_SDK_PATH: /opt/wasi-sdk
           RUST_MIN_STACK: 16777216
-        run: cargo +nightly test --target wasm32-wasip2 -p c2pa -p c2pa-crypto -p cawg-identity --all-features
+        run: cargo +nightly test --target wasm32-wasip2 -p c2pa -p c2pa-crypto -p cawg-identity -p c2patool --all-features
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,6 @@ dependencies = [
  "httpmock",
  "log",
  "mockall",
- "openssl",
  "pem 3.0.4",
  "predicates",
  "reqwest",
@@ -878,6 +877,7 @@ dependencies = [
  "tempfile",
  "treeline",
  "url",
+ "wasi 0.14.1+wasi-0.2.3",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-wasi:
 ifeq ($(PLATFORM),mac)
 	$(eval CC := /opt/homebrew/opt/llvm/bin/clang)
 endif
-	CC=$(CC) CARGO_TARGET_WASM32_WASIP2_RUNNER="wasmtime -S cli -S http --dir ." cargo +nightly test --target wasm32-wasip2 -p c2pa -p c2pa-crypto -p cawg-identity --all-features
+	CC=$(CC) CARGO_TARGET_WASM32_WASIP2_RUNNER="wasmtime -S cli -S http --dir ." cargo +nightly test --target wasm32-wasip2 -p c2pa -p c2pa-crypto -p cawg-identity -p c2patool --all-features
 	rm -r sdk/Users
 
 # Full local validation, build and test all features including wasm

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,15 +39,21 @@ serde_json = "1.0"
 tempfile = "3.3"
 treeline = "0.1.0"
 pem = "3.0.3"
-openssl = { version = "0.10.61", features = ["vendored"] }
-reqwest = { version = "0.12.4", features = ["blocking"] }
 url = "2.5.0"
 
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+reqwest = { version = "0.12.4", features = ["blocking"] }
+
+[target.'cfg(target_os = "wasi")'.dependencies]
+wasi = "0.14"
+
 [dev-dependencies]
+mockall = "0.13.0"
+
+[target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
 assert_cmd = "2.0.14"
 httpmock = "0.7.0"
 predicates = "3.1"
-mockall = "0.13.0"
 
 [package.metadata.binstall]
 # Use defaults

--- a/cli/docs/usage.md
+++ b/cli/docs/usage.md
@@ -290,3 +290,11 @@ c2patool  /Downloads/1080p_out/avc1/init.mp4 \
 ### Additional option
 
 The `--fragments_glob` option is only available with the `fragment` subcommand and specifies the glob pattern to find the fragments of the asset. The path is automatically set to be the same as the "init" segment, so the pattern must match only segment file names, not full paths.
+
+## WASI
+
+The wasm created for wasm32-wasip2 can be run directly with [wasmtime](https://docs.wasmtime.dev/). It also can be transpiled to a JS + core Wasm for JavaScript execution using [jco](https://bytecodealliance.github.io/jco/transpiling.html).
+```
+wasmtime -S cli -S http --dir . c2patool.wasm [OPTIONS] <PATH> [COMMAND]
+```
+

--- a/cli/src/callback_signer.rs
+++ b/cli/src/callback_signer.rs
@@ -192,9 +192,16 @@ mod test {
 
     use super::*;
 
+    fn sign_cert_path() -> PathBuf {
+        #[cfg(not(target_os = "wasi"))]
+        return PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        #[cfg(target_os = "wasi")]
+        return PathBuf::from("/");
+    }
+
     #[test]
     fn test_signing_succeeds_returns_bytes() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/es256_certs.pem");
 
         let sign_config = SignConfig {
@@ -220,7 +227,7 @@ mod test {
 
     #[test]
     fn test_signing_succeeds_returns_error_embedding() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/es256_certs.pem");
 
         let sign_config = SignConfig {
@@ -280,7 +287,7 @@ mod test {
 
     #[test]
     fn test_try_from_succeeds_for_valid_sign_config() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/es256_certs.pem");
 
         let expected_alg = SigningAlg::Es256;
@@ -301,7 +308,7 @@ mod test {
 
     #[test]
     fn test_callback_signer_error_file_not_found() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/NOT-HERE");
 
         let sign_config = SignConfig {
@@ -319,7 +326,7 @@ mod test {
 
     #[test]
     fn test_callback_signer_error_invalid_cert() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/test.json");
 
         let sign_config = SignConfig {
@@ -337,7 +344,7 @@ mod test {
 
     #[test]
     fn test_callback_signer_valid_sign_certs() {
-        let mut sign_cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut sign_cert_path = sign_cert_path();
         sign_cert_path.push("sample/es256_certs.pem");
 
         let sign_config = SignConfig {

--- a/cli/src/signer.rs
+++ b/cli/src/signer.rs
@@ -106,7 +106,7 @@ impl SignConfig {
             A permanent key and cert should be provided in the manifest definition or in the environment variables.\n");
 
         let signer = create_signer::from_keys(DEFAULT_CERTS, DEFAULT_KEY, alg, tsa_url)
-            .context("Invalid certification dato")?;
+            .context("Invalid certification data")?;
 
         Ok(signer)
     }
@@ -129,14 +129,7 @@ pub mod tests {
         let mut sign_config = SignConfig::from_json(CONFIG).expect("from_json");
         sign_config.set_base_path("sample");
 
-        let signer = match sign_config.signer() {
-            Ok(signer) => signer,
-            Err(e) => {
-                println!("Error: {}", e);
-                panic!();
-            }
-        };
-
+        let signer = sign_config.signer().expect("get signer");
         assert_eq!(signer.alg(), SigningAlg::Es256);
     }
 

--- a/cli/src/signer.rs
+++ b/cli/src/signer.rs
@@ -106,7 +106,7 @@ impl SignConfig {
             A permanent key and cert should be provided in the manifest definition or in the environment variables.\n");
 
         let signer = create_signer::from_keys(DEFAULT_CERTS, DEFAULT_KEY, alg, tsa_url)
-            .context("Invalid certification data")?;
+            .context("Invalid certification dato")?;
 
         Ok(signer)
     }
@@ -129,7 +129,14 @@ pub mod tests {
         let mut sign_config = SignConfig::from_json(CONFIG).expect("from_json");
         sign_config.set_base_path("sample");
 
-        let signer = sign_config.signer().expect("get signer");
+        let signer = match sign_config.signer() {
+            Ok(signer) => signer,
+            Err(e) => {
+                println!("Error: {}", e);
+                panic!();
+            }
+        };
+
         assert_eq!(signer.alg(), SigningAlg::Es256);
     }
 

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 // Copyright 2022 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License,
 // Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -1,4 +1,3 @@
-#![cfg(not(target_os = "wasi"))]
 // Copyright 2022 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License,
 // Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
@@ -12,6 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#![cfg(not(target_os = "wasi"))]
 use std::{error::Error, fs, fs::create_dir_all, path::PathBuf, process::Command};
 
 // Add methods on commands

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -33,8 +33,14 @@ use log::error;
 
 #[cfg(feature = "v1_api")]
 use crate::jumbf_io::save_jumbf_to_memory;
+#[cfg(feature = "file_io")]
+use crate::jumbf_io::{
+    get_file_extension, get_supported_file_extension, load_jumbf_from_file, save_jumbf_to_file,
+};
 #[cfg(all(feature = "v1_api", feature = "file_io"))]
 use crate::jumbf_io::{object_locations, remove_jumbf_from_file};
+#[cfg(all(feature = "file_io", feature = "v1_api"))]
+use crate::utils::io_utils::tempdirectory;
 use crate::{
     assertion::{
         Assertion, AssertionBase, AssertionData, AssertionDecodeError, AssertionDecodeErrorCause,
@@ -76,13 +82,6 @@ use crate::{
 };
 #[cfg(feature = "v1_api")]
 use crate::{external_manifest::ManifestPatchCallback, RemoteSigner};
-#[cfg(feature = "file_io")]
-use crate::{
-    jumbf_io::{
-        get_file_extension, get_supported_file_extension, load_jumbf_from_file, save_jumbf_to_file,
-    },
-    utils::io_utils::tempdirectory,
-};
 
 const MANIFEST_STORE_EXT: &str = "c2pa"; // file extension for external manifests
 


### PR DESCRIPTION
## Changes in this pull request
The wasm created for wasm32-wasip2 can be run directly with [wasmtime](https://docs.wasmtime.dev/). It also can be transpiled to a JS + core Wasm for JavaScript execution using [jco](https://bytecodealliance.github.io/jco/transpiling.html).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
