### PR TITLE
fix: only enable "asm" feature on aarch64 macos

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -176,7 +176,7 @@ x509-parser = "0.16.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 zip = { version = "3.0.0", default-features = false }
 
-# Use the asm feature of sha2 on aarch64 for better performance. This nearly
+# Use the asm feature of sha2 on aarch64 macOS for better performance. This nearly
 # halves hashing time for large assets (> 50gb mp4, for example).
 #
 # Note: This feature has been removed in later versions of sha2.
@@ -184,10 +184,10 @@ zip = { version = "3.0.0", default-features = false }
 #
 # See: https://github.com/RustCrypto/hashes/pull/542 and
 # https://github.com/RustCrypto/hashes/tree/master/sha2#backends (which hasn't been released yet).
-[target.'cfg(target_arch = "aarch64")'.dependencies]
-sha2 = { version = "0.10.6", features = ["asm"] }
-[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
 sha2 = "0.10.6"
+# Apply the "asm" feature only for macOS on AArch64.
+[target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
+sha2 = { version = "0.10.6", features = ["asm"] }
 
 # This list matches the `rust_native_crypto` feature since they are not optional on WASM.
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
## Changes in this pull request
This PR disables the “asm” feature of sha2 for AArch64 Windows. Windows aarch64 builds are failing internally because of this feature.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
