### PR TITLE
Enhance CAI store functionality and update supported types

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1036,13 +1036,15 @@ impl BmffHash {
             let c2pa_boxes = read_bmff_c2pa_boxes(&mut seg_reader)?;
             let box_infos = &c2pa_boxes.box_infos;
 
-            if box_infos.iter().filter(|b| b.path == "moof").count() != 1 {
-                return Err(Error::BadParam("expected 1 moof in fragment".to_string()));
-            }
+            // TODO: add support for multiple moofs in a fragment
+            // if box_infos.iter().filter(|b| b.path == "moof").count() != 1 {
+            //     return Err(Error::BadParam("expected 1 moof in fragment".to_string()));
+            // }
 
-            if box_infos.iter().filter(|b| b.path == "mdat").count() != 1 {
-                return Err(Error::BadParam("expected 1 mdat in fragment".to_string()));
-            }
+            // TODO: add support for multiple mdats in a fragment
+            // if box_infos.iter().filter(|b| b.path == "mdat").count() != 1 {
+            //     return Err(Error::BadParam("expected 1 mdat in fragment".to_string()));
+            // }
 
             // we don't currently support adding to fragments with existing manifests
             if !c2pa_boxes.bmff_merkle.is_empty() {

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -65,7 +65,7 @@ const FULL_BOX_TYPES: &[&str; 80] = &[
     "txtC", "mime", "uri ", "uriI", "hmhd", "sthd", "vvhd", "medc",
 ];
 
-static SUPPORTED_TYPES: [&str; 13] = [
+static SUPPORTED_TYPES: [&str; 16] = [
     "avif",
     "heif",
     "heic",
@@ -79,6 +79,9 @@ static SUPPORTED_TYPES: [&str; 13] = [
     "image/heif",
     "video/mp4",
     "video/quicktime",
+    "m4s",
+    "mcfv",
+    "mcfa"
 ];
 
 macro_rules! boxtype {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -906,6 +906,16 @@ impl Store {
 
         for manifest_box in claim.get_box_order() {
             match *manifest_box {
+                CLAIM => {
+                    let mut cb = CAIClaimBox::new(claim.version());
+
+                    // Add the Claim json
+                    let claim_cbor_bytes = claim.data()?;
+                    let c_cbor = JUMBFCBORContentBox::new(claim_cbor_bytes);
+                    cb.add_claim(Box::new(c_cbor));
+
+                    cai_store.add_box(Box::new(cb)); // add claim to manifest
+                }
                 ASSERTIONS => {
                     let mut a_store = CAIAssertionStore::new();
 
@@ -916,16 +926,6 @@ impl Store {
                     }
 
                     cai_store.add_box(Box::new(a_store)); // add the assertion store to the manifest
-                }
-                CLAIM => {
-                    let mut cb = CAIClaimBox::new(claim.version());
-
-                    // Add the Claim json
-                    let claim_cbor_bytes = claim.data()?;
-                    let c_cbor = JUMBFCBORContentBox::new(claim_cbor_bytes);
-                    cb.add_claim(Box::new(c_cbor));
-
-                    cai_store.add_box(Box::new(cb)); // add claim to manifest
                 }
                 SIGNATURE => {
                     // create a signature and add placeholder data to the CAI store.
@@ -1122,8 +1122,8 @@ impl Store {
                 let (box_label, _instance) =
                     Claim::box_name_label_instance(desc_box.label().as_ref());
                 match box_label.as_ref() {
-                    ASSERTIONS => box_order.push(ASSERTIONS),
                     CLAIM => box_order.push(CLAIM),
+                    ASSERTIONS => box_order.push(ASSERTIONS),
                     SIGNATURE => box_order.push(SIGNATURE),
                     CREDENTIALS => box_order.push(CREDENTIALS),
                     DATABOXES => box_order.push(DATABOXES),


### PR DESCRIPTION
- Added functionality to handle CLAIM boxes in the CAI store. They were added in a different order than the order they are read.
- Updated the order of box processing to ensure ASSERTIONS are handled correctly.
- Commented out validation for multiple moof and mdat boxes in BmffHash.
- Expanded the list of supported types in BMFF IO to include m4s, mcfv, and mcfa.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
