### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.52.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.51.1...c2pa-v0.52.0)
+_16 May 2025_
+
+### Added
+
+* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
+* [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
+
 ## [0.51.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.51.0...c2pa-v0.51.1)
 _16 May 2025_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ _16 May 2025_
 
 ### Added
 
-* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
 * [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
 
 ## [0.51.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.51.0...c2pa-v0.51.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.51.1"
+version = "0.52.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "c2pa-status-tracker"
@@ -841,7 +841,7 @@ version = "0.6.2"
 
 [[package]]
 name = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]

--- a/c_api/Cargo.toml
+++ b/c_api/Cargo.toml
@@ -14,7 +14,7 @@ json_api = ["c2pa/v1_api"]
 
 [dependencies]
 tokio = { version = "1.36", features = ["rt-multi-thread","rt"] }
-c2pa = { path = "../sdk", version = "0.51.1", features = [
+c2pa = { path = "../sdk", version = "0.52.0", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.51.1", features = [
+c2pa = { path = "../sdk", version = "0.52.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.9.0...c2pa-crypto-v0.10.0)
+_16 May 2025_
+
+### Added
+
+* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
+* [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
+
 ## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.2...c2pa-crypto-v0.9.0)
 _14 May 2025_
 

--- a/internal/crypto/CHANGELOG.md
+++ b/internal/crypto/CHANGELOG.md
@@ -11,7 +11,6 @@ _16 May 2025_
 
 ### Added
 
-* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
 * [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
 
 ## [0.9.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.8.2...c2pa-crypto-v0.9.0)

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.9.0"
+version = "0.10.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.51.1"
+version = "0.52.0"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.51.1 -> 0.52.0 (✓ API compatible changes)
* `c2patool`: 0.16.5 -> 0.17.0
* `c2pa-crypto`: 0.9.0 -> 0.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.52.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.51.1...c2pa-v0.52.0)

_16 May 2025_

### Added

* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
* [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
</blockquote>

## `c2patool`

<blockquote>

## [0.17.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.17.0)

_14 May 2025_

### Added

* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))

### Documented

* Replace old c2patool release notes with CHANGELOG ([#1063](https://github.com/contentauth/c2pa-rs/pull/1063))
</blockquote>

## `c2pa-crypto`

<blockquote>

## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.9.0...c2pa-crypto-v0.10.0)

_16 May 2025_

### Added

* Merge c2pa-crypto crate into c2pa ([#1107](https://github.com/contentauth/c2pa-rs/pull/1107))
* [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).