### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.60.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.60.0...c2pa-v0.60.1)
+_27 August 2025_
+
+### Fixed
+
+* Removes asm feature for sha2 ([#1343](https://github.com/contentauth/c2pa-rs/pull/1343))
+* Reset settings after test_stream_thumbnail ([#1339](https://github.com/contentauth/c2pa-rs/pull/1339))
+
 ## [0.60.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.59.1...c2pa-v0.60.0)
 _26 August 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2621,7 +2621,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.60.0"
+version = "0.60.1"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.60.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.60.0...c2pa-c-ffi-v0.60.1)
+_27 August 2025_
+
 ## [0.60.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.59.1...c2pa-c-ffi-v0.60.0)
 _26 August 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.60.0", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.60.1", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.20.2...c2patool-v0.20.3)
+_27 August 2025_
+
 ## [0.20.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.20.1...c2patool-v0.20.2)
 _26 August 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.20.2"
+version = "0.20.3"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.60.0", features = [
+c2pa = { path = "../sdk", version = "0.60.1", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.60.0", features = [
+c2pa = { path = "../sdk", version = "0.60.1", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.60.0 -> 0.60.1 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.60.0 -> 0.60.1
* `c2patool`: 0.20.2 -> 0.20.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.60.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.60.0...c2pa-v0.60.1)

_27 August 2025_

### Fixed

* Removes asm feature for sha2 ([#1343](https://github.com/contentauth/c2pa-rs/pull/1343))
* Reset settings after test_stream_thumbnail ([#1339](https://github.com/contentauth/c2pa-rs/pull/1339))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.60.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.60.0...c2pa-c-ffi-v0.60.1)

_27 August 2025_
</blockquote>

## `c2patool`

<blockquote>

## [0.20.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.20.2...c2patool-v0.20.3)

_27 August 2025_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).