### PR TITLE
fix: Update namespace to not produce double ::

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -68,7 +68,7 @@ use HashedUri as C2PAAssertion;
 
 const GH_FULL_VERSION_LIST: &str = "Sec-CH-UA-Full-Version-List";
 const GH_UA: &str = "Sec-CH-UA";
-const C2PA_NAMESPACE_V2: &str = "urn:c2pa:";
+const C2PA_NAMESPACE_V2: &str = "urn:c2pa";
 const C2PA_NAMESPACE_V1: &str = "urn:uuid";
 
 static _V2_SPEC_DEPRECATED_ASSERTIONS: [&str; 4] = [


### PR DESCRIPTION
Current output is e.g. `"active_manifest": "urn:c2pa::61a66f8b-4612-4176-ab49-d5ed40045d33"`

## Changes in this pull request
Currently the outputted claims don't match the valid regex

Didn't add any tests yet, but can't patch this on our client side due to there being no way to supply a different namespace.  Will see if any tests break due to this

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
