### PR TITLE
feat: define `DigitalSourceType` as enum

### DIFF
--- a/sdk/examples/c2pa.toml
+++ b/sdk/examples/c2pa.toml
@@ -90,7 +90,7 @@ action = "c2pa.edited"
 # The source type field is required for the c2pa.created action.
 #
 # For more information, see `c2pa::assertions::actions::source_type`.
-source_type = "http://c2pa.org/digitalsourcetype/empty"
+source_type = "Empty"
 # Description for the action
 description = "Some edit action."
 # Arbitrary key/value pairs to store in the action.
@@ -122,7 +122,7 @@ enabled = true
 # The source type field is required for the c2pa.created action.
 #
 # For more information, see `c2pa::assertions::actions::source_type`.
-source_type = "http://c2pa.org/digitalsourcetype/empty"
+source_type = "Empty"
 
 # Settings for configuring how c2pa.opened actions are auto created.
 #
@@ -134,7 +134,7 @@ enabled = true
 # For more information, see `c2pa::assertions::actions::source_type`.
 #
 # Note this field is optional for the c2pa.opened action.
-source_type = "http://c2pa.org/digitalsourcetype/empty"
+source_type = "Empty"
 
 # Settings for configuring how c2pa.placed actions are auto created.
 #
@@ -146,7 +146,7 @@ enabled = true
 # For more information, see `c2pa::assertions::actions::source_type`.
 #
 # Note this field is optional for the c2pa.placed action.
-source_type = "http://c2pa.org/digitalsourcetype/empty"
+source_type = "Empty"
 
 # Settings for automatic thumbnail generation.
 [builder.thumbnail]

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -14,10 +14,11 @@
 //! Assertion helpers to build, validate, and parse assertions.
 
 mod actions;
-#[allow(unused)]
-pub(crate) use actions::source_type;
 pub(crate) use actions::V2_DEPRECATED_ACTIONS;
-pub use actions::{c2pa_action, Action, ActionTemplate, Actions, SoftwareAgent};
+pub use actions::{
+    c2pa_action, Action, ActionTemplate, Actions, C2paDigitalSourceType, DigitalSourceType,
+    IptcDigitalSourceType, SoftwareAgent,
+};
 
 mod asset_reference;
 pub use asset_reference::AssetReference;

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -17,7 +17,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assertions::{
-        region_of_interest::RegionOfInterest, Action, ActionTemplate, Actor, SoftwareAgent,
+        region_of_interest::RegionOfInterest, Action, ActionTemplate, Actor, DigitalSourceType,
+        SoftwareAgent,
     },
     cbor_types::DateT,
     resource_store::UriOrResource,
@@ -122,10 +123,9 @@ impl SettingsValidate for ThumbnailSettings {
 pub(crate) struct AutoActionSettings {
     /// Whether to enable this auto action or not.
     pub enabled: bool,
-    // TODO: enum
     /// The default source type for the auto action.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_type: Option<String>,
+    pub source_type: Option<DigitalSourceType>,
 }
 
 /// Settings for how to specify the claim generator info's operating system.
@@ -211,7 +211,7 @@ pub(crate) struct ActionTemplateSettings {
     pub software_agent_index: Option<usize>,
     /// One of the defined URI values at `<https://cv.iptc.org/newscodes/digitalsourcetype/>`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_type: Option<String>,
+    pub source_type: Option<DigitalSourceType>,
     // TODO: handle paths/urls and document in the sample c2pa.toml
     /// Reference to an icon.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -293,7 +293,7 @@ pub(crate) struct ActionSettings {
     pub actors: Option<Vec<Actor>>,
     /// One of the defined URI values at `<https://cv.iptc.org/newscodes/digitalsourcetype/>`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_type: Option<String>,
+    pub source_type: Option<DigitalSourceType>,
     /// List of related actions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related: Option<Vec<Action>>,
@@ -442,8 +442,9 @@ impl SettingsValidate for BuilderSettings {
 pub mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use crate::assertions::C2paDigitalSourceType;
+
     use super::*;
-    use crate::assertions::source_type;
 
     #[test]
     fn test_auto_created_action_without_source_type() {
@@ -463,7 +464,7 @@ pub mod tests {
         let actions_settings = ActionsSettings {
             auto_created_action: AutoActionSettings {
                 enabled: true,
-                source_type: Some(source_type::EMPTY.to_owned()),
+                source_type: Some(C2paDigitalSourceType::Empty.into()),
             },
             ..Default::default()
         };

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -4596,6 +4596,7 @@ pub mod tests {
     use sha2::Sha256;
 
     use super::*;
+    use crate::assertions::C2paDigitalSourceType;
     #[cfg(all(feature = "file_io", feature = "v1_api"))]
     use crate::{
         assertion::AssertionJson,
@@ -4639,9 +4640,8 @@ pub mod tests {
     }
 
     fn create_capture_claim(claim: &mut Claim) -> Result<&mut Claim> {
-        let actions = Actions::new().add_action(
-            Action::new("c2pa.created").set_source_type("http://c2pa.org/digitalsourcetype/empty"),
-        );
+        let actions = Actions::new()
+            .add_action(Action::new("c2pa.created").set_source_type(C2paDigitalSourceType::Empty));
 
         claim.add_assertion(&actions)?;
 

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -35,8 +35,8 @@ use crate::crypto::{
 use crate::signer::RemoteSigner;
 use crate::{
     assertions::{
-        labels, Action, Actions, EmbeddedData, Ingredient, Relationship, ReviewRating,
-        SchemaDotOrg, Thumbnail, User,
+        labels, Action, Actions, C2paDigitalSourceType, EmbeddedData, Ingredient, Relationship,
+        ReviewRating, SchemaDotOrg, Thumbnail, User,
     },
     asset_io::CAIReadWrite,
     claim::Claim,
@@ -148,8 +148,7 @@ pub fn create_test_claim() -> Result<Claim> {
         .set_thumbnail(Some(&ingredient_thumbnail_ref));
     let ingredient_ref2 = claim.add_assertion_with_salt(&ingredient2, &DefaultSalt::default())?;
 
-    let created_action =
-        Action::new("c2pa.created").set_source_type("http://c2pa.org/digitalsourcetype/empty");
+    let created_action = Action::new("c2pa.created").set_source_type(C2paDigitalSourceType::Empty);
 
     let placed_action = Action::new("c2pa.placed")
         .set_parameter("ingredients", vec![ingredient_ref, ingredient_ref2])?;


### PR DESCRIPTION
## Changes in this pull request
Define `Actions::source_type` as an enum so user's no longer need to manually specify the entire URL.

### Questions
* Do we want to provide the `Other(String)` variant or ensure they are only what we support?
  * This has the flexibility that it supports future c2pa versions but it can allow for incorrect URLs. 
* Do we want the `DigitalSourceType` variants in PascalCase, camelCase, snake_case, something else?
* A side-effect of this implementation is that we allow digital source types to be read as, e.g. "Empty" in addition to the URL, which is technically incorrect according to the spec but offers a much more convenient JSON manifest/settings definition.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
