### PR TITLE
feat: Builder setIntent API exposed in C2PA C FFI

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1847,7 +1847,7 @@ mod tests {
     }
 
     #[test]
-    fn builder_create_intend_and_sign() {
+    fn builder_create_intent_and_sign() {
         let source_image = include_bytes!(fixture_path!("IMG_0003.jpg"));
         let mut source_stream = TestC2paStream::from_bytes(source_image.to_vec());
         let dest_vec = Vec::new();
@@ -1904,7 +1904,7 @@ mod tests {
     }
 
     #[test]
-    fn builder_edit_intend_and_sign() {
+    fn builder_edit_intent_and_sign() {
         // Use an already-signed image as the source for editing
         let signed_source_image = include_bytes!(fixture_path!("C.jpg"));
         let mut source_stream = TestC2paStream::from_bytes(signed_source_image.to_vec());


### PR DESCRIPTION
## Changes in this pull request
- Add the Builder.set_intent API to C2PA C FFI.
- Refactor some test setups.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
