### PR TITLE
docs: Edit settings doc

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -161,13 +161,11 @@ The `builder.claim_generator_info` specifies the default claim generator informa
 Only the `name` property is required. For example:
 
 ```json
-"claim_generator_info": [
   {
     "name": "Adobe Content Authenticity",
     "com.adobe.aca-version": "81c4a25",
     "org.cai.c2pa_rs": "0.49.3"
   }
-]
 ```
 
 ### cawg_trust


### PR DESCRIPTION
I still have some questions I'd like to resolve before landing this, e.g.

- How does an specify this JSON file?  I see there's a reference to the test_settings.json in [sdk/examples/api.rs](https://github.com/contentauth/c2pa-rs/blob/c1aad99903b8dfe6f19f9ba4f55889127b1e3939/sdk/examples/api.rs#L87) but what about language bindings?
- `builder.claim_generator_info` is not explained well.  It says it's an object, and I assume the properties are those shown in https://opensource.contentauthenticity.org/docs/manifest/json-ref/reader#claimgeneratorinfo but we should be explicit. Does it have a default value?  What happens when it's not specified?
- Is there a default value for `core.merkle_tree_chunk_size_in_kb` ?
- Is there any diff between specifying a value of 'null' vs. not specifying a property at all?

Changes:
- Put property reference into tables.
- Alphabetize reference sections.
- Add notes in relevant places instead of at the end.
