### PR TITLE
feat: No Send for CAIRead on wasm

### DIFF
--- a/sdk/src/asset_io.rs
+++ b/sdk/src/asset_io.rs
@@ -40,9 +40,15 @@ pub struct HashObjectPositions {
     pub htype: HashBlockObjectType, // type of hash block object
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub trait CAIRead: Read + Seek + Send {}
+#[cfg(target_arch = "wasm32")]
+pub trait CAIRead: Read + Seek {}
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> CAIRead for T where T: Read + Seek + Send {}
+#[cfg(target_arch = "wasm32")]
+impl<T> CAIRead for T where T: Read + Seek {}
 
 impl From<String> for Box<dyn CAIRead> {
     fn from(val: String) -> Self {

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -324,6 +324,7 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn object_locations_from_stream<R>(
     format: &str,
     stream: &mut R,
@@ -332,7 +333,21 @@ where
     R: Read + Seek + Send + ?Sized,
 {
     let mut reader = CAIReadAdapter { reader: stream };
+    match get_caiwriter_handler(format) {
+        Some(handler) => handler.get_object_locations_from_stream(&mut reader),
+        _ => Err(Error::UnsupportedType),
+    }
+}
 
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn object_locations_from_stream<R>(
+    format: &str,
+    stream: &mut R,
+) -> Result<Vec<HashObjectPositions>>
+where
+    R: Read + Seek + ?Sized,
+{
+    let mut reader = CAIReadAdapter { reader: stream };
     match get_caiwriter_handler(format) {
         Some(handler) => handler.get_object_locations_from_stream(&mut reader),
         _ => Err(Error::UnsupportedType),

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -126,7 +126,23 @@ impl Reader {
     /// println!("{}", reader.json());
     /// ```
     #[async_generic()]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_stream(format: &str, mut stream: impl Read + Seek + Send) -> Result<Reader> {
+        let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
+        let mut validation_log = StatusTracker::default();
+
+        let store = if _sync {
+            Store::from_stream(format, &mut stream, verify, &mut validation_log)
+        } else {
+            Store::from_stream_async(format, &mut stream, verify, &mut validation_log).await
+        }?;
+
+        Self::from_store(store, &validation_log)
+    }
+
+    #[async_generic()]
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_stream(format: &str, mut stream: impl Read + Seek) -> Result<Reader> {
         let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
         let mut validation_log = StatusTracker::default();
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3892,6 +3892,7 @@ impl Store {
 
     /// Load store from a stream
     #[async_generic]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_stream(
         format: &str,
         mut stream: impl Read + Seek + Send,
@@ -3929,12 +3930,79 @@ impl Store {
         Ok(store)
     }
 
+    /// Load store from a stream
+    #[async_generic]
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_stream(
+        format: &str,
+        mut stream: impl Read + Seek,
+        verify: bool,
+        validation_log: &mut StatusTracker,
+    ) -> Result<Self> {
+        let (manifest_bytes, remote_url) = Store::load_jumbf_from_stream(format, &mut stream)?;
+
+        let store = if _sync {
+            Self::from_manifest_data_and_stream(
+                &manifest_bytes,
+                format,
+                &mut stream,
+                verify,
+                validation_log,
+            )
+        } else {
+            Self::from_manifest_data_and_stream_async(
+                &manifest_bytes,
+                format,
+                &mut stream,
+                verify,
+                validation_log,
+            )
+            .await
+        };
+
+        let mut store = store?;
+        if remote_url.is_none() {
+            store.embedded = true;
+        } else {
+            store.remote_url = remote_url;
+        }
+
+        Ok(store)
+    }
+
     /// Load store from a manifest data and stream
     #[async_generic()]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_manifest_data_and_stream(
         c2pa_data: &[u8],
         format: &str,
         mut stream: impl Read + Seek + Send,
+        verify: bool,
+        validation_log: &mut StatusTracker,
+    ) -> Result<Self> {
+        // first we convert the JUMBF into a usable store
+        let store = Store::from_jumbf(c2pa_data, validation_log)?;
+
+        //let verify = get_settings_value::<bool>("verify.verify_after_reading")?; // defaults to true
+
+        if verify {
+            let mut asset_data = ClaimAssetData::Stream(&mut stream, format);
+            if _sync {
+                Store::verify_store(&store, &mut asset_data, validation_log)
+            } else {
+                Store::verify_store_async(&store, &mut asset_data, validation_log).await
+            }?;
+        }
+        Ok(store)
+    }
+
+    /// Load store from a manifest data and stream
+    #[async_generic()]
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_manifest_data_and_stream(
+        c2pa_data: &[u8],
+        format: &str,
+        mut stream: impl Read + Seek,
         verify: bool,
         validation_log: &mut StatusTracker,
     ) -> Result<Self> {


### PR DESCRIPTION
## Changes in this pull request
`unsafe impl Send` will no longer be required on Wasm. Wasm is single threaded.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
