### PR TITLE
fix: Make zip script

### DIFF
--- a/c2pa_c_ffi/Makefile
+++ b/c2pa_c_ffi/Makefile
@@ -37,7 +37,7 @@ define make_zip
 	fi; \
 	mkdir -p $(TARGET_DIR)/artifacts $(1)/include $(1)/lib; \
 	cp $(1)/c2pa.h $(1)/include/; \
-	if [[ "$(2)" == *"ios"* ]]; then \
+	if echo "$(2)" | grep -q "ios"; then \
 		cp $(1)/libc2pa_c.a $(1)/lib/; \
 	else \
 		find $(1) -name "libc2pa_c.*" ! -name "*.a" ! -path "*/deps/*" -exec cp {} $(1)/lib/ \;; \


### PR DESCRIPTION
## Changes in this pull request
- Fixes the syntax of the makefiles script to accomodate more shells.
Previously, the jobs logged the error `/bin/sh: 1: [[: not found`. With this change, that error should go away.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
