### PR TITLE
feat: fallback c2patool to settings signer

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -740,9 +740,10 @@ fn main() -> Result<()> {
 
             Box::new(signer)
         } else {
-            match sign_config.signer() {
+            match Settings::signer() {
                 Ok(signer) => signer,
-                Err(err) => Settings::signer().context(err)?,
+                Err(Error::MissingSignerSettings) => sign_config.signer()?,
+                Err(err) => Err(err)?,
             }
         };
 


### PR DESCRIPTION
This makes it so `c2patool` falls back to the settings signer if passed via `--settings`.