### PR TITLE
feature: Add ability to set/get the description for an action.

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -252,6 +252,13 @@ impl Action {
         self.changes.as_deref()
     }
 
+    /// Gets the description of the action, if it exists.
+    ///
+    /// This field is only applicable to the v2 assertion.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
     /// Returns the additional parameters for this action.
     ///
     /// These vary by the type of action.
@@ -403,6 +410,15 @@ impl Action {
     /// Sets the array of [`Actor`]s that undertook this action.
     pub fn set_actors(mut self, actors: Option<&Vec<Actor>>) -> Self {
         self.actors = actors.cloned();
+        self
+    }
+
+    /// Sets the description of the action.
+    ///
+    /// This is only present in the v2 actions assertion.
+    /// See <https://spec.c2pa.org/specifications/specifications/1.4/specs/C2PA_Specification.html#_actions>
+    pub fn set_description<S: Into<String>>(mut self, description: S) -> Self {
+        self.description = Some(description.into());
         self
     }
 
@@ -720,7 +736,8 @@ pub mod tests {
                             ..Default::default()
                         }],
                         ..Default::default()
-                    }),
+                    })
+                    .set_description("Apply a gaussian blur to the image"),
             )
             .add_metadata(
                 AssertionMetadata::new()
@@ -755,6 +772,11 @@ pub mod tests {
         assert_eq!(
             result.metadata.unwrap().date_time(),
             original.metadata.unwrap().date_time()
+        );
+        assert!(result.actions[0].description().is_none());
+        assert_eq!(
+            result.actions[1].description(),
+            Some("Apply a gaussian blur to the image")
         );
     }
 

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -252,7 +252,7 @@ impl Action {
         self.changes.as_deref()
     }
 
-    /// Gets the description of the action, if it exists.
+    /// Returns the description of the action.
     ///
     /// This field is only applicable to the v2 assertion.
     pub fn description(&self) -> Option<&str> {


### PR DESCRIPTION
## Changes in this pull request
For a `c2pa.actions.v2` assertion, actions have a description field. There was no way to get or set the description on the action without using serialization. This was reported in #1275. 

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
