### PR TITLE
ci: build latest docs.rs environment to defend against failed deployments

### DIFF
--- a/.github/workflows/release_readiness.yml
+++ b/.github/workflows/release_readiness.yml
@@ -176,27 +176,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2025-06-05
-          # Nightly is used here because the docs.rs build
-          # uses nightly and we use doc_cfg features that are
-          # not in stable Rust as of this writing (Rust 1.87).
+        uses: dtolnay/rust-toolchain@nightly
 
-          # Pinning to specific nightly build for now. More recent versions
-          # introduce a lifetime check that creates a whole slew of build
-          # errors.
-
-      - name: Run cargo docs
-        # This is intended to mimic the docs.rs build
-        # environment. The goal is to fail PR validation
-        # if the subsequent release would result in a failed
-        # documentation build on docs.rs.
-        run: cargo +nightly-2025-06-05 doc --workspace --features "$FEATURES" --no-deps
-        env:
-          FEATURES: ${{needs.get-features.outputs.openssl-features}}
-          RUSTDOCFLAGS: --cfg docsrs
-          DOCS_RS: 1
+      - name: Build docs.rs
+        uses: dtolnay/install@cargo-docs-rs
 
   unused_deps:
     name: Check for unused dependencies


### PR DESCRIPTION
Currently our docs build for release readiness uses an outdated nightly and doesn't match the exact flags used to build our docs.rs documentation. Because of this, build errors sneak through and the docs.rs deployment fails under our nose, see the latest build here: https://docs.rs/crate/c2pa/0.67.1.

This PR uses a tool called [cargo-docs-rs](https://github.com/dtolnay/cargo-docs-rs) to closely match the docs.rs build environment and use our flags specified in the Cargo.toml. I've also unpinned the Rust version since docs.rs will always use the latest.

* Closes #1481