### PR TITLE
fix: Work around `typed-path` issue on WASI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
- "typed-path",
  "ureq",
  "url",
  "uuid",
@@ -526,7 +525,8 @@ dependencies = [
  "wstd",
  "x509-parser",
  "zeroize",
- "zip",
+ "zip 6.0.0",
+ "zip 7.0.0",
 ]
 
 [[package]]
@@ -4495,12 +4495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
-name = "typed-path"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41713888c5ccfd99979fcd1afd47b71652e331b3d4a0e19d30769e80fec76cce"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,6 +5260,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -213,10 +213,12 @@ ureq = { version = "3.1.0", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-# TODO: Keep these two crates pinned until typed-path works on WASI without wasip2. See https://github.com/contentauth/c2pa-rs/issues/1759.
-# Zip 7.2.0 pulls typed-path 0.12.0 on WASI, so pin to 7.0.0 here.
-typed-path = "=0.10.0"
-zip = { version = "=7.0.0", default-features = false }
+# TODO: Keep zip crate pinned until typed-path works on WASI.
+# See https://github.com/contentauth/c2pa-rs/issues/1759 and
+# http://github.com/chipsenkbeil/typed-path/pull/57.
+# Zip 7.x adds a dependency on typed-path 0.12.0 which doesn't compile on WASI,
+# so pin to 6.x here.
+zip = { version = "6.0", default-features = false }
 
 wasi = { version = "0.14.3", optional = true }
 wstd = { version = "0.5.4", optional = true }


### PR DESCRIPTION
The latest version of `typed-path` crate (0.12.0) doesn't compile on WASI.

Pin `zip` and `typed-path` to known-good versions until #1759 is addressed.