### PR TITLE
ci: auto update schema docs on site on new release

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -17,5 +17,4 @@ jobs:
         with:
           event-type: c2pa-rs-release
           repository: contentauth/json-manifest-reference
-          # REVIEW-NOTE what is the caiopensrc PAT?
           token: ${{ secrets.TRIGGER_JSON_MANIFEST_UPDATE }}


### PR DESCRIPTION
This change adds a workflow that automatically sends a repository dispatch to our schemas repo, so that on new c2pa-rs releases it may auto-update the documentation site.

* Related https://github.com/contentauth/json-manifest-reference/pull/28
* Closes #1473