### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.69.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.68.0...c2pa-v0.69.0)
+_31 October 2025_
+
+### Added
+
+* Adds support and documentation for JSON formatted Settings ([#1533](https://github.com/contentauth/c2pa-rs/pull/1533))
+* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))
+
+### Fixed
+
+* Add JsonSchema to Action ([#1550](https://github.com/contentauth/c2pa-rs/pull/1550))
+* Update to avoid deprecation warning for Command::cargo_bin ([#1548](https://github.com/contentauth/c2pa-rs/pull/1548))
+
+### Updated dependencies
+
+* Bump zip from 3.0.0 to 6.0.0 ([#1540](https://github.com/contentauth/c2pa-rs/pull/1540))
+* Bump coset from 0.3.8 to 0.4.0 ([#1539](https://github.com/contentauth/c2pa-rs/pull/1539))
+* Bump hex-literal from 0.4.1 to 1.0.0 ([#1527](https://github.com/contentauth/c2pa-rs/pull/1527))
+
 ## [0.68.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.67.1...c2pa-v0.68.0)
 _24 October 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2323,7 +2323,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.68.0"
+version = "0.69.0"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.69.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.68.0...c2pa-c-ffi-v0.69.0)
+_31 October 2025_
+
+### Added
+
+* Adds support and documentation for JSON formatted Settings ([#1533](https://github.com/contentauth/c2pa-rs/pull/1533))
+* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))
+
 ## [0.68.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.67.1...c2pa-c-ffi-v0.68.0)
 _24 October 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.68.0", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.69.0", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.24.0...c2patool-v0.25.0)
+_31 October 2025_
+
+### Added
+
+* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))
+
+### Fixed
+
+* Update to avoid deprecation warning for Command::cargo_bin ([#1548](https://github.com/contentauth/c2pa-rs/pull/1548))
+
 ## [0.24.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.23.4...c2patool-v0.24.0)
 _24 October 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.24.0"
+version = "0.25.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -22,7 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.68.0", features = [
+c2pa = { path = "../sdk", version = "0.69.0", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.68.0", features = [
+c2pa = { path = "../sdk", version = "0.69.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.68.0 -> 0.69.0 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.68.0 -> 0.69.0
* `c2patool`: 0.24.0 -> 0.25.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.69.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.68.0...c2pa-v0.69.0)

_31 October 2025_

### Added

* Adds support and documentation for JSON formatted Settings ([#1533](https://github.com/contentauth/c2pa-rs/pull/1533))
* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))

### Fixed

* Add JsonSchema to Action ([#1550](https://github.com/contentauth/c2pa-rs/pull/1550))
* Update to avoid deprecation warning for Command::cargo_bin ([#1548](https://github.com/contentauth/c2pa-rs/pull/1548))

### Updated dependencies

* Bump zip from 3.0.0 to 6.0.0 ([#1540](https://github.com/contentauth/c2pa-rs/pull/1540))
* Bump coset from 0.3.8 to 0.4.0 ([#1539](https://github.com/contentauth/c2pa-rs/pull/1539))
* Bump hex-literal from 0.4.1 to 1.0.0 ([#1527](https://github.com/contentauth/c2pa-rs/pull/1527))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.69.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.68.0...c2pa-c-ffi-v0.69.0)

_31 October 2025_

### Added

* Adds support and documentation for JSON formatted Settings ([#1533](https://github.com/contentauth/c2pa-rs/pull/1533))
* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))
</blockquote>

## `c2patool`

<blockquote>

## [0.25.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.24.0...c2patool-v0.25.0)

_31 October 2025_

### Added

* Allow reading a manifest store as a Builder to continue editing ([#1476](https://github.com/contentauth/c2pa-rs/pull/1476))

### Fixed

* Update to avoid deprecation warning for Command::cargo_bin ([#1548](https://github.com/contentauth/c2pa-rs/pull/1548))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).