### PR TITLE
fix: Update openssl to address a recently-announced vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2958,9 +2958,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -2999,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/cawg_identity/src/validator.rs
+++ b/cawg_identity/src/validator.rs
@@ -37,7 +37,7 @@ impl AsyncPostValidator for CawgValidator {
         partial_claim: &PartialClaim,
         tracker: &mut StatusTracker,
     ) -> c2pa::Result<Option<Value>> {
-        if label == "cawg.identity" {
+        if label.starts_with("cawg.identity") {
             let identity_assertion: IdentityAssertion = assertion.to_assertion()?;
             tracker.push_current_uri(uri);
             let result = identity_assertion

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,7 +156,6 @@ fn parse_resource_string(s: &str) -> Result<TrustResource> {
 // We only construct one per invocation, not worth shrinking this.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
-#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Sub-command to configure trust store options, "trust --help for more details"
     Trust {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -16,7 +16,7 @@
 #![deny(clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 
-//! This library supports reading, creating and embedding C2PA data
+//! This library supports reading, creating, and embedding C2PA data
 //! with a variety of asset types.
 //!
 //! Some functionality requires you to enable specific crate features,


### PR DESCRIPTION
Contains trivial changes to each downstream project as a hedge against https://github.com/release-plz/release-plz/issues/2164.