### PR TITLE
feat: Changes required for Node SDK with Neon

### DIFF
--- a/cawg_identity/src/builder/identity_assertion_builder.rs
+++ b/cawg_identity/src/builder/identity_assertion_builder.rs
@@ -35,7 +35,7 @@ use crate::{builder::AsyncCredentialHolder, IdentityAssertion, SignerPayload};
 ///
 /// [`IdentityAssertionSigner`]: crate::builder::IdentityAssertionSigner
 pub struct IdentityAssertionBuilder {
-    credential_holder: Box<dyn CredentialHolder>,
+    credential_holder: Box<dyn CredentialHolder + Sync + Send>,
     referenced_assertions: HashSet<String>,
     roles: Vec<String>,
 }
@@ -43,7 +43,9 @@ pub struct IdentityAssertionBuilder {
 impl IdentityAssertionBuilder {
     /// Create an `IdentityAssertionBuilder` for the given `CredentialHolder`
     /// instance.
-    pub fn for_credential_holder<CH: CredentialHolder + 'static>(credential_holder: CH) -> Self {
+    pub fn for_credential_holder<CH: CredentialHolder + 'static + Send + Sync>(
+        credential_holder: CH,
+    ) -> Self {
         Self {
             credential_holder: Box::new(credential_holder),
             referenced_assertions: HashSet::new(),
@@ -231,7 +233,46 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
     }
 }
 
-fn finalize_identity_assertion(
+/// Finalizes the creation of an identity assertion.
+///
+/// This function takes the signer payload, an optional size constraint, and the result of a signature operation.
+/// It serializes the identity assertion into CBOR format, optionally padding it to meet the specified size,
+/// and returns the serialized assertion as `DynamicAssertionContent`.
+///
+/// # Arguments
+///
+/// * `signer_payload` - The payload containing the data to be signed and metadata about the signing process.
+/// * `size` - An optional size constraint for the serialized assertion. If provided, the function ensures
+///   the serialized assertion does not exceed this size, adding padding if necessary.
+/// * `signature_result` - The result of the signature operation, containing the signature bytes or an error.
+///
+/// # Returns
+///
+/// Returns a `c2pa::Result` containing the serialized `DynamicAssertionContent` if successful, or an error
+/// if the operation fails (e.g., due to serialization issues or size constraints).
+///
+/// # Errors
+///
+/// This function returns a `c2pa::Error` in the following cases:
+/// - If the signature operation fails.
+/// - If the serialized assertion exceeds the specified size constraint.
+/// - If CBOR serialization fails.
+///
+/// # Example
+///
+/// ```rust
+/// let signer_payload = SignerPayload {
+///     referenced_assertions: vec![],
+///     sig_type: "example_sig_type".to_string(),
+///     roles: vec!["example_role".to_string()],
+/// };
+/// let signature_result = Ok(vec![0x01, 0x02, 0x03]);
+/// let result = finalize_identity_assertion(signer_payload, Some(128), signature_result);
+/// match result {
+///     Ok(content) => println!("Serialized assertion: {:?}", content),
+///     Err(e) => eprintln!("Error: {:?}", e),
+/// }
+pub fn finalize_identity_assertion(
     signer_payload: SignerPayload,
     size: Option<usize>,
     signature_result: Result<Vec<u8>, IdentityBuilderError>,

--- a/cawg_identity/src/builder/identity_assertion_builder.rs
+++ b/cawg_identity/src/builder/identity_assertion_builder.rs
@@ -235,21 +235,26 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
 
 /// Finalizes the creation of an identity assertion.
 ///
-/// This function takes the signer payload, an optional size constraint, and the result of a signature operation.
-/// It serializes the identity assertion into CBOR format, optionally padding it to meet the specified size,
-/// and returns the serialized assertion as `DynamicAssertionContent`.
+/// This function takes the signer payload, an optional size constraint, and the
+/// result of a signature operation. It serializes the identity assertion into
+/// CBOR format, optionally padding it to meet the specified size, and returns
+/// the serialized assertion as `DynamicAssertionContent`.
 ///
 /// # Arguments
 ///
-/// * `signer_payload` - The payload containing the data to be signed and metadata about the signing process.
-/// * `size` - An optional size constraint for the serialized assertion. If provided, the function ensures
-///   the serialized assertion does not exceed this size, adding padding if necessary.
-/// * `signature_result` - The result of the signature operation, containing the signature bytes or an error.
+/// * `signer_payload` - The payload containing the data to be signed and
+///   metadata about the signing process.
+/// * `size` - An optional size constraint for the serialized assertion. If
+///   provided, the function ensures the serialized assertion does not exceed
+///   this size, adding padding if necessary.
+/// * `signature_result` - The result of the signature operation, containing the
+///   signature bytes or an error.
 ///
 /// # Returns
 ///
-/// Returns a `c2pa::Result` containing the serialized `DynamicAssertionContent` if successful, or an error
-/// if the operation fails (e.g., due to serialization issues or size constraints).
+/// Returns a `c2pa::Result` containing the serialized `DynamicAssertionContent`
+/// if successful, or an error if the operation fails (e.g., due to
+/// serialization issues or size constraints).
 ///
 /// # Errors
 ///
@@ -257,21 +262,6 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
 /// - If the signature operation fails.
 /// - If the serialized assertion exceeds the specified size constraint.
 /// - If CBOR serialization fails.
-///
-/// # Example
-///
-/// ```rust
-/// let signer_payload = SignerPayload {
-///     referenced_assertions: vec![],
-///     sig_type: "example_sig_type".to_string(),
-///     roles: vec!["example_role".to_string()],
-/// };
-/// let signature_result = Ok(vec![0x01, 0x02, 0x03]);
-/// let result = finalize_identity_assertion(signer_payload, Some(128), signature_result);
-/// match result {
-///     Ok(content) => println!("Serialized assertion: {:?}", content),
-///     Err(e) => eprintln!("Error: {:?}", e),
-/// }
 pub fn finalize_identity_assertion(
     signer_payload: SignerPayload,
     size: Option<usize>,

--- a/cawg_identity/src/builder/identity_assertion_builder.rs
+++ b/cawg_identity/src/builder/identity_assertion_builder.rs
@@ -233,36 +233,7 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
     }
 }
 
-/// Finalizes the creation of an identity assertion.
-///
-/// This function takes the signer payload, an optional size constraint, and the
-/// result of a signature operation. It serializes the identity assertion into
-/// CBOR format, optionally padding it to meet the specified size, and returns
-/// the serialized assertion as `DynamicAssertionContent`.
-///
-/// # Arguments
-///
-/// * `signer_payload` - The payload containing the data to be signed and
-///   metadata about the signing process.
-/// * `size` - An optional size constraint for the serialized assertion. If
-///   provided, the function ensures the serialized assertion does not exceed
-///   this size, adding padding if necessary.
-/// * `signature_result` - The result of the signature operation, containing the
-///   signature bytes or an error.
-///
-/// # Returns
-///
-/// Returns a `c2pa::Result` containing the serialized `DynamicAssertionContent`
-/// if successful, or an error if the operation fails (e.g., due to
-/// serialization issues or size constraints).
-///
-/// # Errors
-///
-/// This function returns a `c2pa::Error` in the following cases:
-/// - If the signature operation fails.
-/// - If the serialized assertion exceeds the specified size constraint.
-/// - If CBOR serialization fails.
-pub fn finalize_identity_assertion(
+fn finalize_identity_assertion(
     signer_payload: SignerPayload,
     size: Option<usize>,
     signature_result: Result<Vec<u8>, IdentityBuilderError>,

--- a/cawg_identity/src/builder/mod.rs
+++ b/cawg_identity/src/builder/mod.rs
@@ -24,7 +24,9 @@ mod error;
 pub use error::IdentityBuilderError;
 
 pub(crate) mod identity_assertion_builder;
-pub use identity_assertion_builder::{AsyncIdentityAssertionBuilder, IdentityAssertionBuilder};
+pub use identity_assertion_builder::{
+    finalize_identity_assertion, AsyncIdentityAssertionBuilder, IdentityAssertionBuilder,
+};
 
 mod identity_assertion_signer;
 pub use identity_assertion_signer::IdentityAssertionSigner;

--- a/cawg_identity/src/builder/mod.rs
+++ b/cawg_identity/src/builder/mod.rs
@@ -24,9 +24,7 @@ mod error;
 pub use error::IdentityBuilderError;
 
 pub(crate) mod identity_assertion_builder;
-pub use identity_assertion_builder::{
-    finalize_identity_assertion, AsyncIdentityAssertionBuilder, IdentityAssertionBuilder,
-};
+pub use identity_assertion_builder::{AsyncIdentityAssertionBuilder, IdentityAssertionBuilder};
 
 mod identity_assertion_signer;
 pub use identity_assertion_signer::IdentityAssertionSigner;

--- a/cawg_identity/src/x509/x509_credential_holder.rs
+++ b/cawg_identity/src/x509/x509_credential_holder.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// [`SignatureVerifier`]: crate::SignatureVerifier
 /// [§8.2, X.509 certificates and COSE signatures]: https://cawg.io/identity/1.1-draft/#_x_509_certificates_and_cose_signatures
-pub struct X509CredentialHolder(Box<dyn RawSigner + 'static>);
+pub struct X509CredentialHolder(Box<dyn RawSigner + Sync + Send + 'static>);
 
 impl X509CredentialHolder {
     /// Create an `X509CredentialHolder` instance by wrapping an instance of
@@ -37,7 +37,7 @@ impl X509CredentialHolder {
     /// the relevant certificates and private key material.
     ///
     /// [`RawSigner`]: c2pa_crypto::raw_signature::RawSigner
-    pub fn from_raw_signer(signer: Box<dyn RawSigner + 'static>) -> Self {
+    pub fn from_raw_signer(signer: Box<dyn RawSigner + Sync + Send + 'static>) -> Self {
         Self(signer)
     }
 }


### PR DESCRIPTION
## Changes in this pull request

Due to Node.js's memory management, many cawg identity traits need to be reimplemented in the c2pa-bindings Node.js SDK.

* Export finalize_identity_assertion
* Add Send + Sync to CredentialHolder

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
