### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.72.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.71.3...c2pa-v0.72.0)
+_17 November 2025_
+
+### Added
+
+* Remove x509_certificate ([#1547](https://github.com/contentauth/c2pa-rs/pull/1547))
+
+### Fixed
+
+* Remove ring altogether ([#1606](https://github.com/contentauth/c2pa-rs/pull/1606))
+
 ## [0.71.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.71.2...c2pa-v0.71.3)
 _17 November 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.71.3"
+version = "0.72.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.71.3"
+version = "0.72.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.71.3"
+version = "0.72.0"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.4"
+version = "0.26.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.71.3"
+version = "0.72.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2311,7 +2311,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.71.3"
+version = "0.72.0"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.71.3"
+version = "0.72.0"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.71.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.71.3...c2pa-c-ffi-v0.71.4)
+_17 November 2025_
+
 ## [0.71.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.71.2...c2pa-c-ffi-v0.71.3)
 _17 November 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.71.3", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.72.0", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.4...c2patool-v0.26.5)
+_17 November 2025_
+
 ## [0.26.4](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.3...c2patool-v0.26.4)
 _17 November 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.4"
+version = "0.26.5"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.71.3", features = [
+c2pa = { path = "../sdk", version = "0.72.0", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.71.3", features = [
+c2pa = { path = "../sdk", version = "0.72.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.71.3 -> 0.72.0 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.71.3 -> 0.71.4
* `c2patool`: 0.26.4 -> 0.26.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.72.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.71.3...c2pa-v0.72.0)

_17 November 2025_

### Added

* Remove x509_certificate ([#1547](https://github.com/contentauth/c2pa-rs/pull/1547))

### Fixed

* Remove ring altogether ([#1606](https://github.com/contentauth/c2pa-rs/pull/1606))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.71.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.71.3...c2pa-c-ffi-v0.71.4)

_17 November 2025_
</blockquote>

## `c2patool`

<blockquote>

## [0.26.5](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.4...c2patool-v0.26.5)

_17 November 2025_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).