### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.75.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.75.1...c2pa-v0.75.2)
+_15 January 2026_
+
+### Fixed
+
+* Fix streams handling for TIFF ([#1728](https://github.com/contentauth/c2pa-rs/pull/1728))
+
 ## [0.75.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.75.0...c2pa-v0.75.1)
 _15 January 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2282,7 +2282,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.75.1"
+version = "0.75.2"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.75.1"
+version = "0.75.2"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.75.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.75.1...c2pa-c-ffi-v0.75.2)
+_15 January 2026_
+
 ## [0.75.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.75.0...c2pa-c-ffi-v0.75.1)
 _15 January 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -24,7 +24,7 @@ rust_native_crypto = ["c2pa/rust_native_crypto"]
 pdf = ["c2pa/pdf"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.75.1", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.75.2", default-features = false, features = [
     "add_thumbnails",
     "fetch_remote_manifests",
     "file_io",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.13](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.12...c2patool-v0.26.13)
+_15 January 2026_
+
 ## [0.26.12](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.11...c2patool-v0.26.12)
 _15 January 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.12"
+version = "0.26.13"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.2"
-c2pa = { path = "../sdk", version = "0.75.1", features = [
+c2pa = { path = "../sdk", version = "0.75.2", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.75.1", features = [
+c2pa = { path = "../sdk", version = "0.75.2", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.75.1 -> 0.75.2 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.75.1 -> 0.75.2
* `c2patool`: 0.26.12 -> 0.26.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.75.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.75.1...c2pa-v0.75.2)

_15 January 2026_

### Fixed

* Fix streams handling for TIFF ([#1728](https://github.com/contentauth/c2pa-rs/pull/1728))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.75.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.75.1...c2pa-c-ffi-v0.75.2)

_15 January 2026_
</blockquote>

## `c2patool`

<blockquote>

## [0.26.13](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.12...c2patool-v0.26.13)

_15 January 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).