### PR TITLE
feat: Add CAWG roles support to SignerSettings

### DIFF
--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -253,11 +253,7 @@ impl Signer for CawgX509IdentitySigner {
 
         // Add roles if configured
         if !self.cawg_roles.is_empty() {
-            let roles: Vec<&str> = self
-                .cawg_roles
-                .iter()
-                .map(|s| s.as_str())
-                .collect();
+            let roles: Vec<&str> = self.cawg_roles.iter().map(|s| s.as_str()).collect();
             iab.add_roles(&roles);
         }
 


### PR DESCRIPTION
## Changes in this pull request
This PR adds a feature that allows CAWG roles to be added to the `cawg.identity` assertion using a settings file.  It follows the same approach as CAWG referenced assertions.

Example usage in a settings.toml file:

```
[cawg_x509_signer]

[cawg_x509_signer.local]

roles = ["cawg.creator", "cawg.editor", "cawg.publisher"]
```

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
