### PR TITLE
fix: enable post_validate_async for WASI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "treeline",
  "url",
  "wasi 0.14.2+wasi-0.2.4",
+ "wstd",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.14"
+wstd = "0.5"
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,6 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use c2pa::{Builder, ClaimGeneratorInfo, Error, Ingredient, ManifestDefinition, Reader, Signer};
-#[cfg(not(target_os = "wasi"))]
 use cawg_identity::validator::CawgValidator;
 use clap::{Parser, Subcommand};
 use log::debug;
@@ -36,6 +35,8 @@ use signer::SignConfig;
 #[cfg(not(target_os = "wasi"))]
 use tokio::runtime::Runtime;
 use url::Url;
+#[cfg(target_os = "wasi")]
+use wstd::runtime::block_on;
 
 use crate::{
     callback_signer::{CallbackSigner, CallbackSignerConfig, ExternalProcessRunner},
@@ -530,7 +531,7 @@ fn validate_cawg(reader: &mut Reader) -> Result<()> {
     }
     #[cfg(target_os = "wasi")]
     {
-        Ok(())
+        block_on(reader.post_validate_async(&CawgValidator {})).map_err(anyhow::Error::from)
     }
 }
 


### PR DESCRIPTION
Verified with:
`wasmtime -S cli -S http --dir . --dir cawg_identity/src/tests/fixtures/claim_aggregation target/wasm32-wasip2/debug/c2patool.wasm cawg_identity/src/tests/fixtures/claim_aggregation/adobe_connected_identities.jpg`
