### PR TITLE
feat: include `HttpResolverError::Other` source error in error message

### DIFF
--- a/sdk/src/http/mod.rs
+++ b/sdk/src/http/mod.rs
@@ -234,7 +234,7 @@ pub enum HttpResolverError {
     UriDisallowed { uri: String },
 
     /// An error occured from the underlying HTTP resolver.
-    #[error("an error occurred from the underlying http resolver: {0}")]
+    #[error("an error occurred from the underlying http resolver")]
     Other(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 


### PR DESCRIPTION
Adds the underlying error of `HttpResolverError::Other` to the error message, especially useful for logging.

We should consider avoiding `{0}` in the error message as it can be obtained by following `Error::source` calls. Libraries such as `anyhow` do this automatically. 