### PR TITLE
chore: use c2pa test async macro

### DIFF
--- a/sdk/src/identity/builder/identity_assertion_builder.rs
+++ b/sdk/src/identity/builder/identity_assertion_builder.rs
@@ -294,6 +294,7 @@ mod tests {
 
     use std::io::{Cursor, Seek};
 
+    use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -316,12 +317,7 @@ mod tests {
     const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
     const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../tests/fixtures/thumbnail.jpg");
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn simple_case() {
         // NOTE: This needs to be async for now because the verification side is
         // async-only.
@@ -377,12 +373,7 @@ mod tests {
         assert_eq!(nc_json, "{}");
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn simple_case_async() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);

--- a/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
+++ b/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
@@ -605,19 +605,15 @@ impl IcaSignatureVerifier {
             ));
         };
 
-        // TO DO: Bring in substitute for now() on Wasm.
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let now = Utc::now().fixed_offset();
+        let now = Utc::now().fixed_offset();
 
-            if now < valid_from {
-                return Err((
-                    IcaValidationError::InvalidValidFromDate(
-                        "validFrom is after current date/time".to_owned(),
-                    ),
-                    "cawg.ica.valid_from.invalid",
-                ));
-            }
+        if now < valid_from {
+            return Err((
+                IcaValidationError::InvalidValidFromDate(
+                    "validFrom is after current date/time".to_owned(),
+                ),
+                "cawg.ica.valid_from.invalid",
+            ));
         }
 
         if let Some(tst_info) = maybe_tst_info {
@@ -651,19 +647,15 @@ impl IcaSignatureVerifier {
             return Ok(());
         };
 
-        // TO DO: Bring in substitute for now() on Wasm.
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let now = Utc::now().fixed_offset();
+        let now = Utc::now().fixed_offset();
 
-            if now > valid_until {
-                return Err((
-                    IcaValidationError::InvalidValidUntilDate(
-                        "validUntil is before current date/time".to_owned(),
-                    ),
-                    "cawg.ica.valid_until.invalid",
-                ));
-            }
+        if now > valid_until {
+            return Err((
+                IcaValidationError::InvalidValidUntilDate(
+                    "validUntil is before current date/time".to_owned(),
+                ),
+                "cawg.ica.valid_until.invalid",
+            ));
         }
 
         if let Some(tst_info) = maybe_tst_info {

--- a/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
+++ b/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
@@ -167,6 +167,8 @@ mod tests {
     use chrono::{DateTime, FixedOffset};
     use iref::UriBuf;
     use non_empty_string::NonEmptyString;
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::{
         crypto::raw_signature,

--- a/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
+++ b/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
@@ -163,6 +163,7 @@ mod tests {
         str::FromStr,
     };
 
+    use c2pa_macros::c2pa_test_async;
     use chrono::{DateTime, FixedOffset};
     use iref::UriBuf;
     use non_empty_string::NonEmptyString;
@@ -190,12 +191,7 @@ mod tests {
     const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
     const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../tests/fixtures/thumbnail.jpg");
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn x509_simple_case() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);
@@ -266,12 +262,7 @@ mod tests {
         // TO DO: Not sure what to check from COSE_Sign1.
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn adobe_connected_identities() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
@@ -365,12 +356,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test::wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn err_naive_credential_holder() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);

--- a/sdk/src/identity/tests/claim_aggregation/interop.rs
+++ b/sdk/src/identity/tests/claim_aggregation/interop.rs
@@ -13,6 +13,7 @@
 
 use std::{io::Cursor, str::FromStr};
 
+use c2pa_macros::c2pa_test_async;
 use chrono::{DateTime, FixedOffset};
 use iref::UriBuf;
 use non_empty_string::NonEmptyString;
@@ -28,12 +29,7 @@ use crate::{
     HashedUri, Reader,
 };
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn adobe_connected_identities() {
     crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
@@ -119,12 +115,7 @@ async fn adobe_connected_identities() {
     );
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn ims_multiple_manifests() {
     crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 

--- a/sdk/src/identity/tests/claim_aggregation/validation.rs
+++ b/sdk/src/identity/tests/claim_aggregation/validation.rs
@@ -764,12 +764,7 @@ async fn unsupported_did_method() {
     assert!(log_items.next().is_none());
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn unresolvable_did() {
     // If the DID can not be resolved, the validator MUST issue the failure code
     // `cawg.ica.did_unavailable` but MAY continue validation.

--- a/sdk/src/identity/tests/claim_aggregation/validation.rs
+++ b/sdk/src/identity/tests/claim_aggregation/validation.rs
@@ -1191,9 +1191,7 @@ async fn valid_from_missing() {
     assert!(log_items.next().is_none());
 }
 
-// TO DO (CAI-7996): Not sure why this doesn't run on Wasm/WASI.
-#[cfg(not(target_arch = "wasm32"))]
-#[tokio::test]
+#[c2pa_test_async]
 async fn valid_from_in_future() {
     // 8.1.7.2.6. Verify the credential’s validity range
     //
@@ -1264,9 +1262,7 @@ async fn valid_from_in_future() {
     assert!(log_items.next().is_none());
 }
 
-// TO DO (CAI-7996): Not sure why this doesn't run on Wasm/WASI.
-#[cfg(not(target_arch = "wasm32"))]
-#[tokio::test]
+#[c2pa_test_async]
 async fn valid_from_after_time_stamp() {
     // 8.1.7.2.6. Verify the credential’s validity range
     //
@@ -1425,9 +1421,7 @@ async fn valid_until_in_future() {
     assert!(log_items.next().is_none());
 }
 
-// TO DO (CAI-7996): Not sure why this doesn't run on Wasm/WASI.
-#[cfg(not(target_arch = "wasm32"))]
-#[tokio::test]
+#[c2pa_test_async]
 async fn valid_until_in_past() {
     // If the expiration date is present, the validator SHALL compare the expiration
     // date of the credential against each of the following values, if available:

--- a/sdk/src/identity/tests/examples/x509_signing.rs
+++ b/sdk/src/identity/tests/examples/x509_signing.rs
@@ -17,6 +17,8 @@
 
 use std::io::{Cursor, Seek};
 
+use c2pa_macros::c2pa_test_async;
+
 use crate::{
     crypto::raw_signature,
     identity::{
@@ -32,7 +34,7 @@ use crate::{
 const TEST_IMAGE: &[u8] = include_bytes!("../../../../tests/fixtures/CA.jpg");
 const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../../tests/fixtures/thumbnail.jpg");
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[c2pa_test_async]
 #[ignore] // We'll only run this occasionally if we need to update this test.
 async fn x509_signing() {
     let format = "image/jpeg";

--- a/sdk/src/identity/tests/validation_method/continue_when_possible.rs
+++ b/sdk/src/identity/tests/validation_method/continue_when_possible.rs
@@ -16,6 +16,7 @@
 
 use std::io::Cursor;
 
+use c2pa_macros::c2pa_test_async;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -32,12 +33,7 @@ use crate::{
 /// report assertions that do not follow this rule.
 ///
 /// [Section 5.2, “CBOR schema”]: https://cawg.io/identity/1.1-draft/#_cbor_schema
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn malformed_cbor() {
     let format = "image/jpeg";
     let test_image = include_bytes!("../fixtures/validation_method/malformed_cbor.jpg");
@@ -74,12 +70,7 @@ async fn malformed_cbor() {
 
 /// A validator SHALL NOT consider any extra fields not documented in the
 /// `identity` rule during the validation process.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn extra_fields() {
     // The test asset `extra_field.jpg` was written using a temporarily modified
     // version of this SDK that generated an `other_stuff` string value at the top
@@ -134,12 +125,7 @@ async fn extra_fields() {
 /// entry must appear in the `assertions` entry.) The
 /// `cawg.identity.assertion.mismatch` error code SHALL be used to report
 /// violations of this rule.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn assertion_not_in_claim_v1() {
     // The test asset `extra_assertion_claim_v1.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly added an extra hashed URI to
@@ -222,12 +208,7 @@ async fn assertion_not_in_claim_v1() {
 // entry must appear in the `assertions` entry.) The
 // `cawg.identity.assertion.mismatch` error code SHALL be used to report
 // violations of this rule.
-// #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-// #[cfg_attr(
-//     all(target_arch = "wasm32", not(target_os = "wasi")),
-//     wasm_bindgen_test
-// )]
-// #[cfg_attr(target_os = "wasi", wstd::test)]
+// #[c2pa_test_async]
 // #[ignore]
 // async fn assertion_not_in_claim_v2() {
 //     todo!("Generate a suitable V2 asset with an extra assertion");
@@ -237,12 +218,7 @@ async fn assertion_not_in_claim_v1() {
 /// `signer_payload.referenced_assertions` is duplicated. The
 /// `cawg.identity.assertion.duplicate` error code SHALL be used to report
 /// violations of this rule.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn duplicate_assertion_reference() {
     // The test asset `duplicate_assertion_reference.jpg` was written using a
     // temporarily modified version of this SDK that incorrectly added a
@@ -327,12 +303,7 @@ async fn duplicate_assertion_reference() {
 /// missing hard binding assertion.
 ///
 /// [Section 9.2, “Hard bindings”]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_hard_bindings
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn no_hard_binding() {
     // The test asset `duplicate_assertion.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly added a duplicate hashed URI to
@@ -415,6 +386,7 @@ mod invalid_sig_type {
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
+    use super::*;
     use crate::{
         identity::{
             claim_aggregation::IcaSignatureVerifier, x509::X509SignatureVerifier, IdentityAssertion,
@@ -423,12 +395,7 @@ mod invalid_sig_type {
         Reader,
     };
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn x509_signature_verifier() {
         // The test asset `invalid_sig_type.jpg` was written using a temporarily
         // modified version of this SDK that added a proof-of-concept signature type
@@ -501,12 +468,7 @@ mod invalid_sig_type {
         );
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn ica_verifier() {
         // The test asset `invalid_sig_type.jpg` was written using a temporarily
         // modified version of this SDK that added a proof-of-concept signature type
@@ -583,12 +545,7 @@ mod invalid_sig_type {
 /// The `pad1` and `pad2` fields of an identity assertion MUST contain only
 /// zero-value (`0x00`) bytes. The `cawg.identity.pad.invalid` error code SHALL
 /// be used to report assertions that contain other values in these fields.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn pad1_invalid() {
     // The test asset `pad1_invalid.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly placed a non-zero value in the
@@ -658,12 +615,7 @@ async fn pad1_invalid() {
     );
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn pad2_invalid() {
     // The test asset `pad1_invalid.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly placed a non-zero value in the

--- a/sdk/src/identity/tests/validation_method/stop_on_error.rs
+++ b/sdk/src/identity/tests/validation_method/stop_on_error.rs
@@ -16,6 +16,7 @@
 
 use std::io::Cursor;
 
+use c2pa_macros::c2pa_test_async;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -31,12 +32,7 @@ use crate::{
 /// report assertions that do not follow this rule.
 ///
 /// [Section 5.2, “CBOR schema”]: https://cawg.io/identity/1.1-draft/#_cbor_schema
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn malformed_cbor() {
     let format = "image/jpeg";
     let test_image = include_bytes!("../fixtures/validation_method/malformed_cbor.jpg");
@@ -72,12 +68,7 @@ async fn malformed_cbor() {
 
 /// A validator SHALL NOT consider any extra fields not documented in the
 /// `identity` rule during the validation process.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn extra_fields() {
     // The test asset `extra_field.jpg` was written using a temporarily modified
     // version of this SDK that generated an `other_stuff` string value at the top
@@ -132,12 +123,7 @@ async fn extra_fields() {
 /// entry must appear in the `assertions` entry.) The
 /// `cawg.identity.assertion.mismatch` error code SHALL be used to report
 /// violations of this rule.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn assertion_not_in_claim_v1() {
     // The test asset `extra_assertion_claim_v1.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly added an extra hashed URI to
@@ -212,12 +198,7 @@ async fn assertion_not_in_claim_v1() {
 // entry must appear in the `assertions` entry.) The
 // `cawg.identity.assertion.mismatch` error code SHALL be used to report
 // violations of this rule.
-// #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-// #[cfg_attr(
-//     all(target_arch = "wasm32", not(target_os = "wasi")),
-//     wasm_bindgen_test
-// )]
-// // #[cfg_attr(target_os = "wasi", wstd::test)] #[ignore] is ignored on WASI
+// #[c2pa_test_async]
 // #[ignore]
 // async fn assertion_not_in_claim_v2() {
 //     todo!("Generate a suitable V2 asset with an extra assertion");
@@ -227,12 +208,7 @@ async fn assertion_not_in_claim_v1() {
 /// `signer_payload.referenced_assertions` is duplicated. The
 /// `cawg.identity.assertion.duplicate` error code SHALL be used to report
 /// violations of this rule.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn duplicate_assertion_reference() {
     // The test asset `duplicate_assertion_reference.jpg` was written using a
     // temporarily modified version of this SDK that incorrectly added a
@@ -309,12 +285,7 @@ async fn duplicate_assertion_reference() {
 /// missing hard binding assertion.
 ///
 /// [Section 9.2, “Hard bindings”]: https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_hard_bindings
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn no_hard_binding() {
     // The test asset `duplicate_assertion.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly added a duplicate hashed URI to
@@ -388,6 +359,7 @@ async fn no_hard_binding() {
 mod invalid_sig_type {
     use std::io::Cursor;
 
+    use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -399,12 +371,7 @@ mod invalid_sig_type {
         Reader,
     };
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn x509_signature_verifier() {
         // The test asset `invalid_sig_type.jpg` was written using a temporarily
         // modified version of this SDK that added a proof-of-concept signature type
@@ -479,12 +446,7 @@ mod invalid_sig_type {
         );
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn ica_verifier() {
         // The test asset `invalid_sig_type.jpg` was written using a temporarily
         // modified version of this SDK that added a proof-of-concept signature type
@@ -563,12 +525,7 @@ mod invalid_sig_type {
 /// The `pad1` and `pad2` fields of an identity assertion MUST contain only
 /// zero-value (`0x00`) bytes. The `cawg.identity.pad.invalid` error code SHALL
 /// be used to report assertions that contain other values in these fields.
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn pad1_invalid() {
     // The test asset `pad1_invalid.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly placed a non-zero value in the
@@ -632,12 +589,7 @@ async fn pad1_invalid() {
     assert_eq!(err.to_string(), "invalid padding");
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-#[cfg_attr(
-    all(target_arch = "wasm32", not(target_os = "wasi")),
-    wasm_bindgen_test
-)]
-#[cfg_attr(target_os = "wasi", wstd::test)]
+#[c2pa_test_async]
 async fn pad2_invalid() {
     // The test asset `pad1_invalid.jpg` was written using a temporarily
     // modified version of this SDK that incorrectly placed a non-zero value in the

--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -60,6 +60,7 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use std::io::Cursor;
 
+    use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -75,12 +76,7 @@ mod tests {
     const MULTIPLE_IDENTITIES_VALID: &[u8] =
         include_bytes!("tests/fixtures/claim_aggregation/ims_multiple_manifests.jpg");
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn test_connected_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
@@ -102,12 +98,7 @@ mod tests {
         );
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn test_multiple_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
@@ -127,12 +118,7 @@ mod tests {
         assert_eq!(reader.validation_state(), ValidationState::Valid);
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn test_post_validate_with_hard_binding_missing() {
         let mut stream = Cursor::new(NO_HARD_BINDING);
         let mut reader = Reader::from_stream("image/jpeg", &mut stream).unwrap();

--- a/sdk/src/identity/x509/async_x509_credential_holder.rs
+++ b/sdk/src/identity/x509/async_x509_credential_holder.rs
@@ -104,6 +104,7 @@ mod tests {
 
     use std::io::{Cursor, Seek};
 
+    use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -122,12 +123,7 @@ mod tests {
     const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
     const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../tests/fixtures/thumbnail.jpg");
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn simple_case_async() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);

--- a/sdk/src/identity/x509/x509_credential_holder.rs
+++ b/sdk/src/identity/x509/x509_credential_holder.rs
@@ -76,6 +76,7 @@ mod tests {
 
     use std::io::{Cursor, Seek};
 
+    use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -94,12 +95,7 @@ mod tests {
     const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
     const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../tests/fixtures/thumbnail.jpg");
 
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    #[cfg_attr(
-        all(target_arch = "wasm32", not(target_os = "wasi")),
-        wasm_bindgen_test
-    )]
-    #[cfg_attr(target_os = "wasi", wstd::test)]
+    #[c2pa_test_async]
     async fn simple_case() {
         let format = "image/jpeg";
         let mut source = Cursor::new(TEST_IMAGE);


### PR DESCRIPTION
## Changes in this pull request
Use the `c2pa_test_async` macro to simplify async tests.
Use chrono::Utc::now on wasm  for ICA signature validation

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
