### PR TITLE
feat: C FFI API should be usable in other Rust projects too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ version = "0.56.2"
 c2pa = { path = "sdk", default-features = false }
 
 [profile.release]
-strip = true  # Automatically strip symbols from the binary. 
+strip = true  # Automatically strip symbols from the binary.
 opt-level = 3
 lto = "thin"  # Link time optimization.

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -3,19 +3,19 @@ name = "c2pa-c-ffi"
 
 version.workspace = true
 
-description = "C language FFI bindings for c2pa crate"
+description = "C language FFI bindings and Rust library for c2pa crate"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/c2pa-c-ffi"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2pa-rs"
-keywords = ["metadata"]
+keywords = ["metadata", "rust", "ffi"]
 categories = ["api-bindings"]
 
 [lib]
 name = "c2pa_c_ffi"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
 file_io = ["c2pa/file_io"]

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -3,9 +3,9 @@ name = "c2pa-c-ffi"
 
 version.workspace = true
 
-description = "C language FFI bindings and Rust library for c2pa crate"
+description = "C language FFI base for c2pa crate to create bindings"
 edition = "2021"
-authors = ["Gavin Peacock <gpeacock@adobe.com>"]
+authors = ["Gavin Peacock <gpeacock@adobe.com>", "Tania Mathern <mathern@adobe.com>"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/c2pa-c-ffi"
 homepage = "https://contentauthenticity.org"
@@ -14,7 +14,7 @@ keywords = ["metadata", "rust", "ffi"]
 categories = ["api-bindings"]
 
 [lib]
-name = "c2pa_c_ffi"
+name = "c2pa_c"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["metadata"]
 categories = ["api-bindings"]
 
 [lib]
-name = "c2pa_c"
+name = "c2pa_c_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [features]

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/c2pa-c-ffi"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2pa-rs"
-keywords = ["metadata", "rust", "ffi"]
+keywords = ["metadata", "ffi", "bindings"]
 categories = ["api-bindings"]
 
 [lib]

--- a/c2pa_c_ffi/README.md
+++ b/c2pa_c_ffi/README.md
@@ -1,6 +1,6 @@
 # C2PA C API
 
-This is the C API wrapper for the [C2PA Rust SDK](../sdk). It provides a C-compatible interface for working with content credentials, with same formats supported as the Rust SDK.
+This is the C API wrapper for the [C2PA Rust SDK](../sdk). It provides a C-compatible interface for working with content credentials, with same formats supported as the Rust SDK. This crate can also be used in Rust code to write C-compatible bindings with the exposed types.
 
 ## Overview
 


### PR DESCRIPTION
## Changes in this pull request
- Build target changes so that C FFI API may be usable in other Rust projects too

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
