### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "actix",
  "asn1-rs",

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.13.0"
+version = "0.14.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -31,7 +31,7 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 async-trait = "0.1.78"
 base64 = "0.22.1"
 c2pa = { path = "../sdk", version = "0.50.0" }
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.9.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.2" }
 chrono = { version = "0.4.38", features = ["serde"] }
 ciborium = "0.2.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,7 +29,7 @@ c2pa = { path = "../sdk", version = "0.50.0", features = [
 	"pdf"
 ] }
 cawg-identity = { path = "../cawg_identity", version = "0.14.0" }
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.9.0" }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"
 glob = "0.3.1"

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.2...c2pa-crypto-v0.9.0)
+_14 May 2025_
+
+### Added
+
+* [**breaking**] Improve error handling for CAWG ICA validation ([#1011](https://github.com/contentauth/c2pa-rs/pull/1011))
+
+### Fixed
+
+* Chore to fix unexpected build error
+
 ## [0.8.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.1...c2pa-crypto-v0.8.2)
 _09 April 2025_
 

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.8.2"
+version = "0.9.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,7 +71,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-crypto = { path = "../internal/crypto", version = "0.8.2" }
+c2pa-crypto = { path = "../internal/crypto", version = "0.9.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.2" }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"


### PR DESCRIPTION



## 🤖 New release

* `c2pa-crypto`: 0.8.2 -> 0.9.0 (✓ API compatible changes)
* `cawg-identity`: 0.13.0 -> 0.14.0 (✓ API compatible changes)
* `c2pa-c`: 0.49.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa-crypto`

<blockquote>

## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.2...c2pa-crypto-v0.9.0)

_14 May 2025_

### Added

* [**breaking**] Improve error handling for CAWG ICA validation ([#1011](https://github.com/contentauth/c2pa-rs/pull/1011))

### Fixed

* Chore to fix unexpected build error
</blockquote>

## `cawg-identity`

<blockquote>

## [0.14.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.13.0...cawg-identity-v0.14.0)

_14 May 2025_

### Added

* [**breaking**] Improve error handling for CAWG ICA validation ([#1011](https://github.com/contentauth/c2pa-rs/pull/1011))

### Documented

* Initial docs for CAWG identity ([#1030](https://github.com/contentauth/c2pa-rs/pull/1030))
</blockquote>

## `c2pa-c`

<blockquote>

## [0.49.5](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-v0.49.5)

_14 May 2025_

### Added

* Adds c_api for dynamic library releases ([#1047](https://github.com/contentauth/c2pa-rs/pull/1047))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).