### PR TITLE
docs: Fix links that are broken on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 
 The **[Coalition for Content Provenance and Authenticity](https://c2pa.org)** (C2PA) addresses the prevalence of misleading information online through the development of technical standards for certifying the source and history (or provenance) of media content. The C2PA Rust library is part of the [Content Authenticity Initiative](https://contentauthenticity.org) open-source SDK.
 
-For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/rust-sdk/).  Some additional documentation for this repository is also available on GitHub:
+For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/rust-sdk/).  
 
-- [Usage](docs/usage.md)
-- [Supported formats](docs/supported-formats.md)
-- [Release notes](docs/release-notes.md)
-- [Contributing to the project](docs/project-contributions.md)
+You can also read the documentation directly in GitHub:
+
+- [Usage](https://github.com/contentauth/c2pa-rs/blob/main/docs/usage.md)
+- [Supported formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md)
+- [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
+- [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/docs/project-contributions.md)
 
 - [C2PA Tool](cli/README.md) documentation:
   - [Using C2PA Tool](cli/docs/usage.md)
@@ -27,12 +29,12 @@ For the best experience, read the docs on the [CAI Open Source SDK documentation
 
 The library enables a desktop, mobile, or embedded application to:
 * Create and sign C2PA [claims](https://c2pa.org/specifications/specifications/1.4/specs/C2PA_Specification.html#_claims) and [manifests](https://c2pa.org/specifications/specifications/1.4/specs/C2PA_Specification.html#_manifests).
-* Embed manifests in [supported file formats](docs/supported-formats.md).
-* Parse and validate manifests found in [supported file formats](docs/supported-formats.md).
+* Embed manifests in [supported file formats](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/supported-formats).
+* Parse and validate manifests found in [supported file formats](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/supported-formats).
 
 The library supports several common C2PA [assertions](https://c2pa.org/specifications/specifications/1.4/specs/C2PA_Specification.html#_c2pa_standard_assertions) and [hard bindings](https://c2pa.org/specifications/specifications/1.4/specs/C2PA_Specification.html#_hard_bindings).
 
-For details on what you can do with the library, see [Using the Rust library](docs/usage.md).
+For details on what you can do with the library, see [Using the Rust library](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/usage).
 
 ## State of the project
 
@@ -40,7 +42,7 @@ This is a beta release (version 0.x.x) of the project. The minor version number 
 
 ### New API
 
-NOTE: The current release includes a new API that replaces old methods of reading and writing C2PA data, which are deprecated.  See the [release notes](docs/release-notes.md) for more information. 
+NOTE: The current release includes a new API that replaces old methods of reading and writing C2PA data, which are deprecated.  See the [release notes](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/release-notes) for more information. 
 
 ### Rust language requirement (MSRV)
 
@@ -48,7 +50,7 @@ The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of 
 
 ### Contributions and feedback
 
-We welcome contributions to this project.  For information on contributing, providing feedback, and about ongoing work, see [Contributing](https://github.com/contentauth/c2pa-rs/blob/main/CONTRIBUTING.md).  For additional information on nightly builds and testing, see [Contributing to the project](docs/project-contributions.md).
+We welcome contributions to this project.  For information on contributing, providing feedback, and about ongoing work, see [Contributing](https://github.com/contentauth/c2pa-rs/blob/main/CONTRIBUTING.md).  For additional information on nightly builds and testing, see [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/docs/project-contributions.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ You can also read the documentation directly in GitHub:
 - [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
 - [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/docs/project-contributions.md)
 
-- [C2PA Tool](cli/README.md) documentation:
-  - [Using C2PA Tool](cli/docs/usage.md)
-  - [Manifest definition file](cli/docs/manifest.md)
-  - [Using an X.509 certificate](cli/docs/x_509.md)
-  - [Release notes](cli/docs/release-notes.md)
+- [C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/README.md) documentation:
+  - [Using C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/usage.md)
+  - [Manifest definition file](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/manifest.md)
+  - [Using an X.509 certificate](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/x_509.md)
+  - [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/release-notes.md)
 
 </div>
 


### PR DESCRIPTION
As discussed, some links in the README are broken on https://crates.io/crates/c2pa. I fixed the broken links by either:
- Changing to an absolute GitHub URL, for links that will be show only on crates.io and GitHub (in the intro para, which is not displayed on the doc site).
- Changing to an absolute URL on https://opensource.contentauthenticity.org/docs (elsewhere on the page, which is displayed on the doc site).
