### PR TITLE
docs: Remove use case numbering

### DIFF
--- a/docs/intents-and-archives.md
+++ b/docs/intents-and-archives.md
@@ -305,7 +305,7 @@ builder.save_to_stream(FORMAT, &mut source, &mut dest)?;
 - Better user experience
 - Supports iterative workflows
 
-### Use case 3: Ingredient libraries
+### Ingredient libraries
 
 **Scenario:** Content library with pre-validated assets.
 


### PR DESCRIPTION
## Changes in this pull request
Minor fix, as there is no use case 1 or use case 2, might drop the numbering.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
