### PR TITLE
chore: update Bytes crate to avoid RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -103,7 +103,7 @@ async-trait = "0.1.78"
 atree = "0.5.2"
 base64 = "0.22.1"
 bcder = "0.7.3"
-bytes = "1.7.2"
+bytes = "1.11.1"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }


### PR DESCRIPTION
We aren't using the VULN feature so we are ok anyway, but we may as well update. 