### PR TITLE
fix: cbindgen change for C2PA_DYNAMIC_LOADING variable

### DIFF
--- a/c2pa_c_ffi/cbindgen.toml
+++ b/c2pa_c_ffi/cbindgen.toml
@@ -30,21 +30,21 @@ after_includes = """
     #define C2PA_API
 #else
     #if defined(_WIN32) || defined(_WIN64)
-        #if C2PA_DLL
-            #if __GNUC__
+        #if defined(C2PA_DLL) && C2PA_DLL
+            #if defined(__GNUC__) && __GNUC__
                 #define C2PA_API __attribute__((dllexport))
             #else
                 #define C2PA_API __declspec(dllexport)
             #endif
         #else
-            #if __GNUC__
+            #if defined(__GNUC__) && __GNUC__
                 #define C2PA_API __attribute__((dllimport))
             #else
                 #define C2PA_API __declspec(dllimport)
             #endif
         #endif
     #else
-        #if __GNUC__
+        #if defined(__GNUC__) && __GNUC__
             #define C2PA_API __attribute__((visibility("default")))
         #else
             #define C2PA_API


### PR DESCRIPTION
## Changes in this pull request
If compiling C/C++ with stricter compiler settings (treating warnings as errors) and if the compiler settings are configured to generate a warning about using undefined macros, the existing version of this line can generate a compile error. 

The fix here is to first determine if the value is defined before checking it.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
