### PR TITLE
fix: rewind output  stream after adding dynamic assertions

### DIFF
--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -39,16 +39,13 @@ impl AsyncPostValidator for CawgValidator {
     ) -> crate::Result<Option<Value>> {
         if label == "cawg.identity" || label.starts_with("cawg.identity__") {
             let identity_assertion: IdentityAssertion = assertion.to_assertion()?;
-            tracker.push_current_uri(uri);
-
+            tracker.push_current_uri(uri.to_string());
             let result = identity_assertion
                 .validate_partial_claim(partial_claim, tracker)
                 .await
-                .map(Some)
-                .map_err(|e| crate::Error::ClaimVerification(e.to_string()));
-
+                .ok();
             tracker.pop_current_uri();
-            return result;
+            return Ok(result);
         };
         Ok(None)
     }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2834,6 +2834,7 @@ impl Store {
                 }
                 _ => (),
             };
+            output_stream.rewind()?;
         }
 
         let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;


### PR DESCRIPTION
CawgValidate should not return errors since it will log.