### PR TITLE
chore: publish c2patool and cawg_identity updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -853,7 +853,7 @@ version = "0.6.0"
 
 [[package]]
 name = "c2patool"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -30,7 +30,7 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.48.1" }
+c2pa = { path = "../sdk", version = "0.48.2" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.7.1" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.16.1"
+version = "0.16.2"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.48.1", features = [
+c2pa = { path = "../sdk", version = "0.48.2", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.48.1"
+version = "0.48.2"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION
c2patool and cawg_identity won't publish to crates.io unless c2pa_rs is updated, so this updates c2pa_rs sdk to force that publish (hopefully)
