### PR TITLE
feat: Support JSON settings in `c2patool`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -390,7 +390,7 @@ fn blocking_get(url: &str) -> Result<String> {
 
 fn configure_sdk(args: &CliArgs) -> Result<()> {
     if args.settings.exists() {
-        Settings::from_file(&args.settings)?
+        Settings::from_file(&args.settings)?;
     }
 
     let mut enable_trust_checks = false;


### PR DESCRIPTION
This adds support for JSON settings in `c2patool`. Should the system settings file also look for both JSON and TOML? Which one would it prioritize?