### PR TITLE
fix: ISSUE-967: Remove the `RST0..=RST7` check from the `has_length` method for the JPEG asset handler.

### DIFF
--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -678,7 +678,7 @@ fn get_entropy_size(input_stream: &mut dyn CAIRead) -> Result<usize> {
 }
 
 fn has_length(marker: u8) -> bool {
-    matches!(marker, RST0..=RST7 | APP0..=APP15 | SOF0..=SOF15 | SOS | COM | DQT | DRI)
+    matches!(marker, APP0..=APP15 | SOF0..=SOF15 | SOS | COM | DQT | DRI)
 }
 
 fn get_seg_size(input_stream: &mut dyn CAIRead) -> Result<usize> {


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

As #967 states, this removes the ReSTart 0 through 7 segment markers from the `has_length` check. As these markers are standalone markers and do not have a 2-byte length specified after them.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
