### PR TITLE
docs: Emphasize, clarify and add more re v2 claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For details on what you can do with the library, see [Using the Rust library](ht
 
 This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
 
-**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](release-notes.md#c2pa-v2-claims).
+**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](docs/release-notes.md#c2pa-v2-claims).
 
 ### New API
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For details on what you can do with the library, see [Using the Rust library](ht
 
 This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
 
-**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](docs/release-notes.md#c2pa-v2-claims).
+**NOTE**: The library now supports [C2PA v2 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](docs/release-notes.md#c2pa-v2-claims).
 
 ### New API
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ For details on what you can do with the library, see [Using the Rust library](ht
 
 ## State of the project
 
-This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.  
+This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
+
+**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](release-notes.md#c2pa-v2-claims).
 
 ### New API
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,15 +24,15 @@ An `AssetType` assertion is now supported.
 
 ### C2PA v2 claims
 
-The library now supports claims as described in the [C2PA 2.1 specification](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and it is not fully implemented yet. 
+**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.
 
-A `claim_version` field is now allowed in a manifest definition for `Builder` and, if set to `2` will generate v2 claims.
+To generate v2 claims, set the `Builder` manifest definition `claim_version` field to `2`.
 
 The `title()` and `format()` methods of both `Manifest` and `Ingredient` objects now return an `Option<String>` because in v2 claims, `title` is optional and `format` does not exist.
 
 In v2 claims, the first `action` must be `c2pa.created` or `c2pa.opened`. 
 
-There are many more checks and status codes added for v2 claims.
+V2 claims have many new checks and status codes.
 
 ### Using the old API
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,7 @@ An `AssetType` assertion is now supported.
 
 ### C2PA v2 claims
 
-**NOTE**: The library now supports [C2PA v2.1 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.
+**NOTE**: The library now supports [C2PA v2 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.
 
 To generate v2 claims, set the `Builder` manifest definition `claim_version` field to `2`.
 


### PR DESCRIPTION
Update docs to discourage production use of 2.1 claims for now, per discussion.
