### PR TITLE
feat: Add archive marking and detection plus Reader into builder options

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -2417,13 +2417,7 @@ impl Builder {
 
     /// Add an ingredient to the manifest from a Reader.
     ///
-    /// This method handles different types of readers:
-    /// - **Builder Archive**: Extracts all ingredients from the archived builder
-    /// - **Archived Ingredient**: Extracts the single archived ingredient
-    /// - **Regular C2PA Manifest**: Converts the manifest into a parent ingredient
-    ///
-    /// Note: This method needs to read the reader's data to determine its type.
-    /// For efficiency, consider using the stream-based methods when possible.
+    /// This method extracts ingredient(s) from the reader and adds them to the builder.
     ///
     /// # Arguments
     /// * `reader` - The Reader to get the ingredient from.
@@ -2433,26 +2427,13 @@ impl Builder {
         &mut self,
         reader: &crate::Reader,
     ) -> Result<&mut Ingredient> {
-        // Determine the archive type and handle accordingly
-        match reader.manifest_type() {
-            crate::reader::ManifestType::ArchivedIngredient => {
-                // Simple case: just extract the ingredient without full conversion
-                let ingredient = reader.to_ingredient()?;
-                self.add_ingredient(ingredient);
-                self.definition
-                    .ingredients
-                    .last_mut()
-                    .ok_or(Error::IngredientNotFound)
-            }
-            _ => {
-                // For Builder archives and regular manifests, we need the full into_builder logic
-                // But we can't clone Reader, so we'll need to manually extract the data
-                // This is less efficient but maintains the API
-                Err(Error::BadParam(
-                    "add_ingredient_from_reader with Builder archives or regular manifests requires ownership. Use add_ingredient_from_stream instead.".to_string()
-                ))
-            }
-        }
+        // Use the simple to_ingredient() extraction for backward compatibility
+        let ingredient = reader.to_ingredient()?;
+        self.add_ingredient(ingredient);
+        self.definition
+            .ingredients
+            .last_mut()
+            .ok_or(Error::IngredientNotFound)
     }
 
     /// This creates a working store from the builder

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -2434,8 +2434,8 @@ impl Builder {
         reader: &crate::Reader,
     ) -> Result<&mut Ingredient> {
         // Determine the archive type and handle accordingly
-        match reader.archive_type() {
-            crate::reader::ArchiveType::Ingredient => {
+        match reader.manifest_type() {
+            crate::reader::ManifestType::ArchivedIngredient => {
                 // Simple case: just extract the ingredient without full conversion
                 let ingredient = reader.to_ingredient()?;
                 self.add_ingredient(ingredient);
@@ -4322,8 +4322,8 @@ mod tests {
         builder_archive.rewind()?;
         let reader = Reader::from_stream("application/c2pa", &mut builder_archive)?;
         assert_eq!(
-            reader.archive_type(),
-            crate::reader::ArchiveType::Builder,
+            reader.manifest_type(),
+            crate::reader::ManifestType::ArchivedBuilder,
             "Should be detected as Builder archive"
         );
 
@@ -4363,8 +4363,8 @@ mod tests {
         signed_output.rewind()?;
         let manifest_reader = Reader::from_stream("image/jpeg", &mut signed_output)?;
         assert_eq!(
-            manifest_reader.archive_type(),
-            crate::reader::ArchiveType::Manifest,
+            manifest_reader.manifest_type(),
+            crate::reader::ManifestType::SignedManifest,
             "Should be detected as regular Manifest"
         );
 
@@ -4397,8 +4397,8 @@ mod tests {
         ingredient_archive.rewind()?;
         let ingredient_reader = Reader::from_stream("application/c2pa", &mut ingredient_archive)?;
         assert_eq!(
-            ingredient_reader.archive_type(),
-            crate::reader::ArchiveType::Ingredient,
+            ingredient_reader.manifest_type(),
+            crate::reader::ManifestType::ArchivedIngredient,
             "Should be detected as archived Ingredient"
         );
 

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -406,6 +406,18 @@ impl Ingredient {
         self
     }
 
+    /// Sets the validation status for this ingredient.
+    pub(crate) fn set_validation_status(&mut self, status: Vec<ValidationStatus>) -> &mut Self {
+        self.validation_status = Some(status);
+        self
+    }
+
+    /// Sets the validation results for this ingredient.
+    pub(crate) fn set_validation_results(&mut self, results: ValidationResults) -> &mut Self {
+        self.validation_results = Some(results);
+        self
+    }
+
     /// Sets the thumbnail from a ResourceRef.
     pub fn set_thumbnail_ref(&mut self, thumbnail: ResourceRef) -> Result<&mut Self> {
         self.thumbnail = Some(thumbnail);

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1259,20 +1259,18 @@ impl Reader {
                 Ok(builder)
             }
             ManifestType::SignedManifest => {
-                // Regular manifest: use existing manifest_into_builder logic
-                // TODO: In the future, this should convert the entire reader to a parent ingredient
-                // For now, preserve existing behavior for backward compatibility
-                self.manifest_into_builder()
+                // Regular manifest: convert the entire reader to a parent ingredient
+                let ingredient = self.reader_to_parent_ingredient()?;
+                let mut builder = crate::Builder::from_shared_context(&self.context);
+                builder.add_ingredient(ingredient);
+                Ok(builder)
             }
         }
     }
 
     /// Converts the entire Reader into a single parent Ingredient.
     /// The entire manifest store is embedded as manifest_data.
-    /// Returns the ingredient and the context to use for the new builder.
-    fn reader_to_parent_ingredient(self) -> Result<(Ingredient, Arc<Context>)> {
-        let context = self.context.clone();
-        
+    pub(crate) fn reader_to_parent_ingredient(&self) -> Result<Ingredient> {
         let manifest = self
             .active_manifest()
             .ok_or(Error::ClaimMissing {
@@ -1327,7 +1325,7 @@ impl Reader {
             }
         }
 
-        Ok((ingredient, context))
+        Ok(ingredient)
     }
 
     /// Converts a Reader into a Builder by rebuilding ingredient stores from the unified store.

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -46,7 +46,7 @@ use crate::{
     utils::hash_utils::hash_to_b64,
     validation_results::{ValidationResults, ValidationState},
     validation_status::{ValidationStatus, ASSERTION_MISSING, ASSERTION_NOT_REDACTED},
-    Ingredient, Manifest, ManifestAssertion, Relationship,
+    Ingredient, Manifest, ManifestAssertion,
 };
 
 /// MaybeSend allows for no Send bound on wasm32 targets
@@ -1305,62 +1305,13 @@ impl Reader {
     /// Returns an [`Error`] if there is no parent ingredient.
     pub(crate) fn to_ingredient(&self) -> Result<Ingredient> {
         // make a copy of the parent ingredient (or return an error if not found)
-        let mut ingredient = self
+        let ingredient = self
             .active_manifest()
-            .and_then(|m| {
-                m.ingredients()
-                    .iter()
-                    .find(|&i| *i.relationship() == Relationship::ParentOf)
-            })
+            .and_then(|m| m.ingredients().first())
             .ok_or_else(|| Error::IngredientNotFound)?
             .to_owned();
 
-        // now we need to rebuild the manifest data for the ingredient
-        // strip out the active manifest claim from the store before adding it to the ingredient
-        // We only care about the ingredient and any claims it references
-        if let Some(active_label) = ingredient.active_manifest() {
-            let claim = self
-                .store
-                .get_claim(active_label)
-                .ok_or_else(|| Error::ClaimMissing {
-                    label: active_label.to_string(),
-                })?;
-
-            // build a new store with just the ingredient claim and any referenced claims
-            let ingredient_store = {
-                let mut store = Store::new();
-                let mut active_claim = claim.clone();
-
-                // Recursively collect all ingredient claims and add them to primary_claim
-                let mut visited = std::collections::HashSet::new();
-                let mut path = Vec::new();
-                self.collect_ingredient_claims_recursive(
-                    claim,
-                    &mut active_claim,
-                    &mut visited,
-                    &mut path,
-                )?;
-
-                // Add the main claim last
-                store.commit_claim(active_claim)?;
-                store
-            };
-            let c2pa_data = ingredient_store.to_jumbf_internal(0)?;
-            ingredient.set_manifest_data(c2pa_data)?;
-        }
-
         Ok(ingredient)
-    }
-
-    /// Recursively collect all ingredient claims and add them to the primary claim
-    fn collect_ingredient_claims_recursive(
-        &self,
-        claim: &Claim,
-        active_claim: &mut Claim,
-        visited: &mut std::collections::HashSet<String>,
-        path: &mut Vec<String>,
-    ) -> Result<()> {
-        Self::collect_ingredient_claims_impl(&self.store, claim, active_claim, visited, path)
     }
 }
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1271,11 +1271,9 @@ impl Reader {
     /// Converts the entire Reader into a single parent Ingredient.
     /// The entire manifest store is embedded as manifest_data.
     pub(crate) fn reader_to_parent_ingredient(&self) -> Result<Ingredient> {
-        let manifest = self
-            .active_manifest()
-            .ok_or(Error::ClaimMissing {
-                label: "active manifest".to_string(),
-            })?;
+        let manifest = self.active_manifest().ok_or(Error::ClaimMissing {
+            label: "active manifest".to_string(),
+        })?;
 
         // Create ingredient from manifest metadata
         let mut ingredient = Ingredient::new(
@@ -1298,7 +1296,7 @@ impl Reader {
                 ingredient.set_validation_status(validation_status);
             }
         }
-        
+
         if let Some(validation_results) = self.validation_results.clone() {
             ingredient.set_validation_results(validation_results);
         }
@@ -1314,7 +1312,11 @@ impl Reader {
                     let mut active_claim = claim.clone();
 
                     // Recursively collect all nested ingredient claims
-                    Self::collect_ingredient_claims_for_store(&self.store, claim, &mut active_claim)?;
+                    Self::collect_ingredient_claims_for_store(
+                        &self.store,
+                        claim,
+                        &mut active_claim,
+                    )?;
 
                     store.commit_claim(active_claim)?;
                     store
@@ -1446,7 +1448,7 @@ impl Reader {
             .assertions()
             .iter()
             .any(|a| a.label() == crate::assertions::DataHash::LABEL);
-        
+
         let has_box_hash = manifest
             .assertions()
             .iter()

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1294,6 +1294,17 @@ impl Reader {
             ingredient.set_thumbnail_ref(thumb_ref.clone())?;
         }
 
+        // Add validation results from the reader
+        if let Some(validation_status) = self.validation_status.clone() {
+            if !validation_status.is_empty() {
+                ingredient.set_validation_status(validation_status);
+            }
+        }
+        
+        if let Some(validation_results) = self.validation_results.clone() {
+            ingredient.set_validation_results(validation_results);
+        }
+
         // Set active manifest label
         if let Some(label) = &self.active_manifest {
             ingredient.set_active_manifest(label.clone());


### PR DESCRIPTION
NOTE: This is NOT ready to Merge and is just a draft of ideas in progress:

Archive Type Detection Using Custom Metadata Assertion
Added org.contentauth.archive.metadata custom assertion to mark and detect archive types, replacing the format-based approach that failed with v2 claims.
Key Changes:
Archive Creation (builder.rs):
working_store_sign() now adds org.contentauth.archive.metadata assertion with archive:type field
Archive type determined by calling method: to_archive() → "builder", to_ingredient_archive() → "ingredient"
Fixed double hash binding (BoxHash + DataHash): now conditionally uses BoxHash or DataHash based on signer availability - this will sign with the current context signer if it is available, making a valid box hashed signed archive.
Archive Detection (reader.rs):
manifest_type() checks for archive metadata assertion first using Metadata type
Falls back to heuristics for old archives (double binding, presence of ingredients)
manifest_into_builder() strips the archive metadata assertion when restoring (no longer an archive)
Three-Way Conversion Logic (reader.rs, builder.rs):
Reader.into_builder(): ArchivedBuilder → restores builder state, ArchivedIngredient → extracts ingredient, SignedManifest → converts to parent ingredient
Builder.add_ingredient_from_reader(): handles all three types appropriately
Archive metadata naturally removed when converting to ingredient (ingredient archives only contain the ingredient, not the parent manifest)
New API (builder.rs):
Added Builder.to_ingredient_archive() for creating ingredient archives with validation
