### PR TITLE
ci: Use `dtolnay/rust-toolchain` consistently

### DIFF
--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -3,7 +3,7 @@ name: Publish c2pa-library binaries
 on:
   push:
     tags:
-      - 'c2pa-v*' # Trigger on version tags (e.g., v1.0.0)
+      - "c2pa-v*" # Trigger on version tags (e.g., v1.0.0)
   workflow_dispatch:
 
 jobs:
@@ -47,10 +47,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Build Windows release
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -37,9 +37,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Get all features
         id: get-features

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Build C library for mobile target
         run: make release TARGET=${{ matrix.target }}


### PR DESCRIPTION
Removes usage of `actions-rust-lang/setup-rust-toolchain` and replaces it with `dtolnay/rust-toolchain` and `Swatinem/rust-cache` that we normally use. Potentially fixes a previously reported issue with intermittent errors building the Android libraries.