### PR TITLE
feat: use Rust resolver 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 members = [
     "c2pa_c_ffi",


### PR DESCRIPTION
Noticed this while investigating something else. The new resolver 3 is Rust MSRV-aware and will try to select dependency versions compatible with our MSRV or fail quickly. Note that this is also default in Rust edition 2024 which we should also consider upgrading.

https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions