### PR TITLE
chore: relax tempfile bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,9 +2259,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3539,15 +3539,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4141,16 +4141,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -180,7 +180,7 @@ serde-transcode = "1.1.1"
 sha1 = "0.10.6"
 spki = { version = "0.7.3", optional = true }
 static-iref = "3.0"
-tempfile = ">=3.15.0, <4.0"
+tempfile = "3.23.0"
 thiserror = "2.0.17"
 url = "2.5.3"
 uuid = { version = "1.18.0", features = ["serde", "v4"] }
@@ -241,9 +241,6 @@ p521 = { version = "0.13.3", features = [
 pkcs1 = "0.7.5"
 rsa = { version = "0.9.6", features = ["sha2"] }
 spki = "0.7.3"
-
-[target.'cfg(target_env = "p2")'.dependencies]
-tempfile = { version = ">=3.15.0, <4.0", features = ["nightly"] }
 
 [target.'cfg(any(target_os = "wasi", not(target_arch = "wasm32")))'.dependencies]
 image = { version = "0.25.6", default-features = false, features = [


### PR DESCRIPTION
## Changes in this pull request

The exact version makes integrating this package into workspaces with conflicting bounds difficult, e.g.: packages with bounds such as >3.16.0.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
