### PR TITLE
fix: Switch zip dependency to a non-yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2601,6 +2602,15 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5518,18 +5528,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
  "indexmap 2.9.0",
  "memchr",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zopfli"

--- a/c_api/Cargo.toml
+++ b/c_api/Cargo.toml
@@ -24,7 +24,7 @@ scopeguard = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.64"
-zip = { version = "2.6.1", default-features = false, features = ["deflate"] }
+zip = { version = "3.0.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3.7.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -133,7 +133,7 @@ url = "2.5.3"
 uuid = { version = "=1.12.0", features = ["serde", "v4"] }
 x509-parser = "0.16.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
-zip = { version = "2.4.1", default-features = false }
+zip = { version = "3.0.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rsa = { version = "0.9.6", features = ["sha2"] }


### PR DESCRIPTION
Appears the major version bump (2.6.1 -> 3.0.0) was triggered by removal of a crate feature that we weren't using. Other changes appear minimal.