### PR TITLE
Fix xmp jpeg write

### DIFF
--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -620,7 +620,7 @@ impl RemoteRefEmbed for JpegIO {
                     .unwrap_or((None, MIN_XMP));
 
                 // add provenance and JPEG XMP prefix
-                let xmp = format!("{XMP_SIGNATURE}\0 {}", add_provenance(xmp, &manifest_uri)?);
+                let xmp = format!("{XMP_SIGNATURE}\0{}", add_provenance(xmp, &manifest_uri)?);
                 let segment = JpegSegment::new_with_contents(markers::APP1, Bytes::from(xmp));
                 // insert or add the segment
                 match xmp_index {

--- a/sdk/src/utils/xmp_inmemory_utils.rs
+++ b/sdk/src/utils/xmp_inmemory_utils.rs
@@ -93,7 +93,6 @@ fn extract_xmp_key(xmp: &str, key: &str) -> Option<String> {
 /// Add a value to XMP using a key, replaces the value if the key exists, or adds it only once
 fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
     let orig_length = xmp.len();
-    println!("original length: {orig_length}");
 
     // Minimal padding should be 2 KB to 4 KB. This is used if no XMP packet is found.
     let mut target_length = 4096;
@@ -109,7 +108,6 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
     } else {
         xmp
     };
-    println!("target length: {target_length}");
 
     let mut reader = Reader::from_str(xmp_body);
     // Do not trim text to preserve whitespace
@@ -201,12 +199,7 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
         }
     }
     let padding_length = target_length.saturating_sub(writer.get_ref().get_ref().len());
-    println!("padding length {padding_length}");
     write_xmp_padding(&mut writer.get_mut(), padding_length)?;
-    println!("final length: {}", writer.get_ref().get_ref().len());
-    if padding_length > 0 {
-        assert_eq!(writer.get_ref().get_ref().len(), orig_length);
-    }
     let result = writer.into_inner().into_inner();
     String::from_utf8(result).map_err(|e| Error::XmpWriteError(e.to_string()))
 }

--- a/sdk/src/utils/xmp_inmemory_utils.rs
+++ b/sdk/src/utils/xmp_inmemory_utils.rs
@@ -90,11 +90,32 @@ fn extract_xmp_key(xmp: &str, key: &str) -> Option<String> {
 }
 
 // writes the event to the writer)
-/// Add a value to XMP using a key, replaces the value if the key exists
+/// Add a value to XMP using a key, replaces the value if the key exists, or adds it only once
 fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
-    let mut reader = Reader::from_str(xmp);
-    reader.config_mut().trim_text(true);
-    let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2);
+    let orig_length = xmp.len();
+    println!("original length: {orig_length}");
+
+    // Minimal padding should be 2 KB to 4 KB. This is used if no XMP packet is found.
+    let mut target_length = 4096;
+    // Remove trailing xpacket if present for easier manipulation
+    let xpacket_end_single = "<?xpacket end='w'?>";
+    let xpacket_end_double = "<?xpacket end=\"w\"?>";
+    let xmp_body = if let Some(pos) = xmp.rfind(xpacket_end_single) {
+        target_length = orig_length - xpacket_end_single.len();
+        xmp[..pos].trim_end()
+    } else if let Some(pos) = xmp.rfind(xpacket_end_double) {
+        target_length = orig_length - xpacket_end_double.len();
+        xmp[..pos].trim_end()
+    } else {
+        xmp
+    };
+    println!("target length: {target_length}");
+
+    let mut reader = Reader::from_str(xmp_body);
+    // Do not trim text to preserve whitespace
+    reader.config_mut().trim_text(false);
+    reader.config_mut().expand_empty_elements = false;
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
     let mut added = false;
     loop {
         let event = reader
@@ -102,7 +123,7 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
             .map_err(|e| Error::XmpReadError(e.to_string()))?;
         // println!("{:?}", event);
         match event {
-            Event::Start(ref e) if e.name() == QName(RDF_DESCRIPTION) => {
+            Event::Start(ref e) if e.name() == QName(RDF_DESCRIPTION) && !added => {
                 // creates a new element
                 let mut elem = BytesStart::from_content(
                     String::from_utf8_lossy(RDF_DESCRIPTION),
@@ -130,13 +151,14 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
                 if !added {
                     // didn't exist, so add it
                     elem.push_attribute((key, value));
+                    added = true;
                 }
                 // writes the event to the writer
                 writer
                     .write_event(Event::Start(elem))
                     .map_err(|e| Error::XmpWriteError(e.to_string()))?;
             }
-            Event::Empty(ref e) if e.name() == QName(RDF_DESCRIPTION) => {
+            Event::Empty(ref e) if e.name() == QName(RDF_DESCRIPTION) && !added => {
                 // creates a new element
                 let mut elem = BytesStart::from_content(
                     String::from_utf8_lossy(RDF_DESCRIPTION),
@@ -163,6 +185,7 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
                 if !added {
                     // didn't exist, so add it
                     elem.push_attribute((key, value));
+                    added = true;
                 }
                 // writes the event to the writer
                 writer
@@ -176,6 +199,13 @@ fn add_xmp_key(xmp: &str, key: &str, value: &str) -> Result<String> {
                     .map_err(|e| Error::XmpWriteError(e.to_string()))?;
             }
         }
+    }
+    let padding_length = target_length.saturating_sub(writer.get_ref().get_ref().len());
+    println!("padding length {padding_length}");
+    write_xmp_padding(&mut writer.get_mut(), padding_length)?;
+    println!("final length: {}", writer.get_ref().get_ref().len());
+    if padding_length > 0 {
+        assert_eq!(writer.get_ref().get_ref().len(), orig_length);
     }
     let result = writer.into_inner().into_inner();
     String::from_utf8(result).map_err(|e| Error::XmpWriteError(e.to_string()))
@@ -202,6 +232,32 @@ pub fn add_provenance(xmp: &str, provenance: &str) -> Result<String> {
     add_xmp_key(&xmp, "dcterms:provenance", provenance)
 }
 
+// According to the XMP Spec, the recommended practice is to use the ASCII space
+// character (U+0020) in the appropriate encoding, with a newline about every 100 characters
+fn write_xmp_padding<W: std::io::Write>(writer: &mut W, len: usize) -> std::io::Result<()> {
+    let mut remaining = len;
+    // Add newline before trailer no matter what.
+    writer.write_all(b"\n")?;
+    remaining = remaining.saturating_sub(1);
+
+    if remaining > 0 {
+        // Account for final newline since we are adding whitespace.
+        remaining -= 1;
+        while remaining > 0 {
+            let chunk = remaining.min(99);
+            writer.write_all(&vec![b' '; chunk])?;
+            remaining -= chunk;
+            if remaining > 0 {
+                writer.write_all(b"\n")?;
+                remaining -= 1;
+            }
+        }
+        writer.write_all(b"\n")?;
+    }
+    writer.write_all(b"<?xpacket end=\"w\"?>")?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
@@ -209,6 +265,8 @@ mod tests {
 
     //use env_logger;
     use super::*;
+    use crate::asset_handlers::jpeg_io::JpegIO;
+    use crate::asset_io::{AssetIO, RemoteRefEmbedType};
 
     const XMP_DATA: &str = r#"<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
     <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="contentauth">
@@ -260,5 +318,55 @@ mod tests {
         let unicorn = extract_provenance(&xmp);
         println!("{xmp}");
         assert_eq!(unicorn, Some(PROVENANCE.to_string()));
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), actix::test)]
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test
+    )]
+    #[cfg_attr(target_os = "wasi", wstd::test)]
+    async fn test_broken_xmp_read_write_stream() {
+        let source_bytes = include_bytes!("../../tests/fixtures/broken.jpg");
+        let test_msg = "https://cai-manifests-stage.adobe.com/manifests/urn-c2pa-0ab6e8b8-5c28-4ef1-8f58-86c21f0349bf-adobe";
+
+        let handler = JpegIO::new("");
+
+        let assetio_handler = handler.get_handler("jpg");
+
+        let remote_ref_handler = assetio_handler.remote_ref_writer_ref().unwrap();
+
+        let mut source_stream = Cursor::new(source_bytes.to_vec());
+        let mut output_stream = Cursor::new(Vec::new());
+
+        let original_xmp_length = assetio_handler
+            .get_reader()
+            .read_xmp(&mut source_stream)
+            .unwrap()
+            .len();
+        source_stream.set_position(0);
+
+        remote_ref_handler
+            .embed_reference_to_stream(
+                &mut source_stream,
+                &mut output_stream,
+                RemoteRefEmbedType::Xmp(test_msg.to_string()),
+            )
+            .unwrap();
+
+        output_stream.set_position(0);
+
+        // read back in XMP
+        let read_xmp = assetio_handler
+            .get_reader()
+            .read_xmp(&mut output_stream)
+            .unwrap();
+
+        output_stream.set_position(0);
+
+        std::fs::write("../target/xmp_write.jpg", output_stream.into_inner()).unwrap();
+
+        assert!(read_xmp.contains(test_msg));
+        assert_eq!(read_xmp.len(), original_xmp_length);
     }
 }


### PR DESCRIPTION
## Changes in this pull request
Adding the manifest url to large XMP segments could cause the XMP data
to exceed the limit of 65503 bytes.

There were 3 causes of this issue:
1. Extra whitespace from formatting. The quick_xml writer shiftwidth
   could be much larger than that of the original. Potentially adding
   several KB of whitespace.
2. Manifest url added multiple times. The manifest url was added to
   multiple keys within the XMP data.
3. Lack of padding awareness. According to the spec, XMP segments should
   have 2KB to 4KB of padding. The padding should be adjusted to keep
   the XMP data length the same with the addition of the remote manifest
   url. This is important for data hashes as it keeps the offsets of the
   JPEG metadata the same.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
