### PR TITLE
fix: Work around compilation issues introduced by `typed_path` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,6 +4474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typed-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7922f2cdc51280d47b491af9eafc41eb0cdab85eabcb390c854412fcbf26dbe8"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,13 +5249,14 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9013f1222db8a6d680f13a7ccdc60a781199cd09c2fa4eff58e728bb181757fc"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
  "indexmap 2.13.0",
  "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/sdk/src/identity/tests/validation_method/continue_when_possible.rs
+++ b/sdk/src/identity/tests/validation_method/continue_when_possible.rs
@@ -63,7 +63,7 @@ async fn malformed_cbor() {
     assert!(log.label.ends_with("/c2pa.assertions/cawg.identity"));
     assert_eq!(log.description, "invalid CBOR");
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.cbor.invalid"
     );
 }
@@ -190,7 +190,7 @@ async fn assertion_not_in_claim_v1() {
     assert_eq!(log.description, "referenced assertion not in claim");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.assertion.mismatch"
     );
 
@@ -208,7 +208,7 @@ async fn assertion_not_in_claim_v1() {
     );
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "signingCredential.trusted"
     );
 
@@ -302,7 +302,7 @@ async fn duplicate_assertion_reference() {
     assert_eq!(log.description, "multiple references to same assertion");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.assertion.duplicate"
     );
 
@@ -319,7 +319,7 @@ async fn duplicate_assertion_reference() {
         "signing certificate trusted, found in User trust anchors"
     );
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "signingCredential.trusted"
     );
 
@@ -392,7 +392,7 @@ async fn no_hard_binding() {
     assert_eq!(log.description, "no hard binding assertion");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.hard_binding_missing"
     );
 
@@ -410,7 +410,7 @@ async fn no_hard_binding() {
     );
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "signingCredential.trusted"
     );
 
@@ -516,7 +516,7 @@ mod invalid_sig_type {
         assert_eq!(log.description, "unsupported signature type");
 
         assert_eq!(
-            log.validation_status.as_ref().unwrap().as_ref(),
+            log.validation_status.as_ref().unwrap().as_ref() as &str,
             "cawg.identity.sig_type.unknown"
         );
     }
@@ -589,7 +589,7 @@ mod invalid_sig_type {
         assert_eq!(log.description, "unsupported signature type");
 
         assert_eq!(
-            log.validation_status.as_ref().unwrap().as_ref(),
+            log.validation_status.as_ref().unwrap().as_ref() as &str,
             "cawg.identity.sig_type.unknown"
         );
     }
@@ -657,7 +657,7 @@ async fn pad1_invalid() {
     assert_eq!(log.description, "invalid value in pad fields");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.pad.invalid"
     );
 
@@ -675,7 +675,7 @@ async fn pad1_invalid() {
     );
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "signingCredential.trusted"
     );
 
@@ -748,7 +748,7 @@ async fn pad2_invalid() {
     assert_eq!(log.description, "invalid value in pad fields");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.pad.invalid"
     );
 
@@ -766,7 +766,7 @@ async fn pad2_invalid() {
     );
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "signingCredential.trusted"
     );
 

--- a/sdk/src/identity/tests/validation_method/stop_on_error.rs
+++ b/sdk/src/identity/tests/validation_method/stop_on_error.rs
@@ -61,7 +61,7 @@ async fn malformed_cbor() {
     assert!(log.label.ends_with("/c2pa.assertions/cawg.identity"));
     assert_eq!(log.description, "invalid CBOR");
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.cbor.invalid"
     );
 }
@@ -185,7 +185,7 @@ async fn assertion_not_in_claim_v1() {
     assert_eq!(log.description, "referenced assertion not in claim");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.assertion.mismatch"
     );
 
@@ -271,7 +271,7 @@ async fn duplicate_assertion_reference() {
     assert_eq!(log.description, "multiple references to same assertion");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.assertion.duplicate"
     );
 
@@ -338,7 +338,7 @@ async fn no_hard_binding() {
 
     assert_eq!(log.description, "no hard binding assertion");
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.hard_binding_missing"
     );
 
@@ -441,7 +441,7 @@ mod invalid_sig_type {
         assert_eq!(log.description, "unsupported signature type");
 
         assert_eq!(
-            log.validation_status.as_ref().unwrap().as_ref(),
+            log.validation_status.as_ref().unwrap().as_ref() as &str,
             "cawg.identity.sig_type.unknown"
         );
     }
@@ -516,7 +516,7 @@ mod invalid_sig_type {
         assert_eq!(log.description, "unsupported signature type");
 
         assert_eq!(
-            log.validation_status.as_ref().unwrap().as_ref(),
+            log.validation_status.as_ref().unwrap().as_ref() as &str,
             "cawg.identity.sig_type.unknown"
         );
     }
@@ -582,7 +582,7 @@ async fn pad1_invalid() {
 
     assert_eq!(log.description, "invalid value in pad fields");
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.pad.invalid"
     );
 
@@ -650,7 +650,7 @@ async fn pad2_invalid() {
     assert_eq!(log.description, "invalid value in pad fields");
 
     assert_eq!(
-        log.validation_status.as_ref().unwrap().as_ref(),
+        log.validation_status.as_ref().unwrap().as_ref() as &str,
         "cawg.identity.pad.invalid"
     );
 

--- a/sdk/src/identity/x509/x509_signature_verifier.rs
+++ b/sdk/src/identity/x509/x509_signature_verifier.rs
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(log.description, "signing certificate untrusted");
 
         assert_eq!(
-            log.validation_status.as_ref().unwrap().as_ref(),
+            log.validation_status.as_ref().unwrap().as_ref() as &str,
             "signingCredential.untrusted"
         );
     }


### PR DESCRIPTION
Fixed the compilation errors caused by type ambiguity when calling `as_ref()` on `Cow<'_, str>` values. The issue occurred because the `typed_path` crate (referenced from `zip` crate) added a conflicting `AsRef` implementation for `Cow<str>`.