### PR TITLE
fix: Use cose_sign1 signature field for timestamp assertion verification

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2074,15 +2074,17 @@ impl Store {
                 // we only use valid timestamps, otherwise just ignore
                 for (referenced_claim, time_stamp_token) in timestamp_assertion.as_ref() {
                     if let Some(rc) = svi.manifest_map.get(referenced_claim) {
-                        if let Ok(tst_info) = verify_time_stamp(
-                            time_stamp_token,
-                            rc.signature_val(),
-                            &self.ctp,
-                            validation_log,
-                            // no trust checks for leagacy timestamps
-                            rc.version() != 1,
-                        ) {
-                            svi.timestamps.insert(rc.label().to_owned(), tst_info);
+                        if let Ok(sign1) = rc.cose_sign1() {
+                            if let Ok(tst_info) = verify_time_stamp(
+                                time_stamp_token,
+                                &sign1.signature,
+                                &self.ctp,
+                                validation_log,
+                                // no trust checks for leagacy timestamps
+                                rc.version() != 1,
+                            ) {
+                                svi.timestamps.insert(rc.label().to_owned(), tst_info);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Changes in this pull request
Timestamp assertions are displaying `timeStamp.mismatch` errors in the informational array on validation.
```
{
  "code": "timeStamp.mismatch",
  "url": "",
  "explanation": "timestamp message digest did not match: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
}
```

It appears that verify_time_stamp() is getting passed the CoseSign1 structure bytes instead of just the CoseSign1 raw signature.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
