### PR TITLE
update: Use zip crate 2.4.x

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -125,7 +125,7 @@ treeline = "0.1.0"
 url = "2.5.3"
 uuid = { version = "=1.12.0", features = ["serde", "v4"] }
 x509-parser = "0.16.0"
-zip = { version = "2.2.1", default-features = false }
+zip = { version = "2.4", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rsa = { version = "0.9.6", features = ["sha2"] }


### PR DESCRIPTION
Due to GHSA-94vh-gphv-8pm8, the zip crate should be updated to 2.4.x immediately, to prevent specially-crafted templates from writing files outside the destination directory if `extract()` is called on a `ZipArchive` or `ZipStreamReader`.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
