### PR TITLE
fix: Mark the CreativeWork assertion as deprecated

### DIFF
--- a/sdk/examples/client/client.rs
+++ b/sdk/examples/client/client.rs
@@ -16,6 +16,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+#[allow(deprecated)]
 use c2pa::{
     assertions::{c2pa_action, labels, Action, Actions, CreativeWork, Exif, SchemaDotOrgPerson},
     create_signer,
@@ -49,6 +50,7 @@ fn show_manifest(reader: &Reader, manifest_label: &str, level: usize) -> Result<
                         println!("{}{}", indent, action.action());
                     }
                 }
+                #[allow(deprecated)]
                 labels::CREATIVE_WORK => {
                     let creative_work: CreativeWork = assertion.to_assertion()?;
                     if let Some(authors) = creative_work.author() {
@@ -118,6 +120,8 @@ pub fn main() -> Result<()> {
     );
 
     // build a creative work assertion
+    // TO DO: Replace this example.
+    #[allow(deprecated)]
     let creative_work =
         CreativeWork::new().add_author(SchemaDotOrgPerson::new().set_name("me")?)?;
 
@@ -140,6 +144,7 @@ pub fn main() -> Result<()> {
     builder.definition.claim_version = Some(2);
     let mut generator = ClaimGeneratorInfo::new(GENERATOR);
     generator.set_version("0.1");
+    #[allow(deprecated)]
     builder
         .set_claim_generator_info(generator)
         .add_ingredient(parent)

--- a/sdk/examples/data_hash.rs
+++ b/sdk/examples/data_hash.rs
@@ -23,6 +23,7 @@ use std::{
 #[cfg(feature = "file_io")]
 use c2pa::crypto::raw_signature::SigningAlg;
 #[cfg(feature = "file_io")]
+#[allow(deprecated)]
 use c2pa::{
     assertions::{
         c2pa_action, labels::*, Action, Actions, CreativeWork, DataHash, Exif, SchemaDotOrgPerson,
@@ -54,6 +55,8 @@ fn builder_from_source<S: AsRef<Path>>(source: S) -> Result<Builder> {
     );
 
     // build a creative work assertion
+    // TO DO: Remove this example.
+    #[allow(deprecated)]
     let creative_work =
         CreativeWork::new().add_author(SchemaDotOrgPerson::new().set_name("me")?)?;
 

--- a/sdk/src/assertions/creative_work.rs
+++ b/sdk/src/assertions/creative_work.rs
@@ -36,7 +36,7 @@ const CW_AUTHOR: &str = "author";
 /// new manifests.
 #[deprecated(
     since = "0.59.0",
-    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity and/or metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
 )]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreativeWork(SchemaDotOrg);

--- a/sdk/src/assertions/creative_work.rs
+++ b/sdk/src/assertions/creative_work.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#![allow(deprecated)]
+
 use std::ops::Deref;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -25,6 +27,17 @@ use crate::{
 const ASSERTION_CREATION_VERSION: usize = 1;
 const CW_AUTHOR: &str = "author";
 
+/// Assertion that implements various schema.org-based assertions,
+/// including the now-deprecated CreativeWork assertion.
+///
+/// This structure is here to allow parsing of existing C2PA 1.x manifests
+/// this assertion. The CreativeWork assertion is no longer part of the
+/// C2PA Technical Specification and it should not be used when creating
+/// new manifests.
+#[deprecated(
+    since = "0.59.0",
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreativeWork(SchemaDotOrg);
 

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -37,6 +37,7 @@ mod data_hash;
 pub use data_hash::DataHash;
 
 mod creative_work;
+#[allow(deprecated)]
 pub use creative_work::CreativeWork;
 
 mod exif;
@@ -58,6 +59,7 @@ pub use assertion_metadata::{
 };
 
 mod schema_org;
+#[allow(deprecated)]
 pub use schema_org::{SchemaDotOrg, SchemaDotOrgPerson};
 
 mod thumbnail;

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -25,6 +27,7 @@ use crate::{
 
 const ASSERTION_CREATION_VERSION: usize = 1;
 
+/// Assertion that implements various schema.org-based assertions.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchemaDotOrg {
     #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]
@@ -130,6 +133,17 @@ impl AssertionBase for SchemaDotOrg {
         Self::from_json_assertion(assertion)
     }
 }
+
+/// Description of a person in the now-deprecated CreativeWork assertion.
+///
+/// This structure is here to allow parsing of existing C2PA 1.x manifests
+/// this assertion. The CreativeWork assertion is no longer part of the
+/// C2PA Technical Specification and it should not be used when creating
+/// new manifests.
+#[deprecated(
+    since = "0.59.0",
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchemaDotOrgPerson(SchemaDotOrg);
 

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -142,7 +142,7 @@ impl AssertionBase for SchemaDotOrg {
 /// new manifests.
 #[deprecated(
     since = "0.59.0",
-    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion and/or metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion and/or CAWG metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
 )]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchemaDotOrgPerson(SchemaDotOrg);

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -142,7 +142,7 @@ impl AssertionBase for SchemaDotOrg {
 /// new manifests.
 #[deprecated(
     since = "0.59.0",
-    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity assertion and/or metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
 )]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchemaDotOrgPerson(SchemaDotOrg);

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -26,6 +26,7 @@ use serde_with::skip_serializing_none;
 use uuid::Uuid;
 use zip::{write::SimpleFileOptions, ZipArchive, ZipWriter};
 
+#[allow(deprecated)]
 use crate::{
     assertion::AssertionDecodeError,
     assertions::{
@@ -994,9 +995,9 @@ impl Builder {
 
                     claim.add_assertion(&actions)
                 }
+                #[allow(deprecated)]
                 CreativeWork::LABEL => {
                     let cw: CreativeWork = manifest_assertion.to_assertion()?;
-
                     claim.add_gathered_assertion_with_salt(&cw, &salt)
                 }
                 Exif::LABEL => {

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -42,6 +42,7 @@ use crate::{
     ClaimGeneratorInfo, ManifestAssertionKind,
 };
 #[cfg(feature = "v1_api")]
+#[allow(deprecated)]
 use crate::{
     assertions::{CreativeWork, DataHash, Exif, User, UserCbor},
     asset_io::{CAIRead, CAIReadWrite},
@@ -994,6 +995,7 @@ impl Manifest {
 
                     claim.add_assertion(&actions)
                 }
+                #[allow(deprecated)]
                 CreativeWork::LABEL => {
                     let mut cw: CreativeWork = manifest_assertion.to_assertion()?;
                     // insert a credentials field if we have a vc that matches the identifier


### PR DESCRIPTION
CreativeWork assertion is no longer part of the C2PA Technical Specification and its use should be avoided when creating new manifests.