### PR TITLE
feat: Make OpenSSL a default feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,31 @@ on:
     - cron: "0 18 * * 1,4,6" # 1800 UTC every Monday, Thursday, Saturday
 
 jobs:
+  get-features:
+    name: Get features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Get all features
+        run: |
+          cargo metadata --format-version=1 | jq -r '[.packages[] | select(.name=="c2pa" or .name=="c2pa-c") | .features | keys | map(select(. != "default")) | .[]] | unique | join(" ")' > features.txt
+
+      - name: Upload features
+        uses: actions/upload-artifact@v4
+        with:
+          name: features
+          path: features.txt
+
   tests:
     name: Unit tests
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -36,6 +59,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -45,13 +73,40 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Run tests with rust_native_crypto
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          $features = Get-Content features.txt
+          $features = $features -replace 'openssl', ''
+          cargo test --no-default-features --features "$features"
+
+      - name: Run tests with rust_native_crypto
+        if: runner.os != 'Windows'
+        run: |
+          FEATURES=$(cat features.txt | sed 's/openssl//g')
+          cargo test --no-default-features --features "$FEATURES"
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate code coverage
+      - name: Generate code coverage for openssl
         env:
           RUST_BACKTRACE: "1"
-        run: cargo llvm-cov --lib --all-features --lcov --output-path lcov.info
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          $features = Get-Content features.txt
+          $features = $features -replace 'rust_native_crypto', ''
+          cargo llvm-cov --lib --features "$features" --lcov --output-path lcov.info
+
+      - name: Generate code coverage for openssl
+        env:
+          RUST_BACKTRACE: "1"
+        if: runner.os != 'Windows'
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -69,6 +124,7 @@ jobs:
 
   tests-cli:
     name: Unit tests (c2patool)
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -88,6 +144,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -103,7 +164,20 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-        run: cargo llvm-cov --bins --all-features --lcov --output-path lcov.info
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          $features = Get-Content features.txt
+          $features = $features -replace 'rust_native_crypto', ''
+          cargo llvm-cov --bins --features "$features" --lcov --output-path lcov.info
+
+      - name: Generate code coverage
+        env:
+          RUST_BACKTRACE: "1"
+        if: runner.os != 'Windows'
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo llvm-cov --bins --features "$FEATURES" --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -118,9 +192,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+          files: lcov-*.info
 
   doc-tests:
     name: Doc tests (requires nightly Rust)
+    needs: get-features
     # TODO: Remove this once cargo-llvm-cov can run doc tests and generate
     # coverage. (This requires a bug fix that is only available in nightly Rust.)
     # Watch https://github.com/taiki-e/cargo-llvm-cov/issues/2
@@ -144,6 +220,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       # - name: Install Rust toolchain
@@ -163,13 +244,25 @@ jobs:
       # doc tests.
 
       - name: Run doc tests (COVERAGE DISABLED)
-        run:
-          cargo test --workspace --all-features --doc
-      
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          $features = Get-Content features.txt
+          $features = $features -replace 'rust_native_crypto', ''
+          cargo test --workspace --features "$features" --doc
+
+      - name: Run doc tests (COVERAGE DISABLED)
+        if: runner.os != 'Windows'
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo test --workspace --features "$FEATURES" --doc
+
       # - name: Generate code coverage
       #   env:
       #     RUST_BACKTRACE: "1"
-      #   run: cargo llvm-cov --workspace --all-features --lcov --doctests --output-path lcov.info
+      #   run: |
+      #   FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+      #   cargo llvm-cov --workspace --features "$FEATURES" --lcov --doctests --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -211,6 +304,7 @@ jobs:
         
   tests-cross:
     name: Unit tests
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -230,6 +324,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -247,10 +346,13 @@ jobs:
       # environment. (A PR to fix this would be welcomed!)
 
       - name: Run unit tests (cross build)
-        run: cross test --all-targets --all-features --target ${{ matrix.target }}
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }}
 
   tests-wasm:
     name: Unit tests (Wasm)
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -270,12 +372,13 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Run Wasm tests
-        run: wasm-pack test --chrome --headless
+      - name: Run Wasm tests (c2pa-rs)
+        run: wasm-pack test --chrome --headless --no-default-features --features rust_native_crypto
         working-directory: ./sdk
 
   tests-wasi:
     name: Unit tests (WASI)
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -288,6 +391,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
 
         # nightly required for testing until this issue is resolved:
         # wasip2 target should not conditionally feature gate stdlib APIs rust-lang/rust#130323 https://github.com/rust-lang/rust/issues/130323
@@ -326,10 +434,13 @@ jobs:
           CC: /opt/wasi-sdk/bin/clang
           WASI_SDK_PATH: /opt/wasi-sdk
           RUST_MIN_STACK: 16777216
-        run: cargo +nightly-2025-05-14 test --target wasm32-wasip2 -p c2pa -p c2patool --all-features
+        run: |
+          FEATURES=$(cat features.txt | sed 's/openssl//g' | sed 's/json_api//g')
+          cargo +nightly-2025-05-14 test --target wasm32-wasip2 -p c2pa -p c2patool --features "$FEATURES" --no-default-features
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -348,6 +459,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -362,10 +478,22 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: cargo +nightly-2025-01-24 test -Z direct-minimal-versions --all-targets --all-features
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          $features = Get-Content features.txt
+          $features = $features -replace 'rust_native_crypto', ''
+          cargo +nightly-2025-01-24 test -Z direct-minimal-versions --all-targets --features "$features"
+
+      - name: Run tests
+        if: runner.os != 'Windows'
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo +nightly-2025-01-24 test -Z direct-minimal-versions --all-targets --features "$FEATURES"
 
   clippy_check:
     name: Clippy
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -379,6 +507,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -388,7 +521,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
-        run: cargo clippy --all-features --all-targets -- -Dwarnings
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo clippy --features "$FEATURES" --all-targets -- -Dwarnings
 
   cargo_fmt:
     name: Enforce Rust code format
@@ -415,6 +550,7 @@ jobs:
 
   docs_rs:
     name: Preflight docs.rs build
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -428,6 +564,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install nightly Rust toolchain
         # Nightly is used here because the docs.rs build
         # uses nightly and we use doc_cfg features that are
@@ -439,7 +580,9 @@ jobs:
         # environment. The goal is to fail PR validation
         # if the subsequent release would result in a failed
         # documentation build on docs.rs.
-        run: cargo +nightly doc --workspace --all-features --no-deps
+        run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
+          cargo +nightly doc --workspace --features "$FEATURES" --no-deps
         env:
           RUSTDOCFLAGS: --cfg docsrs
           DOCS_RS: 1
@@ -476,6 +619,7 @@ jobs:
 
   unused_deps:
     name: Check for unused dependencies
+    needs: get-features
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
@@ -492,12 +636,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download features
+        uses: actions/download-artifact@v4
+        with:
+          name: features
+
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Run cargo-udeps
         run: |
+          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           mv ./.github/temp-bin/cargo-udeps /home/runner/.cargo/bin/cargo-udeps
-          cargo udeps --all-targets --all-features
+          cargo udeps --all-targets --features "$FEATURES"
           # NOTE: Using pre-built binary as a workaround for
           # https://github.com/aig787/cargo-udeps-action/issues/6.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   get-features:
     name: Get features
     runs-on: ubuntu-latest
+    outputs:
+      rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
+      openssl-features: ${{ steps.get-features.outputs.openssl-features }}
+      wasi-features: ${{ steps.get-features.outputs.wasi-features }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,14 +32,15 @@ jobs:
           toolchain: stable
 
       - name: Get all features
+        id: get-features
         run: |
-          cargo metadata --format-version=1 | jq -r '[.packages[] | select(.name=="c2pa" or .name=="c2pa-c") | .features | keys | map(select(. != "default")) | .[]] | unique | join(" ")' > features.txt
-
-      - name: Upload features
-        uses: actions/upload-artifact@v4
-        with:
-          name: features
-          path: features.txt
+          FEATURES=$(cargo metadata --format-version=1 | jq -r '[.packages[] | select(.name=="c2pa" or .name=="c2pa-c") | .features | keys | map(select(. != "default")) | .[]] | unique | join(" ")')
+          RUST_NATIVE_FEATURES=$(echo $FEATURES | sed 's/openssl//g')
+          OPENSSL_FEATURES=$(echo $FEATURES | sed 's/rust_native_crypto//g')
+          WASI_FEATURES=$(echo $RUST_NATIVE_FEATURES | sed 's/json_api//g')
+          echo "rust-native-features=$RUST_NATIVE_FEATURES" >> "$GITHUB_OUTPUT"
+          echo "openssl-features=$OPENSSL_FEATURES" >> "$GITHUB_OUTPUT"
+          echo "wasi-features=$WASI_FEATURES" >> "$GITHUB_OUTPUT"
 
   tests:
     name: Unit tests
@@ -59,11 +64,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -74,17 +74,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests with rust_native_crypto
-        shell: pwsh
-        if: runner.os == 'Windows'
+        env:
+          RUST_BACKTRACE: "1"
+          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
         run: |
-          $features = Get-Content features.txt
-          $features = $features -replace 'openssl', ''
-          cargo test --no-default-features --features "$features"
-
-      - name: Run tests with rust_native_crypto
-        if: runner.os != 'Windows'
-        run: |
-          FEATURES=$(cat features.txt | sed 's/openssl//g')
           cargo test --no-default-features --features "$FEATURES"
 
       - name: Install cargo-llvm-cov
@@ -93,19 +86,8 @@ jobs:
       - name: Generate code coverage for openssl
         env:
           RUST_BACKTRACE: "1"
-        shell: pwsh
-        if: runner.os == 'Windows'
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          $features = Get-Content features.txt
-          $features = $features -replace 'rust_native_crypto', ''
-          cargo llvm-cov --lib --features "$features" --lcov --output-path lcov.info
-
-      - name: Generate code coverage for openssl
-        env:
-          RUST_BACKTRACE: "1"
-        if: runner.os != 'Windows'
-        run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
@@ -144,11 +126,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -164,19 +141,8 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-        shell: pwsh
-        if: runner.os == 'Windows'
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          $features = Get-Content features.txt
-          $features = $features -replace 'rust_native_crypto', ''
-          cargo llvm-cov --bins --features "$features" --lcov --output-path lcov.info
-
-      - name: Generate code coverage
-        env:
-          RUST_BACKTRACE: "1"
-        if: runner.os != 'Windows'
-        run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo llvm-cov --bins --features "$FEATURES" --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
@@ -220,11 +186,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       # - name: Install Rust toolchain
@@ -244,24 +205,16 @@ jobs:
       # doc tests.
 
       - name: Run doc tests (COVERAGE DISABLED)
-        shell: pwsh
-        if: runner.os == 'Windows'
+        env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          $features = Get-Content features.txt
-          $features = $features -replace 'rust_native_crypto', ''
-          cargo test --workspace --features "$features" --doc
-
-      - name: Run doc tests (COVERAGE DISABLED)
-        if: runner.os != 'Windows'
-        run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo test --workspace --features "$FEATURES" --doc
 
       # - name: Generate code coverage
       #   env:
       #     RUST_BACKTRACE: "1"
+      #     FEATURES: ${{needs.get-features.outputs.openssl-features}}
       #   run: |
-      #   FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
       #   cargo llvm-cov --workspace --features "$FEATURES" --lcov --doctests --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
@@ -301,7 +254,7 @@ jobs:
 
       - name: "`cargo check` with default features"
         run: cargo check
-        
+
   tests-cross:
     name: Unit tests
     needs: get-features
@@ -324,11 +277,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -346,8 +294,9 @@ jobs:
       # environment. (A PR to fix this would be welcomed!)
 
       - name: Run unit tests (cross build)
+        env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }}
 
   tests-wasm:
@@ -392,13 +341,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
-        # nightly required for testing until this issue is resolved:
-        # wasip2 target should not conditionally feature gate stdlib APIs rust-lang/rust#130323 https://github.com/rust-lang/rust/issues/130323
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -419,7 +361,7 @@ jobs:
             ARCH="${RUNNER_ARCH}";
           fi
           wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-${ARCH}-${RUNNER_OS}.tar.gz
-          tar xvf wasi-sdk-25.0-${ARCH}-${RUNNER_OS}.tar.gz
+          tar xf wasi-sdk-25.0-${ARCH}-${RUNNER_OS}.tar.gz
           mv $(echo wasi-sdk-25.0-${ARCH}-${RUNNER_OS} | tr '[:upper:]' '[:lower:]') /opt/wasi-sdk
 
       - name: Add wasm32-wasip2 target
@@ -434,8 +376,8 @@ jobs:
           CC: /opt/wasi-sdk/bin/clang
           WASI_SDK_PATH: /opt/wasi-sdk
           RUST_MIN_STACK: 16777216
+          FEATURES: ${{needs.get-features.outputs.wasi-features}}
         run: |
-          FEATURES=$(cat features.txt | sed 's/openssl//g' | sed 's/json_api//g')
           cargo +nightly-2025-05-14 test --target wasm32-wasip2 -p c2pa -p c2patool --features "$FEATURES" --no-default-features
 
   test-direct-minimal-versions:
@@ -459,11 +401,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -478,17 +415,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        shell: pwsh
-        if: runner.os == 'Windows'
+        env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          $features = Get-Content features.txt
-          $features = $features -replace 'rust_native_crypto', ''
-          cargo +nightly-2025-01-24 test -Z direct-minimal-versions --all-targets --features "$features"
-
-      - name: Run tests
-        if: runner.os != 'Windows'
-        run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo +nightly-2025-01-24 test -Z direct-minimal-versions --all-targets --features "$FEATURES"
 
   clippy_check:
@@ -507,11 +436,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -521,8 +445,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
+        env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo clippy --features "$FEATURES" --all-targets -- -Dwarnings
 
   cargo_fmt:
@@ -564,11 +489,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install nightly Rust toolchain
         # Nightly is used here because the docs.rs build
         # uses nightly and we use doc_cfg features that are
@@ -581,9 +501,9 @@ jobs:
         # if the subsequent release would result in a failed
         # documentation build on docs.rs.
         run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           cargo +nightly doc --workspace --features "$FEATURES" --no-deps
         env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
           RUSTDOCFLAGS: --cfg docsrs
           DOCS_RS: 1
 
@@ -636,17 +556,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download features
-        uses: actions/download-artifact@v4
-        with:
-          name: features
-
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Run cargo-udeps
+        env:
+          FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          FEATURES=$(cat features.txt | sed 's/rust_native_crypto//g')
           mv ./.github/temp-bin/cargo-udeps /home/runner/.cargo/bin/cargo-udeps
           cargo udeps --all-targets --features "$FEATURES"
           # NOTE: Using pre-built binary as a workaround for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         rust_version: [stable, 1.82.0]
+        crypto: [rust-native, openssl]
 
     steps:
       - name: Checkout repository
@@ -80,15 +81,17 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
+        if: matrix.crypto == 'rust-native'
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
 
       - name: Generate code coverage for openssl
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
+        if: matrix.crypto == 'openssl'
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl.info
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -103,7 +106,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
-          files: ./lcov-openssl.info,./lcov-rust_native_crypto.info
+          files: ./lcov.info
 
   tests-cli:
     name: Unit tests (c2patool)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,32 +73,22 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Run tests with rust_native_crypto
-        shell: pwsh
-        if: runner.os == 'Windows'
-        env:
-          RUST_BACKTRACE: "1"
-          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
-        run: |
-          cargo test --no-default-features --features "$env:FEATURES"
-
-      - name: Run tests with rust_native_crypto
-        if: runner.os != 'Windows'
-        env:
-          RUST_BACKTRACE: "1"
-          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
-        run: |
-          cargo test --no-default-features --features "$FEATURES"
-
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage for rust_native_crypto
+        env:
+          RUST_BACKTRACE: "1"
+          FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
+        run: |
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
 
       - name: Generate code coverage for openssl
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -331,7 +321,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Run Wasm tests (c2pa-rs)
+      - name: Run Wasm tests
         run: wasm-pack test --chrome --headless --no-default-features --features rust_native_crypto
         working-directory: ./sdk
 
@@ -351,6 +341,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+        # nightly required for testing until this issue is resolved:
+        # wasip2 target should not conditionally feature gate stdlib APIs rust-lang/rust#130323 https://github.com/rust-lang/rust/issues/130323
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -510,8 +502,7 @@ jobs:
         # environment. The goal is to fail PR validation
         # if the subsequent release would result in a failed
         # documentation build on docs.rs.
-        run: |
-          cargo +nightly doc --workspace --features "$FEATURES" --no-deps
+        run: cargo +nightly doc --workspace --features "$FEATURES" --no-deps
         env:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
           RUSTDOCFLAGS: --cfg docsrs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+          files: ./lcov-openssl.info,./lcov-rust_native_crypto.info
 
   tests-cli:
     name: Unit tests (c2patool)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         rust_version: [stable, 1.82.0]
-        crypto: [rust-native, openssl]
 
     steps:
       - name: Checkout repository
@@ -81,17 +80,15 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
-        if: matrix.crypto == 'rust-native'
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
 
       - name: Generate code coverage for openssl
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
-        if: matrix.crypto == 'openssl'
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov.info
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -106,7 +103,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
-          files: ./lcov.info
+          files: ./lcov-openssl.info,./lcov-rust_native_crypto.info
 
   tests-cli:
     name: Unit tests (c2patool)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests with rust_native_crypto
+        shell: pwsh
+        if: runner.os == 'Windows'
+        env:
+          RUST_BACKTRACE: "1"
+          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
+        run: |
+          cargo test --no-default-features --features "$env:FEATURES"
+
+      - name: Run tests with rust_native_crypto
+        if: runner.os != 'Windows'
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust-native-features}}

--- a/c_api/Cargo.toml
+++ b/c_api/Cargo.toml
@@ -9,8 +9,10 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [features]
-default = ["json_api",]
+default = ["json_api", "openssl"]
 json_api = ["c2pa/v1_api"]
+openssl = ["c2pa/openssl"]
+rust_native_crypto = ["c2pa/rust_native_crypto"]
 
 [dependencies]
 tokio = { version = "1.36", features = ["rt-multi-thread","rt"] }
@@ -18,8 +20,7 @@ c2pa = { path = "../sdk", version = "0.53.0", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",
-    "rust_native_crypto",
-] }
+], default-features = false }
 scopeguard = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,11 @@ edition = "2018"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2pa-rs/tree/main/cli"
 
+[features]
+default = ["openssl"]
+openssl = ["c2pa/openssl"]
+rust_native_crypto = ["c2pa/rust_native_crypto"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 # Workaround for https://github.com/est31/cargo-udeps/issues/293.
@@ -27,7 +32,7 @@ c2pa = { path = "../sdk", version = "0.53.0", features = [
 	"file_io",
 	"add_thumbnails",
 	"pdf"
-] }
+], default-features = false }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"
 glob = "0.3.1"

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -10,8 +10,13 @@ rust-version = "1.82.0"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 # Workaround for https://github.com/est31/cargo-udeps/issues/293.
 
+[features]
+default = ["openssl"]
+openssl = ["c2pa/openssl"]
+rust_native_crypto = ["c2pa/rust_native_crypto"]
+
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", default-features = false, features = ["json_schema"] }
+c2pa = { path = "../sdk", features = ["json_schema"], default-features = false }
 schemars = "0.8.21"
 serde_json = "1.0.117"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["default"]
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk" }
+c2pa = { path = "../sdk", default-features = false }
 env_logger = "0.11"
 log = "0.4.8"
 image = { version = "0.25.2", default-features = false, features = [
@@ -32,4 +32,6 @@ tempfile = "3.15.0"
 
 [features]
 # prevents these features from being always enabled in the workspace
-default = ["c2pa/file_io"]
+default = ["c2pa/file_io", "openssl"]
+openssl = ["c2pa/openssl"]
+rust_native_crypto = ["c2pa/rust_native_crypto"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -123,7 +123,7 @@ non-empty-string = { version = "=0.2.4", features = ["serde"] }
 nonempty-collections = { version = "0.2.9", features = ["serde"] }
 num-bigint-dig = { version = "0.8.4", optional = true }
 p256 = { version = "0.13.2", optional = true }
-p384 = {version = "0.13.0", optional = true }
+p384 = { version = "0.13.0", optional = true }
 p521 = { version = "0.13.3", features = ["pkcs8", "digest", "ecdsa"], optional = true }
 pem = "3.0.2"
 pkcs1 = { version = "0.7.5", optional = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -26,17 +26,23 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+default = ["openssl"]
 add_thumbnails = ["image"]
 file_io = []
 serialize_thumbnails = []
 no_interleaved_io = ["file_io"]
 fetch_remote_manifests = ["dep:wasi"]
 json_schema = ["dep:schemars"]
+openssl = ["dep:openssl"]
 pdf = ["dep:lopdf"]
 rust_native_crypto = [
     "dep:const-oid",
+    "dep:ecdsa",
     "dep:der",
     "dep:num-bigint-dig",
+    "dep:p256",
+    "dep:p384",
+    "dep:p521",
     "dep:pkcs1",
     "dep:rsa",
     "dep:spki",
@@ -97,7 +103,7 @@ conv = "0.3.3"
 coset = "0.3.8"
 extfmt = "0.1.1"
 der = { version = "0.7.9", optional = true }
-ecdsa = { version = "0.16.9", features = ["digest", "sha2"] }
+ecdsa = { version = "0.16.9", features = ["digest", "sha2"], optional = true }
 ed25519-dalek = { version = "2.1.1", features = ["alloc", "digest", "pem", "pkcs8", "rand_core"] }
 getrandom = { version = "0.2.7", features = ["js"] }
 hex = "0.4.3"
@@ -116,9 +122,9 @@ nom = "7.1.3"
 non-empty-string = { version = "=0.2.4", features = ["serde"] }
 nonempty-collections = { version = "0.2.9", features = ["serde"] }
 num-bigint-dig = { version = "0.8.4", optional = true }
-p256 = "0.13.2"
-p384 = "0.13.0"
-p521 = { version = "0.13.3", features = ["pkcs8", "digest", "ecdsa"] }
+p256 = { version = "0.13.2", optional = true }
+p384 = {version = "0.13.0", optional = true }
+p521 = { version = "0.13.3", features = ["pkcs8", "digest", "ecdsa"], optional = true }
 pem = "3.0.2"
 pkcs1 = { version = "0.7.5", optional = true }
 pkcs8 = "0.10.2"
@@ -168,7 +174,7 @@ spki = "0.7.3"
 tempfile = { version = "3.15", features = ["nightly"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-openssl = { version = "0.10.72", features = ["vendored"] }
+openssl = { version = "0.10.72", features = ["vendored"], optional = true }
 ureq = "2.4.0"
 url = "2.5.3"
 

--- a/sdk/src/crypto/cose/certificate_trust_policy.rs
+++ b/sdk/src/crypto/cose/certificate_trust_policy.rs
@@ -100,7 +100,7 @@ impl CertificateTrustPolicy {
             return Ok(());
         }
 
-        #[cfg(any(target_arch = "wasm32", feature = "rust_native_crypto", test))]
+        #[cfg(feature = "rust_native_crypto")]
         {
             return crate::crypto::raw_signature::rust_native::check_certificate_trust::check_certificate_trust(
                 self,
@@ -110,7 +110,7 @@ impl CertificateTrustPolicy {
             );
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         {
             return crate::crypto::raw_signature::openssl::check_certificate_trust::check_certificate_trust(
                 self,
@@ -355,14 +355,14 @@ pub enum CertificateTrustError {
     InternalError(String),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<openssl::error::ErrorStack> for CertificateTrustError {
     fn from(err: openssl::error::ErrorStack) -> Self {
         Self::CryptoLibraryError(err.to_string())
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<crate::crypto::raw_signature::openssl::OpenSslMutexUnavailable>
     for CertificateTrustError
 {
@@ -649,7 +649,7 @@ zGxQnM2hCA==
         let ps512 = test_signer(SigningAlg::Ps512);
         let es256 = test_signer(SigningAlg::Es256);
         let es384 = test_signer(SigningAlg::Es384);
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512 = test_signer(SigningAlg::Es512);
         let ed25519 = test_signer(SigningAlg::Ed25519);
 
@@ -658,7 +658,7 @@ zGxQnM2hCA==
         let ps512_certs = ps512.cert_chain().unwrap();
         let es256_certs = es256.cert_chain().unwrap();
         let es384_certs = es384.cert_chain().unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512_certs = es512.cert_chain().unwrap();
         let ed25519_certs = ed25519.cert_chain().unwrap();
 
@@ -672,7 +672,7 @@ zGxQnM2hCA==
             .unwrap();
         ctp.check_certificate_trust(&es384_certs[1..], &es384_certs[0], None)
             .unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         ctp.check_certificate_trust(&es512_certs[1..], &es512_certs[0], None)
             .unwrap();
         ctp.check_certificate_trust(&ed25519_certs[1..], &ed25519_certs[0], None)
@@ -742,7 +742,7 @@ zGxQnM2hCA==
         let ps512 = test_signer(SigningAlg::Ps512);
         let es256 = test_signer(SigningAlg::Es256);
         let es384 = test_signer(SigningAlg::Es384);
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512 = test_signer(SigningAlg::Es512);
         let ed25519 = test_signer(SigningAlg::Ed25519);
 
@@ -751,7 +751,7 @@ zGxQnM2hCA==
         let ps512_certs = ps512.cert_chain().unwrap();
         let es256_certs = es256.cert_chain().unwrap();
         let es384_certs = es384.cert_chain().unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512_certs = es512.cert_chain().unwrap();
         let ed25519_certs = ed25519.cert_chain().unwrap();
 
@@ -792,7 +792,7 @@ zGxQnM2hCA==
             CertificateTrustError::CertificateNotTrusted
         );
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         assert_eq!(
             ctp.check_certificate_trust(&es512_certs[2..], &es512_certs[0], None)
                 .unwrap_err(),
@@ -933,7 +933,7 @@ zGxQnM2hCA==
         let ps512 = test_signer(SigningAlg::Ps512);
         let es256 = test_signer(SigningAlg::Es256);
         let es384 = test_signer(SigningAlg::Es384);
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512 = test_signer(SigningAlg::Es512);
         let ed25519 = test_signer(SigningAlg::Ed25519);
 
@@ -942,7 +942,7 @@ zGxQnM2hCA==
         assert_eq!(ps512.alg(), SigningAlg::Ps512);
         assert_eq!(es256.alg(), SigningAlg::Es256);
         assert_eq!(es384.alg(), SigningAlg::Es384);
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         assert_eq!(es512.alg(), SigningAlg::Es512);
         assert_eq!(ed25519.alg(), SigningAlg::Ed25519);
 
@@ -951,7 +951,7 @@ zGxQnM2hCA==
         let ps512_certs = ps512.cert_chain().unwrap();
         let es256_certs = es256.cert_chain().unwrap();
         let es384_certs = es384.cert_chain().unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         let es512_certs = es512.cert_chain().unwrap();
         let ed25519_certs = ed25519.cert_chain().unwrap();
 
@@ -965,7 +965,7 @@ zGxQnM2hCA==
             .unwrap();
         ctp.check_certificate_trust(&es384_certs[1..], &es384_certs[0], None)
             .unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(feature = "openssl")]
         ctp.check_certificate_trust(&es512_certs[1..], &es512_certs[0], None)
             .unwrap();
         ctp.check_certificate_trust(&ed25519_certs[1..], &ed25519_certs[0], None)

--- a/sdk/src/crypto/raw_signature/mod.rs
+++ b/sdk/src/crypto/raw_signature/mod.rs
@@ -15,10 +15,10 @@
 
 pub(crate) mod oids;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 pub(crate) mod openssl;
 
-#[cfg(any(target_arch = "wasm32", feature = "rust_native_crypto", test))]
+#[cfg(feature = "rust_native_crypto")]
 pub(crate) mod rust_native;
 
 pub(crate) mod signer;

--- a/sdk/src/crypto/raw_signature/rust_native/signers/mod.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/signers/mod.rs
@@ -351,8 +351,7 @@ mod async_signer_tests {
         validator.validate(&signature, data, pub_key).unwrap();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
-    // #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(feature = "openssl", actix::test)]
     async fn es512() {
         let cert_chain =
             include_bytes!("../../../../../tests/fixtures/crypto/raw_signature/es512.pub");

--- a/sdk/src/crypto/raw_signature/signer.rs
+++ b/sdk/src/crypto/raw_signature/signer.rs
@@ -157,14 +157,14 @@ impl From<std::io::Error> for RawSignerError {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<openssl::error::ErrorStack> for RawSignerError {
     fn from(err: openssl::error::ErrorStack) -> Self {
         Self::CryptoLibraryError(err.to_string())
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<crate::crypto::raw_signature::openssl::OpenSslMutexUnavailable> for RawSignerError {
     fn from(err: crate::crypto::raw_signature::openssl::OpenSslMutexUnavailable) -> Self {
         Self::InternalError(err.to_string())
@@ -187,7 +187,7 @@ pub fn signer_from_cert_chain_and_private_key(
     alg: SigningAlg,
     time_stamp_service_url: Option<String>,
 ) -> Result<Box<dyn RawSigner + Send + Sync>, RawSignerError> {
-    #[cfg(any(target_arch = "wasm32", feature = "rust_native_crypto"))]
+    #[cfg(feature = "rust_native_crypto")]
     {
         match crate::crypto::raw_signature::rust_native::signers::signer_from_cert_chain_and_private_key(
             cert_chain,
@@ -201,7 +201,7 @@ pub fn signer_from_cert_chain_and_private_key(
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     {
         return crate::crypto::raw_signature::openssl::signers::signer_from_cert_chain_and_private_key(
             cert_chain,

--- a/sdk/src/crypto/raw_signature/tests/async_signers.rs
+++ b/sdk/src/crypto/raw_signature/tests/async_signers.rs
@@ -21,7 +21,11 @@ use crate::crypto::raw_signature::{
 };
 
 #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
-// #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
+#[cfg_attr(target_os = "wasi", wstd::test)]
 async fn es256() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es256.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es256.priv");
@@ -47,7 +51,11 @@ async fn es256() {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
-// #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
+#[cfg_attr(target_os = "wasi", wstd::test)]
 async fn es384() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es384.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es384.priv");
@@ -72,8 +80,7 @@ async fn es384() {
     validator.validate(&signature, data, pub_key).unwrap();
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), actix::test)]
-// #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(feature = "openssl", actix::test)]
 async fn es512() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.priv");

--- a/sdk/src/crypto/raw_signature/tests/signers.rs
+++ b/sdk/src/crypto/raw_signature/tests/signers.rs
@@ -19,8 +19,10 @@ use crate::crypto::raw_signature::{
 };
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")), wasm_bindgen_test)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
 fn es256() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es256.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es256.priv");
@@ -42,8 +44,10 @@ fn es256() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")), wasm_bindgen_test)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
 fn es384() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es384.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es384.priv");
@@ -65,8 +69,7 @@ fn es384() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")), wasm_bindgen_test)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 fn es512() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.priv");
@@ -114,8 +117,10 @@ fn ed25519() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")),
-// wasm_bindgen_test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
 fn ps256() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps256.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps256.priv");
@@ -137,8 +142,10 @@ fn ps256() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")),
-// wasm_bindgen_test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
 fn ps384() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps384.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps384.priv");
@@ -160,8 +167,10 @@ fn ps384() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")),
-// wasm_bindgen_test)]
+#[cfg_attr(
+    all(target_arch = "wasm32", not(target_os = "wasi")),
+    wasm_bindgen_test
+)]
 fn ps512() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps512.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/ps512.priv");

--- a/sdk/src/crypto/raw_signature/tests/validators.rs
+++ b/sdk/src/crypto/raw_signature/tests/validators.rs
@@ -97,8 +97,7 @@ fn es384() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")),
-// wasm_bindgen_test)] // ES512 not implemented
+#[cfg(not(target_arch = "wasm32"))]
 fn es512() {
     let signature = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.raw_sig");
     let pub_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.pub_key");
@@ -242,7 +241,7 @@ const SHA384_OID: Oid = bcder::Oid(OctetString::from_static(&[96, 134, 72, 1, 10
 
 const SHA512_OID: Oid = bcder::Oid(OctetString::from_static(&[96, 134, 72, 1, 101, 3, 4, 2, 3]));
 
-#[cfg_attr(target_arch = "wasm32", allow(unused))]
+#[cfg_attr(feature = "rust_native_crypto", allow(unused))]
 const SHA1_OID: Oid = bcder::Oid(OctetString::from_static(&[43, 14, 3, 2, 26]));
 
 #[test]
@@ -341,9 +340,7 @@ fn rs512() {
 }
 
 #[test]
-// #[cfg_attr(all(target_arch = "wasm32", not(target_os = "wasi")), wasm_bindgen_test)] // SHA1 not
-// implemented
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 fn sha1() {
     let signature =
         include_bytes!("../../../../tests/fixtures/crypto/raw_signature/legacy/sha1.raw_sig");

--- a/sdk/src/crypto/raw_signature/validator.rs
+++ b/sdk/src/crypto/raw_signature/validator.rs
@@ -65,7 +65,7 @@ pub trait AsyncRawSignatureValidator {
 /// Which validators are available may vary depending on the platform and
 /// which crate features were enabled.
 pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignatureValidator>> {
-    #[cfg(any(target_arch = "wasm32", feature = "rust_native_crypto"))]
+    #[cfg(feature = "rust_native_crypto")]
     {
         if let Some(validator) =
             crate::crypto::raw_signature::rust_native::validators::validator_for_signing_alg(alg)
@@ -74,7 +74,7 @@ pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignature
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     if let Some(validator) =
         crate::crypto::raw_signature::openssl::validators::validator_for_signing_alg(alg)
     {
@@ -95,7 +95,7 @@ pub(crate) fn validator_for_sig_and_hash_algs(
     hash_alg: &Oid,
 ) -> Option<Box<dyn RawSignatureValidator>> {
     // TO REVIEW: Do we need any of the RSA-PSS algorithms for this use case?
-    #[cfg(any(target_arch = "wasm32", feature = "rust_native_crypto"))]
+    #[cfg(feature = "rust_native_crypto")]
     {
         if let Some(validator) =
             crate::crypto::raw_signature::rust_native::validators::validator_for_sig_and_hash_algs(
@@ -106,7 +106,7 @@ pub(crate) fn validator_for_sig_and_hash_algs(
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "openssl")]
     if let Some(validator) =
         crate::crypto::raw_signature::openssl::validators::validator_for_sig_and_hash_algs(
             sig_alg, hash_alg,
@@ -175,14 +175,14 @@ pub enum RawSignatureValidationError {
     InternalError(String),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<openssl::error::ErrorStack> for RawSignatureValidationError {
     fn from(err: openssl::error::ErrorStack) -> Self {
         Self::CryptoLibraryError(err.to_string())
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "openssl")]
 impl From<crate::crypto::raw_signature::openssl::OpenSslMutexUnavailable>
     for RawSignatureValidationError
 {

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1877,7 +1877,7 @@ mod tests_file_io {
     }
 
     #[test]
-    #[cfg(feature = "file_io")]
+    #[cfg(all(feature = "file_io", feature = "add_thumbnails"))]
     fn test_jpg_prerelease() {
         let ap = fixture_path(PRERELEASE_JPEG);
         let ingredient = Ingredient::from_file(ap).expect("from_file");

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -184,3 +184,12 @@ pub(crate) mod store;
 
 pub(crate) mod utils;
 pub(crate) use utils::{cbor_types, hash_utils};
+
+#[cfg(all(feature = "openssl", feature = "rust_native_crypto"))]
+compile_error!("Features 'openssl' and 'rust_native_crypto' cannot be enabled at the same time.");
+
+#[cfg(not(any(feature = "openssl", feature = "rust_native_crypto")))]
+compile_error!("Either 'openssl' or 'rust_native_crypto' feature must be enabled.");
+
+#[cfg(all(feature = "openssl", target_arch = "wasm32"))]
+compile_error!("Feature 'openssl' is not available for wasm32.");


### PR DESCRIPTION
## Changes in this pull request
Openssl will not be included when building rust native crypto
CI tests for both openssl and rust_native_crypto features

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
