### PR TITLE
feat(sdk): Introduce new API to retrieve raw JUMBF manifest from C2paReader

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -764,14 +764,14 @@ pub unsafe extern "C" fn c2pa_reader_detailed_json(reader_ptr: *mut C2paReader) 
 /// The returned value MUST be released by calling c2pa_string_free
 /// and it is no longer valid after that call.
 #[no_mangle]
-pub unsafe extern "C" fn c2pa_reader_raw_jumbf(
+pub unsafe extern "C" fn c2pa_reader_raw_manifest_jumbf(
     reader_ptr: *mut C2paReader,
     manifest_bytes_ptr: *mut *const c_uchar,
 ) -> i64 {
     check_or_return_int!(reader_ptr);
     check_or_return_int!(manifest_bytes_ptr);
     let c2pa_reader = guard_boxed!(reader_ptr);
-    let result = c2pa_reader.jumbf_manifest();
+    let result = c2pa_reader.raw_manifest_jumbf();
     ok_or_return_int!(result, |manifest_bytes: Vec<u8>| {
         let len = manifest_bytes.len() as i64;
         if !manifest_bytes_ptr.is_null() {
@@ -1861,7 +1861,8 @@ mod tests {
         assert!(json_content.contains("com.example.test-action"));
 
         let mut manifest_bytes_ptr = std::ptr::null();
-        let raw_jumbf_result = unsafe { c2pa_reader_raw_jumbf(reader, &mut manifest_bytes_ptr) };
+        let raw_jumbf_result =
+            unsafe { c2pa_reader_raw_manifest_jumbf(reader, &mut manifest_bytes_ptr) };
         assert!(raw_jumbf_result > 0);
         assert!(!manifest_bytes_ptr.is_null());
 

--- a/sdk/src/crypto/asn1/mod.rs
+++ b/sdk/src/crypto/asn1/mod.rs
@@ -334,8 +334,8 @@ mod tests {
 
     // Helper to load test certificate
     fn load_test_cert_pem(name: &str) -> Vec<u8> {
-        let path = format!("tests/fixtures/certs/{}", name);
-        std::fs::read(&path).unwrap_or_else(|_| panic!("Failed to read test certificate: {}", path))
+        let path = format!("tests/fixtures/certs/{name}");
+        std::fs::read(&path).unwrap_or_else(|_| panic!("Failed to read test certificate: {path}"))
     }
 
     // Helper to parse PEM and extract DER certificate
@@ -622,13 +622,11 @@ mod tests {
             // Verify we got valid DER data for each cert type
             assert!(
                 !cert_der.is_empty(),
-                "Certificate {} DER should not be empty",
-                cert_name
+                "Certificate {cert_name} DER should not be empty"
             );
             assert_eq!(
                 cert_der[0], 0x30,
-                "Certificate {} should start with SEQUENCE tag",
-                cert_name
+                "Certificate {cert_name} should start with SEQUENCE tag"
             );
         }
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -522,6 +522,12 @@ impl Reader {
         }
     }
 
+    /// Get the Reader as a raw JUMBF Manifest
+    /// This just calls to_jumbf_internal on the store with no min_reserved_size
+    pub fn jumbf_manifest(&self) -> Result<Vec<u8>> {
+        self.store.to_jumbf_internal(0)
+    }
+
     /// Returns the remote url of the manifest if this [`Reader`] obtained the manifest remotely.
     pub fn remote_url(&self) -> Option<&str> {
         self.store.remote_url()

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -524,7 +524,7 @@ impl Reader {
 
     /// Get the Reader as a raw JUMBF Manifest
     /// This just calls to_jumbf_internal on the store with no min_reserved_size
-    pub fn jumbf_manifest(&self) -> Result<Vec<u8>> {
+    pub fn raw_manifest_jumbf(&self) -> Result<Vec<u8>> {
         self.store.to_jumbf_internal(0)
     }
 


### PR DESCRIPTION
Adding an API to the Reader that allows clients to extract the RAW JUMBF Manifest from an asset.

This has been a feature I've been talking to @mauricefisher64 about for a month or two now. It's my understanding that contentauth is tracking this item, but internal Microsoft teams are beginning to become blocked on it not existing. 

We are working on adding manifestData to ingredient assertions and have no clean way, without 3p tools, to get the Raw JUMBF manifest from the file.

## Changes in this pull request
Adding raw jumbf method to the reader and exposing it to the bindings code.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
