### PR TITLE
fix: do not generate multiple `c2pa.placed` actions with settings

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -922,7 +922,7 @@ impl Builder {
                     let mut updates = Vec::new();
                     //#[allow(clippy::explicit_counter_loop)]
                     for (index, action) in actions.actions_mut().iter_mut().enumerate() {
-                        // find and remove the temporary ingredientIds parameter (This h)
+                        // find and remove the temporary ingredientIds parameter
                         let ids = action.extract_ingredient_ids();
 
                         if let Some(ids) = ids {

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -919,8 +919,6 @@ impl Builder {
 
                     let mut actions: Actions = manifest_assertion.to_assertion()?;
 
-                    Self::add_actions_assertion_settings(&ingredient_map, &mut actions)?;
-
                     let mut updates = Vec::new();
                     //#[allow(clippy::explicit_counter_loop)]
                     for (index, action) in actions.actions_mut().iter_mut().enumerate() {
@@ -997,6 +995,10 @@ impl Builder {
                             }
                         }
                     }
+
+                    // Do this at the end of the preprocessing step to ensure all ingredient references
+                    // are resolved to their hashed URIs.
+                    Self::add_actions_assertion_settings(&ingredient_map, &mut actions)?;
 
                     claim.add_assertion(&actions)
                 }


### PR DESCRIPTION
Actions can be linked to ingredients in various ways. Our previous checks assumed they would always be specified as a hashed URI, which is incorrect. The new behavior is to do the same check AFTER all of the non-hashed URI references are resolved to hashed URIs.