### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.73.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.72.1...c2pa-v0.73.0)
+_04 December 2025_
+
+### Added
+
+* Restricted HTTP resolvers ([#1630](https://github.com/contentauth/c2pa-rs/pull/1630))
+
 ## [0.72.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.72.0...c2pa-v0.72.1)
 _04 December 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.72.1"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.72.1"
+version = "0.73.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.72.1"
+version = "0.73.0"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.72.1"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2339,7 +2339,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.72.1"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.72.1"
+version = "0.73.0"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.72.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.72.1...c2pa-c-ffi-v0.72.2)
+_04 December 2025_
+
 ## [0.72.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.72.0...c2pa-c-ffi-v0.72.1)
 _04 December 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.72.1", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.73.0", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.6...c2patool-v0.26.7)
+_04 December 2025_
+
 ## [0.26.6](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.5...c2patool-v0.26.6)
 _04 December 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.6"
+version = "0.26.7"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.72.1", features = [
+c2pa = { path = "../sdk", version = "0.73.0", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.72.1", features = [
+c2pa = { path = "../sdk", version = "0.73.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.72.1 -> 0.73.0 (⚠ API breaking changes)
* `c2pa-c-ffi`: 0.72.1 -> 0.72.2
* `c2patool`: 0.26.6 -> 0.26.7

### ⚠ `c2pa` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Core.allowed_network_hosts in /tmp/.tmp9saaPC/c2pa-rs/sdk/src/settings/mod.rs:272
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.73.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.72.1...c2pa-v0.73.0)

_04 December 2025_

### Added

* Restricted HTTP resolvers ([#1630](https://github.com/contentauth/c2pa-rs/pull/1630))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.72.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.72.1...c2pa-c-ffi-v0.72.2)

_04 December 2025_
</blockquote>

## `c2patool`

<blockquote>

## [0.26.7](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.6...c2patool-v0.26.7)

_04 December 2025_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).