### PR TITLE
build: Replace once_cell Lazy with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,6 @@ dependencies = [
  "non-empty-string",
  "nonempty-collections",
  "num-bigint-dig",
- "once_cell",
  "openssl",
  "p256",
  "p384",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -290,7 +290,6 @@ hex-literal = "1.0.0"
 jumbf = "0.4.0"
 c2pa_macros = { path = "../macros" }
 mockall = "0.13.1"
-once_cell = "1.17.2"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.55"

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -19,10 +19,10 @@ use std::{
     collections::HashMap,
     io::{Cursor, Read, Write},
     path::PathBuf,
+    sync::LazyLock,
 };
 
 use env_logger;
-use once_cell::sync::Lazy;
 use tempfile::TempDir;
 
 use crate::{
@@ -85,7 +85,7 @@ macro_rules! define_fixtures {
         )*
 
         // Create the registry mapping filenames to data and format
-        static EMBEDDED_FIXTURES: Lazy<HashMap<&'static str, (&'static [u8], &'static str)>> = Lazy::new(|| {
+        static EMBEDDED_FIXTURES: LazyLock<HashMap<&'static str, (&'static [u8], &'static str)>> = LazyLock::new(|| {
             let mut map = HashMap::new();
             $(
                 // Convert to &[u8] slice to avoid fixed-size array type issues


### PR DESCRIPTION
Removes the once_cell dependency and uses the std alternatives.