### PR TITLE
feat(crypto): Add new `sign_v2_embedded` API

### DIFF
--- a/internal/crypto/src/cose/mod.rs
+++ b/internal/crypto/src/cose/mod.rs
@@ -33,7 +33,7 @@ mod ocsp;
 pub use ocsp::{check_ocsp_status, check_ocsp_status_async, OcspFetchPolicy};
 
 mod sign;
-pub use sign::{sign, sign_async};
+pub use sign::{sign, sign_async, sign_v2_embedded, sign_v2_embedded_async, CosePayload};
 
 mod sign1;
 pub use sign1::{

--- a/internal/crypto/src/cose/sign.rs
+++ b/internal/crypto/src/cose/sign.rs
@@ -200,6 +200,93 @@ pub fn sign_v2(
     box_size: Option<usize>,
     tss: TimeStampStorage,
 ) -> Result<Vec<u8>, CoseError> {
+    if _sync {
+        sign_v2_embedded(signer, data, box_size, CosePayload::Detached, tss)
+    } else {
+        sign_v2_embedded_async(signer, data, box_size, CosePayload::Detached, tss).await
+    }
+}
+
+/// Configure whether the COSE payload is embedded or detached.
+///
+/// In C2PA usage, the payload is always detached; in other usages, it may be
+/// embedded.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CosePayload {
+    /// Remove the payload from the signature body because it is available
+    /// elsewhere.
+    Detached,
+
+    /// Include the payload in the signature body because it is not available
+    /// elsewhere.
+    Embedded,
+}
+
+/// Given an arbitrary block of data and a [`RawSigner`] or [`AsyncRawSigner`]
+/// instance, generate a COSE signature for that block of data.
+///
+/// The `payload` flag allows you to configure whether the payload is detached
+/// (default ofor C2PA use cases) or embedded (may be useful in other
+/// applications).
+///
+/// Returns a byte vector that is a `Cose_Sign1` data structure.
+///
+/// From [§14.5, X.509 Certificates] of the C2PA Technical Specification:
+///
+/// > X.509 Certificates are stored as defined by [RFC 9360] (CBOR Object
+/// > Signing and Encryption (COSE): Header Parameters for Carrying and
+/// > Referencing X.509 Certificates). For convenience, the definition of
+/// > `x5chain` is copied below.
+/// >
+/// > ...
+/// >
+/// > `x5chain`: This header parameter contains an ordered array of X.509
+/// > certificates. The certificates are to be ordered starting with the
+/// > certificate containing the end-entity key followed by the certificate that
+/// > signed it, and so on. There is no requirement for the entire chain to be
+/// > present in the element if there is reason to believe that the relying
+/// > party already has, or can locate, the missing certificates. This means
+/// > that the relying party is still required to do path building but that a
+/// > candidate path is proposed in this header parameter.
+/// >
+/// > The trust mechanism MUST process any certificates in this parameter as
+/// > untrusted input. The presence of a self-signed certificate in the
+/// > parameter MUST NOT cause the update of the set of trust anchors without
+/// > some out-of-band confirmation. As the contents of this header parameter
+/// > are untrusted input, the header parameter can be in either the protected
+/// > or unprotected header bucket. Sending the header parameter in the
+/// > unprotected header bucket allows an intermediary to remove or add
+/// > certificates.
+/// >
+/// > The end-entity certificate MUST be integrity protected by COSE. This can,
+/// > for example, be done by sending the header parameter in the protected
+/// > header, sending an `x5chain` in the unprotected header combined with an
+/// > `x5t` in the protected header, or including the end-entity certificate in
+/// > the `external_aad`.
+/// >
+/// > This header parameter allows for a single X.509 certificate or a chain of
+/// > X.509 certificates to be carried in the message.
+/// >
+/// > * If a single certificate is conveyed, it is placed in a CBOR byte string.
+/// > * If multiple certificates are conveyed, a CBOR array of byte strings is
+/// > used, with each certificate being in its own byte string.
+///
+/// [§14.5, X.509 Certificates]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#x509_certificates
+/// [RFC 9360]: https://datatracker.ietf.org/doc/html/rfc9360
+#[async_generic(async_signature(
+    signer: &dyn AsyncRawSigner,
+    data: &[u8],
+    box_size: Option<usize>,
+    payload: CosePayload,
+    tss: TimeStampStorage
+))]
+pub fn sign_v2_embedded(
+    signer: &dyn RawSigner,
+    data: &[u8],
+    box_size: Option<usize>,
+    payload: CosePayload,
+    tss: TimeStampStorage,
+) -> Result<Vec<u8>, CoseError> {
     let alg = signer.alg();
 
     let protected_header = if _sync {
@@ -261,9 +348,11 @@ pub fn sign_v2(
         _ => signature,
     };
 
-    // The payload is provided elsewhere, so we don't need to repeat it in the
+    // If the payload is provided elsewhere, we don't need to repeat it in the
     // `Cose_Sign1` structure.
-    sign1.payload = None;
+    if payload == CosePayload::Detached {
+        sign1.payload = None;
+    }
 
     let sig_data = ByteBuf::from(sign1.signature.clone());
     let mut sig_data_cbor: Vec<u8> = vec![];


### PR DESCRIPTION
This API takes a new `CosePayload` enum parameter which can be configured to allow the COSE payload to include or exclude the payload as appropriate for the use case.
