### PR TITLE
fix: Fix wasm-pack yet again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,17 +317,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Chrome
-        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: stable
+          chrome-version: 137
           install-chromedriver: true
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Run Wasm tests
-        run: wasm-pack test --chrome --headless --no-default-features --features rust_native_crypto
+        run: wasm-pack test --chrome --chromedriver ${{ steps.setup-chrome.outputs.chromedriver-path }} --headless --no-default-features --features rust_native_crypto
         working-directory: ./sdk
+        env:
+          WASM_BINDGEN_TEST_TIMEOUT: 60
 
   tests-wasi:
     name: Unit tests (WASI)


### PR DESCRIPTION
## Changes in this pull request
 * Set longer timeout
 * Use Chrome for testing version 137 to show output
 * Explicitly set chrome-driver to use
