### PR TITLE
docs: fix docs.rs build by removing removed features

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -14,7 +14,7 @@
 #![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
 #![deny(clippy::unwrap_used)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! This library supports reading, creating, and embedding C2PA data
 //! for a variety of asset types.


### PR DESCRIPTION
Latest build of ours docs is failing due to removed Rust features. This PR removes those features that have now been merged into the `doc_cfg` feature.

See logs here: https://docs.rs/crate/c2pa/0.67.1/builds/2553949