### PR TITLE
fix: Add linker flags to Android library builds

### DIFF
--- a/c2pa_c_ffi/Makefile
+++ b/c2pa_c_ffi/Makefile
@@ -26,6 +26,9 @@ IPHONEOS_DEPLOYMENT_TARGET ?= 15.0
 # This clears RUSTFLAGS to prevent -D warnings from failing the cross installation
 CROSS_INSTALL_RUSTFLAGS = RUSTFLAGS=""
 
+# Android 16KB page size alignment requirement
+ANDROID_LINKER_FLAGS = -C link-arg=-Wl,-z,max-page-size=16384
+
 # Helper function to create a zip file
 define make_zip
 	set -e; \
@@ -142,25 +145,25 @@ release-ios-arm64-sim:
 # 64-bit Android devices
 release-android-arm64:
 	$(CROSS_INSTALL_RUSTFLAGS) cargo install cross --git https://github.com/cross-rs/cross
-	cross build --target=aarch64-linux-android $(CARGO_BUILD_FLAGS)
+	RUSTFLAGS="$${RUSTFLAGS} $(ANDROID_LINKER_FLAGS)" cross build --target=aarch64-linux-android $(CARGO_BUILD_FLAGS)
 	@$(call make_zip,$(TARGET_DIR)/aarch64-linux-android/release,aarch64-linux-android)
 
 # 32-bit Android devices
 release-android-armv7:
 	$(CROSS_INSTALL_RUSTFLAGS) cargo install cross --git https://github.com/cross-rs/cross
-	cross build --target=armv7-linux-androideabi $(CARGO_BUILD_FLAGS)
+	RUSTFLAGS="$${RUSTFLAGS} $(ANDROID_LINKER_FLAGS)" cross build --target=armv7-linux-androideabi $(CARGO_BUILD_FLAGS)
 	@$(call make_zip,$(TARGET_DIR)/armv7-linux-androideabi/release,armv7-linux-androideabi)
 
 # 32-bit x86 Android emulators
 release-android-x86:
 	$(CROSS_INSTALL_RUSTFLAGS) cargo install cross --git https://github.com/cross-rs/cross
-	cross build --target=i686-linux-android $(CARGO_BUILD_FLAGS)
+	RUSTFLAGS="$${RUSTFLAGS} $(ANDROID_LINKER_FLAGS)" cross build --target=i686-linux-android $(CARGO_BUILD_FLAGS)
 	@$(call make_zip,$(TARGET_DIR)/i686-linux-android/release,i686-linux-android)
 
 # 64-bit x86 Android emulators
 release-android-x86_64:
 	$(CROSS_INSTALL_RUSTFLAGS) cargo install cross --git https://github.com/cross-rs/cross
-	cross build --target=x86_64-linux-android $(CARGO_BUILD_FLAGS)
+	RUSTFLAGS="$${RUSTFLAGS} $(ANDROID_LINKER_FLAGS)" cross build --target=x86_64-linux-android $(CARGO_BUILD_FLAGS)
 	@$(call make_zip,$(TARGET_DIR)/x86_64-linux-android/release,x86_64-linux-android)
 
 


### PR DESCRIPTION
## Changes in this pull request

Fixes https://github.com/contentauth/c2pa-rs/issues/1294

Added linker flags to Android library builds to meet an upcoming Google Play Store requirement for larger page sizes and to silence an annoying warning in Android Studio. I am adding the flags to all Android builds for consistency, even though only 64-bit devices will take advantage of the increased page size.

More info:

"Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices." [Details](https://developer.android.com/guide/practices/page-sizes)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
