### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "actix",
  "asn1-rs",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.6.0"
+version = "0.6.1"
 
 [[package]]
 name = "c2patool"
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.5.0",
+ "half 2.6.0",
 ]
 
 [[package]]
@@ -1899,9 +1899,9 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2728,9 +2728,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2990,9 +2990,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -31,8 +31,8 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 async-trait = "0.1.78"
 base64 = "0.22.1"
 c2pa = { path = "../sdk", version = "0.49.2" }
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.1" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.1" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ c2pa = { path = "../sdk", version = "0.49.2", features = [
 	"pdf"
 ] }
 cawg-identity = { path = "../cawg_identity", version = "0.12.0" }
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.1" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.1...c2pa-crypto-v0.8.2)
+_09 April 2025_
+
+### Fixed
+
+* Dup check with validation kind ([#1035](https://github.com/contentauth/c2pa-rs/pull/1035))
+
 ## [0.8.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.0...c2pa-crypto-v0.8.1)
 _04 April 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.8.1"
+version = "0.8.2"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -48,7 +48,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.6.0" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.6.1" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.6.0...c2pa-status-tracker-v0.6.1)
+_09 April 2025_
+
+### Fixed
+
+* Dup check with validation kind ([#1035](https://github.com/contentauth/c2pa-rs/pull/1035))
+
 ## [0.6.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.5.0...c2pa-status-tracker-v0.6.0)
 _18 March 2025_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.6.0"
+version = "0.6.1"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,8 +71,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.1" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.0" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.1" }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `c2pa-status-tracker`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `c2pa-crypto`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa-status-tracker`

<blockquote>

## [0.6.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.6.0...c2pa-status-tracker-v0.6.1)

_09 April 2025_

### Fixed

* Dup check with validation kind ([#1035](https://github.com/contentauth/c2pa-rs/pull/1035))
</blockquote>

## `c2pa-crypto`

<blockquote>

## [0.8.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.1...c2pa-crypto-v0.8.2)

_09 April 2025_

### Fixed

* Dup check with validation kind ([#1035](https://github.com/contentauth/c2pa-rs/pull/1035))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).