### PR TITLE
feat: Add synchronous version of `X509CredentialHolder`

### DIFF
--- a/cawg_identity/examples/cawg.rs
+++ b/cawg_identity/examples/cawg.rs
@@ -30,7 +30,7 @@ mod cawg {
     use cawg_identity::{
         builder::{AsyncIdentityAssertionBuilder, AsyncIdentityAssertionSigner},
         validator::CawgValidator,
-        x509::X509CredentialHolder,
+        x509::AsyncX509CredentialHolder,
     };
     use serde_json::json;
 
@@ -92,7 +92,7 @@ mod cawg {
 
         let mut ia_signer = AsyncIdentityAssertionSigner::new(c2pa_raw_signer);
 
-        let x509_holder = X509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
+        let x509_holder = AsyncX509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
         let iab = AsyncIdentityAssertionBuilder::for_credential_holder(x509_holder);
         ia_signer.add_identity_assertion(iab);
         Ok(ia_signer)

--- a/cawg_identity/src/tests/examples/x509_signing.rs
+++ b/cawg_identity/src/tests/examples/x509_signing.rs
@@ -24,7 +24,7 @@ use c2pa_status_tracker::StatusTracker;
 use crate::{
     builder::{AsyncIdentityAssertionBuilder, AsyncIdentityAssertionSigner},
     tests::fixtures::{cert_chain_and_private_key_for_alg, manifest_json, parent_json},
-    x509::{X509CredentialHolder, X509SignatureVerifier},
+    x509::{AsyncX509CredentialHolder, X509SignatureVerifier},
     IdentityAssertion,
 };
 
@@ -60,7 +60,7 @@ async fn x509_signing() {
     )
     .unwrap();
 
-    let x509_holder = X509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
+    let x509_holder = AsyncX509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
     let iab = AsyncIdentityAssertionBuilder::for_credential_holder(x509_holder);
     c2pa_signer.add_identity_assertion(iab);
 

--- a/cawg_identity/src/tests/identity_assertion/built_in_signature_verifier.rs
+++ b/cawg_identity/src/tests/identity_assertion/built_in_signature_verifier.rs
@@ -34,7 +34,7 @@ use crate::{
         cert_chain_and_private_key_for_alg, default_built_in_signature_verifier, manifest_json,
         parent_json, NaiveCredentialHolder,
     },
-    x509::X509CredentialHolder,
+    x509::AsyncX509CredentialHolder,
     IdentityAssertion, SignerPayload, ValidationError,
 };
 
@@ -74,7 +74,7 @@ async fn x509_simple_case() {
     )
     .unwrap();
 
-    let x509_holder = X509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
+    let x509_holder = AsyncX509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
     let iab = AsyncIdentityAssertionBuilder::for_credential_holder(x509_holder);
     c2pa_signer.add_identity_assertion(iab);
 

--- a/cawg_identity/src/tests/x509.rs
+++ b/cawg_identity/src/tests/x509.rs
@@ -20,9 +20,12 @@ use c2pa_status_tracker::StatusTracker;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 use crate::{
-    builder::{AsyncIdentityAssertionBuilder, AsyncIdentityAssertionSigner},
+    builder::{
+        AsyncIdentityAssertionBuilder, AsyncIdentityAssertionSigner, IdentityAssertionBuilder,
+        IdentityAssertionSigner,
+    },
     tests::fixtures::{cert_chain_and_private_key_for_alg, manifest_json, parent_json},
-    x509::{X509CredentialHolder, X509SignatureVerifier},
+    x509::{AsyncX509CredentialHolder, X509CredentialHolder, X509SignatureVerifier},
     IdentityAssertion,
 };
 
@@ -49,6 +52,79 @@ async fn simple_case() {
         .add_resource("thumbnail.jpg", Cursor::new(TEST_THUMBNAIL))
         .unwrap();
 
+    let mut c2pa_signer = IdentityAssertionSigner::from_test_credentials(SigningAlg::Ps256);
+
+    let (cawg_cert_chain, cawg_private_key) =
+        cert_chain_and_private_key_for_alg(SigningAlg::Ed25519);
+
+    let cawg_raw_signer = raw_signature::signer_from_cert_chain_and_private_key(
+        &cawg_cert_chain,
+        &cawg_private_key,
+        SigningAlg::Ed25519,
+        None,
+    )
+    .unwrap();
+
+    let x509_holder = X509CredentialHolder::from_raw_signer(cawg_raw_signer);
+    let iab = IdentityAssertionBuilder::for_credential_holder(x509_holder);
+    c2pa_signer.add_identity_assertion(iab);
+
+    builder
+        .sign(&c2pa_signer, format, &mut source, &mut dest)
+        .unwrap();
+
+    // Read back the Manifest that was generated.
+    dest.rewind().unwrap();
+
+    let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+    assert_eq!(manifest_store.validation_status(), None);
+
+    let manifest = manifest_store.active_manifest().unwrap();
+    let mut st = StatusTracker::default();
+    let mut ia_iter = IdentityAssertion::from_manifest(manifest, &mut st);
+
+    // Should find exactly one identity assertion.
+    let ia = ia_iter.next().unwrap().unwrap();
+    assert!(ia_iter.next().is_none());
+    drop(ia_iter);
+
+    // And that identity assertion should be valid for this manifest.
+    let x509_verifier = X509SignatureVerifier {};
+    let sig_info = ia
+        .validate(manifest, &mut st, &x509_verifier)
+        .await
+        .unwrap();
+
+    let cert_info = &sig_info.cert_info;
+    assert_eq!(cert_info.alg.unwrap(), SigningAlg::Ed25519);
+    assert_eq!(
+        cert_info.issuer_org.as_ref().unwrap(),
+        "C2PA Test Signing Cert"
+    );
+
+    // TO DO: Not sure what to check from COSE_Sign1.
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
+#[cfg_attr(target_os = "wasi", wstd::test)]
+async fn simple_case_async() {
+    let format = "image/jpeg";
+    let mut source = Cursor::new(TEST_IMAGE);
+    let mut dest = Cursor::new(Vec::new());
+
+    let mut builder = Builder::from_json(&manifest_json()).unwrap();
+    builder
+        .add_ingredient_from_stream(parent_json(), format, &mut source)
+        .unwrap();
+
+    builder
+        .add_resource("thumbnail.jpg", Cursor::new(TEST_THUMBNAIL))
+        .unwrap();
+
     let mut c2pa_signer = AsyncIdentityAssertionSigner::from_test_credentials(SigningAlg::Ps256);
 
     let (cawg_cert_chain, cawg_private_key) =
@@ -62,7 +138,7 @@ async fn simple_case() {
     )
     .unwrap();
 
-    let x509_holder = X509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
+    let x509_holder = AsyncX509CredentialHolder::from_async_raw_signer(cawg_raw_signer);
     let iab = AsyncIdentityAssertionBuilder::for_credential_holder(x509_holder);
     c2pa_signer.add_identity_assertion(iab);
 

--- a/cawg_identity/src/x509/async_x509_credential_holder.rs
+++ b/cawg_identity/src/x509/async_x509_credential_holder.rs
@@ -1,0 +1,96 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use async_trait::async_trait;
+use c2pa_crypto::{
+    cose::{sign_async, TimeStampStorage},
+    raw_signature::AsyncRawSigner,
+};
+
+use crate::{
+    builder::{AsyncCredentialHolder, IdentityBuilderError},
+    SignerPayload,
+};
+
+/// An implementation of [`AsyncCredentialHolder`] that generates COSE
+/// signatures using X.509 credentials as specified in [§8.2, X.509 certificates
+/// and COSE signatures].
+///
+/// [`SignatureVerifier`]: crate::SignatureVerifier
+/// [§8.2, X.509 certificates and COSE signatures]: https://cawg.io/identity/1.1-draft/#_x_509_certificates_and_cose_signatures
+#[cfg(not(target_arch = "wasm32"))]
+pub struct AsyncX509CredentialHolder(Box<dyn AsyncRawSigner + Send + Sync + 'static>);
+
+/// An implementation of [`AsyncCredentialHolder`] that generates COSE
+/// signatures using X.509 credentials as specified in [§8.2, X.509 certificates
+/// and COSE signatures].
+///
+/// [`AsyncCredentialHolder`]: crate::builder::AsyncCredentialHolder
+/// [§8.2, X.509 certificates and COSE signatures]: https://cawg.io/identity/1.1-draft/#_x_509_certificates_and_cose_signatures
+#[cfg(target_arch = "wasm32")]
+pub struct AsyncX509CredentialHolder(Box<dyn AsyncRawSigner + 'static>);
+
+impl AsyncX509CredentialHolder {
+    /// Create an `AsyncX509CredentialHolder` instance by wrapping an instance
+    /// of [`AsyncRawSigner`].
+    ///
+    /// The [`AsyncRawSigner`] implementation actually holds (or has access to)
+    /// the relevant certificates and private key material.
+    ///
+    /// [`AsyncRawSigner`]: c2pa_crypto::raw_signature::AsyncRawSigner
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_async_raw_signer(signer: Box<dyn AsyncRawSigner + Send + Sync + 'static>) -> Self {
+        Self(signer)
+    }
+
+    /// Create an `AsyncX509CredentialHolder` instance by wrapping an instance
+    /// of [`AsyncRawSigner`].
+    ///
+    /// The [`AsyncRawSigner`] implementation actually holds (or has access to)
+    /// the relevant certificates and private key material.
+    ///
+    /// [`AsyncRawSigner`]: c2pa_crypto::raw_signature::AsyncRawSigner
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_async_raw_signer(signer: Box<dyn AsyncRawSigner + 'static>) -> Self {
+        Self(signer)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl AsyncCredentialHolder for AsyncX509CredentialHolder {
+    fn sig_type(&self) -> &'static str {
+        super::CAWG_X509_SIG_TYPE
+    }
+
+    fn reserve_size(&self) -> usize {
+        self.0.reserve_size()
+    }
+
+    async fn sign(&self, signer_payload: &SignerPayload) -> Result<Vec<u8>, IdentityBuilderError> {
+        // TO DO: Check signing cert (see signing_cert_valid in c2pa-rs's cose_sign).
+
+        let mut sp_cbor: Vec<u8> = vec![];
+        ciborium::into_writer(signer_payload, &mut sp_cbor)
+            .map_err(|e| IdentityBuilderError::CborGenerationError(e.to_string()))?;
+
+        Ok(sign_async(
+            self.0.as_ref(),
+            &sp_cbor,
+            None,
+            TimeStampStorage::V2_sigTst2_CTT,
+        )
+        .await
+        .map_err(|e| IdentityBuilderError::SignerError(e.to_string()))?)
+    }
+}

--- a/cawg_identity/src/x509/mod.rs
+++ b/cawg_identity/src/x509/mod.rs
@@ -19,6 +19,9 @@
 //! [`SignatureVerifier`]: crate::SignatureVerifier
 //! [§8.2, X.509 certificates and COSE signatures]: https://cawg.io/identity/1.1-draft/#_x_509_certificates_and_cose_signatures
 
+mod async_x509_credential_holder;
+pub use async_x509_credential_holder::AsyncX509CredentialHolder;
+
 mod x509_credential_holder;
 pub use x509_credential_holder::X509CredentialHolder;
 


### PR DESCRIPTION
IMPORTANT: This renames the existing async version of X509CredentialHolder to AsyncX509CredentialHolder to fit the naming pattern used elsewhere.
