### PR TITLE
fix: Use correct list so that empty cert chains are processed

### DIFF
--- a/internal/crypto/src/raw_signature/rust_native/check_certificate_trust.rs
+++ b/internal/crypto/src/raw_signature/rust_native/check_certificate_trust.rs
@@ -72,7 +72,7 @@ pub(crate) fn check_certificate_trust(
     }
 
     // Work back from last cert in chain against the trust anchors.
-    for cert in chain_der.iter().rev() {
+    for cert in full_chain.iter().rev() {
         let (_, chain_cert) = X509Certificate::from_der(cert)
             .map_err(|_e| CertificateTrustError::CertificateNotTrusted)?;
 


### PR DESCRIPTION
The full list of certs should be used to check the complete build chain.  This will allow for chains with only the end-entity cert to be verified against a set of anchors. 

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
