### PR TITLE
chore: Add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "update"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,3 +18,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Changes in this pull request
Add a cooldown to dependabot before it suggests PRs for updates.
Reference docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

I set a cooldown for all dependencies ("default") to 7 days, we can fine tune later (eg. 30 days for major versions) if we think we need that kind of fine-tuning.

ps: If we ever need, we can exclude dependencies from the cooldown too.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
