### PR TITLE
ci: Fix update schemas to dispatch correct repo and delete json-manifest-reference dispatch

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -16,12 +16,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v4
         with:
           event-type: c2pa-rs-release
-          repository: contentauth/json-manifest-reference
-          token: ${{ secrets.TRIGGER_JSON_MANIFEST_UPDATE }}
-
-      - name: Send repository dispatch to contentauth/json-manifest-reference
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          event-type: c2pa-rs-release
-          repository: contentauth/json-manifest-reference
+          repository: contentauth/opensource.contentauth.org
           token: ${{ secrets.TRIGGER_JSON_MANIFEST_UPDATE }}


### PR DESCRIPTION
`contentauth/json-manifest-reference` has been completely superseded by `contentauth/opensource.contentauth.org` and thus can be removed. This PR also fixes the link to the open source site repo.