### PR TITLE
fix: we lost the ability to read the deprecated instanceId actions parameters field.

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -65,8 +65,7 @@ unsafe fn safe_slice_from_raw_parts(
 
     if !is_safe_buffer_size(len, ptr) {
         return Err(Error::Other(format!(
-            "Buffer size {} is invalid for parameter '{}'",
-            len, param_name
+            "Buffer size {len} is invalid for parameter '{param_name}'",
         )));
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -233,7 +233,7 @@ struct ManifestDef {
 fn special_errs(e: c2pa::Error) -> anyhow::Error {
     match e {
         Error::JumbfNotFound => anyhow!("No claim found"),
-        Error::FileNotFound(name) => anyhow!("File not found: {}", name),
+        Error::FileNotFound(name) => anyhow!("File not found: {name}"),
         Error::UnsupportedType => anyhow!("Unsupported file type"),
         Error::PrereleaseError => anyhow!("Prerelease claim found"),
         _ => e.into(),


### PR DESCRIPTION
This restores that backwards compatible feature.
