### PR TITLE
update: bump zip from 7.4.0 to 8.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,9 +5445,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.4.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc12baa6db2b15a140161ce53d72209dacea594230798c24774139b54ecaa980"
+checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
 dependencies = [
  "crc32fast",
  "indexmap 2.13.0",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -176,7 +176,7 @@ uuid = { version = "1.18.0", features = ["serde", "v4"] }
 web-time = "1.1"
 x509-parser = "0.18.0"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
-zip = { version = "7.4.0", default-features = false }
+zip = { version = "8.1.0", default-features = false }
 
 # Use the asm feature of sha2 on aarch64 macOS for better performance. This nearly
 # halves hashing time for large assets (> 50gb mp4, for example).


### PR DESCRIPTION
7.4.0 was yanked from crates.