### PR TITLE
fix: Attempt a cleaner forced update approach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,19 @@ jobs:
           # Ensure we're on a clean main branch
           git checkout main
           git pull origin main
-          
+
           # Extract the new version of c2pa from the release PR output JSON
           NEW_VERSION=$(echo "$PR" | jq -r '.releases[] | select(.package_name == "c2pa") | .version')
-          
-          # Add a comment to the lib.rs file to trigger a change
-          echo "// Updated to use c2pa crate version $NEW_VERSION" >> c2pa_c_ffi/src/lib.rs
-          
+
+          # Update the c2pa dependency version in c2pa_c_ffi/Cargo.toml
+          sed -i.bak "s/\(c2pa = { path = \"..\/sdk\", version = \"\)[^\"]*\"/\1$NEW_VERSION\"/" c2pa_c_ffi/Cargo.toml
+          rm c2pa_c_ffi/Cargo.toml.bak
+
           # Configure git and commit the changes
           git config user.name "CAI Open Source Builds"
           git config user.email "caiopensrc@adobe.com"
-          git add c2pa_c_ffi/src/lib.rs
-          git commit -m "fix: Pick up latest c2pa-rs build"
+          git add c2pa_c_ffi/Cargo.toml
+          git commit -m "fix: Update c2pa dependency to $NEW_VERSION"
           git push origin main
 
       - name: Force update of c2patool if only c2pa-rs is updated
@@ -72,18 +73,19 @@ jobs:
           # Ensure we're on a clean main branch
           git checkout main
           git pull origin main
-          
+
           # Extract the new version of c2pa from the release PR output JSON
           NEW_VERSION=$(echo "$PR" | jq -r '.releases[] | select(.package_name == "c2pa") | .version')
-          
-          # Add a comment to the lib.rs file to trigger a change
-          echo "// Updated to use c2pa crate version $NEW_VERSION" >> cli/src/lib.rs
-          
+
+          # Update the c2pa dependency version in cli/Cargo.toml
+          sed -i.bak "s/\(c2pa = { path = \"..\/sdk\", version = \"\)[^\"]*\"/\1$NEW_VERSION\"/" cli/Cargo.toml
+          rm cli/Cargo.toml.bak
+
           # Configure git and commit the changes
           git config user.name "CAI Open Source Builds"
           git config user.email "caiopensrc@adobe.com"
-          git add cli/src/lib.rs
-          git commit -m "fix: Pick up latest c2pa-rs build"
+          git add cli/Cargo.toml
+          git commit -m "fix: Update c2pa dependency to $NEW_VERSION"
           git push origin main
 
       - name: Clean up stale release-plz branches
@@ -94,12 +96,12 @@ jobs:
             tail -n +2 |\
             sed 's/origin\///' |\
             xargs -I {} git push origin --delete {}
-  
+
       - name: Identify c2patool release
         id: sniff-c2patool-release-tag
         run: |
           echo tag=`git tag --contains HEAD | grep '^c2patool-'` >> "$GITHUB_OUTPUT" || true
-    
+
   publish-c2patool-binaries:
     name: Publish c2patool binaries
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Changes in this pull request
I suspect the previous way of forcing releases did not properly work:
- I can't find the comment it was supposed to add
- The file the workflow tried to modify for the c2patool does not exist (and it never landed on main, which seems unlikely)?

So suggesting another "hack-fix".

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
