### PR TITLE
fix: remove extra hash binding verification for update manifests

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1943,12 +1943,6 @@ impl Store {
                         }
                     }
 
-                    // if this ingredient is the hash binding claim (update manifest)
-                    // then we have to check the binding here
-                    if ingredient.label() == svi.binding_claim {
-                        Claim::verify_hash_binding(ingredient, asset_data, svi, validation_log)?;
-                    }
-
                     Claim::verify_claim_async(
                         ingredient,
                         asset_data,


### PR DESCRIPTION
We no longer need the extra check to validate hard bindings on an update manifest as that's already being done in `Claim::verify_claim`.