### PR TITLE
fix: settings.builder.created_assertion_lables was not being applied.

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1275,7 +1275,8 @@ impl Builder {
                 definition.vendor.as_deref(),
                 self.claim_version().into(),
             ),
-        };
+        }
+        .with_context(self.context.clone());
 
         // add claim generator info to claim and resolve icons
         for info in &claim_generator_info {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2699,7 +2699,7 @@ impl Store {
         }
 
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
-        // always add dynamic assertions as gathered assertions
+        // add dynamic assertions (respects created_assertion_labels settings)
         assertions.iter().map(|a| pc.add_assertion(a)).collect()
     }
 


### PR DESCRIPTION
Adds a context to Claim so it can propogate at this level when needed - i.e. when created from builder.