### PR TITLE
fix: Enable trust checks for all unit tests

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1855,6 +1855,9 @@ pub mod tests {
 
         use crate::store::Store;
 
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let ap = fixture_path("video1.mp4");
 
         let mut log = StatusTracker::default();

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1855,8 +1855,7 @@ pub mod tests {
 
         use crate::store::Store;
 
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let ap = fixture_path("video1.mp4");
 

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -277,6 +277,14 @@ mod tests {
 
     #[test]
     fn test_sign_claim() {
+        // todo: we have to disable trust checks here for now because these
+        // tests use the passthrough mode:
+        // let passthrough_cap = CertificateTrustPolicy::default();
+        // mode which does not pass through the top level (c2pa-rs) unit tests
+        //configuration so the test trust list is not loaded
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let mut claim = Claim::new("extern_sign_test", Some("contentauth"), 1);
         claim.build().unwrap();
 
@@ -294,6 +302,14 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(target_os = "wasi", wstd::test)]
     async fn test_sign_claim_async() {
+        // todo: we have to disable trust checks here for now because these
+        // tests use the passthrough mode:
+        // let passthrough_cap = CertificateTrustPolicy::default();
+        // mode which does not pass through the top level (c2pa-rs) unit tests
+        //configuration so the test trust list is not loaded
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         use c2pa_crypto::raw_signature::SigningAlg;
 
         use crate::{cose_sign::sign_claim_async, AsyncSigner};

--- a/sdk/src/cose_sign.rs
+++ b/sdk/src/cose_sign.rs
@@ -282,8 +282,7 @@ mod tests {
         // let passthrough_cap = CertificateTrustPolicy::default();
         // mode which does not pass through the top level (c2pa-rs) unit tests
         //configuration so the test trust list is not loaded
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let mut claim = Claim::new("extern_sign_test", Some("contentauth"), 1);
         claim.build().unwrap();
@@ -307,8 +306,7 @@ mod tests {
         // let passthrough_cap = CertificateTrustPolicy::default();
         // mode which does not pass through the top level (c2pa-rs) unit tests
         //configuration so the test trust list is not loaded
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         use c2pa_crypto::raw_signature::SigningAlg;
 

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -192,8 +192,7 @@ pub mod tests {
 
     #[test]
     fn test_no_timestamp() {
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let mut validation_log = StatusTracker::default();
 
@@ -222,8 +221,7 @@ pub mod tests {
             time_stamp::{TimeStampError, TimeStampProvider},
         };
 
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let mut validation_log = StatusTracker::default();
 

--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -192,6 +192,9 @@ pub mod tests {
 
     #[test]
     fn test_no_timestamp() {
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let mut validation_log = StatusTracker::default();
 
         let mut claim = crate::claim::Claim::new("extern_sign_test", Some("contentauth"), 1);
@@ -218,6 +221,9 @@ pub mod tests {
             raw_signature::{signer_from_cert_chain_and_private_key, RawSigner, RawSignerError},
             time_stamp::{TimeStampError, TimeStampProvider},
         };
+
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
 
         let mut validation_log = StatusTracker::default();
 

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1651,8 +1651,7 @@ mod tests {
     #[cfg_attr(target_os = "wasi", wstd::test)]
     #[cfg(feature = "fetch_remote_manifests")]
     async fn test_jpg_cloud_from_memory() {
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
@@ -1676,8 +1675,7 @@ mod tests {
     )]
     #[cfg_attr(all(target_os = "wasi", not(feature = "file_io")), wstd::test)]
     async fn test_jpg_cloud_from_memory_no_file_io() {
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
@@ -1703,8 +1701,7 @@ mod tests {
     )]
     #[cfg_attr(target_os = "wasi", wstd::test)]
     async fn test_jpg_cloud_from_memory_and_manifest() {
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let asset_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let manifest_bytes = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1651,6 +1651,9 @@ mod tests {
     #[cfg_attr(target_os = "wasi", wstd::test)]
     #[cfg(feature = "fetch_remote_manifests")]
     async fn test_jpg_cloud_from_memory() {
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
         let ingredient = Ingredient::from_memory_async(format, image_bytes)
@@ -1673,6 +1676,9 @@ mod tests {
     )]
     #[cfg_attr(all(target_os = "wasi", not(feature = "file_io")), wstd::test)]
     async fn test_jpg_cloud_from_memory_no_file_io() {
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let image_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let format = "image/jpeg";
         let ingredient = Ingredient::from_memory_async(format, image_bytes)
@@ -1697,6 +1703,9 @@ mod tests {
     )]
     #[cfg_attr(target_os = "wasi", wstd::test)]
     async fn test_jpg_cloud_from_memory_and_manifest() {
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let asset_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let manifest_bytes = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");
         let format = "image/jpeg";

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -702,6 +702,9 @@ mod tests {
     #[allow(deprecated)]
     #[cfg(feature = "v1_api")]
     async fn manifest_report_from_manifest_and_asset_bytes_async() {
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let asset_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let manifest_bytes = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");
 

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -702,8 +702,7 @@ mod tests {
     #[allow(deprecated)]
     #[cfg(feature = "v1_api")]
     async fn manifest_report_from_manifest_and_asset_bytes_async() {
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let asset_bytes = include_bytes!("../tests/fixtures/cloud.jpg");
         let manifest_bytes = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -860,20 +860,21 @@ pub mod tests {
         Ok(())
     }
 
-    // This test is disabled until we can set settings without interfering with other tests
-    // #[test]
-    // fn test_reader_trusted() -> Result<()> {
-    //     const TEST_SETTINGS: &str = include_str!("../tests/fixtures/certs/trust/test_settings.toml");
-    //     crate::settings::load_settings_from_str(TEST_SETTINGS, "toml")?;
-    //     let reader = Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
-    //     assert_eq!(reader.validation_state(), ValidationState::Trusted);
-    //     crate::settings::set_settings_value("verify.trusted", false)?;
-    //     Ok(())
-    // }
+    #[test]
+    fn test_reader_trusted() -> Result<()> {
+        let reader =
+            Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
+        assert_eq!(reader.validation_state(), ValidationState::Trusted);
+        Ok(())
+    }
 
     #[test]
     /// Test that the reader can validate a file with nested assertion errors
     fn test_reader_from_file_nested_errors() -> Result<()> {
+        // disable trust check so that the status is Valid vs Trusted
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
+
         let reader =
             Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
         println!("{reader}");

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -872,8 +872,7 @@ pub mod tests {
     /// Test that the reader can validate a file with nested assertion errors
     fn test_reader_from_file_nested_errors() -> Result<()> {
         // disable trust check so that the status is Valid vs Trusted
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let reader =
             Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -861,6 +861,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "wasi"))] // todo: enable when disable we find out wasi trust issues
     fn test_reader_trusted() -> Result<()> {
         let reader =
             Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;

--- a/sdk/src/settings.rs
+++ b/sdk/src/settings.rs
@@ -39,7 +39,7 @@ pub(crate) trait SettingsValidate {
 }
 
 // Settings for trust list feature
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 #[allow(unused)]
 pub(crate) struct Trust {
@@ -95,6 +95,33 @@ impl Trust {
         } else {
             Err(Error::NotFound)
         }
+    }
+}
+
+impl Default for Trust {
+    fn default() -> Self {
+        let mut trust = Self {
+            private_anchors: None,
+            trust_anchors: None,
+            trust_config: None,
+            allowed_list: None,
+        };
+
+        // load test config store for unit tests
+        if cfg!(test) {
+            trust.trust_config = Some(
+                String::from_utf8_lossy(include_bytes!("../tests/fixtures/certs/trust/store.cfg"))
+                    .into_owned(),
+            );
+            trust.trust_anchors = Some(
+                String::from_utf8_lossy(include_bytes!(
+                    "../tests/fixtures/certs/trust/test_cert_root_bundle.pem"
+                ))
+                .into_owned(),
+            );
+        }
+
+        trust
     }
 }
 
@@ -171,7 +198,7 @@ impl Default for Verify {
         Self {
             verify_after_reading: true,
             verify_after_sign: true,
-            verify_trust: false, //cfg!(test),
+            verify_trust: cfg!(test),
             ocsp_fetch: false,
             remote_manifest_fetch: true,
             check_ingredient_trust: true,

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6662,6 +6662,8 @@ pub mod tests {
         // bypass auto sig check
         crate::settings::load_settings_from_str(r#"{"verify.verify_after_sign": false}"#, "json")
             .unwrap();
+        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
+            .unwrap();
 
         builder
             .sign(&signer, "image/png", &mut Cursor::new(png), &mut dst)

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6660,10 +6660,8 @@ pub mod tests {
         let mut dst = Cursor::new(Vec::new());
 
         // bypass auto sig check
-        crate::settings::load_settings_from_str(r#"{"verify.verify_after_sign": false}"#, "json")
-            .unwrap();
-        crate::settings::load_settings_from_str(r#"{"verify.verify_trust": false}"#, "json")
-            .unwrap();
+        crate::settings::set_settings_value("verify.verify_after_sign", false).unwrap();
+        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         builder
             .sign(&signer, "image/png", &mut Cursor::new(png), &mut dst)


### PR DESCRIPTION
## Changes in this pull request
This PR turns on trust list check for all unit test expect those where we do not have access to the source certificate.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
