### PR TITLE
docs: Doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,34 @@ NOTE: The current release includes a new API that replaces old methods of readin
 
 ### Prerequisites
 
-**Minimal supported Rust version (MSRV)**: The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
+**Install Rust and Cargo**
 
 To use the CAI Rust library, you must install [Rust and Cargo](https://doc.rust-lang.org/cargo/index.html).
+
+Minimal supported Rust version (MSRV): The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
+
+**Install C build tools**
+
+Install the C build tools for your development platoform"
+
+- macOS: XCode with command-line tools
+- Windows: Microsoft Visual C++ (MSVC)
+
+### Build
+
+The easiest way to build the library is by using the `Makefile`.
+
+To build unit tests, use this command:
+
+```
+make test
+```
+
+To build the binary libraries, use this command:
+
+```
+make release
+```
 
 ### Add dependency
 

--- a/README.md
+++ b/README.md
@@ -54,29 +54,11 @@ NOTE: The current release includes a new API that replaces old methods of readin
 
 **Minimal supported Rust version (MSRV)**: The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
 
-To use the CAI Rust library, you must install [Cargo](https://doc.rust-lang.org/cargo/index.html), the Rust package manager.
+To use the CAI Rust library, you must install [Rust and Cargo](https://doc.rust-lang.org/cargo/index.html).
 
-Install the current stable release of Rust by using `rustup`, which will also install Cargo. On Linux and macOS systems, enter this command:
+### Add dependency
 
-```sh
-curl https://sh.rustup.rs -sSf | sh
-```
-
-If everything goes well, you’ll see this message in your terminal:
-
-```
-Rust is installed now. Great!
-```
-
-### Install C2PA crate
-
-To install the C2PA crate, run the following Cargo command in your project directory:
-
-```
-cargo add c2pa
-```
-
-Or add the following line to your `Cargo.toml`:
+Add the following line to your `Cargo.toml`:
 
 ```
 c2pa = "<VERSION_NUMBER>"

--- a/README.md
+++ b/README.md
@@ -42,22 +42,47 @@ For details on what you can do with the library, see [Using the Rust library](ht
 
 This is a beta release (version 0.x.x) of the project. The minor version number (0.x.0) is incremented when there are breaking API changes, which may happen frequently.
 
-**NOTE**: The library now supports [C2PA v2 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](docs/release-notes.md#c2pa-v2-claims).
+**NOTE**: The library now supports [C2PA v2 claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims), however development is still in progress and all features are not fully implemented yet. While you can experiment with this functionality, it is not recommended for production use at this time.  For details, see [C2PA v2 claims](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/release-notes#c2pa-v2-claims).
 
 ### New API
 
 NOTE: The current release includes a new API that replaces old methods of reading and writing C2PA data, which are deprecated.  See the [release notes](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/release-notes) for more information. 
 
-### CAWG identity assertion: Known limitations
+## Installation
 
-The SDK does not currently support the following optional fields from the CAWG identity assertion:
-* `expected_partial_claim`
-* `expected_claim_generator`
-* `expected_countersigners`
+### Prerequisite: Install Rust
 
-### Rust language requirement (MSRV)
+To use the CAI Rust library, you must install [Cargo](https://doc.rust-lang.org/cargo/index.html), the Rust package manager.
 
-The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
+Install the current stable release of Rust by using `rustup`, which will also install cargo. On Linux and macOS systems, enter this command:
+
+```sh
+curl https://sh.rustup.rs -sSf | sh
+```
+
+If everything goes well, you’ll see this message in your terminal:
+
+```
+Rust is installed now. Great!
+```
+
+**Minimal supported Rust version (MSRV)**: The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
+
+### Install C2PA crate
+
+To install the C2PA crate, run the following Cargo command in your project directory:
+
+```
+cargo add c2pa
+```
+
+Or add the following line to your Cargo.toml:
+
+```
+c2pa = "<VERSION_NUMBER>"
+```
+
+Where `<VERSION_NUMBER>` is the [latest version of the crate as shown on crates.io](https://crates.io/crates/c2pa).
 
 ## Contributions and feedback
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The [`c2pa` crate](https://crates.io/crates/c2pa) implements a subset of the [C2
 
 The library enables a desktop, mobile, or embedded application to:
 * Create and sign C2PA [claims](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_claims) and [manifests](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_manifests).
-* Create, sign, and validate [CAWG identity assertions](https://cawg.io/identity) in C2PA manifests.
+* Create, sign, and validate [CAWG identity assertions](https://cawg.io/identity) in C2PA manifests.  See [Using the CAWG identity assertion](docs/cawg-identity.md) for more information.
 * Embed manifests in [supported file formats](docs/supported-formats.md).
 * Parse and validate manifests found in [supported file formats](docs/supported-formats.md).
 
@@ -50,11 +50,13 @@ NOTE: The current release includes a new API that replaces old methods of readin
 
 ## Installation
 
-### Prerequisite: Install Rust
+### Prerequisites
+
+**Minimal supported Rust version (MSRV)**: The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
 
 To use the CAI Rust library, you must install [Cargo](https://doc.rust-lang.org/cargo/index.html), the Rust package manager.
 
-Install the current stable release of Rust by using `rustup`, which will also install cargo. On Linux and macOS systems, enter this command:
+Install the current stable release of Rust by using `rustup`, which will also install Cargo. On Linux and macOS systems, enter this command:
 
 ```sh
 curl https://sh.rustup.rs -sSf | sh
@@ -66,8 +68,6 @@ If everything goes well, you’ll see this message in your terminal:
 Rust is installed now. Great!
 ```
 
-**Minimal supported Rust version (MSRV)**: The `c2pa` crate requires Rust version 1.82.0 or newer. When a newer version of Rust becomes required, a new minor (0.x.0) version of this crate will be released.
-
 ### Install C2PA crate
 
 To install the C2PA crate, run the following Cargo command in your project directory:
@@ -76,7 +76,7 @@ To install the C2PA crate, run the following Cargo command in your project direc
 cargo add c2pa
 ```
 
-Or add the following line to your Cargo.toml:
+Or add the following line to your `Cargo.toml`:
 
 ```
 c2pa = "<VERSION_NUMBER>"

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,7 +45,7 @@ NOTE: You also may want to get some of the example files provided in the reposit
 
 ### Installing from source
 
-Instead of installing a prebuilt binary, you can [build the project from source](https://github.com/contentauth/c2pa-rs/blob/docs/no-c2patool-binstall/cli/docs/project-contributions.md#building-from-source).
+Instead of installing a prebuilt binary, you can [build the project from source](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/project-contributions.md#building-from-source).
 
 ### Upgrading
 

--- a/docs/cawg-identity.md
+++ b/docs/cawg-identity.md
@@ -2,6 +2,15 @@
 
 The CAI Rust library includes an implementation of the [Creator Assertions Working Group (CAWG) identity assertion specification](https://cawg.io/identity/1.1-draft).
 
+## Known limitations
+
+The library does not currently support the following optional fields from the CAWG identity assertion:
+* `expected_partial_claim`
+* `expected_claim_generator`
+* `expected_countersigners`
+
+## Example
+
 The code in [`sdk/examples/cawg.rs`](https://github.com/contentauth/c2pa-rs/blob/main/sdk/examples/cawg.rs) provides a minimal example of signing and verifying a claim including a CAWG identitiy assertion.  Run it by entering the command:
 
 ```sh


### PR DESCRIPTION
## Changes in this pull request

- Change some links to absolute URLs so they work everywhere
- Add minimall Rust installation instructions
- Move note about CAWG assertion limitations to doc on CAWG
