### PR TITLE
ci: Update update-schemas.yml workflow title to correct repo

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -1,4 +1,4 @@
-name: Update schemas in contentauth/json-manifest-reference
+name: Update schemas in contentauth/opensource.contentauth.org
 on:
   push:
     tags:


### PR DESCRIPTION
`contentauth/json-manifest-reference` is no longer used and has been replaced by `contentauth/opensource.contentauth.org`.