### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.47.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.46.0...c2pa-v0.47.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
+* Add `Sync` to `AsyncDynamicAssertion` (#953)
+* Simplify `StatusTracker` interface (#937)
+* Add WASI to c2patool (#945)
+* Add WASI support to cawg_identity (#942)
+* Add ES256 and ES384 Rust native signing (#941)
+* Adds validation_state to the json reports from the Reader (#930)
+* Wasm32 wasi 0.41.0 (#888)
+
+### Fixed
+
+* Remove circular dependency between C2PA and CAWG crates (#982)
+* ISSUE-967: Remove the `RST0..=RST7` check from the `has_length` method for the JPEG asset handler. (#968)
+* Fix broken c2patool fragment feature (#960)
+* Feature flag `v1_api` without `file_io` didn't compile (#944)
+* Use older version of x509-certificate for wasm32-unknown (#934)
+* Fix new Clippy warnings for Rust 1.85.0 (#933)
+
+### Other
+
+* Remove `openssl` feature flag (#940)
+
+### Updated dependencies
+
+* Bump zip crate to 2.4.1 (#981)
+* Bump x509-certificate to 0.24.0 (#957)
+
 ## [0.46.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.45.3...c2pa-v0.46.0)
 _15 February 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -853,7 +853,7 @@ version = "0.6.0"
 
 [[package]]
 name = "c2patool"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.9.0...cawg-identity-v0.10.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
+* Simplify `StatusTracker` interface (#937)
+* Add WASI support to cawg_identity (#942)
+* Adds validation_state to the json reports from the Reader (#930)
+
+### Fixed
+
+* Remove circular dependency between C2PA and CAWG crates (#982)
+* Add example file with CAWG X.509 signing (#948)
+* Update CAWG SDK README to reflect current status (#947)
+
+### Other
+
+* Remove `openssl` feature flag (#940)
+
 ## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.8.0...cawg-identity-v0.9.0)
 _15 February 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.9.0"
+version = "0.10.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -30,7 +30,7 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.46.0" }
+c2pa = { path = "../sdk", version = "0.47.0" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.7.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.15.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.14.0...c2patool-v0.15.0)
+_18 March 2025_
+
+### Added
+
+* Adds `reader.post_validate` method for CAWG validation support (#976)
+* Add WASI to c2patool (#945)
+
+### Fixed
+
+* Remove circular dependency between C2PA and CAWG crates (#982)
+
+### Updated dependencies
+
+* Bump env_logger from 0.11.6 to 0.11.7 (#963)
+
 ## [0.13.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.13.1...c2patool-v0.13.3)
 _11 February 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.14.0"
+version = "0.15.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,13 +22,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.46.0", features = [
+c2pa = { path = "../sdk", version = "0.47.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf"
 ] }
-cawg-identity = { path = "../cawg_identity", version = "0.9.0" }
+cawg-identity = { path = "../cawg_identity", version = "0.10.0" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.7.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.46.0"
+version = "0.47.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION
## 🤖 New release
* `cawg-identity`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `c2pa`: 0.46.0 -> 0.47.0 (⚠️ API breaking changes)
* `c2patool`: 0.14.0 -> 0.15.0

### ⚠️ `c2pa` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_missing.ron

Failed in:
  enum c2pa::DynamicAssertionContent, previously in file /tmp/.tmptIDXaZ/c2pa/src/dynamic_assertion.rs:23

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature openssl in the package's Cargo.toml
  feature openssl_sign in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_missing.ron

Failed in:
  function c2pa::validation_status::validation_results_for_store, previously in file /tmp/.tmptIDXaZ/c2pa/src/validation_status.rs:203

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  c2pa::validation_results::ValidationResults::add_status now takes 2 parameters instead of 3, in /tmp/.tmpeEEJmQ/c2pa-rs/sdk/src/validation_results.rs:232
  c2pa::ValidationResults::add_status now takes 2 parameters instead of 3, in /tmp/.tmpeEEJmQ/c2pa-rs/sdk/src/validation_results.rs:232

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct c2pa::PreliminaryClaim, previously in file /tmp/.tmptIDXaZ/c2pa/src/dynamic_assertion.rs:178

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/trait_missing.ron

Failed in:
  trait c2pa::AsyncDynamicAssertion, previously in file /tmp/.tmptIDXaZ/c2pa/src/dynamic_assertion.rs:88
  trait c2pa::DynamicAssertion, previously in file /tmp/.tmptIDXaZ/c2pa/src/dynamic_assertion.rs:40
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cawg-identity`
<blockquote>

## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.9.0...cawg-identity-v0.10.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
* Simplify `StatusTracker` interface (#937)
* Add WASI support to cawg_identity (#942)
* Adds validation_state to the json reports from the Reader (#930)

### Fixed

* Remove circular dependency between C2PA and CAWG crates (#982)
* Add example file with CAWG X.509 signing (#948)
* Update CAWG SDK README to reflect current status (#947)

### Other

* Remove `openssl` feature flag (#940)
</blockquote>

## `c2pa`
<blockquote>

## [0.47.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.46.0...c2pa-v0.47.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add `StatusTracker` to `IdentityAssertion` parsing and validation APIs (#943)
* Add `Sync` to `AsyncDynamicAssertion` (#953)
* Simplify `StatusTracker` interface (#937)
* Add WASI to c2patool (#945)
* Add WASI support to cawg_identity (#942)
* Add ES256 and ES384 Rust native signing (#941)
* Adds validation_state to the json reports from the Reader (#930)
* Wasm32 wasi 0.41.0 (#888)

### Fixed

* Remove circular dependency between C2PA and CAWG crates (#982)
* ISSUE-967: Remove the `RST0..=RST7` check from the `has_length` method for the JPEG asset handler. (#968)
* Fix broken c2patool fragment feature (#960)
* Feature flag `v1_api` without `file_io` didn't compile (#944)
* Use older version of x509-certificate for wasm32-unknown (#934)
* Fix new Clippy warnings for Rust 1.85.0 (#933)

### Other

* Remove `openssl` feature flag (#940)

### Updated dependencies

* Bump zip crate to 2.4.1 (#981)
* Bump x509-certificate to 0.24.0 (#957)
</blockquote>

## `c2patool`
<blockquote>

## [0.15.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.14.0...c2patool-v0.15.0)

_18 March 2025_

### Added

* Adds `reader.post_validate` method for CAWG validation support (#976)
* Add WASI to c2patool (#945)

### Fixed

* Remove circular dependency between C2PA and CAWG crates (#982)

### Updated dependencies

* Bump env_logger from 0.11.6 to 0.11.7 (#963)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).