### PR TITLE
chore: remove unused `async-std` dependency from `c2patool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,6 @@ version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "async-std",
  "atree",
  "c2pa",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,11 +23,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 anyhow = "1.0"
 atree = "0.5.2"
 c2pa = { path = "../sdk", version = "0.58.0", features = [
-	"fetch_remote_manifests",
-	"file_io",
-	"add_thumbnails",
-	"pdf"
-]}
+    "fetch_remote_manifests",
+    "file_io",
+    "add_thumbnails",
+    "pdf",
+] }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.7"
 glob = "0.3.1"
@@ -41,7 +41,6 @@ pem = "3.0.3"
 url = "2.5.0"
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
 reqwest = { version = "0.12.4", features = ["blocking"] }
 tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
 


### PR DESCRIPTION
## Changes in this pull request
`async-std` is a rather large unused dependency of `c2patool`. This PR removes it.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
