### PR TITLE
fix: Flush stream to finish write operations before rewind

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -8886,7 +8886,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_save_stream_requires_flush() {
+    fn test_stream_context_handling_for_c_ffi_layer() {
         // Building a stream wrapper that simulates C FFI behavior
 
         /// Stream wrapper that simulates the streams like it would be in C FFI layer.
@@ -9026,7 +9026,7 @@ pub mod tests {
 
     /// Another test for stream context issues, with unsafe pointers
     #[test]
-    fn test_save_stream_flush_prevents_use_after_free() {
+    fn test_stream_context_handling_for_c_ffi_layer_no_use_after_free() {
         use std::io::Cursor;
 
         // This struct simulates an FFI stream context that could be freed any time


### PR DESCRIPTION
## Changes in this pull request
Flush stream to finish write operations before rewind. 

This fixes a bug that can only happen when using the Rust lib through the C FFI layer, due to handling of streams contexts.

When saving manifest store through the C FFI layer (with streams), the output stream wasn't (forcefully/always) flushed before rewind() was called. This could cause a use-after-free crash where the C(++) stream context could be accessed after being freed (dangling pointers). This got caught by Windows builds, since the compiler warned about possible un-initialized memory. (The tests covering this are a bit convoluted to simulate those cases without writing tests spanning multiple repos to totally mimic that).

-----

The extended details:
"Rust's buffering semantics didn't match C++'s expectations about when I/O operations complete."

When data is written to a stream through the C FFI layer, it sits in a buffer before written to the underlying C++ stream flavor. The Rust code (here) would then call rewind to reset the stream position, but this operation requires accessing the stream's internal state (which is partially managed in C++ when using the C FFI layer).

Without flushing, the buffered data and the stream's internal state can be out of sync. When rewind is called by the Rust code, it tries to access the stream context through the C FFI pointer...

But the C++ side may have already freed or invalidated that context (wrongfully thinking the write operation was complete due to out-of-sync states when crossing language barriers). Here is the exact point where Rust and C++ expectations collide/differ. This results in accessing freed memory (from the point of view of C++ and the compiler, because C++ freed things, but Rust can't know about that), and crashes accordingly (some OS/compiler seems to be more carefully looking at this, and it will not fail on all. I wager it depends also partially on the underlying streams handling per OS).

Flushing forces buffered data to be immediately written to the underlying C(++) stream and ensures I/O operations complete before returning. This guarantees the stream context (especially the internal state) remains synchronized when rewind is called, preventing the use-after-free that could otherwise be observed from C++ point of view (aka: through the C FFI layer).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
