### PR TITLE
fix: Fix ARM builds

### DIFF
--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -26,8 +26,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: windows-latest
-            target: aarm64-pc-windows-msvc
           - os: macos-latest
             target: aarch64-apple-ios
           - os: macos-latest
@@ -49,8 +47,6 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
 
       - name: Build Windows release
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -26,6 +26,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
           - os: macos-latest
             target: aarch64-apple-ios
           - os: macos-latest
@@ -47,6 +49,8 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: Build Windows release
         if: matrix.os == 'windows-latest'
@@ -54,8 +58,15 @@ jobs:
         run: |
           ./make_release.ps1
 
+      - name: Build Windows ARM release
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $env:TARGET_ARCH = "aarch64"
+          ./make_release.ps1
+
       - name: Build release
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest' && matrix.os != 'windows-11-arm'
         run: make release TARGET=${{ matrix.target }}
 
       - name: Upload build artifacts

--- a/c2pa_c_ffi/Makefile
+++ b/c2pa_c_ffi/Makefile
@@ -68,7 +68,6 @@ release-win-x86_64:
 	rustup target add x86_64-pc-windows-msvc
 	cargo build --target=x86_64-pc-windows-msvc $(CARGO_BUILD_FLAGS)
 
-
 release-win-aarch64:
 	rustup update stable-msvc
 	rustup target add aarch64-pc-windows-msvc
@@ -174,7 +173,7 @@ ifdef TARGET
 ifeq ($(TARGET),x86_64-pc-windows-msvc)
 release: release-win-x86_64
 else ifeq ($(TARGET),aarch64-pc-windows-msvc)
-release: echo "No release build for aarch64 on Windows"
+release: release-win-aarch64
 else ifeq ($(TARGET),aarch64-apple-darwin)
 release: release-mac-arm
 else ifeq ($(TARGET),x86_64-apple-darwin)

--- a/make_release.ps1
+++ b/make_release.ps1
@@ -9,12 +9,18 @@ $ErrorActionPreference = "Stop"
 Write-Host "Setting up Rust with OpenSSL (MSVC) environment..."
 
 # Detect hardware architecture and set $arch to "x86_64" or "aarch64"
-switch ($env:PROCESSOR_ARCHITECTURE) {
-    "AMD64" { $arch = "x86_64" }
-    "ARM64" { $arch = "aarch64" }
-    default { $arch = $env:PROCESSOR_ARCHITECTURE }
+# Allow override via TARGET_ARCH environment variable
+if ($env:TARGET_ARCH) {
+    $arch = $env:TARGET_ARCH
+    Write-Host "Using target architecture from environment: $arch"
+} else {
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        "AMD64" { $arch = "x86_64" }
+        "ARM64" { $arch = "aarch64" }
+        default { $arch = $env:PROCESSOR_ARCHITECTURE }
+    }
+    Write-Host "Detected architecture: $arch"
 }
-Write-Host "Detected architecture: $arch"
 
 # Ensure rustup is in PATH
 $env:PATH = "$env:USERPROFILE\.cargo\bin;" + $env:PATH


### PR DESCRIPTION
## Changes in this pull request
I thought caching was the issue that corrupts the Windows libraries. I removed caching in this PR: https://github.com/contentauth/c2pa-rs/pull/1422. I believe that hypothesis has been proven wrong, as I observed one more corruption in the latest release.

So I continued looking into this. I wanted to check how the Windows ARM files look, since Win ARM is also in the build matrix. But there were none on the release page (for WinARM, only Intel). It turns out, that we attempt a build for Windows ARM, and the build script (make_release.ps1) detects the CPU architecture to put it in the name. For both targets, if detects x86_64 (Intel) architecture, and does not cross-compile. I now believe that those two builds running in parallel override each other's zips on the last upload (since they do have the same zip name - this is an issue that can happen; file collisions if they have the same names), creating the observed ZIP corruption.

I tested the Windows builds from the fork https://github.com/tmathern/c2pa-rs-sandbox/actions with multiple pipeline runs, and the Intel libraries for Windows seem to be OK now. 
(Sidenote: I see the serde build starting to fail again for Linux Android in the fork, but did not look further into that, as I was focusing on Windows. @scouten-adobe We may need to check the fix status of this build if it occurs here too - workaround for now is to leave the build cache OFF).

Fixing the ARM build and having the artifacts with proper names fixes the corruption, since now they don't override each other anymore.

ps: I can only assume initally deactivating the cache actually helped to get "clean" builds when running the builds and sometimes avoid the *timing* issue (since essentially, the file override each other only if they upload in parallel). If one of the two Windows builds uploaded fully before the other, there was no issue. Also it seems there is a cache somewhere that stays for an hour, so waiting an hour before rerunning only the Intel Windows is a workaround to fix the library corruption after the fact.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
