### PR TITLE
docs: Replace old c2patool release notes with CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ You can also read the documentation directly in GitHub:
 
 - [Usage](https://github.com/contentauth/c2pa-rs/blob/main/docs/usage.md)
 - [Supported formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md)
-- [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
+- [Change log](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
 - [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/docs/project-contributions.md)
 
 - [C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/README.md) documentation:
   - [Using C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/usage.md)
   - [Manifest definition file](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/manifest.md)
   - [Using an X.509 certificate](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/x_509.md)
-  - [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/release-notes.md)
+  - [Change log](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can also read the documentation directly in GitHub:
 
 - [Usage](https://github.com/contentauth/c2pa-rs/blob/main/docs/usage.md)
 - [Supported formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md)
-- [Change log](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
+- [Release notes](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-notes.md)
 - [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/docs/project-contributions.md)
 
 - [C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/README.md) documentation:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,9 @@
+<div class="github-only" >
+  
 # Changelog
+</div>
 
-All changes to this project are documented in this file.  For a high-level summary of changes, see the [Release Notes](../docs/release-notes.md).
+All changes to C2PA Tool are documented in this file.  For additional information on versions 0.9.x and earlier, see the [Archived release motes](../docs/release-notes.md).
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,7 @@ For a simple example of calling c2patool from a Node.js server application, see 
 - [Using C2PA Tool](./docs/usage.md)
 - [Manifest definition file](./docs/manifest.md)
 - [Using an X.509 certificate](./docs/x_509.md)
-- [Release notes](./docs/release-notes.md)
+- [Change log / release notes](./CHANGELOG.md)
 - [Contributing to the project](./docs/project-contributions.md)
 
 </div>

--- a/cli/docs/release-notes.md
+++ b/cli/docs/release-notes.md
@@ -1,8 +1,8 @@
-# C2PA Tool release notes 
+# C2PA Tool release notes - ARCHIVE
 
-This page highlights noteworthy changes in each release of the `c2patool` CLI.
+This page highlights noteworthy changes in each release of the `c2patool` CLI.  
 
-Refer to the [CHANGELOG](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md) for detailed Git changes.
+NOTE: This page provides information on releases 0.9.x and earlier and is not being updated.  Refer to the [CHANGELOG](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md) for information on more recent releases.
 
 ## 0.9.x
 

--- a/cli/docs/release-notes.md
+++ b/cli/docs/release-notes.md
@@ -1,8 +1,10 @@
 # C2PA Tool release notes - ARCHIVE
 
-This page highlights noteworthy changes in each release of the `c2patool` CLI.  
+NOTE: This page provides information on releases 0.9.x and earlier and is not being updated.  It will be removed in the near future.
 
-NOTE: This page provides information on releases 0.9.x and earlier and is not being updated.  Refer to the [CHANGELOG](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md) for information on more recent releases.
+Refer to the [CHANGELOG](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md) for information on more recent releases.
+
+This page highlights noteworthy changes in each release of the `c2patool` CLI.  
 
 ## 0.9.x
 


### PR DESCRIPTION
## Changes in this pull request

The C2PA Tool release notes have not been updated for a long time (since v 0.9), and the CHANGELOG really contains the most recent release notes.  This is already reflected in the [open source doc site](https://opensource.contentauthenticity.org/docs/c2patool-rns).

This PR changes links to point to the CHANGELOG instead of the old release notes, and adds a small caveat to the top of the (old) release notes,  along with a few other minor tweaks.

