### PR TITLE
docs: Fix doc for verify_after_sign due to bug

### DIFF
--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -317,7 +317,7 @@ pub struct Verify {
     /// Whether to verify the manifest after signing in the [`Builder`].
     ///
     /// The default value is false.
-    /// There is a known bug related to this setting: [#1875](https://github.com/contentauth/c2pa-rs/issues/1875). 
+    /// There is a known bug related to this setting: [#1875](https://github.com/contentauth/c2pa-rs/issues/1875).
     /// When the bug is fixed, the default value should be true.
     ///
     /// <div class="warning">


### PR DESCRIPTION
## Changes in this pull request

Update doc comments to specify the actual current default, due to known bug: https://github.com/contentauth/c2pa-rs/issues/1875


