### PR TITLE
fix: Add rust_native_crypto and file_io feature to test

### DIFF
--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -40,10 +40,10 @@ check-format:
 	cargo +nightly fmt -- --check
 
 clippy:
-	cargo clippy -- -D warnings
+	cargo clippy --features "rust_native_crypto, file_io" -- -D warnings
 
 test-local:
-	cargo test
+	cargo test --features "rust_native_crypto, file_io"
 
 # Full local validation, build and test all features including wasm
 # Run this before pushing a PR to pre-validate


### PR DESCRIPTION
## Changes in this pull request
Adds `rusts_native_crypto `and `file_io` features to test. Previously, running `make test` would result in a compile error.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
