### PR TITLE
feat: impl `ReaderBuilder`

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -816,11 +816,10 @@ impl BmffHash {
         Ok(())
     }
 
-    #[cfg(feature = "file_io")]
     pub fn verify_stream_segments(
         &self,
         init_stream: &mut dyn CAIRead,
-        fragment_paths: &Vec<std::path::PathBuf>,
+        fragment_paths: &mut [Box<dyn CAIRead>],
         alg: Option<&str>,
     ) -> crate::Result<()> {
         self.verify_self()?;
@@ -849,11 +848,9 @@ impl BmffHash {
                 return Err(Error::HashMismatch("No fragment specified".to_string()));
             }
 
-            for fp in fragment_paths {
-                let mut fragment_stream = std::fs::File::open(fp)?;
-
+            for mut fragment_stream in fragment_paths {
                 // get merkle boxes from segment
-                let c2pa_boxes = read_bmff_c2pa_boxes(&mut fragment_stream)?;
+                let c2pa_boxes = read_bmff_c2pa_boxes(fragment_stream)?;
                 let bmff_merkle = c2pa_boxes.bmff_merkle;
 
                 if bmff_merkle.is_empty() {

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -113,8 +113,7 @@ pub enum ClaimAssetData<'a> {
     Bytes(&'a [u8], &'a str),
     Stream(&'a mut dyn CAIRead, &'a str),
     StreamFragment(&'a mut dyn CAIRead, &'a mut dyn CAIRead, &'a str),
-    #[cfg(feature = "file_io")]
-    StreamFragments(&'a mut dyn CAIRead, &'a Vec<std::path::PathBuf>, &'a str),
+    StreamFragments(&'a mut dyn CAIRead, &'a mut [Box<dyn CAIRead>], &'a str),
 }
 
 #[derive(PartialEq, Debug, Eq, Clone, Hash)]
@@ -2687,7 +2686,6 @@ impl Claim {
                                 *fragment_data,
                                 Some(claim.alg()),
                             ),
-                        #[cfg(feature = "file_io")]
                         ClaimAssetData::StreamFragments(initseg_data, fragment_paths, _) => dh
                             .verify_stream_segments(
                                 *initseg_data,

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -364,7 +364,7 @@ pub enum Error {
 }
 
 /// A specialized `Result` type for C2PA toolkit operations.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl From<CoseError> for Error {
     fn from(err: CoseError) -> Self {


### PR DESCRIPTION
Implements a `ReaderBuilder` for constructing a `Reader` with settings and various other options. We may want to consider introducing a similar pattern to the `Builder`, although that may take additional design consideration.

For some background, we need methods of passing in `Settings` to a `Reader` or `Builder` that are instance-local, rather than thread-local. There are numerous reasons why this is needed  that have taken place in other discussions. The reason we decided to introduce a `ReaderBuilder` is because it's impractical and arguably unidiomatic to create or change ~9 of the `Reader` constructors. It also offers much more flexibility and enables many new permutations of constructing a `Reader`.

Blocked by:
- #1444 
- #1447 