### PR TITLE
fix: Make sure manifests are signed with end-entity certs

### DIFF
--- a/internal/crypto/src/cose/ocsp.rs
+++ b/internal/crypto/src/cose/ocsp.rs
@@ -100,7 +100,7 @@ fn check_stapled_ocsp_response(
     // If we get a valid response, validate the certs.
     if ocsp_data.revoked_at.is_none() {
         if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
-            check_certificate_profile(&ocsp_certs[0], ctp, validation_log, Some(tst_info))?;
+            check_certificate_profile(&ocsp_certs[0], false, ctp, validation_log, Some(tst_info))?;
         }
     }
 
@@ -149,7 +149,7 @@ fn fetch_and_check_ocsp_response(
         // If we get a valid response validate the certs.
         if ocsp_data.revoked_at.is_none() {
             if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
-                check_certificate_profile(&ocsp_certs[0], ctp, validation_log, None)?;
+                check_certificate_profile(&ocsp_certs[0], false, ctp, validation_log, None)?;
             }
         }
 

--- a/internal/crypto/src/cose/verifier.rs
+++ b/internal/crypto/src/cose/verifier.rs
@@ -200,6 +200,7 @@ impl Verifier<'_> {
         match tst_info_res {
             Ok(tst_info) => Ok(check_certificate_profile(
                 end_entity_cert_der,
+                true,
                 ctp,
                 validation_log,
                 Some(tst_info),
@@ -207,6 +208,7 @@ impl Verifier<'_> {
 
             Err(CoseError::NoTimeStampToken) => Ok(check_certificate_profile(
                 end_entity_cert_der,
+                true,
                 ctp,
                 validation_log,
                 None,

--- a/internal/crypto/src/raw_signature/rust_native/check_certificate_trust.rs
+++ b/internal/crypto/src/raw_signature/rust_native/check_certificate_trust.rs
@@ -72,7 +72,7 @@ pub(crate) fn check_certificate_trust(
     }
 
     // Work back from last cert in chain against the trust anchors.
-    for cert in chain_der.iter().rev() {
+    for cert in full_chain.iter().rev() {
         let (_, chain_cert) = X509Certificate::from_der(cert)
             .map_err(|_e| CertificateTrustError::CertificateNotTrusted)?;
 

--- a/internal/crypto/src/tests/cose/certificate_profile.rs
+++ b/internal/crypto/src/tests/cose/certificate_profile.rs
@@ -31,7 +31,7 @@ fn expired_cert() {
         "../fixtures/cose/rsa-pss256_key-expired.pub"
     ));
 
-    assert!(check_certificate_profile(&cert_der, &ctp, &mut validation_log, None).is_err());
+    assert!(check_certificate_profile(&cert_der, true, &ctp, &mut validation_log, None).is_err());
 
     assert!(!validation_log.logged_items().is_empty());
 
@@ -56,10 +56,10 @@ fn cert_algorithms() {
     let es512_cert = x509_der_from_pem(include_bytes!("../fixtures/raw_signature/es512.pub"));
     let ps256_cert = x509_der_from_pem(include_bytes!("../fixtures/raw_signature/ps256.pub"));
 
-    check_certificate_profile(&es256_cert, &ctp, &mut validation_log, None).unwrap();
-    check_certificate_profile(&es384_cert, &ctp, &mut validation_log, None).unwrap();
-    check_certificate_profile(&es512_cert, &ctp, &mut validation_log, None).unwrap();
-    check_certificate_profile(&ps256_cert, &ctp, &mut validation_log, None).unwrap();
+    check_certificate_profile(&es256_cert, true, &ctp, &mut validation_log, None).unwrap();
+    check_certificate_profile(&es384_cert, true, &ctp, &mut validation_log, None).unwrap();
+    check_certificate_profile(&es512_cert, true, &ctp, &mut validation_log, None).unwrap();
+    check_certificate_profile(&ps256_cert, true, &ctp, &mut validation_log, None).unwrap();
 }
 
 fn x509_der_from_pem(cert_pem: &[u8]) -> Vec<u8> {

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -151,6 +151,7 @@ fn signing_cert_valid(signing_cert: &[u8]) -> Result<()> {
 
     Ok(check_certificate_profile(
         signing_cert,
+        true,
         &passthrough_cap,
         &mut cose_log,
         None,


### PR DESCRIPTION
## Changes in this pull request
Adds check to make sure end-entity certs are used where we expect them.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
