### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.59.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.59.0...c2pa-v0.59.1)
+_15 August 2025_
+
+### Fixed
+
+* Add common name to manifest dump ([#1319](https://github.com/contentauth/c2pa-rs/pull/1319))
+* Support box hash exclusions ([#1317](https://github.com/contentauth/c2pa-rs/pull/1317))
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
 
 Since version 0.36.2, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
@@ -686,7 +686,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "quote",
  "syn 2.0.105",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2685,7 +2685,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.59.0"
+version = "0.59.1"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.59.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.59.0...c2pa-c-ffi-v0.59.1)
+_15 August 2025_
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.59.0", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.59.1", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.20.1](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.20.0...c2patool-v0.20.1)
+_15 August 2025_
+# Changelog
+
 All changes to C2PA Tool are documented in this file.  For additional information on versions 0.9.x and earlier, see the [Archived release motes](../docs/release-notes.md).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.20.0"
+version = "0.20.1"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.59.0", features = [
+c2pa = { path = "../sdk", version = "0.59.1", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.59.0", features = [
+c2pa = { path = "../sdk", version = "0.59.1", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.59.0 -> 0.59.1 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.59.0 -> 0.59.1
* `c2patool`: 0.20.0 -> 0.20.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.59.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.59.0...c2pa-v0.59.1)

_15 August 2025_

### Fixed

* Add common name to manifest dump ([#1319](https://github.com/contentauth/c2pa-rs/pull/1319))
* Support box hash exclusions ([#1317](https://github.com/contentauth/c2pa-rs/pull/1317))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.59.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.59.0...c2pa-c-ffi-v0.59.1)

_15 August 2025_
</blockquote>

## `c2patool`

<blockquote>

## [0.20.1](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.20.0...c2patool-v0.20.1)

_15 August 2025_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).