### PR TITLE
docs: Change relative to absolute URLs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -14,11 +14,11 @@ For a simple example of calling c2patool from a Node.js server application, see 
 
 **Additional documentation**:
 
-- [Using C2PA Tool](./docs/usage.md)
-- [Manifest definition file](./docs/manifest.md)
-- [Using an X.509 certificate](./docs/x_509.md)
-- [Change log / release notes](./CHANGELOG.md)
-- [Contributing to the project](./docs/project-contributions.md)
+- [Using C2PA Tool](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/usage.md)
+- [Manifest definition file](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/manifest.md)
+- [Using an X.509 certificate](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/x_509.md)
+- [Change log / release notes](https://github.com/contentauth/c2pa-rs/blob/main/cli/CHANGELOG.md)
+- [Contributing to the project](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/project-contributions.md)
 
 </div>
 


### PR DESCRIPTION
## Changes in this pull request

Fixed links so they work in docs.rs per https://jira.corp.adobe.com/browse/CAI-9484.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
