### PR TITLE
chore: ensures dylib in release folder is copied

### DIFF
--- a/c2pa_c_ffi/Makefile
+++ b/c2pa_c_ffi/Makefile
@@ -40,7 +40,7 @@ define make_zip
 	if [[ "$(2)" == *"ios"* ]]; then \
 		cp $(1)/libc2pa_c.a $(1)/lib/; \
 	else \
-		find $(1) -name "libc2pa_c.*" ! -name "*.a" -exec cp {} $(1)/lib/ \;; \
+		find $(1) -name "libc2pa_c.*" ! -name "*.a" ! -path "*/deps/*" -exec cp {} $(1)/lib/ \;; \
 	fi; \
 	(cd $(1) && zip -9 -r ../../artifacts/c2pa-v$${VERSION}-$(2).zip include lib); \
 	echo "Zip file created: $(TARGET_DIR)/artifacts/c2pa-v$${VERSION}-$(2).zip"


### PR DESCRIPTION
The dylib / dlls in the deps file were being copied to the zip output instead of the artifacts in the release folder. This was messing up the paths in the dylibs as we were converting the paths to relative paths in the dylibs, using install_name_tool, in the release folder, then copying the dylibs from the deps folder (where the paths were not updated)  into the zip during release.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
