### PR TITLE
fix: Make OpenSSL code path enforce COSE specified salt length

### DIFF
--- a/sdk/src/crypto/raw_signature/openssl/validators/rsa_validator.rs
+++ b/sdk/src/crypto/raw_signature/openssl/validators/rsa_validator.rs
@@ -15,7 +15,7 @@ use openssl::{
     hash::MessageDigest,
     pkey::PKey,
     rsa::{Padding, Rsa},
-    sign::Verifier,
+    sign::{RsaPssSaltlen, Verifier},
 };
 
 use crate::crypto::raw_signature::{
@@ -58,6 +58,7 @@ impl RawSignatureValidator for RsaValidator {
                 let mut verifier = Verifier::new(MessageDigest::sha256(), &public_key)?;
                 verifier.set_rsa_padding(Padding::PKCS1_PSS)?;
                 verifier.set_rsa_mgf1_md(MessageDigest::sha256())?;
+                verifier.set_rsa_pss_saltlen(RsaPssSaltlen::DIGEST_LENGTH)?;
                 verifier
             }
 
@@ -65,7 +66,7 @@ impl RawSignatureValidator for RsaValidator {
                 let mut verifier = Verifier::new(MessageDigest::sha384(), &public_key)?;
                 verifier.set_rsa_padding(Padding::PKCS1_PSS)?;
                 verifier.set_rsa_mgf1_md(MessageDigest::sha384())?;
-
+                verifier.set_rsa_pss_saltlen(RsaPssSaltlen::DIGEST_LENGTH)?;
                 verifier
             }
 
@@ -73,6 +74,7 @@ impl RawSignatureValidator for RsaValidator {
                 let mut verifier = Verifier::new(MessageDigest::sha512(), &public_key)?;
                 verifier.set_rsa_padding(Padding::PKCS1_PSS)?;
                 verifier.set_rsa_mgf1_md(MessageDigest::sha512())?;
+                verifier.set_rsa_pss_saltlen(RsaPssSaltlen::DIGEST_LENGTH)?;
                 verifier
             }
         };


### PR DESCRIPTION
## Changes in this pull request
This PR brings c2patool in line with how the current Verify/Inspect sites perform.  It removes the RSA-PSS automatic salt detection performed by OpenSSL in favor of what is specified in the Cose [spec](https://datatracker.ietf.org/doc/html/rfc8230/#section-2).  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
