### PR TITLE
fix: Ingredient from_stream/memory not loading remote manifests

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1234,6 +1234,7 @@ mod tests {
 
     #[cfg(feature = "file_io")]
     const TEST_IMAGE_CLEAN: &[u8] = include_bytes!("../tests/fixtures/IMG_0003.jpg");
+    const TEST_IMAGE_CLOUD: &[u8] = include_bytes!("../tests/fixtures/cloud.jpg");
     const TEST_IMAGE: &[u8] = include_bytes!("../tests/fixtures/CA.jpg");
     const TEST_THUMBNAIL: &[u8] = include_bytes!("../tests/fixtures/thumbnail.jpg");
 
@@ -1950,4 +1951,47 @@ mod tests {
 
         // println!("{manifest_store}");
     }
+
+    #[test]
+    /// example of creating a builder directly with a [`ManifestDefinition`]
+    fn test_add_cloud_ingredient() {
+        let mut input = Cursor::new(TEST_IMAGE_CLEAN);
+        let mut cloud_image = Cursor::new(TEST_IMAGE_CLOUD);
+
+        let definition = ManifestDefinition {
+            claim_generator_info: [ClaimGeneratorInfo::default()].to_vec(),
+            format: "image/jpeg".to_string(),
+            title: Some("Test_Manifest".to_string()),
+            ..Default::default()
+        };
+
+        let mut builder = Builder {
+            definition,
+            ..Default::default()
+        };
+
+        builder
+            .add_ingredient_from_stream(parent_json(), "image/jpeg", &mut cloud_image)
+            .unwrap();
+
+        builder
+            .add_assertion("org.test.assertion", &"assertion".to_string())
+            .unwrap();
+
+        let signer = test_signer(SigningAlg::Ps256);
+        // Embed a manifest using the signer.
+        let mut output = Cursor::new(Vec::new());
+        builder
+            .sign(signer.as_ref(), "jpeg", &mut input, &mut output)
+            .expect("builder sign");
+
+        output.set_position(0);
+
+        let reader = Reader::from_stream("jpeg", &mut output).expect("from_bytes");
+        println!("reader = {reader}");
+        let m = reader.active_manifest().unwrap();
+        assert_eq!(m.ingredients().len(), 1);
+        assert!(m.ingredients()[0].active_manifest().is_some());
+    }
+
 }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1232,7 +1232,6 @@ mod tests {
         .to_string()
     }
 
-    #[cfg(feature = "file_io")]
     const TEST_IMAGE_CLEAN: &[u8] = include_bytes!("../tests/fixtures/IMG_0003.jpg");
     const TEST_IMAGE_CLOUD: &[u8] = include_bytes!("../tests/fixtures/cloud.jpg");
     const TEST_IMAGE: &[u8] = include_bytes!("../tests/fixtures/CA.jpg");
@@ -1993,5 +1992,4 @@ mod tests {
         assert_eq!(m.ingredients().len(), 1);
         assert!(m.ingredients()[0].active_manifest().is_some());
     }
-
 }

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -40,7 +40,6 @@ use crate::{
         self,
         labels::{assertion_label_from_uri, manifest_label_from_uri, to_assertion_uri},
     },
-    jumbf_io::load_jumbf_from_stream,
     resource_store::{skip_serializing_resources, ResourceRef, ResourceStore},
     store::Store,
     utils::xmp_inmemory_utils::XmpInfo,
@@ -870,7 +869,7 @@ impl Ingredient {
         let mut validation_log = StatusTracker::default();
 
         // retrieve the manifest bytes from embedded, sidecar or remote and convert to store if found
-        let jumbf_stream = load_jumbf_from_stream(format, stream);
+        let jumbf_stream = Store::load_jumbf_from_stream(format, stream);
 
         // We can't use functional combinators since we can't use async callbacks (https://github.com/rust-lang/rust/issues/62290)
         let (result, manifest_bytes) = if let Ok(manifest_bytes) = jumbf_stream {


### PR DESCRIPTION
Builder::add_stream was lot fetching remote ingredient manifests when that feature is enabled.
This corrects that and adds a test for it.
