### PR TITLE
build: update release-plz for c_api name.

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -50,7 +50,7 @@ changelog_path = "./CHANGELOG.md"
 name = "c2patool"
 
 [[package]]
-name = "c2pa-c"
+name = "c_api"
 publish = false
 release = false
 


### PR DESCRIPTION
I renamed the internal c2pa-c match the c_api folder name, but I didn't update release-plz to know about the name change.