### PR TITLE
feat: Publish C2PA C ffi API (only package renamed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "c2pa-c-ffi"
+version = "0.55.0"
+dependencies = [
+ "c2pa",
+ "cbindgen",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "zip",
+]
+
+[[package]]
 name = "c2pa_macros"
 version = "0.55.0"
 dependencies = [
@@ -846,21 +861,6 @@ dependencies = [
  "url",
  "wasi 0.14.2+wasi-0.2.4",
  "wstd",
-]
-
-[[package]]
-name = "c_api"
-version = "0.55.0"
-dependencies = [
- "c2pa",
- "cbindgen",
- "scopeguard",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "zip",
 ]
 
 [[package]]

--- a/c_api/Cargo.toml
+++ b/c_api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "c_api"
+name = "c2pa-c-ffi"
 version.workspace = true
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -17,7 +17,7 @@ endif
 
 TARGET_DIR := ../target
 
-CARGO_BUILD_FLAGS = --release -p c_api --no-default-features --features "rust_native_crypto, file_io"
+CARGO_BUILD_FLAGS = --release -p c2pa-c-ffi --no-default-features --features "rust_native_crypto, file_io"
 
 IPHONEOS_DEPLOYMENT_TARGET ?= 15.0
 

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -166,7 +166,7 @@ release-android-x86_64:
 
 
 # make release
-# Builds and packages a zip for c_api for each platform
+# Builds and packages a zip for c_api folder (c2pa-c-ffi) for each platform
 
 # If TARGET is explicity set, use that
 ifdef TARGET

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -1,0 +1,20 @@
+# C2PA C API
+
+This is the C API wrapper for the [C2PA Rust SDK](../sdk). It provides a C-compatible interface for working with content credentials, with same formats supported as the Rust SDK.
+
+## Overview
+
+The C2PA C API allows developers to integrate content authenticity features into their applications using C or any language that can interface with C libraries.
+
+## Building locally
+
+Pre-requisite: You will need the Rust toolchain (cargo) installed.
+
+To build and test locally, run:
+
+```sh
+make test
+```
+
+The build will have 2 features activated: `rust_native_crypto` and `file_io`.
+Note that running the `make test` command will also check formatting of the code.

--- a/c_api/build.rs
+++ b/c_api/build.rs
@@ -22,7 +22,7 @@ fn main() {
 
     // Get the workspace target directory.
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR environment variable not set");
-    println!("Running c_api build script: {:?}", out_dir);
+    println!("Running c_api folder build script: {:?}", out_dir);
 
     let workspace_target_dir = Path::new(&out_dir)
         .ancestors()

--- a/make_release.ps1
+++ b/make_release.ps1
@@ -80,7 +80,7 @@ Write-Host "`nEnvironment setup complete. You can now run 'make release'."
 Write-Host "Building Rust project with msvc and clang toolchain ..."
 rustup update stable-$arch-pc-windows-msvc
 rustup target add $arch-pc-windows-msvc
-cargo build --target="$arch-pc-windows-msvc" -p c_api --release --no-default-features --features "rust_native_crypto, file_io"
+cargo build --target="$arch-pc-windows-msvc" -p c2pa-c-ffi --release --no-default-features --features "rust_native_crypto, file_io"
 
 
 # generate zip file with version and platform and add to artifacts folder

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -50,9 +50,7 @@ changelog_path = "./CHANGELOG.md"
 name = "c2patool"
 
 [[package]]
-name = "c_api"
-publish = false
-release = false
+name = "c2pa-c-ffi"
 
 [[package]]
 name = "export_schema"


### PR DESCRIPTION
## Changes in this pull request
- Prepare publication of C2PA C ffi API
- Renames c_api to c2pa-c-ffi (package only) so that it gets published under that name (lib name remains c2pa_c)

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
