### PR TITLE
fix: mark `DigitalSourceType` fields as deprecated without warning (new serde update)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,9 +4224,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4274,18 +4274,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -156,7 +156,7 @@ regex = "1.11"
 riff = "2.0.0"
 rsa = { version = "0.9.7", features = ["pem", "sha2", "std"], optional = true }
 schemars = { version = "0.8.21", optional = true }
-serde = { version = "1.0.197", features = ["derive"] }
+serde = { version = "1.0.225", features = ["derive"] }
 serde_bytes = "0.11.14"
 serde_cbor = "0.11.1"
 serde_derive = "1.0.197"

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -13,6 +13,8 @@
 
 use std::{collections::HashMap, fmt};
 
+#[cfg(feature = "json_schema")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
 
@@ -28,175 +30,164 @@ use crate::{
 const ASSERTION_CREATION_VERSION: usize = 2;
 pub const INGREDIENT_IDS: &str = "ingredientIds";
 
-// TODO: this is needed to supress clippy deprecated field warning:  https://github.com/serde-rs/serde/pull/2879
-pub use digital_source_type::DigitalSourceType;
-mod digital_source_type {
-    #![allow(deprecated)]
+/// Description of the source of an asset.
+///
+/// The full list of possible digital source types are found below:
+/// <https://spec.c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_digital_source_type>
+/// <https://cv.iptc.org/newscodes/digitalsourcetype>
+#[non_exhaustive]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
+pub enum DigitalSourceType {
+    /// Media whose digital content is effectively empty, such as a blank canvas or zero-length video.
+    #[serde(alias = "empty", rename = "http://c2pa.org/digitalsourcetype/empty")]
+    Empty,
+    /// Data that is the result of algorithmically using a model derived from sampled content and data.
+    /// Differs from <http://cv.iptc.org/newscodes/digitalsourcetype/>trainedAlgorithmicMedia in that
+    /// the result isn’t a media type (e.g., image or video) but is a data format (e.g., CSV, pickle).
+    #[serde(
+        alias = "trainedAlgorithmicData",
+        rename = "http://c2pa.org/digitalsourcetype/trainedAlgorithmicData"
+    )]
+    TrainedAlgorithmicData,
+    /// The media was captured from a real-life source using a digital camera or digital recording device.
+    #[serde(
+        alias = "digitalCapture",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
+    )]
+    DigitalCapture,
+    /// The media is the result of capturing multiple frames from a real-life source using a digital camera
+    /// or digital recording device, then automatically merging them into a single frame using digital signal
+    /// processing techniques and/or non-generative AI. Includes High Dynamic Range (HDR) processing common in
+    /// smartphone camera apps.
+    #[serde(
+        alias = "computationalCapture",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/computationalCapture"
+    )]
+    ComputationalCapture,
+    /// The media was digitised from a negative on film or other transparent medium.
+    #[serde(
+        alias = "negativeFilm",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/negativeFilm"
+    )]
+    NegativeFilm,
+    /// The media was digitised from a positive on a transparency or other transparent medium.
+    #[serde(
+        alias = "positiveFilm",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/positiveFilm"
+    )]
+    PositiveFilm,
+    /// The media was digitised from a non-transparent medium such as a photographic print.
+    #[serde(
+        alias = "print",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/print"
+    )]
+    Print,
+    /// Minor augmentation or correction by a human, such as a digitally-retouched photo used in a magazine.
+    #[deprecated]
+    #[serde(
+        alias = "minorHumanEdits",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
+    )]
+    MinorHumanEdits,
+    /// Augmentation, correction or enhancement by one or more humans using non-generative tools.
+    #[serde(
+        alias = "humanEdits",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/humanEdits"
+    )]
+    HumanEdits,
+    /// Augmentation, correction or enhancement using a Generative AI model, such as with inpainting or
+    /// outpainting operations.
+    #[serde(
+        alias = "compositeWithTrainedAlgorithmicMedia",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeWithTrainedAlgorithmicMedia"
+    )]
+    CompositeWithTrainedAlgorithmicMedia,
+    /// Modification or correction by algorithm without changing the main content of the media, initiated
+    /// or configured by a human, such as sharpening or applying noise reduction.
+    #[serde(
+        alias = "algorithmicallyEnhanced",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicallyEnhanced"
+    )]
+    AlgorithmicallyEnhanced,
+    /// The digital image was created by computer software.
+    #[deprecated]
+    #[serde(
+        alias = "softwareImage",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/softwareImage"
+    )]
+    SoftwareImage,
+    /// Media created by a human using digital tools.
+    #[deprecated]
+    #[serde(
+        alias = "digitalArt",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalArt"
+    )]
+    DigitalArt,
+    /// Media created by a human using non-generative tools.
+    #[serde(
+        alias = "digitalCreation",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
+    )]
+    DigitalCreation,
+    /// Digital media representation of data via human programming or creativity.
+    #[serde(
+        alias = "dataDrivenMedia",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/dataDrivenMedia"
+    )]
+    DataDrivenMedia,
+    /// Digital media created algorithmically using an Artificial Intelligence model trained on captured
+    /// content.
+    #[serde(
+        alias = "trainedAlgorithmicMedia",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+    )]
+    TrainedAlgorithmicMedia,
+    /// Media created purely by an algorithm not based on any sampled training data, e.g. an image created
+    /// by software using a mathematical formula.
+    #[serde(
+        alias = "algorithmicMedia",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+    )]
+    AlgorithmicMedia,
+    /// A capture of the contents of the screen of a computer or mobile device.
+    #[serde(
+        alias = "screenCapture",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/screenCapture"
+    )]
+    ScreenCapture,
+    /// Live recording of virtual event based on Generative AI and/or captured elements.
+    #[serde(
+        alias = "virtualRecording",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/virtualRecording"
+    )]
+    VirtualRecording,
+    /// Mix or composite of several elements, any of which may or may not be generative AI.
+    #[serde(
+        alias = "composite",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/composite"
+    )]
+    Composite,
+    /// Mix or composite of several elements that are all captures of real life.
+    #[serde(
+        alias = "compositeCapture",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeCapture"
+    )]
+    CompositeCapture,
+    /// Mix or composite of several elements, at least one of which is Generative AI.
+    #[serde(
+        alias = "compositeSynthetic",
+        rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeSynthetic"
+    )]
+    CompositeSynthetic,
+    /// An unknown digital source type.
+    #[serde(untagged)]
+    Other(String),
+}
 
-    #[cfg(feature = "json_schema")]
-    use schemars::JsonSchema;
-
-    use super::*;
-
-    /// Description of the source of an asset.
-    ///
-    /// The full list of possible digital source types are found below:
-    /// <https://spec.c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_digital_source_type>
-    /// <https://cv.iptc.org/newscodes/digitalsourcetype>
-    #[non_exhaustive]
-    #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
-    #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
-    pub enum DigitalSourceType {
-        /// Media whose digital content is effectively empty, such as a blank canvas or zero-length video.
-        #[serde(alias = "empty", rename = "http://c2pa.org/digitalsourcetype/empty")]
-        Empty,
-        /// Data that is the result of algorithmically using a model derived from sampled content and data.
-        /// Differs from <http://cv.iptc.org/newscodes/digitalsourcetype/>trainedAlgorithmicMedia in that
-        /// the result isn’t a media type (e.g., image or video) but is a data format (e.g., CSV, pickle).
-        #[serde(
-            alias = "trainedAlgorithmicData",
-            rename = "http://c2pa.org/digitalsourcetype/trainedAlgorithmicData"
-        )]
-        TrainedAlgorithmicData,
-        /// The media was captured from a real-life source using a digital camera or digital recording device.
-        #[serde(
-            alias = "digitalCapture",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture"
-        )]
-        DigitalCapture,
-        /// The media is the result of capturing multiple frames from a real-life source using a digital camera
-        /// or digital recording device, then automatically merging them into a single frame using digital signal
-        /// processing techniques and/or non-generative AI. Includes High Dynamic Range (HDR) processing common in
-        /// smartphone camera apps.
-        #[serde(
-            alias = "computationalCapture",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/computationalCapture"
-        )]
-        ComputationalCapture,
-        /// The media was digitised from a negative on film or other transparent medium.
-        #[serde(
-            alias = "negativeFilm",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/negativeFilm"
-        )]
-        NegativeFilm,
-        /// The media was digitised from a positive on a transparency or other transparent medium.
-        #[serde(
-            alias = "positiveFilm",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/positiveFilm"
-        )]
-        PositiveFilm,
-        /// The media was digitised from a non-transparent medium such as a photographic print.
-        #[serde(
-            alias = "print",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/print"
-        )]
-        Print,
-        /// Minor augmentation or correction by a human, such as a digitally-retouched photo used in a magazine.
-        #[deprecated]
-        #[serde(
-            alias = "minorHumanEdits",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
-        )]
-        MinorHumanEdits,
-        /// Augmentation, correction or enhancement by one or more humans using non-generative tools.
-        #[serde(
-            alias = "humanEdits",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/humanEdits"
-        )]
-        HumanEdits,
-        /// Augmentation, correction or enhancement using a Generative AI model, such as with inpainting or
-        /// outpainting operations.
-        #[serde(
-            alias = "compositeWithTrainedAlgorithmicMedia",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeWithTrainedAlgorithmicMedia"
-        )]
-        CompositeWithTrainedAlgorithmicMedia,
-        /// Modification or correction by algorithm without changing the main content of the media, initiated
-        /// or configured by a human, such as sharpening or applying noise reduction.
-        #[serde(
-            alias = "algorithmicallyEnhanced",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicallyEnhanced"
-        )]
-        AlgorithmicallyEnhanced,
-        /// The digital image was created by computer software.
-        #[deprecated]
-        #[serde(
-            alias = "softwareImage",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/softwareImage"
-        )]
-        SoftwareImage,
-        /// Media created by a human using digital tools.
-        #[deprecated]
-        #[serde(
-            alias = "digitalArt",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalArt"
-        )]
-        DigitalArt,
-        /// Media created by a human using non-generative tools.
-        #[serde(
-            alias = "digitalCreation",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
-        )]
-        DigitalCreation,
-        /// Digital media representation of data via human programming or creativity.
-        #[serde(
-            alias = "dataDrivenMedia",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/dataDrivenMedia"
-        )]
-        DataDrivenMedia,
-        /// Digital media created algorithmically using an Artificial Intelligence model trained on captured
-        /// content.
-        #[serde(
-            alias = "trainedAlgorithmicMedia",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
-        )]
-        TrainedAlgorithmicMedia,
-        /// Media created purely by an algorithm not based on any sampled training data, e.g. an image created
-        /// by software using a mathematical formula.
-        #[serde(
-            alias = "algorithmicMedia",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-        )]
-        AlgorithmicMedia,
-        /// A capture of the contents of the screen of a computer or mobile device.
-        #[serde(
-            alias = "screenCapture",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/screenCapture"
-        )]
-        ScreenCapture,
-        /// Live recording of virtual event based on Generative AI and/or captured elements.
-        #[serde(
-            alias = "virtualRecording",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/virtualRecording"
-        )]
-        VirtualRecording,
-        /// Mix or composite of several elements, any of which may or may not be generative AI.
-        #[serde(
-            alias = "composite",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/composite"
-        )]
-        Composite,
-        /// Mix or composite of several elements that are all captures of real life.
-        #[serde(
-            alias = "compositeCapture",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeCapture"
-        )]
-        CompositeCapture,
-        /// Mix or composite of several elements, at least one of which is Generative AI.
-        #[serde(
-            alias = "compositeSynthetic",
-            rename = "http://cv.iptc.org/newscodes/digitalsourcetype/compositeSynthetic"
-        )]
-        CompositeSynthetic,
-        /// An unknown digital source type.
-        #[serde(untagged)]
-        Other(String),
-    }
-
-    impl fmt::Display for DigitalSourceType {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            self.serialize(f)
-        }
+impl fmt::Display for DigitalSourceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
     }
 }
 


### PR DESCRIPTION
`serde` was recently updated to allow fields in a struct/enum to be marked as deprecated without always outputting usage of a deprecated field warning. This is a small change to fix that issue with `DigitalSourceType`.