### PR TITLE
chore: unpin UUID dependency

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -184,7 +184,7 @@ tempfile = "=3.15.0"
 thiserror = "2.0.8"
 treeline = "0.1.0"
 url = "2.5.3"
-uuid = { version = "=1.12.0", features = ["serde", "v4"] }
+uuid = { version = "^1.12.0", features = ["serde", "v4"] }
 web-time = "1.1"
 x509-certificate = "0.24.0"
 x509-parser = "0.16.0"


### PR DESCRIPTION
## Changes in this pull request
Happy to also upgrade this if that's preferred (Tested with 1.17.0) - this dependency is a bit old and is blocking some other upgrades

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
