### PR TITLE
chore: Temporarily allow async-std crate, despite its unmaintained status

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ ignore = [
   "RUSTSEC-2021-0127", # serde_cbor
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
   "RUSTSEC-2024-0370", # proc-macro-error
+  "RUSTSEC-2025-0052", # async-std (https://github.com/contentauth/c2pa-rs/issues/1351)
 ]
 
 [bans]


### PR DESCRIPTION
See #1351, which asks that we update httpmock as soon as an update is available.
