### PR TITLE
fix: Freeze base64ct crate at 1.7.3 for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "async-trait",
  "atree",
  "base64 0.22.1",
+ "base64ct",
  "bcder",
  "byteorder",
  "byteordered",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -102,6 +102,7 @@ async-recursion = "1.1.1"
 async-trait = "0.1.78"
 atree = "0.5.2"
 base64 = "0.22.1"
+base64ct = "=1.7.3"
 bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
@@ -257,5 +258,8 @@ httpmock = "0.7.0"
 tokio = { version = "1.44.2", features = ["full"] }
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["windows-core"]
+normal = ["windows-core", "base64ct"]
     # REMOVE once chrono and other crates update to avoid yanked version of windows-core
+
+    # CAI-8799: Remove the base64ct override once we bump c2pa-rs MSRV
+    # to 1.85 or higher.


### PR DESCRIPTION
Temporary fix until we review c2pa-rs MSRV.
