### PR TITLE
fix: Use patched version of typed-path for zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,7 +525,8 @@ dependencies = [
  "wstd",
  "x509-parser",
  "zeroize",
- "zip",
+ "zip 6.0.0",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -1076,6 +1086,17 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4476,7 +4497,8 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 [[package]]
 name = "typed-path"
 version = "0.12.0"
-source = "git+https://github.com/cdmurph32/typed-path?branch=wasip2_fix#12b0113ac811c89d37e267eaf57221e1673bcd9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7922f2cdc51280d47b491af9eafc41eb0cdab85eabcb390c854412fcbf26dbe8"
 
 [[package]]
 name = "typenum"
@@ -5244,6 +5266,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ version = "0.75.4"
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }
 
-# Remove once http://github.com/chipsenkbeil/typed-path/pull/57 is merged and released
-[patch.crates-io]
-typed-path = { git = "https://github.com/cdmurph32/typed-path", branch = "wasip2_fix" }
-
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
 opt-level = 3

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -183,7 +183,6 @@ uuid = { version = "1.18.0", features = ["serde", "v4"] }
 web-time = "1.1"
 x509-parser = "0.18.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
-zip = { version = "7.0.0", default-features = false }
 
 # Use the asm feature of sha2 on aarch64 macOS for better performance. This nearly
 # halves hashing time for large assets (> 50gb mp4, for example).
@@ -211,10 +210,13 @@ openssl = { version = "0.10.72", features = ["vendored"], optional = true }
 ureq = { version = "3.1.0", default-features = false, features = [
     "rustls"
 ], optional = true }
+zip = { version = "7.0.0", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = { version = "0.14.3", optional = true }
 wstd = { version = "0.5.4", optional = true }
+# Use zip 6 for WASI to avoid typed-path wasip2 issue. Fix: http://github.com/chipsenkbeil/typed-path/pull/57
+zip = { version = "6.0.0", default-features = false }
 
 # `wstd` is required for testing, but optional as a normal dependency.
 [target.'cfg(target_os = "wasi")'.dev-dependencies]
@@ -282,6 +284,7 @@ web-sys = { version = "0.3.58", features = [
     "Window",
     "WorkerGlobalScope",
 ] }
+zip = { version = "7.0.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.97"


### PR DESCRIPTION
## Changes in this pull request
Temporary fix until https://github.com/chipsenkbeil/typed-path/pull/57 is merged.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
