### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.49.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.49.3...c2pa-v0.49.4)
+_24 April 2025_
+
+### Fixed
+
+* Fix missing Action fields ([#1050](https://github.com/contentauth/c2pa-rs/pull/1050))
+
 ## [0.49.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.49.2...c2pa-v0.49.3)
 _16 April 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
@@ -711,7 +711,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.49.3"
+version = "0.49.4"
 dependencies = [
  "actix",
  "anyhow",
@@ -734,7 +734,7 @@ dependencies = [
  "coset",
  "ed25519-dalek",
  "extfmt",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "glob",
  "hex",
  "hex-literal",
@@ -811,7 +811,7 @@ dependencies = [
  "der",
  "ecdsa",
  "ed25519-dalek",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hex",
  "js-sys",
  "nom",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.6.1"
+version = "0.6.2"
 
 [[package]]
 name = "c2patool"
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1110,7 +1110,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2483,9 +2483,9 @@ checksum = "68cf72bc7b75b6615ffd06bfe6840f3c57e7e4ea615558a2a452f458ebf5551e"
 
 [[package]]
 name = "jiff"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
 dependencies = [
  "jiff-static",
  "log",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2605,9 +2605,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -3459,13 +3459,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3525,13 +3525,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3560,7 +3559,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3698,7 +3697,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3806,7 +3805,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4219,9 +4218,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -4454,7 +4453,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4633,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4840,7 +4839,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "serde",
  "wasm-bindgen",
 ]
@@ -5294,9 +5293,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]

--- a/cawg_identity/CHANGELOG.md
+++ b/cawg_identity/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.12.2...cawg-identity-v0.13.0)
+_24 April 2025_
+
+### Added
+
+* Changes required for Node SDK with Neon ([#1043](https://github.com/contentauth/c2pa-rs/pull/1043))
+
 ## [0.12.2](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.12.1...cawg-identity-v0.12.2)
 _16 April 2025_
 

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.12.2"
+version = "0.13.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -30,9 +30,9 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.49.3" }
+c2pa = { path = "../sdk", version = "0.49.4" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.1" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.2" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"
 coset = "0.3.8"
@@ -62,7 +62,7 @@ wasm-bindgen = "0.2.95"
 
 [dev-dependencies]
 anyhow = "1.0.97"
-c2pa = { path = "../sdk", version = "0.49.3", features = ["file_io"] }
+c2pa = { path = "../sdk", version = "0.49.4", features = ["file_io"] }
 serde = { version = "1.0.197", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,13 +22,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.49.3", features = [
+c2pa = { path = "../sdk", version = "0.49.4", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf"
 ] }
-cawg-identity = { path = "../cawg_identity", version = "0.12.2" }
+cawg-identity = { path = "../cawg_identity", version = "0.13.0" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1.77"
 base64 = "0.22.1"
 bcder = "0.7.3"
 bytes = "1.7.2"
-c2pa-status-tracker = { path = "../status-tracker", version = "0.6.1" }
+c2pa-status-tracker = { path = "../status-tracker", version = "0.6.2" }
 ciborium = "0.2.2"
 const-hex = "1.14"
 const-oid = { version = "0.9.6", optional = true }

--- a/internal/status-tracker/CHANGELOG.md
+++ b/internal/status-tracker/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.6.1...c2pa-status-tracker-v0.6.2)
+_24 April 2025_
+
+### Fixed
+
+* Fix missing Action fields ([#1050](https://github.com/contentauth/c2pa-rs/pull/1050))
+
 ## [0.6.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.6.0...c2pa-status-tracker-v0.6.1)
 _09 April 2025_
 

--- a/internal/status-tracker/Cargo.toml
+++ b/internal/status-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-status-tracker"
-version = "0.6.1"
+version = "0.6.2"
 description = "Status tracking internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.49.3"
+version = "0.49.4"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",
@@ -72,7 +72,7 @@ bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
 c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
-c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.1" }
+c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.2" }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [


### PR DESCRIPTION



## 🤖 New release

* `c2pa-status-tracker`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `c2pa`: 0.49.3 -> 0.49.4 (✓ API compatible changes)
* `cawg-identity`: 0.12.2 -> 0.13.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa-status-tracker`

<blockquote>

## [0.6.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-status-tracker-v0.6.1...c2pa-status-tracker-v0.6.2)

_24 April 2025_

### Fixed

* Fix missing Action fields ([#1050](https://github.com/contentauth/c2pa-rs/pull/1050))
</blockquote>

## `c2pa`

<blockquote>

## [0.49.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.49.3...c2pa-v0.49.4)

_24 April 2025_

### Fixed

* Fix missing Action fields ([#1050](https://github.com/contentauth/c2pa-rs/pull/1050))
</blockquote>

## `cawg-identity`

<blockquote>

## [0.13.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.12.2...cawg-identity-v0.13.0)

_24 April 2025_

### Added

* Changes required for Node SDK with Neon ([#1043](https://github.com/contentauth/c2pa-rs/pull/1043))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).