### PR TITLE
ci: use warpbuild runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-x64-4x

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   title_cc_validation:
     name: Conventional commits validation
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   title_cc_validation:
     name: Conventional commits validation
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   title_cc_validation:
     name: Conventional commits validation
-    runs-on: warp-ubuntu-latest-x64-x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -481,7 +481,7 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: simulation
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
 

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-features:
     name: Get features
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     outputs:
       rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
       openssl-features: ${{ steps.get-features.outputs.openssl-features }}
@@ -60,7 +60,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -116,7 +116,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -172,7 +172,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -273,7 +273,7 @@ jobs:
 
   docs_rs:
     name: Preflight docs.rs build
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     if: |
       github.event_name != 'pull_request' ||
@@ -327,7 +327,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -384,7 +384,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -410,7 +410,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -457,7 +457,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-warp-ubuntu-latest-x64-2x-x64-2x
 
     steps:
       - name: Checkout repository
@@ -496,7 +496,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -545,7 +545,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -575,7 +575,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository
@@ -600,7 +600,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -457,7 +457,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-warp-ubuntu-latest-x64-2x-x64-2x
+    runs-on: warp-ubuntu-latest-x64-2x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-features:
     name: Get features
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
     outputs:
       rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
       openssl-features: ${{ steps.get-features.outputs.openssl-features }}
@@ -60,7 +60,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -116,7 +116,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -172,7 +172,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -273,7 +273,7 @@ jobs:
 
   docs_rs:
     name: Preflight docs.rs build
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     if: |
       github.event_name != 'pull_request' ||
@@ -327,7 +327,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -384,7 +384,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -410,7 +410,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -457,7 +457,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -496,7 +496,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -545,7 +545,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -575,7 +575,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository
@@ -600,7 +600,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe to test') ||
       contains(github.event.pull_request.labels.*.name, 'check-release')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -694,3 +694,29 @@ jobs:
         timeout-minutes: 15
         with:
           limit-access-to-actor: true
+
+  warpbuild-debugger-fail-test:
+    name: Fail test for debugging purposes
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
+
+    runs-on: warp-ubuntu-latest-x64-4x
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Fail the job
+        run: |
+          echo "This job is expected to fail."
+          exit 1
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-features:
     name: Get features
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     outputs:
       rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
       openssl-features: ${{ steps.get-features.outputs.openssl-features }}
@@ -105,6 +105,13 @@ jobs:
           verbose: true
           files: ./lcov-openssl.filtered.info,./lcov-rust_native_crypto.filtered.info
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   tests-rust-native-crypto:
     name: Unit tests (Rust native crypto installed)
     needs: get-features
@@ -161,6 +168,13 @@ jobs:
           verbose: true
           files: ./lcov-openssl.filtered.info,./lcov-rust_native_crypto.filtered.info
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   tests-cli:
     name: Unit tests (c2patool)
     needs: get-features
@@ -210,6 +224,13 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           files: ./lcov-openssl.info,./lcov-rust_native_crypto.info
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
   tests-windows-arm-openssl:
     name: Unit tests (Windows ARM, OpenSSL)
@@ -311,6 +332,13 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
         run: cargo doc -p c2patool --no-deps --all-features
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   doc-tests:
     name: Doc tests (requires nightly Rust)
     needs: get-features
@@ -352,6 +380,13 @@ jobs:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
           cargo test --workspace --features "$FEATURES" --doc
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
       # - name: Generate code coverage
       #   env:
@@ -398,6 +433,13 @@ jobs:
 
       - name: "`cargo check` with default features"
         run: cargo check
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
   tests-wasm:
     name: Unit tests (Wasm)
@@ -447,6 +489,13 @@ jobs:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
           WASM_BINDGEN_TEST_TIMEOUT: 60
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   benchmarks:
     name: Run benchmarks on signing and reading
     if: |
@@ -484,6 +533,13 @@ jobs:
           mode: simulation
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
   tests-wasi:
     name: Unit tests (WASI)
@@ -534,6 +590,13 @@ jobs:
         run: |
           cargo +nightly-2026-01-16 test --target wasm32-wasip2 -p c2pa --features "$FEATURES" --no-default-features -- --no-capture
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   clippy_check:
     name: Clippy
     needs: get-features
@@ -565,6 +628,13 @@ jobs:
         run: |
           cargo clippy --features "$FEATURES" --all-targets -- -Dwarnings
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   cargo_fmt:
     name: Enforce Rust code format
     if: |
@@ -590,6 +660,13 @@ jobs:
       - name: Check format
         run: cargo +nightly-2026-01-16 fmt --all -- --check
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   cargo-deny:
     name: License / vulnerability audit
     if: |
@@ -610,3 +687,10 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories bans licenses sources
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -700,8 +700,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]'
+      github.event.pull_request.author_association == 'MEMBER'
 
     runs-on: warp-ubuntu-latest-x64-4x
 

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -697,11 +697,6 @@ jobs:
 
   warpbuild-debugger-fail-test:
     name: Fail test for debugging purposes
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER'
-
     runs-on: warp-ubuntu-latest-x64-4x
 
     steps:

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, warp-ubuntu-latest-x64-4x]
         rust_version: [stable, 1.88.0]
 
     steps:
@@ -74,6 +74,13 @@ jobs:
         run: |
           cargo test --features "$FEATURES"
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }} && ${{ matrix.os == 'warp-ubuntu-latest-x64-4x' }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
     needs: get-features
@@ -83,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, warp-ubuntu-latest-x64-4x]
         rust_version: [stable, 1.88.0]
 
     steps:
@@ -105,11 +112,18 @@ jobs:
         run: |
           cargo test --features "$FEATURES"
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }} && ${{ matrix.os == 'warp-ubuntu-latest-x64-4x' }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   tests-cross:
     name: Unit tests
     needs: get-features
     if: contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
 
     strategy:
       fail-fast: false
@@ -142,6 +156,13 @@ jobs:
         run: |
           cross test --lib --bins --features "$FEATURES" --target ${{ matrix.target }}
 
+      - name: Setup interactive ssh session
+        if: ${{ failure() }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
+
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
     needs: get-features
@@ -151,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, warp-ubuntu-latest-x64-4x]
 
     steps:
       - name: Checkout repository
@@ -170,6 +191,13 @@ jobs:
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
           cargo +nightly-2025-12-06 test -Z direct-minimal-versions --all-targets --features "$FEATURES"
+
+      - name: Setup interactive ssh session
+        if: ${{ failure() }} && ${{ matrix.os == 'warp-ubuntu-latest-x64-4x' }}
+        uses: Warpbuilds/action-debugger@v1.3
+        timeout-minutes: 15
+        with:
+          limit-access-to-actor: true
 
   unused_deps:
     name: Check for unused dependencies


### PR DESCRIPTION
## Changes in this pull request

This uses warpbuild equivalent runners for a set of CI jobs to compare with GitHub-hosted runners

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
