### PR TITLE
feat(sdk): Introduce new API for file logging in the bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,9 @@ version = "0.72.0"
 dependencies = [
  "c2pa",
  "cbindgen",
+ "chrono",
+ "fern",
+ "log",
  "scopeguard",
  "serde",
  "serde_json",
@@ -1367,6 +1370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -35,6 +35,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.17"
 tokio = { version = "1.36", features = ["rt-multi-thread", "rt"] }
+log = "0.4"
+fern = "0.6"
+chrono = "0.4"   # For timestamps
 
 [dev-dependencies]
 tempfile = "3.7.0"


### PR DESCRIPTION
## Changes in this pull request
This PR sets up file logging in the bindings code so that bindings can utilize and configure the Rust logs

## Checklist
- [ X] This PR represents a single feature, fix, or change.
- [X ] All applicable changes have been documented.
- [X ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
