### PR TITLE
chore: update uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,6 @@ dependencies = [
  "ed25519-dalek",
  "env_logger 0.10.2",
  "extfmt",
- "getrandom 0.2.16",
  "glob",
  "hex",
  "hex-literal",
@@ -691,7 +690,6 @@ dependencies = [
  "quick-xml",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.9.3",
  "range-set",
  "rasn",
  "rasn-cms",
@@ -4935,11 +4933,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
  "wasm-bindgen",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -183,7 +183,7 @@ tempfile = "=3.15.0"
 thiserror = "2.0.8"
 treeline = "0.1.0"
 url = "2.5.3"
-uuid = { version = "=1.12.0", features = ["serde", "v4"] }
+uuid = { version = "1.18.0", features = ["serde", "v4"] }
 web-time = "1.1"
 x509-certificate = "0.24.0"
 x509-parser = "0.16.0"
@@ -237,7 +237,6 @@ image = { version = "0.25.6", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-getrandom = "0.2.7"
 wasi = { version = "0.14", optional = true }
 wstd = "0.5"
 
@@ -252,12 +251,10 @@ chrono = { version = "0.4.39", default-features = false, features = [
     "wasmbind",
 ] }
 console_log = { version = "1.0.0", features = ["color"] }
-getrandom = { version = "0.2.7", features = ["js"] }
 js-sys = "0.3.58"
-rand_core = "0.9.0-alpha.2"
 ring = { version = "0.17.13", features = ["wasm32_unknown_unknown_js"] }
 serde-wasm-bindgen = "0.6.5"
-uuid = { version = "1.10.0", features = ["serde", "v4", "js"] }
+uuid = { version = "1.18.0", features = ["serde", "v4", "js"] }
 wasm-bindgen = "0.2.95"
 wasm-bindgen-futures = "0.4.31"
 web-sys = { version = "0.3.58", features = [


### PR DESCRIPTION
## Changes in this pull request
Random number generation now works without specifying dependencies for Wasm.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
