### PR TITLE
Correct the payload of claim signature box when calculating the hash.

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -58,7 +58,7 @@ use crate::{
     jumbf::{
         self,
         boxes::{
-            BMFFBox, CAICBORAssertionBox, CAIJSONAssertionBox, CAISignatureBox,
+            CAICBORAssertionBox, CAIJSONAssertionBox, CAISignatureBox,
             CAIUUIDAssertionBox, JUMBFCBORContentBox, JumbfEmbeddedFileBox,
         },
         labels::{
@@ -1231,7 +1231,7 @@ impl Claim {
         let sigc = JUMBFCBORContentBox::new(signed_data);
         sigb.add_signature(Box::new(sigc));
 
-        sigb.write_box_payload(&mut hash_bytes)?;
+        sigb.super_box().write_box_payload(&mut hash_bytes)?;
 
         Ok(hash_by_alg(alg, &hash_bytes, None))
     }

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -925,6 +925,10 @@ impl CAISignatureBox {
     pub fn add_signature(&mut self, b: Box<dyn BMFFBox>) {
         self.sig_box.add_data_box(b)
     }
+
+    pub fn super_box(&self) -> &dyn BMFFBox {
+        &self.sig_box
+    }
 }
 
 impl Default for CAISignatureBox {


### PR DESCRIPTION
## Changes in this pull request
This change corrects the payload when calculating the hash of a claim signature box. According to the C2PA spec, the data to hash should be the payload of a super box, excluding the header.

Before this change, the payload was the whole super box, rather than the payload of the super box.

Closes #1464 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
