### PR TITLE
docs: Describe what parameter is missing in c2pa.opened/placed/removed validation

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2227,14 +2227,14 @@ impl Claim {
                     let Some(params) = action.parameters() else {
                         log_item!(
                             label.clone(),
-                            "opened, placed and removed items must have parameters",
+                            "opened, placed and removed items must have ingredient(s) parameters",
                             "verify_actions"
                         )
                         .validation_status(validation_status::ASSERTION_ACTION_INGREDIENT_MISMATCH)
                         .failure(
                             validation_log,
                             Error::ValidationRule(
-                                "opened, placed and removed items must have parameters".into(),
+                                "opened, placed and removed items must have ingredient(s) parameters".into(),
                             ),
                         )?;
                         continue; // Skip the parameter-dependent checks below

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6908,7 +6908,7 @@ pub mod tests {
         // expect action error
         assert!(store.is_err());
         assert!(report.has_error(Error::ValidationRule(
-            "opened, placed and removed items must have parameters".into()
+            "opened, placed and removed items must have ingredient(s) parameters".into()
         )));
         assert!(report.filter_errors().count() == 2);
     }


### PR DESCRIPTION
Currently validation errors when `c2pa.opened`/`c2pa.placed`/`c2pa.removed` actions have no parameters, but we can do better and report which of those parameters are actually missing.