### PR TITLE
Add CAWG validation to reader

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -463,6 +463,10 @@ pub unsafe extern "C" fn c2pa_free_string_array(ptr: *const *const c_char, count
 
 // Run CAWG post-validation - this is async and requires a runtime.
 fn post_validate(result: Result<C2paReader, c2pa::Error>) -> Result<C2paReader, c2pa::Error> {
+    if true {
+        todo!("Remove me?");
+    }
+
     match result {
         Ok(mut reader) => {
             let runtime = match Runtime::new() {

--- a/c2pa_c_ffi/src/json_api.rs
+++ b/c2pa_c_ffi/src/json_api.rs
@@ -24,6 +24,9 @@ use crate::{Error, Result, SignerInfo};
 pub fn read_file(path: &str, data_dir: Option<String>) -> Result<String> {
     let mut reader = Reader::from_file(path).map_err(Error::from_c2pa_error)?;
     let runtime = Runtime::new().map_err(|e| Error::Other(e.to_string()))?;
+    if true {
+        todo!("Remove post_validate_async here?");
+    }
     runtime
         .block_on(reader.post_validate_async(&CawgValidator {}))
         .map_err(Error::from_c2pa_error)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -574,6 +574,9 @@ fn verify_fragmented(init_pattern: &Path, frag_pattern: &Path) -> Result<Vec<Rea
 
 // run cawg validation if supported
 fn validate_cawg(reader: &mut Reader) -> Result<()> {
+    if true {
+        todo!("Remove me?");
+    }
     #[cfg(not(target_os = "wasi"))]
     {
         Runtime::new()?

--- a/sdk/examples/cawg_identity.rs
+++ b/sdk/examples/cawg_identity.rs
@@ -125,9 +125,7 @@ mod cawg {
 
         builder.sign_file_async(&signer, source, &dest).await?;
 
-        let mut reader = Reader::from_file(dest)?;
-
-        reader.post_validate_async(&CawgValidator {}).await?;
+        let reader = Reader::from_file_async(dest).await?;
 
         println!("{reader}");
         Ok(())

--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -78,8 +78,7 @@ mod tests {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let mut stream = Cursor::new(CONNECTED_IDENTITIES_VALID);
-        let mut reader = Reader::from_stream("image/jpeg", &mut stream).unwrap();
-        reader.post_validate_async(&CawgValidator {}).await.unwrap();
+        let reader = Reader::from_stream_async("image/jpeg", &mut stream).await.unwrap();
         //println!("validation results: {}", reader);
         assert_eq!(
             reader
@@ -100,8 +99,7 @@ mod tests {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
         let mut stream = Cursor::new(MULTIPLE_IDENTITIES_VALID);
-        let mut reader = Reader::from_stream("image/jpeg", &mut stream).unwrap();
-        reader.post_validate_async(&CawgValidator {}).await.unwrap();
+        let reader = Reader::from_stream_async("image/jpeg", &mut stream).await.unwrap();
         println!("validation results: {reader}");
         assert_eq!(
             reader
@@ -116,10 +114,9 @@ mod tests {
     }
 
     #[c2pa_test_async]
-    async fn test_post_validate_with_hard_binding_missing() {
+    async fn test_cawg_validate_with_hard_binding_missing() {
         let mut stream = Cursor::new(NO_HARD_BINDING);
-        let mut reader = Reader::from_stream("image/jpeg", &mut stream).unwrap();
-        reader.post_validate_async(&CawgValidator {}).await.unwrap();
+        let reader = Reader::from_stream_async("image/jpeg", &mut stream).await.unwrap();
         assert_eq!(
             reader
                 .validation_results()

--- a/sdk/src/identity/x509/x509_credential_holder.rs
+++ b/sdk/src/identity/x509/x509_credential_holder.rs
@@ -137,6 +137,26 @@ mod tests {
         let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
+        let validation_results = manifest_store.validation_results().unwrap();
+        let active_manifest_results = validation_results.active_manifest().unwrap();
+        let active_manifest_success_codes = active_manifest_results.success();
+
+        dbg!(&active_manifest_success_codes);
+
+        let mut ia_success_codes = active_manifest_success_codes.iter().filter(|s| {
+            s.url()
+                .map(|url| url.ends_with("cawg.identity"))
+                .unwrap_or(false)
+                && !s.code().starts_with("assertion.")
+        });
+
+        let ia_success = ia_success_codes.next().unwrap();
+        dbg!(&ia_success);
+
+        if true {
+            panic!("Look for identity assertion success codes");
+        }
+
         let manifest = manifest_store.active_manifest().unwrap();
         let mut st = StatusTracker::default();
         let mut ia_iter = IdentityAssertion::from_manifest(manifest, &mut st);

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -136,7 +136,13 @@ impl Reader {
             Store::from_stream_async(format, &mut stream, verify, &mut validation_log).await
         }?;
 
-        Self::from_store(store, &validation_log)
+        let /* mut */ result = Self::from_store(store, &validation_log)?;
+        if false {
+            // QUESTION: What to do if we're in the _sync version and there
+            // are identity assertions? Just report an error (needs async)?
+            todo!("Add identity assertion validation here");
+        }
+        Ok(result)
     }
 
     #[async_generic()]
@@ -151,7 +157,11 @@ impl Reader {
             Store::from_stream_async(format, &mut stream, verify, &mut validation_log).await
         }?;
 
-        Self::from_store(store, &validation_log)
+        let mut result = Self::from_store(store, &validation_log)?;
+        if false {
+            todo!("Add identity assertion validation here");
+        }
+        Ok(result)
     }
 
     #[cfg(feature = "file_io")]
@@ -735,6 +745,9 @@ impl Reader {
         validator: &impl AsyncPostValidator
     ))]
     pub fn post_validate(&mut self, validator: &impl PostValidator) -> Result<()> {
+        if true {
+            todo!("Remove me");
+        }
         let mut validation_log = StatusTracker::default();
         let mut validation_results = self.validation_results.take().unwrap_or_default();
         let mut assertion_values = HashMap::new();
@@ -997,6 +1010,9 @@ pub mod tests {
 
     #[test]
     fn test_reader_post_validate() -> Result<()> {
+        if true {
+            todo!("Remove me");
+        }
         use crate::{log_item, status_tracker::StatusTracker};
 
         let mut reader =


### PR DESCRIPTION
This is a sketch of the changes I'd like to see made to the `Reader` interface to make CAWG more directly part of the reading process from clients' point of view.