### PR TITLE
fix: Remove a dbg statement

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1338,7 +1338,6 @@ impl Builder {
                 }
             }
 
-            dbg!(&referenced_uris);
             // If a "ComponentOf" ingredient doesn't have an associated "c2pa.placed" action, create it here.
             for (_id, (relationship, uri)) in ingredient_map.iter() {
                 if *relationship == &Relationship::ComponentOf


### PR DESCRIPTION
## Changes in this pull request
A stray debug log shows up in test logs. We should likely remove it.

Example for the `c2pa-python` test runs:
```
Run python3 ./tests/test_unit_tests.py
......[sdk/src/builder.rs:1341:13] &referenced_uris = {}
...................[sdk/src/builder.rs:1341:13] &referenced_uris = {}
..[sdk/src/builder.rs:1341:13] &referenced_uris = {}
..[sdk/src/builder.rs:1341:13] &referenced_uris = {}
...[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
..[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
.[sdk/src/builder.rs:1341:13] &referenced_uris = {}
... many more entries of the same (this code path is tested/called often)
```

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
