### PR TITLE
Allow timestamp authority to respond with any successful HTTP Response Code

### DIFF
--- a/internal/crypto/src/time_stamp/http_request.rs
+++ b/internal/crypto/src/time_stamp/http_request.rs
@@ -86,7 +86,8 @@ fn time_stamp_request_http(
         .set("Content-Type", HTTP_CONTENT_TYPE_REQUEST)
         .send_bytes(&body)?;
 
-    if response.status() == 200 && response.content_type() == HTTP_CONTENT_TYPE_RESPONSE {
+    let response_status_is_ok = response.status() >= 200 && response.status() < 300;
+    if response_status_is_ok && response.content_type() == HTTP_CONTENT_TYPE_RESPONSE {
         let len = response
             .header("Content-Length")
             .and_then(|s| s.parse::<usize>().ok())


### PR DESCRIPTION
## Changes in this pull request
There's no requirement that I could find that timestamp servers respond with 200 (e.g. 201 would be valid) -- we'd like to loosen the client validation to allow for any successful response code.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
