### PR TITLE
feat: allow specifying external binary manifest to `c2patool`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,6 +89,12 @@ struct CliArgs {
     #[clap(short, long)]
     remote: Option<String>,
 
+    /// Path to the binary .c2pa manifest used for validation.
+    ///
+    /// This field will override if the input asset already has an emebdded or remote asset.
+    #[clap(long)]
+    external_manifest: Option<PathBuf>,
+
     /// Generate a sidecar (.c2pa) manifest
     #[clap(short, long)]
     sidecar: bool,
@@ -586,6 +592,24 @@ fn validate_cawg(reader: &mut Reader) -> Result<()> {
     }
 }
 
+fn reader_from_args(args: &CliArgs) -> Result<Reader> {
+    if let Some(external_manifest) = &args.external_manifest {
+        let c2pa_data = fs::read(external_manifest)?;
+        let format = match c2pa::format_from_path(&args.path) {
+            Some(format) => format,
+            None => {
+                bail!("Format for {:?} is unrecognized", args.path);
+            }
+        };
+        Ok(
+            Reader::from_manifest_data_and_stream(&c2pa_data, &format, File::open(&args.path)?)
+                .map_err(special_errs)?,
+        )
+    } else {
+        Ok(Reader::from_file(&args.path).map_err(special_errs)?)
+    }
+}
+
 fn main() -> Result<()> {
     let args = CliArgs::parse();
 
@@ -869,7 +893,7 @@ fn main() -> Result<()> {
             Ingredient::from_file(&args.path).map_err(special_errs)?
         )
     } else if args.detailed {
-        let mut reader = Reader::from_file(&args.path).map_err(special_errs)?;
+        let mut reader = reader_from_args(&args)?;
         validate_cawg(&mut reader)?;
         println!("{reader:#?}");
     } else if let Some(Commands::Fragment {
@@ -887,7 +911,7 @@ fn main() -> Result<()> {
             println!("{} Init manifests validated", stores.len());
         }
     } else {
-        let mut reader = Reader::from_file(&args.path).map_err(special_errs)?;
+        let mut reader = reader_from_args(&args)?;
         validate_cawg(&mut reader)?;
         println!("{reader}");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,9 +89,9 @@ struct CliArgs {
     #[clap(short, long)]
     remote: Option<String>,
 
-    /// Path to the binary .c2pa manifest used for validation.
+    /// Path to a binary .c2pa manifest to use for validation against the input asset.
     ///
-    /// This field will override if the input asset already has an emebdded or remote asset.
+    /// This field will override the input asset's embedded or remote manifest.
     #[clap(long)]
     external_manifest: Option<PathBuf>,
 


### PR DESCRIPTION
It's currently not possible to pass in an external manifest to `c2patool`. This is useful if a manifest was acquired through means such as a network call externally. This PR adds a new argument `--external-manifest` (open to opinions) to pass in an external manifest during validation.

* Closes #1353