### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.47.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.46.0...c2pa-v0.47.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
+* Add `Sync` to `AsyncDynamicAssertion` (#953)
+* Simplify `StatusTracker` interface (#937)
+* Add WASI to c2patool (#945)
+* Add WASI support to cawg_identity (#942)
+* Add ES256 and ES384 Rust native signing (#941)
+* Adds validation_state to the json reports from the Reader (#930)
+* Wasm32 wasi 0.41.0 (#888)
+
+### Fixed
+
+* ISSUE-967: Remove the `RST0..=RST7` check from the `has_length` method for the JPEG asset handler. (#968)
+* Fix broken c2patool fragment feature (#960)
+* Feature flag `v1_api` without `file_io` didn't compile (#944)
+* Use older version of x509-certificate for wasm32-unknown (#934)
+* Fix new Clippy warnings for Rust 1.85.0 (#933)
+
+### Other
+
+* Remove `openssl` feature flag (#940)
+
+### Updated dependencies
+
+* Bump x509-certificate to 0.24.0 (#957)
+
 ## [0.46.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.45.3...c2pa-v0.46.0)
 _15 February 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -735,7 +735,7 @@ dependencies = [
  "coset",
  "ed25519-dalek",
  "extfmt",
- "getrandom",
+ "getrandom 0.2.15",
  "glob",
  "hex",
  "hex-literal",
@@ -754,8 +754,8 @@ dependencies = [
  "pem",
  "png_pong",
  "quick-xml",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.9.3",
  "range-set",
  "rasn",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -812,7 +812,7 @@ dependencies = [
  "der",
  "ecdsa",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "js-sys",
  "nom",
@@ -823,7 +823,7 @@ dependencies = [
  "p521",
  "pkcs1",
  "pkcs8",
- "rand",
+ "rand 0.8.5",
  "rasn",
  "rasn-ocsp",
  "rasn-pkix",
@@ -850,11 +850,11 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "c2patool"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -900,7 +900,7 @@ dependencies = [
  "multibase",
  "non-empty-string",
  "nonempty-collections",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",
@@ -1109,7 +1109,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1819,6 +1819,20 @@ dependencies = [
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2861,7 +2875,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "smallvec",
  "zeroize",
@@ -3404,8 +3418,8 @@ dependencies = [
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -3422,11 +3436,12 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3436,17 +3451,18 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.3.2",
+ "rand 0.9.0",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3482,6 +3498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,8 +3516,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3509,12 +3542,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3522,6 +3565,9 @@ name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3649,7 +3695,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3685,9 +3731,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3757,7 +3803,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4405,7 +4451,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4470,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -4485,15 +4531,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4791,7 +4837,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
  "wasm-bindgen",
 ]
@@ -5029,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
@@ -5046,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
 ]
@@ -5439,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d48a995652704e4d5061678c5a1d19c851ccc788cebb90aaef5cd4642b0837"
+checksum = "938cc23ac49778ac8340e366ddc422b2227ea176edb447e23fc0627608dddadd"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.9.0...cawg-identity-v0.10.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
+* Simplify `StatusTracker` interface (#937)
+* Add WASI support to cawg_identity (#942)
+* Adds validation_state to the json reports from the Reader (#930)
+
+### Fixed
+
+* Add example file with CAWG X.509 signing (#948)
+* Update CAWG SDK README to reflect current status (#947)
+
+### Other
+
+* Remove `openssl` feature flag (#940)
+
 ## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.8.0...cawg-identity-v0.9.0)
 _15 February 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.9.0"
+version = "0.10.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -30,9 +30,9 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.46.0" }
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.2" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.5.0" }
+c2pa = { path = "../sdk", version = "0.47.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.7.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.15.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.14.0...c2patool-v0.15.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add WASI to c2patool (#945)
+
+### Updated dependencies
+
+* Bump env_logger from 0.11.6 to 0.11.7 (#963)
+
 ## [0.13.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.13.1...c2patool-v0.13.3)
 _11 February 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.14.0"
+version = "0.15.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,14 +22,14 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.46.0", features = [
+c2pa = { path = "../sdk", version = "0.47.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf"
 ] }
-cawg-identity = { path = "../cawg_identity", version = "0.9.0"}
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.2" }
+cawg-identity = { path = "../cawg_identity", version = "0.10.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.7.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.6.2...c2pa-crypto-v0.7.0)
+_18 March 2025_
+
+### Added
+
+* *(crypto)* Add new `sign_v2_embedded` API (#975)
+* Simplify `StatusTracker` interface (#937)
+* Add ES256 and ES384 Rust native signing (#941)
+* Wasm32 wasi 0.41.0 (#888)
+
+### Fixed
+
+* Fix incorrect calculation for the reserved size (#965)
+* Use older version of x509-certificate for wasm32-unknown (#934)
+
+### Updated dependencies
+
+* Bump x509-certificate to 0.24.0 (#957)
+
 ## [0.6.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.6.1...c2pa-crypto-v0.6.2)
 _06 February 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.6.2"
+version = "0.7.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -48,7 +48,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.5.0" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.6.0" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.5.0...c2pa-status-tracker-v0.6.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Simplify `StatusTracker` interface (#937)
+
 ## [0.5.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.4.0...c2pa-status-tracker-v0.5.0)
 _06 February 2025_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.5.0"
+version = "0.6.0"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.46.0"
+version = "0.47.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -75,8 +75,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.6.2" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.5.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.7.0" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [
@@ -170,7 +170,7 @@ web-sys = { version = "0.3.58", features = [
 
 [dev-dependencies]
 anyhow = "1.0.40"
-cawg-identity = { path = "../cawg_identity", version = "0.9.0" }
+cawg-identity = { path = "../cawg_identity", version = "0.10.0" }
 glob = "0.3.1"
 hex-literal = "0.4.1"
 jumbf = "0.4.0"


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `c2pa`: 0.46.0 -> 0.47.0 (⚠️ API breaking changes)
* `c2pa-crypto`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `c2pa-status-tracker`: 0.5.0 -> 0.6.0 (⚠️ API breaking changes)
* `c2patool`: 0.14.0 -> 0.15.0

### ⚠️ `c2pa` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa::DynamicAssertionContent, previously in file /tmp/.tmp4X03Zj/c2pa/src/dynamic_assertion.rs:23

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature openssl_sign in the package's Cargo.toml
  feature openssl in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa::validation_status::validation_results_for_store, previously in file /tmp/.tmp4X03Zj/c2pa/src/validation_status.rs:203

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  c2pa::validation_results::ValidationResults::add_status now takes 2 parameters instead of 3, in /tmp/.tmp8lyNdK/c2pa-rs/sdk/src/validation_results.rs:232
  c2pa::ValidationResults::add_status now takes 2 parameters instead of 3, in /tmp/.tmp8lyNdK/c2pa-rs/sdk/src/validation_results.rs:232

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct c2pa::PreliminaryClaim, previously in file /tmp/.tmp4X03Zj/c2pa/src/dynamic_assertion.rs:178

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_missing.ron

Failed in:
  trait c2pa::AsyncDynamicAssertion, previously in file /tmp/.tmp4X03Zj/c2pa/src/dynamic_assertion.rs:88
  trait c2pa::DynamicAssertion, previously in file /tmp/.tmp4X03Zj/c2pa/src/dynamic_assertion.rs:40
```

### ⚠️ `c2pa-status-tracker` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct c2pa_status_tracker::OneShotStatusTracker, previously in file /tmp/.tmp4X03Zj/c2pa-status-tracker/src/status_tracker/one_shot.rs:22
  struct c2pa_status_tracker::DetailedStatusTracker, previously in file /tmp/.tmp4X03Zj/c2pa-status-tracker/src/status_tracker/detailed.rs:23

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_missing.ron

Failed in:
  trait c2pa_status_tracker::StatusTracker, previously in file /tmp/.tmp4X03Zj/c2pa-status-tracker/src/status_tracker/mod.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.9.0...cawg-identity-v0.10.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
* Simplify `StatusTracker` interface (#937)
* Add WASI support to cawg_identity (#942)
* Adds validation_state to the json reports from the Reader (#930)

### Fixed

* Add example file with CAWG X.509 signing (#948)
* Update CAWG SDK README to reflect current status (#947)

### Other

* Remove `openssl` feature flag (#940)
</blockquote>

## `c2pa`
<blockquote>

## [0.47.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.46.0...c2pa-v0.47.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
* Add `Sync` to `AsyncDynamicAssertion` (#953)
* Simplify `StatusTracker` interface (#937)
* Add WASI to c2patool (#945)
* Add WASI support to cawg_identity (#942)
* Add ES256 and ES384 Rust native signing (#941)
* Adds validation_state to the json reports from the Reader (#930)
* Wasm32 wasi 0.41.0 (#888)

### Fixed

* ISSUE-967: Remove the `RST0..=RST7` check from the `has_length` method for the JPEG asset handler. (#968)
* Fix broken c2patool fragment feature (#960)
* Feature flag `v1_api` without `file_io` didn't compile (#944)
* Use older version of x509-certificate for wasm32-unknown (#934)
* Fix new Clippy warnings for Rust 1.85.0 (#933)

### Other

* Remove `openssl` feature flag (#940)

### Updated dependencies

* Bump x509-certificate to 0.24.0 (#957)
</blockquote>

## `c2pa-crypto`
<blockquote>

## [0.7.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.6.2...c2pa-crypto-v0.7.0)

_18 March 2025_

### Added

* *(crypto)* Add new `sign_v2_embedded` API (#975)
* Simplify `StatusTracker` interface (#937)
* Add ES256 and ES384 Rust native signing (#941)
* Wasm32 wasi 0.41.0 (#888)

### Fixed

* Fix incorrect calculation for the reserved size (#965)
* Use older version of x509-certificate for wasm32-unknown (#934)

### Updated dependencies

* Bump x509-certificate to 0.24.0 (#957)
</blockquote>

## `c2pa-status-tracker`
<blockquote>

## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.5.0...c2pa-status-tracker-v0.6.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Simplify `StatusTracker` interface (#937)
</blockquote>

## `c2patool`
<blockquote>

## [0.15.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.14.0...c2patool-v0.15.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add WASI to c2patool (#945)

### Updated dependencies

* Bump env_logger from 0.11.6 to 0.11.7 (#963)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).