### PR TITLE
feat(c2pa_rs): Support setting the Ingredient manifest_data field for remote manifests using Builder.

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1952,14 +1952,6 @@ mod tests {
         // println!("{manifest_store}");
     }
 
-    #[test]
-    fn test_composed_manifest() {
-        let manifest: &[u8; 4] = b"abcd";
-        let format = "image/jpeg";
-        let composed = Builder::composed_manifest(manifest, format).unwrap();
-        assert_eq!(composed.len(), 16);
-    }
-
     #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
     #[cfg_attr(
         all(target_arch = "wasm32", not(target_os = "wasi")),

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -879,10 +879,6 @@ impl Ingredient {
         let (result, manifest_bytes) = if let Ok(manifest_bytes) = jumbf_result {
             let jumbf_store = Store::from_jumbf(&manifest_bytes, &mut validation_log);
             let result = if let Ok(mut store) = jumbf_store {
-                // if we don't have an active manifest, set it to the one we just loaded
-                // if self.active_manifest.is_none() {
-                //     self.active_manifest = store.provenance_label();
-                // };
                 if _sync {
                     match store.verify_from_stream(stream, format, &mut validation_log) {
                         Ok(_) => Ok(store),
@@ -1154,22 +1150,6 @@ impl Ingredient {
         // this is how any existing claims are added to the new store
         let (active_manifest, claim_signature) = match self.manifest_data_ref() {
             Some(resource_ref) => {
-                // let manifest_label = self
-                //     .active_manifest
-                //     .clone()
-                //     .ok_or(Error::IngredientNotFound)?;
-
-                //if this is the parent ingredient then apply any redactions, converting from labels to uris
-                // let redactions = match self.is_parent() {
-                //     true => redactions.as_ref().map(|redactions| {
-                //         redactions
-                //             .iter()
-                //             .map(|r| to_assertion_uri(&manifest_label, r))
-                //             .collect()
-                //     }),
-                //     false => None,
-                // };
-
                 // get the c2pa manifest bytes
                 let manifest_data = get_resource(&resource_ref.identifier)?;
 
@@ -1209,7 +1189,7 @@ impl Ingredient {
                             });
                     }
                 }
-                // generate c2pa_manifest hashed_uri
+                // generate c2pa_manifest hashed_uris
                 (
                     Some(crate::hashed_uri::HashedUri::new(
                         uri,

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3741,7 +3741,6 @@ impl Store {
     /// data: jumbf data block
     pub fn load_ingredient_to_claim(
         claim: &mut Claim,
-        provenance_label: &str,
         data: &[u8],
         redactions: Option<Vec<String>>,
     ) -> Result<Store> {
@@ -3756,7 +3755,7 @@ impl Store {
             return Err(Error::OtherError("ingredient version too new".into()));
         }
 
-        claim.add_ingredient_data(provenance_label, store.claims.clone(), redactions)?;
+        claim.add_ingredient_data(pc.label(), store.claims.clone(), redactions)?;
         Ok(store)
     }
 }


### PR DESCRIPTION
When the fetch_remote_manifests feature is disabled, as in wasm builds, we need a way with the builder API to set the remote manifest_data that has been fetched in some other way. This can now be done by setting the manifest_data field in the ingredient definition. 
manifest_data {
    "format": "application/c2pa",
    "identifier": "my_identifier"
 }
 
 Then use builder.add_resource_stream("my_identifier", c2pa_data)  to add the binary resource before signing.
 
    