### PR TITLE
fix: Hard binding recursive search for nested update manifests

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3854,4 +3854,55 @@ mod tests {
         assert_eq!(reader2.active_manifest().unwrap().ingredients().len(), 1);
         Ok(())
     }
+
+    #[test]
+    fn update_manifest_to_update_manifest() {
+        Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
+
+        let mut child_image = Cursor::new(Vec::new());
+
+        let mut builder = Builder::new();
+        builder
+            .sign(
+                &Settings::signer().unwrap(),
+                "image/jpeg",
+                &mut Cursor::new(TEST_IMAGE),
+                &mut child_image,
+            )
+            .unwrap();
+
+        child_image.rewind().unwrap();
+
+        let mut parent_image = Cursor::new(Vec::new());
+
+        let mut builder = Builder::new();
+        builder.set_intent(BuilderIntent::Update);
+        builder
+            .sign(
+                &Settings::signer().unwrap(),
+                "image/jpeg",
+                &mut child_image,
+                &mut parent_image,
+            )
+            .unwrap();
+
+        parent_image.rewind().unwrap();
+
+        let mut parent_parent_image = Cursor::new(Vec::new());
+
+        let mut builder = Builder::new();
+        builder.set_intent(BuilderIntent::Update);
+        builder
+            .sign(
+                &Settings::signer().unwrap(),
+                "image/jpeg",
+                &mut parent_image,
+                &mut parent_parent_image,
+            )
+            .unwrap();
+
+        parent_parent_image.rewind().unwrap();
+
+        Reader::from_stream("image/jpeg", parent_parent_image).unwrap();
+    }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3775,7 +3775,7 @@ impl Store {
                     if let Some(parent) = self.get_claim(&parent_label) {
                         // recurse until we find
                         if parent.update_manifest() {
-                            self.get_hash_binding_manifest(parent);
+                            return self.get_hash_binding_manifest(parent);
                         } else if !parent.hash_assertions().is_empty() {
                             return Some(parent.label().to_owned());
                         }
@@ -3783,6 +3783,7 @@ impl Store {
                 }
             }
         }
+
         None
     }
 


### PR DESCRIPTION
When we search for hard bindings recursively, we don't return the result and so it always defaults to None. In the case of an update manifest with an update manifest, it always fails to find the source hard binding.