### PR TITLE
chore: release v0.56.1

### DIFF
--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -6,6 +6,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.56.1](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-ffi-v0.56.1)
+_18 June 2025_
+
+### Added
+
+* Rename c_api to c2pa_c_ffi and publish ([#1159](https://github.com/contentauth/c2pa-rs/pull/1159))
+
+### Fixed
+
+* Move `rust_native_crypto` feature from Cargo.toml default to release-plz config
+* Set `rust_native_crypto` as default feature for c2pa-c-ffi
+* Add required entries to Cargo.toml ([#1166](https://github.com/contentauth/c2pa-rs/pull/1166))
+* Fix c2pa_c_ffi Cargo.toml to allow `cargo publish` to succeed ([#1164](https://github.com/contentauth/c2pa-rs/pull/1164))
+
 ## [0.49.5](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-v0.49.5)
 _14 May 2025_
 


### PR DESCRIPTION



## 🤖 New release

* `c2pa-c-ffi`: 0.56.1
* `c2pa_macros`: 0.56.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa-c-ffi`

<blockquote>

## [0.56.1](https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-c-ffi-v0.56.1)

_18 June 2025_

### Added

* Rename c_api to c2pa_c_ffi and publish ([#1159](https://github.com/contentauth/c2pa-rs/pull/1159))

### Fixed

* Move `rust_native_crypto` feature from Cargo.toml default to release-plz config
* Set `rust_native_crypto` as default feature for c2pa-c-ffi
* Add required entries to Cargo.toml ([#1166](https://github.com/contentauth/c2pa-rs/pull/1166))
* Fix c2pa_c_ffi Cargo.toml to allow `cargo publish` to succeed ([#1164](https://github.com/contentauth/c2pa-rs/pull/1164))
</blockquote>

## `c2pa_macros`

<blockquote>

## [0.56.1](https://github.com/contentauth/c2pa-rs/compare/c2pa_macros-v0.56.0...c2pa_macros-v0.56.1)

_18 June 2025_

### Added

* Update Validation for 2.2 spec compliance ([#1144](https://github.com/contentauth/c2pa-rs/pull/1144))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).