### PR TITLE
chore: Freeze nightly builds at 2025-06-05 to avoid lifetime issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
           # errors.
 
       - name: Check format
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +nightly-2025-06-05 fmt --all -- --check
 
   docs_rs:
     name: Preflight docs.rs build


### PR DESCRIPTION
Newer nightly builds introduce a new set of lifetime issues that appear difficult to resolve.
