### PR TITLE
chore: clean up temp directory usage in tests

### DIFF
--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1950,9 +1950,13 @@ mod tests_file_io {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_jpg_with_path() {
+        use crate::utils::io_utils::tempdirectory;
+
         let ap = fixture_path("CA.jpg");
-        let mut folder = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        folder.push("../target/tmp/ingredient");
+        let temp_dir = tempdirectory().expect("Failed to create temp directory");
+        let folder = temp_dir.path().join("ingredient");
+        std::fs::create_dir_all(&folder).expect("Failed to create subdirectory");
+
         let ingredient = Ingredient::from_file_with_folder(ap, folder).expect("from_file");
         println!("ingredient = {ingredient}");
         assert_eq!(ingredient.validation_status(), None);
@@ -1964,7 +1968,7 @@ mod tests_file_io {
             .identifier
             .contains(labels::JPEG_CLAIM_THUMBNAIL));
 
-        // verify  manifest_data exists
+        // verify manifest_data exists
         assert!(ingredient.manifest_data_ref().is_some());
         assert_eq!(ingredient.thumbnail_ref().unwrap().format, "image/jpeg");
         assert!(ingredient

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -912,6 +912,8 @@ pub mod tests {
         reader.to_folder(temp_dir.path())?;
         let path = temp_dir_path(&temp_dir, "manifest.json");
         assert!(path.exists());
+        #[cfg(target_os = "wasi")]
+        crate::utils::io_utils::wasm_remove_dir_all(temp_dir)?;
         Ok(())
     }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6562,7 +6562,7 @@ pub mod tests {
         // test adding to actual image
 
         let tempdir = tempdirectory().expect("temp dir");
-        let output_path = tempdir.into_path();
+        let output_path = tempdir.path();
 
         // search folders for init segments
         for init in glob::glob(
@@ -6594,7 +6594,10 @@ pub mod tests {
                     let signer = test_signer(SigningAlg::Ps256);
 
                     // add manifest based on
-                    let new_output_path = output_path.join(init_dir.file_name().unwrap());
+                    // Use Tempdir for automatic cleanup
+                    let new_subdir = tempfile::TempDir::new_in(output_path)
+                        .expect("Failed to create temp subdir");
+                    let new_output_path = new_subdir.path().join(init_dir.file_name().unwrap());
                     store
                         .save_to_bmff_fragmented(
                             p.as_path(),

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -175,6 +175,21 @@ pub(crate) fn tempdirectory() -> Result<TempDir> {
     return tempdir().map_err(Error::IoError);
 }
 
+#[allow(unused)]
+#[cfg(target_os = "wasi")]
+pub fn wasm_remove_dir_all<P: AsRef<std::path::Path>>(path: P) -> Result<()> {
+    for entry in std::fs::read_dir(&path)? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            std::fs::remove_file(entry.path())?;
+        } else if entry.path().is_dir() {
+            wasm_remove_dir_all(entry.path())?;
+        }
+    }
+    std::fs::remove_dir_all(&path)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -207,9 +207,7 @@ pub fn fixture_path(file_name: &str) -> PathBuf {
 /// returns a path to a file in the temp_dir folder
 // note, you must pass TempDir from the caller's context
 pub fn temp_dir_path(temp_dir: &TempDir, file_name: &str) -> PathBuf {
-    let mut path = PathBuf::from(temp_dir.path());
-    path.push(file_name);
-    path
+    temp_dir.path().join(file_name)
 }
 
 // copies a fixture to a temp file and returns path to copy

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -67,7 +67,7 @@ fn test_builder_fragmented() -> Result<()> {
     let manifest_def = include_str!("fixtures/simple_manifest.json");
     let mut builder = Builder::from_json(manifest_def)?;
     let tempdir = tempdirectory().expect("temp dir");
-    let output_path = tempdir.into_path();
+    let output_path = tempdir.path();
     let mut init_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     init_path.push("tests/fixtures/bunny/**/BigBuckBunny_2s_init.mp4");
     let pattern = init_path.as_os_str().to_str().unwrap();


### PR DESCRIPTION
A few of the tests were interfering with TempDir's automatic cleanup.

