### PR TITLE
chore: prepare for crates.io publish

### DIFF
--- a/make_test_images/src/make_test_images.rs
+++ b/make_test_images/src/make_test_images.rs
@@ -311,7 +311,7 @@ impl MakeTestImages {
                     {
                         "action": "c2pa.opened",
                         "parameters": {
-                            "org.cai.ingredientIds": [&instance_id]
+                            "ingredientIds": [&instance_id]
                         }
                     }
                 ));
@@ -396,7 +396,7 @@ impl MakeTestImages {
                     {
                         "action": "c2pa.placed",
                         "parameters": {
-                            "org.cai.ingredientIds": [&instance_id]
+                            "ingredientIds": [&instance_id]
                         }
                     }
                 ));

--- a/sdk/src/assertions/region_of_interest.rs
+++ b/sdk/src/assertions/region_of_interest.rs
@@ -235,7 +235,7 @@ pub enum Role {
 ///
 /// This struct can be used from [`Action::changes`][crate::assertions::Action::changes],
 /// [`AssertionMetadata::region_of_interest`][crate::assertions::AssertionMetadata::region_of_interest], or
-/// [`SoftBindingScopeMap::region`][crate::assertions::soft_binding::SoftBindingScopeMap::region].
+/// [`SoftBindingScope::region`][crate::assertions::soft_binding::SoftBindingScope::region].
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]

--- a/sdk/src/assertions/soft_binding.rs
+++ b/sdk/src/assertions/soft_binding.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// The data structure used to store one or more soft bindings across some or all of the asset's content.
 ///
-/// https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#soft_binding_assertion
+/// <https://c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#soft_binding_assertion>
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct SoftBinding {
     /// A string identifying the soft binding algorithm and version of that algorithm used to compute the value,

--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -487,6 +487,7 @@ impl GifIO {
         Ok(())
     }
 
+    #[allow(dead_code)] // this here for wasm builds to pass clippy  (todo: remove)
     fn replace_block_in_place(
         &self,
         stream: &mut dyn CAIReadWrite,

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -29,7 +29,7 @@ fn test_builder_ca_jpg() -> Result<()> {
     let format = "image/jpeg";
     let mut source = Cursor::new(TEST_IMAGE);
 
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
 
     use c2pa::assertions::Action;
     builder.add_action(Action::new("c2pa.published"))?;
@@ -65,7 +65,7 @@ fn test_builder_riff() -> Result<()> {
     let mut source = Cursor::new(include_bytes!("fixtures/sample1.wav"));
     let format = "audio/wav";
 
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
     builder.definition.claim_version = Some(1); // use v1 for this test
     builder.no_embed = true;
     builder.sign(&Settings::signer()?, format, &mut source, &mut io::empty())?;
@@ -79,7 +79,7 @@ fn test_builder_fragmented() -> Result<()> {
     use common::tempdirectory;
     Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
 
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
     let tempdir = tempdirectory().expect("temp dir");
     let output_path = tempdir.path();
     let mut init_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -141,7 +141,7 @@ fn test_builder_fragmented() -> Result<()> {
 fn test_builder_remote_url_no_embed() -> Result<()> {
     Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
     //let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
     // disable remote fetching for this test
     Settings::from_toml(
         &toml::toml! {
@@ -179,7 +179,7 @@ fn test_builder_embedded_v1_otgp() -> Result<()> {
     let mut source = Cursor::new(include_bytes!("fixtures/XCA.jpg"));
     let format = "image/jpeg";
 
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
     let mut dest = Cursor::new(Vec::new());
     builder.sign(&Settings::signer()?, format, &mut source, &mut dest)?;
     dest.set_position(0);
@@ -302,7 +302,7 @@ fn test_dynamic_assertions_builder() -> Result<()> {
     }
 
     //let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
-    let mut builder = Builder::update();
+    let mut builder = Builder::edit();
 
     const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
     let format = "image/jpeg";


### PR DESCRIPTION
changes org.cai.ingredientIds references to ingredientIds
Removes Builder::Create and Builder::Update until we have them implemented.
Renames BuilderFlow to BuilderIntent and open to edit.
fixes some doc issues

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
