### PR TITLE
chore: Remove description format enforcement from .commitlintrc.yml

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,11 +11,6 @@ rules:
   description-empty:
     level: error
 
-  # The commit description must not end with trailing white space
-  description-format:
-    level: error
-    format: ^[\w ]+[\s\S]*$
-
   # Description should be <70 chars
   description-max-length:
     level: warning

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -105,7 +105,7 @@ If `scope` is omitted, the parenthesis must also be omitted.
 
 The following items are not enforced, but we ask that you observe the following preferences in `description`:
 
-* The entire description should be written and capitalized as an English-language sentence, except (as noted earlier) that the trailing period must be omitted.
+* The entire description should be written and capitalized as an English-language sentence, except that the trailing period should be omitted.
 * Any acronyms such as JSON or YAML should be capitalized as per common usage in English-language sentences.
 
 The "body" of the commit message (everything after the PR title) is not subject to any restrictions and may be empty. GitHub, by default, will create a bullet list of the commits that went into the PR. It is _recommended,_ but not enforced, that you delete this list (because it typically contains a lot of signal noise) and either replace it with additional context of why you made the change or leave it empty.


### PR DESCRIPTION
Per feedback on https://github.com/contentauth/c2pa-rs/pull/1057#discussion_r2067457725, relaxing restrictions on commit description format.