### PR TITLE
Docs: API doc clean up and improvement

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -126,7 +126,7 @@ impl From<ClaimGeneratorInfo> for SoftwareAgent {
 /// along with possible other information such as what software performed
 /// the action.
 ///
-/// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_actions>.
+/// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_actions>.
 #[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq)]
 pub struct Action {
     /// The label associated with this action. See ([`c2pa_action`]).
@@ -280,7 +280,7 @@ impl Action {
     /// Returns the list of related actions.
     ///
     /// This is only present in C2PA v2.
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_related>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_related_actions>.
     pub fn related(&self) -> Option<&[Action]> {
         self.related.as_deref()
     }
@@ -288,7 +288,7 @@ impl Action {
     /// Returns the reason why this action was performed.
     ///
     /// This is only present in C2PA v2.
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_reason>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_reason>.
     pub fn reason(&self) -> Option<&str> {
         self.reason.as_deref()
     }
@@ -407,7 +407,7 @@ impl Action {
     /// Sets the list of related actions.
     ///
     /// This is only present in C2PA v2.
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_related>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_related_actions>.
     pub fn set_related(mut self, related: Option<&Vec<Action>>) -> Self {
         self.related = related.cloned();
         self
@@ -416,7 +416,7 @@ impl Action {
     /// Sets the reason why this action was performed.
     ///
     /// This is only present in C2PA v2.
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_reason>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_reason>.
     pub fn set_reason<S: Into<String>>(mut self, reason: S) -> Self {
         self.reason = Some(reason.into());
         self
@@ -492,7 +492,7 @@ impl ActionTemplate {
 /// what took place on the asset, when it took place, along with possible
 /// other information such as what software performed the action.
 ///
-/// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_actions>.
+/// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_actions>.
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Actions {
@@ -519,7 +519,7 @@ pub struct Actions {
 impl Actions {
     /// Label prefix for an [`Actions`] assertion.
     ///
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_actions>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_actions>.
     pub const LABEL: &'static str = labels::ACTIONS;
 
     /// Creates a new [`Actions`] assertion struct.

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -85,7 +85,7 @@ impl Serialize for Ingredient {
 impl Ingredient {
     /// Label prefix for an ingredient assertion.
     ///
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_ingredient>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#ingredient_assertion>.
     pub const LABEL: &'static str = labels::INGREDIENT;
 
     pub fn new(title: &str, format: &str, instance_id: &str, document_id: Option<&str>) -> Self {

--- a/sdk/src/assertions/metadata.rs
+++ b/sdk/src/assertions/metadata.rs
@@ -50,7 +50,7 @@ pub struct Metadata {
 impl Metadata {
     /// Label prefix for an assertion metadata assertion.
     ///
-    /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_metadata_about_assertions>.
+    /// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_metadata_about_assertions>.
     pub const LABEL: &'static str = labels::ASSERTION_METADATA;
 
     pub fn new() -> Self {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -17,13 +17,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 
 //! This library supports reading, creating, and embedding C2PA data
-//! with a variety of asset types.
+//! for a variety of asset types.
 //!
 //! Some functionality requires you to enable specific crate features,
 //! as noted in the documentation.
 //!
-//! The library has a new Builder/Reader API
-//! The new API focuses on stream support and can do more with fewer methods.
+//! The library has a Builder/Reader API that focuses on simplicity 
+//! and stream support.
 //!
 //! # Example: Reading a ManifestStore
 //! ```
@@ -91,15 +91,19 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 // Public modules
 /// The assertions module contains the definitions for the assertions that are part of the C2PA specification.
 pub mod assertions;
+
 /// The cose_sign module contains the definitions for the COSE signing algorithms.
 pub mod cose_sign;
+
 /// The create_signer module contains the definitions for the signers that are part of the C2PA specification.
 pub mod create_signer;
 
 /// Cryptography primitives.
+#[doc(hidden)]
 pub mod crypto;
 
 /// Dynamic assertions are a new feature that allows you to add assertions to a C2PA file as a part of the signing process.
+#[doc(hidden)]
 pub mod dynamic_assertion;
 
 /// The `identity` module provides support for the [CAWG identity assertion](https://cawg.io/identity).
@@ -107,15 +111,20 @@ pub mod identity;
 
 /// The jumbf_io module contains the definitions for the JUMBF data in assets.
 pub mod jumbf_io;
+
 /// The settings module provides a way to configure the C2PA SDK.
+#[doc(hidden)]
 pub mod settings;
 
 /// Supports status tracking as defined in the C2PA Technical Specification.
+#[doc(hidden)]
 pub mod status_tracker;
 
 /// The validation_results module contains the definitions for the validation results that are part of the C2PA specification.
 pub mod validation_results;
+
 /// The validation_status module contains the definitions for the validation status that are part of the C2PA specification.
+#[doc(hidden)]
 pub mod validation_status;
 
 // Public exports

--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -13,7 +13,7 @@
 
 //! Implements validation status for specific parts of a manifest.
 //!
-//! See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_existing_manifests>.
+//! See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_existing_manifests>.
 
 #![deny(missing_docs)]
 
@@ -36,7 +36,7 @@ use crate::{
 /// A `ValidationStatus` struct describes the validation status of a
 /// specific part of a manifest.
 ///
-/// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_existing_manifests>.
+/// See <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_existing_manifests>.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct ValidationStatus {


### PR DESCRIPTION
WIP PR to clean up the docs that are published to https://docs.rs/c2pa/latest/c2pa/ per #1175.

Hide docs for these modules:
- Dynamic_assertions 
- Crypto 
- validation_status 
- status_tracker 
- settings 

Should these be hidden, too?
- Identity
- jumbf_io 

Additional questions:
 - Do we need the Re-exports section?
 
Do we need these?
 - Action
 - ActionTemplate 
 - Actions
 - Metadata



