### PR TITLE
feat: Only bump minor version (0.x.0) when breaking changes are published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+As of December 2025 and until the 1.0.0 version is released, the CAI team will only make minor version changes (incrementing the `x` in `0.x.0`) if breaking changes are made. Features will now result in a patch version change (incrementing the `y` in `0.x.y`). This brings us into closer compliance with typical SemVer practice (and follows the default behavior of [`release-plz`](https://release-plz.dev/docs/config#the-features_always_increment_minor-field).
+
 ## [Unreleased]
 
 ## [0.72.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.71.3...c2pa-v0.72.0)

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,7 +34,7 @@ commit_parsers = [
 
 [workspace]
 dependencies_update = true
-features_always_increment_minor = true
+features_always_increment_minor = false
 pr_labels = ["release"]
 release_always = false
 release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[(:]"


### PR DESCRIPTION
Some SDK users have requested that we provide more clarity about when we are making breaking changes during the 0.x stage.

This change brings us closer to the SemVer behaviors suggested in https://doc.rust-lang.org/cargo/reference/semver.html.