### PR TITLE
feat: Global settings redux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,12 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl.info
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-reader-builder.info -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-other.info -- --exclude builder::tests --exclude reader::tests
+          # Combine coverage reports
+          lcov --add-tracefile lcov-openssl-reader-builder.info --add-tracefile lcov-openssl-other.info --output-file lcov-openssl.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -128,7 +133,12 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust-native-features}}
         run: |
-          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-reader-builder.info -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-other.info -- --exclude builder::tests --exclude reader::tests
+          # Combine coverage reports
+          lcov --add-tracefile lcov-rust_native_crypto-reader-builder.info --add-tracefile lcov-rust_native_crypto-other.info --output-file lcov-rust_native_crypto.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-reader-builder.info -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cargo test --lib --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-other.info -- --exclude builder::tests --exclude reader::tests
+          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-other.info -- $OTHER_TESTS
           # Combine coverage reports
           lcov --add-tracefile lcov-openssl-reader-builder.info --add-tracefile lcov-openssl-other.info --output-file lcov-openssl.info
 
@@ -135,8 +137,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-reader-builder.info -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cargo test -p c2pa --no-default-features --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-other.info -- --exclude builder::tests --exclude reader::tests
+          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-other.info -- $OTHER_TESTS
           # Combine coverage reports
           lcov --add-tracefile lcov-rust_native_crypto-reader-builder.info --add-tracefile lcov-rust_native_crypto-other.info --output-file lcov-rust_native_crypto.info
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,12 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-reader-builder.info -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cargo test --lib --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
-          # Run all other tests multi-threaded for better performance
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl-other.info -- $OTHER_TESTS
-          # Combine coverage reports
-          lcov --add-tracefile lcov-openssl-reader-builder.info --add-tracefile lcov-openssl-other.info --output-file lcov-openssl.info
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cargo llvm-cov -p c2pa --features "$FEATURES" --no-default-features --lib --lcov --output-path lcov-openssl-reader-builder-settings.info -- --test-threads=1 reader::tests builder::tests settings::                                                                                                                                                     │
+          # Run all other tests multi-threaded for better performance                                                                                                                                                                                                                                                                                              │
+          cargo llvm-cov -p c2pa --features "$FEATURES" --no-default-features --lib --lcov --output-path lcov-openssl-other.info -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"                                                                                                                                                             │
+          # Combine coverage reports                                                                                                                                                                                                                                                                                                                               │
+          lcov --add-tracefile lcov-openssl-reader-builder-settings.info --add-tracefile lcov-openssl-other.info --output-file lcov-openssl.info                                                                                                                                                                                                                   │
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -135,14 +133,12 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust-native-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-reader-builder.info -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cargo test -p c2pa --no-default-features --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lib --lcov --output-path lcov-rust_native_crypto-reader-builder-settings.info -- --test-threads=1 reader::tests builder::tests settings::
           # Run all other tests multi-threaded for better performance
-          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto-other.info -- $OTHER_TESTS
+          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lib --lcov --output-path lcov-rust_native_crypto-other.info -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"
           # Combine coverage reports
-          lcov --add-tracefile lcov-rust_native_crypto-reader-builder.info --add-tracefile lcov-rust_native_crypto-other.info --output-file lcov-rust_native_crypto.info
+          lcov --add-tracefile lcov-rust_native_crypto-reader-builder-settings.info --add-tracefile lcov-rust_native_crypto-other.info --output-file lcov-rust_native_crypto.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.

--- a/.github/workflows/release_readiness.yml
+++ b/.github/workflows/release_readiness.yml
@@ -69,7 +69,10 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cargo test --features "$FEATURES"
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cargo test --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
 
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
@@ -100,7 +103,10 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
         run: |
-          cargo test --features "$FEATURES"
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cargo test --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
 
   tests-cross:
     name: Unit tests
@@ -134,7 +140,10 @@ jobs:
         env:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }}
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --exclude builder::tests --exclude reader::tests
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
@@ -163,7 +172,10 @@ jobs:
         env:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES"
+          # Run reader and builder tests single-threaded to avoid global state issues
+          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Run all other tests multi-threaded for better performance
+          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
 
   docs_rs:
     name: Preflight docs.rs build

--- a/.github/workflows/release_readiness.yml
+++ b/.github/workflows/release_readiness.yml
@@ -69,12 +69,10 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cargo test --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cargo test -p c2pa --features "$FEATURES" --no-default-features --lib -- --test-threads=1 reader::tests builder::tests settings::
           # Run all other tests multi-threaded for better performance
-          cargo test --features "$FEATURES" -- $OTHER_TESTS
+          cargo test -p c2pa --features "$FEATURES" --no-default-features --lib -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"
 
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
@@ -105,12 +103,10 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cargo test --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cargo test -p c2pa --features "$FEATURES" --no-default-features --lib -- --test-threads=1 reader::tests builder::tests settings::
           # Run all other tests multi-threaded for better performance
-          cargo test --features "$FEATURES" -- $OTHER_TESTS
+          cargo test -p c2pa --features "$FEATURES" --no-default-features --lib -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"
 
   tests-cross:
     name: Unit tests
@@ -144,12 +140,10 @@ jobs:
         env:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --test-threads=1 reader::tests builder::tests settings::
           # Run all other tests multi-threaded for better performance
-          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- $OTHER_TESTS
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
@@ -178,12 +172,10 @@ jobs:
         env:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          # Run reader and builder tests single-threaded to avoid global state issues
-          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
-          # Get all other test modules (excluding reader and builder)
-          OTHER_TESTS=$(cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
+          # Run reader, builder, and settings tests single-threaded to avoid global state issues
+          cargo +nightly-2025-07-28 test -p c2pa -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --test-threads=1 reader::tests builder::tests settings::
           # Run all other tests multi-threaded for better performance
-          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- $OTHER_TESTS
+          cargo +nightly-2025-07-28 test -p c2pa -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --skip "reader::tests" --skip "builder::tests" --skip "settings::"
 
   docs_rs:
     name: Preflight docs.rs build

--- a/.github/workflows/release_readiness.yml
+++ b/.github/workflows/release_readiness.yml
@@ -71,8 +71,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cargo test --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cargo test --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
+          cargo test --features "$FEATURES" -- $OTHER_TESTS
 
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
@@ -105,8 +107,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cargo test --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cargo test --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cargo test --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
+          cargo test --features "$FEATURES" -- $OTHER_TESTS
 
   tests-cross:
     name: Unit tests
@@ -142,8 +146,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- --exclude builder::tests --exclude reader::tests
+          cross test --all-targets --features "$FEATURES" --target ${{ matrix.target }} -- $OTHER_TESTS
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
@@ -174,8 +180,10 @@ jobs:
         run: |
           # Run reader and builder tests single-threaded to avoid global state issues
           cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --test-threads=1 builder::tests reader::tests
+          # Get all other test modules (excluding reader and builder)
+          OTHER_TESTS=$(cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --list | grep "::tests::" | grep -v "builder::tests\|reader::tests" | sed 's/::tests::.*//' | sort -u | tr '\n' ' ')
           # Run all other tests multi-threaded for better performance
-          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- --exclude builder::tests --exclude reader::tests
+          cargo +nightly-2025-07-28 test -Z direct-minimal-versions --all-targets --features "$FEATURES" -- $OTHER_TESTS
 
   docs_rs:
     name: Preflight docs.rs build

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1955,7 +1955,6 @@ mod tests {
     // Source: https://github.com/contentauth/c2pa-rs/pull/1458
     #[test]
     fn test_builder_one_placed_action_via_ingredient_id_ref() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -2027,7 +2026,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_auto_created() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -2065,7 +2063,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_auto_opened() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         let mut builder = Builder::new();
@@ -2121,7 +2118,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_auto_placed() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -2217,7 +2213,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_all_actions_included() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -2257,7 +2252,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_action_templates() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -2318,7 +2312,6 @@ mod tests {
 
     #[test]
     fn test_builder_settings_actions() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1020,8 +1020,9 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "wasi"))] // todo: enable when disable we find out wasi trust issues
     fn test_reader_trusted() -> Result<()> {
+        crate::settings::reset_default_settings()?;
+
         let reader =
             Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
         assert_eq!(reader.validation_state(), ValidationState::Trusted);

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -439,13 +439,6 @@ impl Settings {
         Settings::from_string(toml, "toml").map(|_| ())
     }
 
-    /// Create [Settings] from a toml string without affecting global state.
-    pub(crate) fn from_toml_str(toml: &str) -> Result<Self> {
-        #[allow(deprecated)]
-        Settings::from_string(toml, "toml")
-    }
-
-
     /// Set the [Settings] from a url to a toml file.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_url(url: &str) -> Result<()> {
@@ -536,7 +529,6 @@ impl Settings {
         }
     }
 
-
     /// Serializes the [Settings] into a toml string.
     pub fn to_toml() -> Result<String> {
         let settings =
@@ -557,10 +549,6 @@ impl Settings {
     #[inline]
     pub fn signer() -> Result<Box<dyn Signer>> {
         SignerSettings::signer()
-    }
-
-    pub(crate) fn signer_from_settings(settings: &Settings) -> Result<Box<dyn Signer>> {
-        SignerSettings::signer_from_settings(settings)
     }
 }
 

--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -300,7 +300,6 @@ pub mod tests {
 
     #[test]
     fn test_make_local_signer() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         // Testing with a different alg than the default test signer.
@@ -330,7 +329,6 @@ pub mod tests {
 
         use crate::create_signer;
 
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         let alg = SigningAlg::Ps384;

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -407,7 +407,6 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_bytes_from_stream() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -437,7 +436,6 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_with_prefer_smallest_format() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(
@@ -504,7 +502,6 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_and_ignore_errors() {
-        #[cfg(target_os = "wasi")]
         Settings::reset().unwrap();
 
         Settings::from_toml(


### PR DESCRIPTION
## Changes in this pull request
Using the C2PA SDK in work-stealing thread scheduling runtimes (like tokio), will lead to inconsistent settings application with thread_local settings

Run Reader and Builder unit tests single threaded. An alternate strategy would be to allow local settings to be passed as an argument to Reader and Builder.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
