### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-crypto"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "c2pa-status-tracker"
@@ -841,7 +841,7 @@ version = "0.6.2"
 
 [[package]]
 name = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Since version 0.10.0, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.17.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.17.0)
-_14 May 2025_
+_16 May 2025_
 
 ### Added
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.16.5"
+version = "0.17.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",

--- a/internal/crypto/Cargo.toml
+++ b/internal/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-crypto"
-version = "0.9.0"
+version = "0.10.0"
 description = "Cryptography internals for c2pa-rs crate"
 authors = [
     "Maurice Fisher <mfisher@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2patool`: 0.16.5 -> 0.17.0
* `c2pa-crypto`: 0.9.0 -> 0.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2patool`

<blockquote>

## [0.17.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.16.5...c2patool-v0.17.0)

_14 May 2025_

### Added

* [**breaking**] Merge CAWG identity SDK into main C2PA crate ([#1089](https://github.com/contentauth/c2pa-rs/pull/1089))

### Documented

* Replace old c2patool release notes with CHANGELOG ([#1063](https://github.com/contentauth/c2pa-rs/pull/1063))
</blockquote>

## `c2pa-crypto`

<blockquote>

## [0.10.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-crypto-v0.9.0...c2pa-crypto-v0.10.0)

_16 May 2025_

### Added

* [**breaking**] Merge c2pa-crypto crate into core c2pa crate ([#1099](https://github.com/contentauth/c2pa-rs/pull/1099))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).