### PR TITLE
feat: Refactor is_zero implementation

### DIFF
--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -35,16 +35,8 @@ pub mod test;
 #[cfg(test)]
 pub(crate) mod test_signer;
 
-// fast 0 vector test using byte alignment to perform faster native byte align comparison
+/// Check if the provided byte slice is empty or contains all zeros.
+#[inline]
 pub(crate) fn is_zero(bytes: &[u8]) -> bool {
-    if bytes.is_empty() {
-        return true;
-    }
-
-    unsafe {
-        let (prefix, aligned, suffix) = bytes.align_to::<u64>();
-        prefix.iter().all(|&x| x == 0)
-            && aligned.iter().all(|&x| x == 0u64)
-            && suffix.iter().all(|&x| x == 0u8)
-    }
+    bytes.iter().all(|b| *b == 0)
 }


### PR DESCRIPTION
## Changes in this pull request

Change `is_zero` implementation by removing `unsafe` code and simply using the slice iterator.

Unless I am missing some part of undocumented functionality here, naive iterator implementation
results in a better codegen: https://godbolt.org/z/sj3vM8xdj

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
