### PR TITLE
docs: Remove instructions to install c2patool using binstall

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -24,20 +24,15 @@ For a simple example of calling c2patool from a Node.js server application, see 
 
 ## Installation
 
-There are two ways to install C2PA Tool:
-- [Using a pre-built binary executable](#installing-a-pre-built-binary): This is the quickest way to install the tool.  If you just want to try C2PA Tool quickly, use this method.
-- [Using Cargo Binstall](#using-cargo-binstall), a low-complexity way to install Rust binaries.  This method is preferable for long-term use. If you know you want to use C2PA Tool for development, use this method.
+To install a prebuilt binary of C2PA Tool:
 
-**NOTE:** If you want to contribute to the C2PA Tool project itself, or if a pre-built binary is not available for your system, see [Contributing to the project](./docs/project-contributions.md).
-
-### Installing a pre-built binary
-
-The quickest way to install the tool is to use the binary executable builds.  If you just want to try C2PA Tool quickly:
-
-1. Go to the [Releases page](https://github.com/contentauth/c2pa-rs/releases). 
-1. Under the latest **c2patool** release, click **Assets**.
-1. Download the archive for your operating system (Linux, macOS, or Windows).
-1. Copy the executable file to a location on your `PATH`.
+1. Go to the [Releases page and filter for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
+1. Under **Assets**, click on the archive file for your operating system:
+   - MacOS: `c2patool-vx.y.z-universal-apple-darwin.zip`
+   - Windows: `c2patool-vx.y.z-x86_64-pc-windows-msvc.zip`
+   - Linux: `c2patool-vx.y.z-x86_64-unknown-linux-gnu.tar.gz`
+1. Download and extract the archive file.
+1. Copy the `c2patool` executable file to a location on your `PATH`.
 
 Confirm that you can run the tool by entering a command such as:
 ```
@@ -46,33 +41,14 @@ c2patool -h
 
 NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2pa-rs.git`.
 
-### Using Cargo Binstall
-
-Installing C2PA Tool using Cargo [Binstall](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file) is recommended because it makes it easier to:
-- Automatically select the correct installation package for your platform/architecture.
-- Update the tool when a new version is released.
-- Maintain, since you don't have to manually keep track of random binaries on your system.
-- Integrate into CI or other scripting environments.
-
-Additionally, using Binstall enables you to automate code signing to ensure package integrity.
-
-#### Process
-
-**PREREQUISITE:** Install [Rust](https://www.rust-lang.org/tools/install).
-
-To install by using Binstall:
-
-1. Install `cargo-binstall` by following the [quick install method](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#quickly) for your OS, or by building from source by running `cargo install cargo-binstall`
-2. Run `cargo binstall c2patool`.
 
 #### Upgrading
 
-To ensure you have the latest version, enter this command:
+To display the version of C2PA Tool that you have, enter this command:
 
 ```
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2pa-rs/releases). 
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
 
-If you need to upgrade, simply run `cargo binstall c2patool` again, or use [cargo-update](https://github.com/nabijaczleweli/cargo-update).

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,7 +42,11 @@ c2patool -h
 
 NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2pa-rs.git`.
 
-#### Upgrading
+### Installing from source
+
+Instead of installing a prebuilt binary, you can [build the project from source](https://github.com/contentauth/c2pa-rs/blob/docs/no-c2patool-binstall/cli/docs/project-contributions.md#building-from-source).
+
+### Upgrading
 
 To display the version of C2PA Tool that you have, enter this command:
 
@@ -50,5 +54,4 @@ To display the version of C2PA Tool that you have, enter this command:
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
-
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  To update the tool, simply install the latest version.

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,7 +26,7 @@ For a simple example of calling c2patool from a Node.js server application, see 
 
 To install a prebuilt binary of C2PA Tool:
 
-1. Go to the [Releases page and filter for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
+1. Go to the [Releases page and filter for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
 1. Under **Assets**, click on the archive file for your operating system:
    - MacOS: `c2patool-vx.y.z-universal-apple-darwin.zip`
    - Windows: `c2patool-vx.y.z-x86_64-pc-windows-msvc.zip`

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,7 +8,7 @@ Use the tool on a file in one of the [supported formats](https://github.com/cont
 - Read a low-level report of C2PA manifest data.
 - Add a C2PA manifest to the file.
 
-For a simple example of calling c2patool from a Node.js server application, see the [c2pa-service-example](https://github.com/contentauth/c2patool-service-example) repository.
+For a simple example of calling c2patool from a Node.js server application, see the [c2patool-service-example](https://github.com/contentauth/c2patool-service-example) repository.
 
 <div style={{display: 'none'}}>
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -54,4 +54,4 @@ To display the version of C2PA Tool that you have, enter this command:
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  If you don't have the latest version, update the tool by installing the latest version.
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  If you don't have the latest version, simply reinstall to get the latest version.

--- a/cli/README.md
+++ b/cli/README.md
@@ -54,4 +54,4 @@ To display the version of C2PA Tool that you have, enter this command:
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  To update the tool, simply install the latest version.
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  If you don't have the latest version, update the tool by installing the latest version.

--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,7 @@ To install a prebuilt binary of C2PA Tool:
    - Linux: `c2patool-vx.y.z-x86_64-unknown-linux-gnu.tar.gz`
 1. Download and extract the archive file.
 1. Copy the `c2patool` executable file to a location on your `PATH`.
+ from an unknown source; for example, on macOS, see [If you want to open an app that hasn’t been notarized or is from an unidentified developer](https://support.apple.com/en-us/102445#openanyway).
 
 Confirm that you can run the tool by entering a command such as:
 ```
@@ -40,7 +41,6 @@ c2patool -h
 ```
 
 NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2pa-rs.git`.
-
 
 #### Upgrading
 


### PR DESCRIPTION
## Changes in this pull request

Removes outdated instructions to install c2patool using `cargo binstall`.

Closes #742.
