### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.73.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.73.1...c2pa-v0.73.2)
+_22 December 2025_
+
+### Fixed
+
+* Nested ingredient serializing-deserializing (fix for #1685) ([#1686](https://github.com/contentauth/c2pa-rs/pull/1686))
+* Flush stream to finish write operations before rewind for FFI layer improvements ([#1672](https://github.com/contentauth/c2pa-rs/pull/1672))
+
 ## [0.73.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.73.0...c2pa-v0.73.1)
 _19 December 2025_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.8"
+version = "0.26.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2179,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
 name = "jfifdump"
@@ -2338,7 +2338,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2939,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3409,9 +3409,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.26"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -3585,9 +3585,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
 
 [[package]]
 name = "same-file"
@@ -3776,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
 dependencies = [
  "indexmap 2.12.1",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.73.1"
+version = "0.73.2"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.73.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.73.1...c2pa-c-ffi-v0.73.2)
+_22 December 2025_
+
 ## [0.73.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.73.0...c2pa-c-ffi-v0.73.1)
 _19 December 2025_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -23,7 +23,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.73.1", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.73.2", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.9](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.8...c2patool-v0.26.9)
+_22 December 2025_
+
 ## [0.26.8](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.7...c2patool-v0.26.8)
 _19 December 2025_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.8"
+version = "0.26.9"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.73.1", features = [
+c2pa = { path = "../sdk", version = "0.73.2", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.73.1", features = [
+c2pa = { path = "../sdk", version = "0.73.2", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.73.1 -> 0.73.2 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.73.1 -> 0.73.2
* `c2patool`: 0.26.8 -> 0.26.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.73.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.73.1...c2pa-v0.73.2)

_22 December 2025_

### Fixed

* Nested ingredient serializing-deserializing (fix for #1685) ([#1686](https://github.com/contentauth/c2pa-rs/pull/1686))
* Flush stream to finish write operations before rewind for FFI layer improvements ([#1672](https://github.com/contentauth/c2pa-rs/pull/1672))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.73.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.73.1...c2pa-c-ffi-v0.73.2)

_22 December 2025_
</blockquote>

## `c2patool`

<blockquote>

## [0.26.9](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.8...c2patool-v0.26.9)

_22 December 2025_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).