### PR TITLE
chore: release v0.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.56.0...c2pa-v0.56.1)
+_18 June 2025_
+
+### Fixed
+
+* To_archive does not store resources associated with ingredients ([#1151](https://github.com/contentauth/c2pa-rs/pull/1151))
+
 ## [0.56.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.55.0...c2pa-v0.56.0)
 _17 June 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2665,7 +2665,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.56.0"
+version = "0.56.1"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.56.0...c2pa-c-ffi-v0.56.1)
+_18 June 2025_
+
+### Added
+
+* Rename c_api to c2pa_c_ffi and publish ([#1159](https://github.com/contentauth/c2pa-rs/pull/1159))
+
+### Fixed
+
+* Add required entries to Cargo.toml ([#1166](https://github.com/contentauth/c2pa-rs/pull/1166))
+* Fix c2pa_c_ffi Cargo.toml to allow `cargo publish` to succeed ([#1164](https://github.com/contentauth/c2pa-rs/pull/1164))
+
 ## [0.49.5](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-v0.49.5)
 _14 May 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -22,7 +22,7 @@ file_io = ["c2pa/file_io"]
 rust_native_crypto = ["c2pa/rust_native_crypto"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.56.0", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.56.1", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.56.0", features = [
+c2pa = { path = "../sdk", version = "0.56.1", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa_macros-v0.56.0...c2pa_macros-v0.56.1)
+_18 June 2025_
+
+### Added
+
+* Update Validation for 2.2 spec compliance ([#1144](https://github.com/contentauth/c2pa-rs/pull/1144))
+
 ## [0.56.0](https://github.com/contentauth/c2pa-rs/compare/c2pa_macros-v0.55.0...c2pa_macros-v0.56.0)
 _17 June 2025_
 


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.56.0 -> 0.56.1 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.56.0 -> 0.56.1
* `c2pa_macros`: 0.56.0 -> 0.56.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.56.0...c2pa-v0.56.1)

_18 June 2025_

### Fixed

* To_archive does not store resources associated with ingredients ([#1151](https://github.com/contentauth/c2pa-rs/pull/1151))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.56.0...c2pa-c-ffi-v0.56.1)

_18 June 2025_

### Added

* Rename c_api to c2pa_c_ffi and publish ([#1159](https://github.com/contentauth/c2pa-rs/pull/1159))

### Fixed

* Add required entries to Cargo.toml ([#1166](https://github.com/contentauth/c2pa-rs/pull/1166))
* Fix c2pa_c_ffi Cargo.toml to allow `cargo publish` to succeed ([#1164](https://github.com/contentauth/c2pa-rs/pull/1164))
</blockquote>

## `c2pa_macros`

<blockquote>

## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa_macros-v0.56.0...c2pa_macros-v0.56.1)

_18 June 2025_

### Added

* Update Validation for 2.2 spec compliance ([#1144](https://github.com/contentauth/c2pa-rs/pull/1144))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).