### PR TITLE
fix: make `openssl` and `rust_native_crypto` features additive

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,19 +24,7 @@ rust-version = "1.86.0"
 exclude = ["tests/fixtures"]
 
 [package.metadata.docs.rs]
-# Build with all features, but not with openssl and rust_native_crypto simulatenously.
-features = [
-    "openssl",
-    "add_thumbnails",
-    "file_io",
-    "serialize_thumbnails",
-    "no_interleaved_io",
-    "fetch_remote_manifests",
-    "json_schema",
-    "pdf",
-    "v1_api",
-    "diagnostics",
-]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -47,8 +35,8 @@ serialize_thumbnails = []
 no_interleaved_io = ["file_io"]
 fetch_remote_manifests = ["dep:wasi"]
 json_schema = ["dep:schemars"]
-openssl = ["dep:openssl"]
 pdf = ["dep:lopdf"]
+openssl = ["dep:openssl"]
 rust_native_crypto = [
     "dep:const-oid",
     "dep:ecdsa",
@@ -203,10 +191,19 @@ sha2 = { version = "0.10.6", features = ["asm"] }
 [target.'cfg(not(target_arch = "aarch64"))'.dependencies]
 sha2 = "0.10.6"
 
+# This list matches the `rust_native_crypto` feature since they are not optional on WASM.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 const-oid = "0.9.6"
 der = "0.7.9"
+ecdsa = { version = "0.16.9", features = ["digest", "sha2"] }
 num-bigint-dig = "0.8.4"
+p256 = "0.13.2"
+p384 = "0.13.0"
+p521 = { version = "0.13.3", features = [
+    "pkcs8",
+    "digest",
+    "ecdsa",
+] }
 pkcs1 = "0.7.5"
 rsa = { version = "0.9.6", features = ["sha2"] }
 spki = "0.7.3"
@@ -289,7 +286,7 @@ wasm-bindgen-test = "0.3.45"
 httpmock = "0.7.0"
 tokio = { version = "1.44.2", features = ["full"] }
 criterion = { package = "codspeed-criterion-compat", version = "3.0.5" }
-#
+
 # WASM/WASI doesn't support default criterion features.
 # https://github.com/bheisler/criterion.rs/blob/4c19e913b84e6a7e4a8470cb0f766796886ed891/book/src/user_guide/wasi.md
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/sdk/src/crypto/raw_signature/mod.rs
+++ b/sdk/src/crypto/raw_signature/mod.rs
@@ -15,10 +15,13 @@
 
 pub(crate) mod oids;
 
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    feature = "openssl",
+    not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+))]
 pub(crate) mod openssl;
 
-#[cfg(feature = "rust_native_crypto")]
+#[cfg(any(feature = "rust_native_crypto", target_arch = "wasm32"))]
 pub(crate) mod rust_native;
 
 pub(crate) mod signer;

--- a/sdk/src/crypto/raw_signature/tests/signers.rs
+++ b/sdk/src/crypto/raw_signature/tests/signers.rs
@@ -69,7 +69,10 @@ fn es384() {
 }
 
 #[test]
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    feature = "openssl",
+    not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+))]
 fn es512() {
     let cert_chain = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.pub");
     let private_key = include_bytes!("../../../../tests/fixtures/crypto/raw_signature/es512.priv");

--- a/sdk/src/crypto/raw_signature/tests/validators.rs
+++ b/sdk/src/crypto/raw_signature/tests/validators.rs
@@ -241,7 +241,10 @@ const SHA384_OID: Oid = bcder::Oid(OctetString::from_static(&[96, 134, 72, 1, 10
 
 const SHA512_OID: Oid = bcder::Oid(OctetString::from_static(&[96, 134, 72, 1, 101, 3, 4, 2, 3]));
 
-#[cfg_attr(feature = "rust_native_crypto", allow(unused))]
+#[cfg_attr(
+    any(feature = "rust_native_crypto", target_arch = "wasm32"),
+    allow(unused)
+)]
 const SHA1_OID: Oid = bcder::Oid(OctetString::from_static(&[43, 14, 3, 2, 26]));
 
 #[test]
@@ -340,7 +343,10 @@ fn rs512() {
 }
 
 #[test]
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    feature = "openssl",
+    not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+))]
 fn sha1() {
     let signature =
         include_bytes!("../../../../tests/fixtures/crypto/raw_signature/legacy/sha1.raw_sig");

--- a/sdk/src/crypto/raw_signature/validator.rs
+++ b/sdk/src/crypto/raw_signature/validator.rs
@@ -65,7 +65,7 @@ pub trait AsyncRawSignatureValidator {
 /// Which validators are available may vary depending on the platform and
 /// which crate features were enabled.
 pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignatureValidator>> {
-    #[cfg(feature = "rust_native_crypto")]
+    #[cfg(any(feature = "rust_native_crypto", target_arch = "wasm32"))]
     {
         if let Some(validator) =
             crate::crypto::raw_signature::rust_native::validators::validator_for_signing_alg(alg)
@@ -74,7 +74,10 @@ pub fn validator_for_signing_alg(alg: SigningAlg) -> Option<Box<dyn RawSignature
         }
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(
+        feature = "openssl",
+        not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+    ))]
     if let Some(validator) =
         crate::crypto::raw_signature::openssl::validators::validator_for_signing_alg(alg)
     {
@@ -95,7 +98,7 @@ pub(crate) fn validator_for_sig_and_hash_algs(
     hash_alg: &Oid,
 ) -> Option<Box<dyn RawSignatureValidator>> {
     // TO REVIEW: Do we need any of the RSA-PSS algorithms for this use case?
-    #[cfg(feature = "rust_native_crypto")]
+    #[cfg(any(feature = "rust_native_crypto", target_arch = "wasm32"))]
     {
         if let Some(validator) =
             crate::crypto::raw_signature::rust_native::validators::validator_for_sig_and_hash_algs(
@@ -106,7 +109,10 @@ pub(crate) fn validator_for_sig_and_hash_algs(
         }
     }
 
-    #[cfg(feature = "openssl")]
+    #[cfg(all(
+        feature = "openssl",
+        not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+    ))]
     if let Some(validator) =
         crate::crypto::raw_signature::openssl::validators::validator_for_sig_and_hash_algs(
             sig_alg, hash_alg,
@@ -175,14 +181,20 @@ pub enum RawSignatureValidationError {
     InternalError(String),
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    feature = "openssl",
+    not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+))]
 impl From<openssl::error::ErrorStack> for RawSignatureValidationError {
     fn from(err: openssl::error::ErrorStack) -> Self {
         Self::CryptoLibraryError(err.to_string())
     }
 }
 
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    feature = "openssl",
+    not(all(feature = "rust_native_crypto", target_arch = "wasm32"))
+))]
 impl From<crate::crypto::raw_signature::openssl::OpenSslMutexUnavailable>
     for RawSignatureValidationError
 {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -203,11 +203,5 @@ pub(crate) mod store;
 pub(crate) mod utils;
 pub(crate) use utils::{cbor_types, hash_utils};
 
-#[cfg(all(feature = "openssl", feature = "rust_native_crypto"))]
-compile_error!("Features 'openssl' and 'rust_native_crypto' cannot be enabled at the same time.");
-
 #[cfg(not(any(feature = "openssl", feature = "rust_native_crypto")))]
 compile_error!("Either 'openssl' or 'rust_native_crypto' feature must be enabled.");
-
-#[cfg(all(feature = "openssl", target_arch = "wasm32"))]
-compile_error!("Feature 'openssl' is not available for wasm32.");


### PR DESCRIPTION
Rust docs state that features [should be additive](https://doc.rust-lang.org/cargo/reference/features.html?highlight=additive#feature-unification) and mutually exclusive features [should be avoided if at all possible](https://doc.rust-lang.org/cargo/reference/features.html?highlight=additive#mutually-exclusive-features) because if you depend on two crates with both features, the features will use the union of them (thus breaking the crate).

The solution is enable `openssl` by default UNLESS the `rust_native_crypto` feature flag is specified. If both are specified, use `rust_native_crypto`.  If neither are specified, there is a compile error (although I think in the future we may not want this).

The added benefit of this is that it allows `--all-features` to work (common especially with `rust-analyzer`), unblocks #1374, and fixes a related issue in #1375.

* Closes #1372