### PR TITLE
feat!: Change `Verifier` to hold a `Cow<'a, CertificateTrustPolicy` rather than a reference

### DIFF
--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::io::Write;
+use std::{borrow::Cow, io::Write};
 
 use async_generic::async_generic;
 use x509_parser::{num_bigint::BigUint, prelude::*};
@@ -56,8 +56,8 @@ pub(crate) fn verify_cose(
 ) -> Result<CertificateInfo> {
     let verifier = if cert_check {
         match get_settings_value::<bool>("verify.verify_trust") {
-            Ok(true) => Verifier::VerifyTrustPolicy(ctp),
-            _ => Verifier::VerifyCertificateProfileOnly(ctp),
+            Ok(true) => Verifier::VerifyTrustPolicy(Cow::Borrowed(ctp)),
+            _ => Verifier::VerifyCertificateProfileOnly(Cow::Borrowed(ctp)),
         }
     } else {
         Verifier::IgnoreProfileAndTrustPolicy

--- a/sdk/src/crypto/cose/certificate_trust_policy.rs
+++ b/sdk/src/crypto/cose/certificate_trust_policy.rs
@@ -41,7 +41,7 @@ pub enum TrustAnchorType {
 /// A `CertificateTrustPolicy` is configured with information about trust
 /// anchors, privately-accepted end-entity certificates, and allowed EKUs. It
 /// can be used to evaluate a signing certificate against those policies.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CertificateTrustPolicy {
     /// Trust anchors (root X.509 certificates) in DER format.
     trust_anchor_ders: Vec<Vec<u8>>,

--- a/sdk/src/crypto/cose/verifier.rs
+++ b/sdk/src/crypto/cose/verifier.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::io::Write;
+use std::{borrow::Cow, io::Write};
 
 use asn1_rs::FromDer;
 use async_generic::async_generic;
@@ -48,12 +48,12 @@ pub enum Verifier<'a> {
     /// Use a [`CertificateTrustPolicy`] to validate the signing certificate's
     /// profile against C2PA requirements _and_ validate the certificate's
     /// membership against a trust configuration.
-    VerifyTrustPolicy(&'a CertificateTrustPolicy),
+    VerifyTrustPolicy(Cow<'a, CertificateTrustPolicy>),
 
     /// Validate the certificate's membership against a trust configuration, but
     /// do not against any trust list. The [`CertificateTrustPolicy`] is used to
     /// enforce EKU (Extended Key Usage) policy only.
-    VerifyCertificateProfileOnly(&'a CertificateTrustPolicy),
+    VerifyCertificateProfileOnly(Cow<'a, CertificateTrustPolicy>),
 
     /// Ignore both trust configuration and trust lists.
     IgnoreProfileAndTrustPolicy,
@@ -184,8 +184,8 @@ impl Verifier<'_> {
         validation_log: &mut StatusTracker,
     ) -> Result<(), CoseError> {
         let ctp = match self {
-            Self::VerifyTrustPolicy(ctp) => *ctp,
-            Self::VerifyCertificateProfileOnly(ctp) => *ctp,
+            Self::VerifyTrustPolicy(ref ctp) => ctp,
+            Self::VerifyCertificateProfileOnly(ref ctp) => ctp,
             Self::IgnoreProfileAndTrustPolicy => {
                 return Ok(());
             }
@@ -196,7 +196,7 @@ impl Verifier<'_> {
 
         Ok(check_end_entity_certificate_profile(
             end_entity_cert_der,
-            ctp,
+            ctp.as_ref(),
             validation_log,
             tst_info,
         )?)
@@ -213,9 +213,9 @@ impl Verifier<'_> {
         // IMPORTANT: This function assumes that verify_profile has already been called.
 
         let ctp = match self {
-            Self::VerifyTrustPolicy(ctp) => *ctp,
+            Self::VerifyTrustPolicy(ref ctp) => ctp,
 
-            Self::VerifyCertificateProfileOnly(_ctp) => {
+            Self::VerifyCertificateProfileOnly(ref _ctp) => {
                 return Ok(TrustAnchorType::NoCheck);
             }
 


### PR DESCRIPTION
(Supports upcoming work I'm planning around configuring trust for reading CAWG identity assertions.)