### PR TITLE
fix: Fix support for user supplied labels

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -68,7 +68,7 @@ use HashedUri as C2PAAssertion;
 
 const GH_FULL_VERSION_LIST: &str = "Sec-CH-UA-Full-Version-List";
 const GH_UA: &str = "Sec-CH-UA";
-const C2PA_NAMESPACE_V2: &str = "urn:c2pa:";
+const C2PA_NAMESPACE_V2: &str = "urn:c2pa";
 const C2PA_NAMESPACE_V1: &str = "urn:uuid";
 
 static _V2_SPEC_DEPRECATED_ASSERTIONS: [&str; 4] = [

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -424,23 +424,54 @@ impl Claim {
         user_guid: S,
         claim_version: usize,
     ) -> Result<Self> {
-        let ug: String = user_guid.into();
+        let mparts = manifest_label_to_parts(&user_guid.into())
+            .ok_or(Error::BadParam("invalid Claim GUID".into()))?;
+
+        if claim_version == 1 && !mparts.is_v1 || claim_version > 1 && mparts.is_v1 {
+            return Err(Error::BadParam("invalid Claim GUID".into()));
+        }
+
+        let ug = &mparts.guid;
         let uuid =
-            Uuid::try_parse(&ug).map_err(|_e| Error::BadParam("invalid Claim GUID".into()))?;
+            Uuid::try_parse(ug).map_err(|_e| Error::BadParam("invalid Claim GUID".into()))?;
         match uuid.get_version() {
             Some(uuid::Version::Random) => (),
             _ => return Err(Error::BadParam("invalid Claim GUID".into())),
         }
-        let label = if claim_version == 1 {
-            uuid.urn()
-                .encode_lower(&mut Uuid::encode_buffer())
-                .to_string()
-        } else {
-            format!(
-                "{}:{}",
-                C2PA_NAMESPACE_V2,
-                uuid.hyphenated().encode_lower(&mut Uuid::encode_buffer())
-            )
+
+        let label = match mparts.vendor {
+            Some(v) => {
+                if mparts.is_v1 {
+                    format!(
+                        "{}:{}:{}",
+                        v.to_lowercase(),
+                        C2PA_NAMESPACE_V1,
+                        uuid.hyphenated().encode_lower(&mut Uuid::encode_buffer())
+                    )
+                } else {
+                    format!(
+                        "{}:{}:{}",
+                        C2PA_NAMESPACE_V2,
+                        uuid.hyphenated().encode_lower(&mut Uuid::encode_buffer()),
+                        v.to_lowercase()
+                    )
+                }
+            }
+            None => {
+                if mparts.is_v1 {
+                    format!(
+                        "{}:{}",
+                        C2PA_NAMESPACE_V1,
+                        uuid.hyphenated().encode_lower(&mut Uuid::encode_buffer())
+                    )
+                } else {
+                    format!(
+                        "{}:{}",
+                        C2PA_NAMESPACE_V2,
+                        uuid.hyphenated().encode_lower(&mut Uuid::encode_buffer())
+                    )
+                }
+            }
         };
 
         Ok(Claim {
@@ -2943,5 +2974,48 @@ pub mod tests {
         if let UriOrResource::HashedUri(r) = cgi[0].icon.as_ref().unwrap() {
             assert_eq!(r.hash(), b"hashed");
         }
+    }
+
+    #[test]
+    fn test_new_with_user_guid() {
+        // good v1
+        Claim::new_with_user_guid(
+            "claim_generator",
+            "acme:urn:uuid:3fad1ead-8ed5-44d0-873b-ea5f58adea82",
+            1,
+        )
+        .unwrap();
+
+        // good v2
+        Claim::new_with_user_guid(
+            "claim_generator",
+            "urn:c2pa:3fad1ead-8ed5-44d0-873b-ea5f58adea82:acme",
+            2,
+        )
+        .unwrap();
+
+        // feature incompatible
+        let c2 = Claim::new_with_user_guid(
+            "claim_generator",
+            "urn:c2pa:3fad1ead-8ed5-44d0-873b-ea5f58adea82:acme",
+            1,
+        );
+        assert!(c2.is_err());
+
+        // version incompatible
+        let c3 = Claim::new_with_user_guid(
+            "claim_generator",
+            "acme:urn:uuid:3fad1ead-8ed5-44d0-873b-ea5f58adea82",
+            2,
+        );
+        assert!(c3.is_err());
+
+        // malformed
+        let c4 = Claim::new_with_user_guid(
+            "claim_generator",
+            "urn:c2pa:3fad1ead-8ed5-44d0-873b-ea5f58adea82:acme",
+            1,
+        );
+        assert!(c4.is_err());
     }
 }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1567,7 +1567,7 @@ pub(crate) mod tests {
         ingredient::Ingredient,
         reader::Reader,
         store::Store,
-        utils::test::{static_test_uuid, temp_remote_signer, TEST_VC},
+        utils::test::{static_test_v1_uuid, temp_remote_signer, TEST_VC},
         utils::test_signer::{async_test_signer, test_signer},
         Manifest, Result,
     };
@@ -1986,7 +1986,7 @@ pub(crate) mod tests {
     fn test_embed_user_label() {
         let temp_dir = tempdirectory().expect("temp dir");
         let output = temp_fixture_path(&temp_dir, TEST_SMALL_JPEG);
-        let my_guid = static_test_uuid();
+        let my_guid = static_test_v1_uuid();
         let signer = test_signer(SigningAlg::Ps256);
 
         let mut manifest = test_manifest();
@@ -2015,7 +2015,7 @@ pub(crate) mod tests {
         let signer = test_signer(SigningAlg::Ps256);
 
         let mut manifest = test_manifest();
-        manifest.set_label(static_test_uuid());
+        manifest.set_label(static_test_v1_uuid());
         manifest.set_remote_manifest(url);
         let c2pa_data = manifest
             .embed(&output, &output, signer.as_ref())

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -82,8 +82,8 @@ pub(crate) fn gen_c2pa_uuid() -> String {
 }
 
 // Returns a non-changing C2PA compatible UUID for testing
-pub(crate) fn static_test_uuid() -> &'static str {
-    const TEST_GUID: &str = "f75ddc48-cdc8-4723-bcfe-77a8d68a5920";
+pub(crate) fn static_test_v1_uuid() -> &'static str {
+    const TEST_GUID: &str = "urn:uuid:f75ddc48-cdc8-4723-bcfe-77a8d68a5920";
     TEST_GUID
 }
 


### PR DESCRIPTION
## Changes in this pull request
Make sure users supplied manifests labels conform and allow support for Claim V2 labels.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
