### PR TITLE
chore: allow deprecated subdependency

### DIFF
--- a/sdk/src/cose_validator.rs
+++ b/sdk/src/cose_validator.rs
@@ -245,6 +245,7 @@ pub(crate) fn get_signing_info(
 pub mod tests {
     use ciborium::Value;
     use coset::Label;
+    #[allow(deprecated)]
     use sha2::digest::generic_array::sequence::Shorten;
     use x509_parser::{certificate::X509Certificate, pem::Pem};
 


### PR DESCRIPTION
## Changes in this pull request
It looks like the `generic_array` package (a sub-sub-dependency of `sha2`) is deprecated, and the latest non-rc version of `sha2` (`0.10.9`) doesn't resolve the issue.

https://github.com/contentauth/c2pa-rs/pull/1507 cannot be merged until this is fixed, so I've gone ahead and allowed the deprecated dependency here.

Tracked: https://github.com/contentauth/c2pa-rs/issues/1509

