### PR TITLE
fix: Fix/trust list check

### DIFF
--- a/sdk/src/crypto/raw_signature/rust_native/check_certificate_trust.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/check_certificate_trust.rs
@@ -125,7 +125,7 @@ pub(crate) fn check_certificate_trust(
                 let data = chain_cert.tbs_certificate.as_ref();
                 let sig = chain_cert.signature_value.as_ref();
 
-                let sig_alg = cert_signing_alg(anchor_cert);
+                let sig_alg = cert_signing_alg(&chain_cert);
 
                 let result = verify_data(anchor_der, sig_alg, sig, data);
 


### PR DESCRIPTION
## Changes in this pull request
RustCrypto path used the wrong value in determining the certificate signature algorithm
Make sure OpenSSL

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
