### PR TITLE
feat: Expose add_assertion_json from the Builder at the C level

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1620,10 +1620,10 @@ mod tests {
         TestC2paStream::drop_c_stream(read_stream);
         unsafe {
             c2pa_manifest_bytes_free(manifest_bytes_ptr);
+            c2pa_builder_free(builder);
+            c2pa_signer_free(signer);
+            c2pa_reader_free(reader);
         }
-        unsafe { c2pa_builder_free(builder) };
-        unsafe { c2pa_signer_free(signer) };
-        unsafe { c2pa_reader_free(reader) };
     }
 
     #[test]

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -907,15 +907,6 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 ///
 /// # Safety
 /// Reads from NULL-terminated C strings.
-///
-/// # Example
-/// ```c
-/// const char* action_json = "{\"action\": \"c2pa.placed\", \"digitalSourceType\": \"http://c2pa.org/digitalsourcetype/empty\"}";
-/// int result = c2pa_builder_add_action(builder, action_json);
-/// if (result == 0) {
-///     // Action added successfully
-/// }
-/// ```
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_builder_add_action(
     builder_ptr: *mut C2paBuilder,
@@ -1547,11 +1538,14 @@ mod tests {
                 "key2": "value2"
             }
         }"#).unwrap();
+
+        // multiple calls add multiple actions
         let result = unsafe { c2pa_builder_add_action(builder, action_json.as_ptr()) };
         assert_eq!(result, 0);
+
         let format = CString::new("image/jpeg").unwrap();
         let mut manifest_bytes_ptr = std::ptr::null();
-        let result = unsafe {
+        let _ = unsafe {
             c2pa_builder_sign(
                 builder,
                 format.as_ptr(),
@@ -1600,6 +1594,7 @@ mod tests {
         assert!(!json.is_null());
         let json_str = unsafe { CString::from_raw(json) };
         let json_content = json_str.to_str().unwrap();
+        println!("json_content: {}", json_content);
 
         assert!(json_content.contains("manifest"));
 

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1696,7 +1696,8 @@ mod tests {
 
         let label = CString::new("com.example.json-assertion").unwrap();
         let data_json = CString::new("{\"value\": \"assertion\"}").unwrap();
-        let result = unsafe { c2pa_builder_add_assertion_json(builder, label.as_ptr(), data_json.as_ptr()) };
+        let result =
+            unsafe { c2pa_builder_add_assertion_json(builder, label.as_ptr(), data_json.as_ptr()) };
         assert_eq!(result, 0);
 
         let format = CString::new("image/jpeg").unwrap();

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -909,7 +909,7 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 /// Reads from NULL-terminated C strings.
 ///
 /// # Example
-/// ```c
+/// ```C
 /// const char* manifest_def = "{}";
 /// C2paBuilder* builder = c2pa_builder_from_json(manifest_def);
 ///
@@ -924,7 +924,8 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 /// int result = c2pa_builder_add_action(builder, action_json);
 /// ```
 ///
-/// This creates a manifest with an actions assertion containing the added action:
+/// This creates a manifest with an actions assertion
+/// ontaining the added action (excerpt of the full manifest):
 /// ```json
 /// "assertions": [
 ///   {
@@ -943,7 +944,6 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 ///           }
 ///         }
 ///       ],
-///       "allActionsIncluded": true
 ///     }
 ///   }
 /// ]

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1617,11 +1617,13 @@ mod tests {
         assert!(json_content.contains("manifest"));
 
         TestC2paStream::drop_c_stream(source_stream);
+        TestC2paStream::drop_c_stream(read_stream);
         unsafe {
             c2pa_manifest_bytes_free(manifest_bytes_ptr);
         }
         unsafe { c2pa_builder_free(builder) };
         unsafe { c2pa_signer_free(signer) };
+        unsafe { c2pa_reader_free(reader) };
     }
 
     #[test]

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -975,54 +975,9 @@ pub unsafe extern "C" fn c2pa_builder_add_action(
     }
 }
 
-/// Adds a CBOR assertion to the manifest.
-///
-/// In most cases, use this function instead of `c2pa_builder_add_assertion_json`, unless the assertion must be stored in JSON format.
-///
-/// # Parameters
-/// * builder_ptr: pointer to a Builder.
-/// * label: A label for the assertion (null-terminated C string).
-/// * data_json: The data for the assertion as a JSON string (null-terminated C string).
-///
-/// # Errors
-/// Returns -1 if there were errors, otherwise returns 0.
-/// The error string can be retrieved by calling c2pa_error.
-///
-/// # Safety
-/// Reads from NULL-terminated C strings.
-#[no_mangle]
-pub unsafe extern "C" fn c2pa_builder_add_assertion(
-    builder_ptr: *mut C2paBuilder,
-    label: *const c_char,
-    data_json: *const c_char,
-) -> c_int {
-    check_or_return_int!(builder_ptr);
-    let mut builder = guard_boxed_int!(builder_ptr);
-    let label = from_cstr_or_return_int!(label);
-    let data_json = from_cstr_or_return_int!(data_json);
-
-    // Parse the JSON into a serde Value to use with the Builder
-    let data_value: serde_json::Value = match serde_json::from_str(&data_json) {
-        Ok(value) => value,
-        Err(err) => {
-            Error::from_c2pa_error(c2pa::Error::JsonError(err)).set_last();
-            return -1;
-        }
-    };
-
-    match builder.add_assertion(&label, &data_value) {
-        Ok(_) => 0, // returns 0 on success
-        Err(err) => {
-            Error::from_c2pa_error(err).set_last();
-            -1
-        }
-    }
-}
-
 /// Adds a JSON assertion to the manifest.
 ///
 /// Use only when the assertion must be stored in JSON format.
-/// In most cases, use `c2pa_builder_add_assertion` instead, unless the assertion must be stored in JSON format.
 ///
 /// # Parameters
 /// * builder_ptr: pointer to a Builder.
@@ -1702,73 +1657,6 @@ mod tests {
         let json_str = unsafe { CString::from_raw(json) };
         let json_content = json_str.to_str().unwrap();
         println!("json_content: {}", json_content);
-
-        assert!(json_content.contains("manifest"));
-
-        TestC2paStream::drop_c_stream(source_stream);
-        TestC2paStream::drop_c_stream(read_stream);
-        unsafe {
-            c2pa_manifest_bytes_free(manifest_bytes_ptr);
-            c2pa_builder_free(builder);
-            c2pa_signer_free(signer);
-            c2pa_reader_free(reader);
-        }
-    }
-
-    #[test]
-    fn builder_add_assertion_and_sign() {
-        let source_image = include_bytes!(fixture_path!("IMG_0003.jpg"));
-        let mut source_stream = TestC2paStream::from_bytes(source_image.to_vec());
-        let dest_vec = Vec::new();
-        let mut dest_stream = TestC2paStream::new(dest_vec).into_c_stream();
-        let certs = include_str!(fixture_path!("certs/ed25519.pub"));
-        let private_key = include_bytes!(fixture_path!("certs/ed25519.pem"));
-        let alg = CString::new("Ed25519").unwrap();
-        let sign_cert = CString::new(certs).unwrap();
-        let private_key = CString::new(private_key).unwrap();
-        let signer_info = C2paSignerInfo {
-            alg: alg.as_ptr(),
-            sign_cert: sign_cert.as_ptr(),
-            private_key: private_key.as_ptr(),
-            ta_url: std::ptr::null(),
-        };
-        let signer = unsafe { c2pa_signer_from_info(&signer_info) };
-
-        assert!(!signer.is_null());
-        let manifest_def = CString::new("{}").unwrap();
-        let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
-        assert!(!builder.is_null());
-
-        let label = CString::new("com.example.assertion").unwrap();
-        let data_json = CString::new("{\"value\": \"assertion\"}").unwrap();
-        let result = unsafe { c2pa_builder_add_assertion(builder, label.as_ptr(), data_json.as_ptr()) };
-        assert_eq!(result, 0);
-
-        let format = CString::new("image/jpeg").unwrap();
-        let mut manifest_bytes_ptr = std::ptr::null();
-        let _ = unsafe {
-            c2pa_builder_sign(
-                builder,
-                format.as_ptr(),
-                &mut source_stream,
-                &mut dest_stream,
-                signer,
-                &mut manifest_bytes_ptr,
-            )
-        };
-
-        // Verify we can read the signed data back
-        let dest_test_stream = TestC2paStream::from_c_stream(dest_stream);
-        let mut read_stream = dest_test_stream.into_c_stream();
-        let format = CString::new("image/jpeg").unwrap();
-
-        let reader = unsafe { c2pa_reader_from_stream(format.as_ptr(), &mut read_stream) };
-        assert!(!reader.is_null());
-
-        let json = unsafe { c2pa_reader_json(reader) };
-        assert!(!json.is_null());
-        let json_str = unsafe { CString::from_raw(json) };
-        let json_content = json_str.to_str().unwrap();
 
         assert!(json_content.contains("manifest"));
 

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1572,13 +1572,16 @@ mod tests {
         let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
         assert!(!builder.is_null());
 
-        let action_json = CString::new(r#"{
+        let action_json = CString::new(
+            r#"{
             "action": "com.example.test-action",
             "parameters": {
                 "key1": "value1",
                 "key2": "value2"
             }
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
 
         // multiple calls add multiple actions
         let result = unsafe { c2pa_builder_add_action(builder, action_json.as_ptr()) };

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -895,7 +895,7 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
     ok_or_return_int!(result, |_| 0) // returns 0 on success
 }
 
-/// Adds an action to the C2paBuilder.
+/// Adds an action to the manifest the Builder is constructing.
 ///
 /// # Parameters
 /// * builder_ptr: pointer to a Builder.
@@ -907,6 +907,47 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 ///
 /// # Safety
 /// Reads from NULL-terminated C strings.
+///
+/// # Example
+/// ```c
+/// const char* manifest_def = "{}";
+/// C2paBuilder* builder = c2pa_builder_from_json(manifest_def);
+///
+/// const char* action_json = "{\n"
+///     "    \"action\": \"com.example.test-action\",\n"
+///     "    \"parameters\": {\n"
+///     "        \"key1\": \"value1\",\n"
+///     "        \"key2\": \"value2\"\n"
+///     "    }\n"
+/// "}";
+///
+/// int result = c2pa_builder_add_action(builder, action_json);
+/// ```
+///
+/// This creates a manifest with an actions assertion containing the added action:
+/// ```json
+/// "assertions": [
+///   {
+///     "label": "c2pa.actions.v2",
+///     "data": {
+///       "actions": [
+///         {
+///           "action": "c2pa.created",
+///           "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty"
+///         },
+///         {
+///           "action": "com.example.test-action",
+///           "parameters": {
+///             "key2": "value2",
+///             "key1": "value1"
+///           }
+///         }
+///       ],
+///       "allActionsIncluded": true
+///     }
+///   }
+/// ]
+/// ```
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_builder_add_action(
     builder_ptr: *mut C2paBuilder,
@@ -1555,32 +1596,6 @@ mod tests {
                 &mut manifest_bytes_ptr,
             )
         };
-
-        /*
-        Sign JSON like this:
-        "assertions":
-          [
-            {
-              "label": "c2pa.actions.v2",
-              "data": {
-                "actions": [
-                  {
-                    "action": "c2pa.created",
-                    "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty"
-                  },
-                  {
-                    "action": "com.example.test-action",
-                    "parameters": {
-                      "key2": "value2",
-                      "key1": "value1"
-                    }
-                  }
-                ],
-                "allActionsIncluded": true
-              }
-            }
-          ]
-         */
 
         // Verify we can read the signed data back
         let dest_test_stream = TestC2paStream::from_c_stream(dest_stream);


### PR DESCRIPTION
## Changes in this pull request
- Expose add_assertion_json at the C level, with label and json content as parameters of the call.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
