### PR TITLE
fix: dup check with validation kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/internal/status-tracker/src/validation_codes.rs
+++ b/internal/status-tracker/src/validation_codes.rs
@@ -191,6 +191,12 @@ pub const TIMESTAMP_UNTRUSTED: &str = "timeStamp.untrusted";
 /// Any corresponding URL should point to a C2PA claim signature box.
 pub const TIMESTAMP_OUTSIDE_VALIDITY: &str = "timeStamp.outsideValidity";
 
+/// The time-stamp response included in the claim signature header is not
+/// properly formed, as per RFC 3161
+///
+/// Any corresponding URL should point to a C2PA claim signature box.
+pub const TIMESTAMP_MALFORMED: &str = "timeStamp.malformed";
+
 /// The hash of the the referenced assertion in the manifest does not
 /// match the corresponding hash in the assertion's hashed URI in the claim.
 ///
@@ -329,9 +335,10 @@ pub fn log_kind(status_code: &str) -> LogKind {
         | ASSERTION_BMFFHASH_MATCH
         | ASSERTION_ACCESSIBLE
         | ASSERTION_BOXHASH_MATCH => LogKind::Success,
-        TIMESTAMP_UNTRUSTED | TIMESTAMP_OUTSIDE_VALIDITY | TIMESTAMP_MISMATCH => {
-            LogKind::Informational
-        }
+        TIMESTAMP_UNTRUSTED
+        | TIMESTAMP_OUTSIDE_VALIDITY
+        | TIMESTAMP_MISMATCH
+        | TIMESTAMP_MALFORMED => LogKind::Informational,
         _ => LogKind::Failure,
     }
 }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1832,6 +1832,9 @@ impl Claim {
         let sig = claim.signature_val();
         let additional_bytes: Vec<u8> = Vec::new();
 
+        // use the signature uri as the current uri while validating the signature info
+        validation_log.push_current_uri(claim.signature.clone());
+
         // make sure signature manifest if present points to this manifest
         let sig_box_err = match jumbf::labels::manifest_label_from_uri(&claim.signature) {
             Some(signature_url) if signature_url != claim.label() => true,
@@ -1902,6 +1905,8 @@ impl Claim {
             ctp,
             validation_log,
         );
+
+        validation_log.pop_current_uri(); // back to the manifest url
 
         Claim::verify_internal(claim, asset_data, is_provenance, verified, validation_log)
             .inspect_err(|_e| {

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1892,12 +1892,16 @@ mod tests_file_io {
         assert_eq!(ingredient.format(), Some("image/jpeg"));
         test_thumbnail(&ingredient, "image/jpeg");
         assert!(ingredient.manifest_data().is_some());
-        assert!(ingredient.validation_status().is_some());
-        assert!(ingredient
-            .validation_status()
-            .unwrap()
-            .iter()
-            .any(|s| s.code() == validation_status::TIMESTAMP_MISMATCH));
+        assert_eq!(
+            ingredient
+                .validation_results()
+                .unwrap()
+                .active_manifest()
+                .unwrap()
+                .informational[0]
+                .code(),
+            validation_status::TIMESTAMP_MISMATCH
+        );
     }
 
     #[test]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -5294,7 +5294,7 @@ pub mod tests {
         // replace the title that is inside the claim data - should cause signature to not match
         let report = patch_and_report("C.jpg", b"C.jpg", b"X.jpg");
         assert!(!report.logged_items().is_empty());
-        assert!(report.has_error(c2pa_crypto::time_stamp::TimeStampError::InvalidData));
+        // note in the older validation statuses, this was an error, but now it is informational
         assert!(report.has_status(validation_status::TIMESTAMP_MISMATCH));
     }
 

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -120,7 +120,16 @@ impl ValidationResults {
                 // Get a flat list of validation statuses from the ingredient.
                 let validation_status = match i.validation_results {
                     Some(v) => Some(v.validation_status()),
-                    None => i.validation_status.map(|s| s.to_owned()),
+                    None => i.validation_status.map(|s| {
+                        s.iter()
+                            .map(|s| {
+                                let status = s.to_owned();
+                                // We need to fix up kind since the older validation statuses don't have it set.
+                                let kind = log_kind(status.code());
+                                status.set_kind(kind)
+                            })
+                            .collect()
+                    }),
                 };
 
                 // Convert any relative manifest urls found in ingredient validation statuses to absolute.

--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -208,7 +208,7 @@ impl ValidationStatus {
 
 impl PartialEq for ValidationStatus {
     fn eq(&self, other: &Self) -> bool {
-        self.code == other.code && self.url == other.url
+        self.code == other.code && self.url == other.url && self.kind == other.kind
     }
 }
 

--- a/sdk/tests/test_failures.rs
+++ b/sdk/tests/test_failures.rs
@@ -1,14 +1,22 @@
 mod common;
-use c2pa::{Reader, Result};
+use c2pa::{validation_status, Reader, Result};
 use common::fixture_stream;
 
 #[test]
 fn test_reader_ts_changed() -> Result<()> {
     let (format, mut stream) = fixture_stream("CA_ct.jpg")?;
     let reader = Reader::from_stream(&format, &mut stream).unwrap();
+    // in the older validation statuses, this was an error, but now it is informational
+    assert_eq!(
+        reader
+            .validation_results()
+            .unwrap()
+            .active_manifest()
+            .unwrap()
+            .informational[0]
+            .code(),
+        validation_status::TIMESTAMP_MALFORMED
+    );
 
-    let vl = reader.validation_status().unwrap();
-
-    assert!(!vl.is_empty());
     Ok(())
 }


### PR DESCRIPTION
Timestamp errors are now informational
maps error & informational codes from from v1 claim ingredients Added timestamp.malformed informational status.
signature errors have correct urls
chore :  update yanked crate
updated timestamp unit tests for informational status