### PR TITLE
chore: Default to c2pa archive format (CAI-9965)

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -155,7 +155,7 @@ Here's the JSON with all default values:
     "certificate_status_should_override": null,
     "intent": null,
     "created_assertion_labels": null,
-    "generate_c2pa_archive": null
+    "generate_c2pa_archive": true
   },
   "signer": null,
   "cawg_x509_signer": null
@@ -184,7 +184,7 @@ The `builder` object specifies settings for the Builder API.
 | `builder.certificate_status_should_override` | Boolean | Override OCSP with certificate status assertions | null |
 | `builder.intent` | object | Default builder intent. The value uses object notation and must be one of: `{"Create": "digitalCapture"}` <br/> `"Edit"` <br/> `"Update"`. | null |
 | `builder.created_assertion_labels` | Array | Array of base assertion labels you want to treated as `created`. When the builder encounters one of these, it will become a created assertion.  | null |
-| `builder.generate_c2pa_archive` | Boolean | Generate C2PA archive format | null |
+| `builder.generate_c2pa_archive` | Boolean | Generate C2PA archive format | true |
 | `builder.actions` | Object | Action assertion configuration. |  |
 | `builder.actions.all_actions_included` | Boolean | Whether all actions are specified | null |
 | `builder.actions.templates` | Array | Action templates | null |

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -448,7 +448,7 @@ impl SettingsValidate for ActionsSettings {
 // TODO: do more validation on URL fields, cert fields, etc.
 /// Settings for the [Builder][crate::Builder].
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BuilderSettings {
     /// The name of the vendor creating the content credential.
     pub vendor: Option<String>,
@@ -504,8 +504,24 @@ pub struct BuilderSettings {
     pub created_assertion_labels: Option<Vec<String>>,
 
     /// Whether to generate a C2PA archive (instead of zip) when writing the manifest builder.
-    /// This will eventually become the default behavior.
+    /// Now always defaults to true - the ability to disable it will be removed in the future.
     pub generate_c2pa_archive: Option<bool>,
+}
+
+impl Default for BuilderSettings {
+    fn default() -> Self {
+        BuilderSettings {
+            vendor: None,
+            claim_generator_info: None,
+            thumbnail: ThumbnailSettings::default(),
+            actions: ActionsSettings::default(),
+            certificate_status_fetch: None,
+            certificate_status_should_override: None,
+            intent: None,
+            created_assertion_labels: None,
+            generate_c2pa_archive: Some(true),
+        }
+    }
 }
 
 /// The scope of which manifests to fetch for OCSP.

--- a/sdk/tests/fixtures/test_settings.json
+++ b/sdk/tests/fixtures/test_settings.json
@@ -17,7 +17,6 @@
     }
   },
   "builder": {
-    "generate_c2pa_archive": true,
     "claim_generator_info": {
       "name": "c2pa-rs testing",
       "version": "1.0.0",

--- a/sdk/tests/fixtures/test_settings.toml
+++ b/sdk/tests/fixtures/test_settings.toml
@@ -412,7 +412,6 @@ tsa_url = "http://timestamp.digicert.com"
 [builder]
 # certificate_status_fetch = "all"
 # certificate_status_should_override = true
-generate_c2pa_archive = true
 intent = "edit"
 
 # Claim generator info list.


### PR DESCRIPTION
Updates the default setting for builder.generate_c2pa_archive to true.
This is a sort of breaking change in that the archive format will now be .c2pa by default.
But since we read back in either kind of archive, it doesn't exactly break things.
Added new unit test for both behaviors
Updated test settings files to match the new pattern