### PR TITLE
fix: docs.rs build using openssl and rust_native_crypto simulatenously

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,7 +24,19 @@ rust-version = "1.82.0"
 exclude = ["tests/fixtures"]
 
 [package.metadata.docs.rs]
-all-features = true
+# Build with all features, but not with openssl and rust_native_crypto simulatenously.
+features = [
+    "openssl",
+    "add_thumbnails",
+    "file_io",
+    "serialize_thumbnails",
+    "no_interleaved_io",
+    "fetch_remote_manifests",
+    "json_schema",
+    "pdf",
+    "v1_api",
+    "diagnostics",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]


### PR DESCRIPTION
## Changes in this pull request
Fixes latest broken docs.rs build due to have all-features enabled even though openssl and rust_native_crypto can't be enabled at the same time. This PR preserves the old doc behavior. May want to consider removing the openssl feature in favor of `#[cfg(not(feature = "rust_native_crypto"))]`, as I also have this issue with rust-analyzer enabling all-features.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
