### PR TITLE
fix: assertion metadata localizations support was missing. CAI-9444

### DIFF
--- a/sdk/src/assertions/assertion_metadata.rs
+++ b/sdk/src/assertions/assertion_metadata.rs
@@ -75,7 +75,7 @@ impl AssertionMetadata {
         self.date_time.as_deref()
     }
 
-    // Returns the localizations map
+    /// Returns the vec of localizations maps if they exist.
     pub fn localizations(&self) -> Option<&Vec<HashMap<String, HashMap<String, String>>>> {
         self.localizations.as_ref()
     }


### PR DESCRIPTION
The AssertionMetadata field "localizations" is in the spec but was missing from our implementation. It is now added and supported.
