### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.51.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.50.0...c2pa-v0.51.0)
+_14 May 2025_
+
+### Added
+
+* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))
+
+### Fixed
+
+* Trigger re-publish of c2pa crate
+
 ## [0.50.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.49.5...c2pa-v0.50.0)
 _14 May 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -880,7 +880,7 @@ version = "0.6.2"
 
 [[package]]
 name = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "cawg-identity"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/c_api/Cargo.toml
+++ b/c_api/Cargo.toml
@@ -15,7 +15,7 @@ json_api = ["c2pa/v1_api"]
 [dependencies]
 tokio = { version = "1.36", features = ["rt-multi-thread","rt"] }
 cawg-identity = { path = "../cawg_identity" }
-c2pa = { path = "../sdk", version = "0.50.0", features = [
+c2pa = { path = "../sdk", version = "0.51.0", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",

--- a/cawg_identity/Cargo.toml
+++ b/cawg_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cawg-identity"
-version = "0.13.0"
+version = "0.14.0"
 description = "Rust SDK for CAWG (Creator Assertions Working Group) identity assertion"
 authors = [
     "Eric Scouten <scouten@adobe.com>",
@@ -30,7 +30,7 @@ v1_api = ["c2pa/v1_api", "c2pa/file_io"]
 [dependencies]
 async-trait = "0.1.78"
 base64 = "0.22.1"
-c2pa = { path = "../sdk", version = "0.50.0" }
+c2pa = { path = "../sdk", version = "0.51.0" }
 c2pa-crypto = { path = "../internal/crypto", version = "0.9.0" }
 c2pa-status-tracker = { path = "../internal/status-tracker", version = "0.6.2" }
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -61,7 +61,7 @@ reqwest = { version = "0.12.8", default-features = false, features = ["rustls-tl
 wasm-bindgen = "0.2.95"
 
 [dev-dependencies]
-c2pa = { path = "../sdk", version = "0.50.0", features = ["file_io"] }
+c2pa = { path = "../sdk", version = "0.51.0", features = ["file_io"] }
 serde = { version = "1.0.197", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.17.0)
+_14 May 2025_
+
+### Added
+
+* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))
+
+### Documented
+
+* Replace old c2patool release notes with CHANGELOG ([#1063](https://github.com/contentauth/c2pa-rs/pull/1063))
+
 ## [0.16.6](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.16.6)
 _14 May 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.50.0", features = [
+c2pa = { path = "../sdk", version = "0.51.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.50.0"
+version = "0.51.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.50.0 -> 0.51.0 (✓ API compatible changes)
* `cawg-identity`: 0.13.0 -> 0.14.0 (⚠ API breaking changes)
* `c2pa-c`: 0.49.5
* `c2patool`: 0.16.5 -> 0.17.0

### ⚠ `cawg-identity` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum cawg_identity::builder::IdentityBuilderError, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/error.rs:20
  enum cawg_identity::ValidationError, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/validation_error.rs:26
  enum cawg_identity::claim_aggregation::IcaValidationError, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/claim_aggregation/ica_validation_error.rs:28

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct cawg_identity::claim_aggregation::IcaSignatureVerifier, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/claim_aggregation/ica_signature_verifier.rs:39
  struct cawg_identity::validator::CawgValidator, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/validator.rs:28
  struct cawg_identity::builder::IdentityAssertionSigner, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/identity_assertion_signer.rs:26
  struct cawg_identity::IdentityAssertion, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/assertion.rs:47
  struct cawg_identity::builder::AsyncIdentityAssertionBuilder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/identity_assertion_builder.rs:137
  struct cawg_identity::x509::X509SignatureVerifier, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/x509/x509_signature_verifier.rs:34
  struct cawg_identity::builder::AsyncIdentityAssertionSigner, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/async_identity_assertion_signer.rs:26
  struct cawg_identity::builder::IdentityAssertionBuilder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/identity_assertion_builder.rs:37
  struct cawg_identity::claim_aggregation::IdentityProvider, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/claim_aggregation/ica_credential.rs:172
  struct cawg_identity::BuiltInSignatureVerifier, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/built_in_signature_verifier.rs:31
  struct cawg_identity::x509::AsyncX509CredentialHolder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/x509/async_x509_credential_holder.rs:32
  struct cawg_identity::x509::X509CredentialHolder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/x509/x509_credential_holder.rs:30
  struct cawg_identity::claim_aggregation::VerifiedIdentity, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/claim_aggregation/ica_credential.rs:88
  struct cawg_identity::SignerPayload, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/signer_payload.rs:34
  struct cawg_identity::x509::X509SignatureInfo, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/x509/x509_signature_verifier.rs:100

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_missing.ron

Failed in:
  trait cawg_identity::builder::CredentialHolder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/credential_holder.rs:29
  trait cawg_identity::ToCredentialSummary, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/signature_verifier.rs:100
  trait cawg_identity::builder::AsyncCredentialHolder, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/builder/credential_holder.rs:64
  trait cawg_identity::SignatureVerifier, previously in file /tmp/.tmpxWyJfe/cawg-identity/src/identity_assertion/signature_verifier.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.51.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.50.0...c2pa-v0.51.0)

_14 May 2025_

### Added

* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))

### Fixed

* Trigger re-publish of c2pa crate
</blockquote>

## `cawg-identity`

<blockquote>

## [0.14.0](https://github.com/contentauth/c2pa-rs/compare/cawg-identity-v0.13.0...cawg-identity-v0.14.0)

_14 May 2025_

### Added

* [**breaking**] Improve error handling for CAWG ICA validation ([#1011](https://github.com/contentauth/c2pa-rs/pull/1011))

### Documented

* Initial docs for CAWG identity ([#1030](https://github.com/contentauth/c2pa-rs/pull/1030))
</blockquote>

## `c2pa-c`

<blockquote>

## [0.49.5](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-v0.49.5)

_14 May 2025_

### Added

* Adds c_api for dynamic library releases ([#1047](https://github.com/contentauth/c2pa-rs/pull/1047))
</blockquote>

## `c2patool`

<blockquote>

## [0.17.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.17.0)

_14 May 2025_

### Added

* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))

### Documented

* Replace old c2patool release notes with CHANGELOG ([#1063](https://github.com/contentauth/c2pa-rs/pull/1063))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).