### PR TITLE
chore: Bump `nonempty-collections` to current version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty-collections"
-version = "0.2.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07626f57b1cb0ee81e5193d331209751d2e18ffa3ceaa0fd6fab63db31fafd9"
+checksum = "3761f83543b22e36b7ea1145309acf9c251ef67dd8b186047f85d8cc985272d4"
 dependencies = [
  "serde",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -138,7 +138,7 @@ memchr = "2.7.4"
 mp4 = "0.14.0"
 nom = "7.1.3"
 non-empty-string = { version = "=0.2.4", features = ["serde"] }
-nonempty-collections = { version = "0.2.9", features = ["serde"] }
+nonempty-collections = { version = "1.0", features = ["serde"] }
 num-bigint-dig = { version = "0.8.4", optional = true }
 p256 = { version = "0.13.2", optional = true }
 p384 = { version = "0.13.0", optional = true }


### PR DESCRIPTION
## Changes in this pull request

This PR bumps the version of `nonempty-collections` in use, as it was two major versions behind.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.

