### PR TITLE
chore: relax tempfile bound from 3.15.0

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -180,7 +180,7 @@ serde-transcode = "1.1.1"
 sha1 = "0.10.6"
 spki = { version = "0.7.3", optional = true }
 static-iref = "3.0"
-tempfile = "=3.15.0"
+tempfile = ">=3.15.0, <4.0"
 thiserror = "2.0.17"
 url = "2.5.3"
 uuid = { version = "1.18.0", features = ["serde", "v4"] }
@@ -243,7 +243,7 @@ rsa = { version = "0.9.6", features = ["sha2"] }
 spki = "0.7.3"
 
 [target.'cfg(target_env = "p2")'.dependencies]
-tempfile = { version = "3.15", features = ["nightly"] }
+tempfile = { version = ">=3.15.0, <4.0", features = ["nightly"] }
 
 [target.'cfg(any(target_os = "wasi", not(target_arch = "wasm32")))'.dependencies]
 image = { version = "0.25.6", default-features = false, features = [


### PR DESCRIPTION
## Changes in this pull request

Unblocks using this library in crates where tempfile is pinned at a version >3.15.0

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
