### PR TITLE
fix: handle meta box without FullBox header from Apple devices

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -44,7 +44,6 @@ pub struct BmffIO {
     bmff_format: String, // can be used for specialized BMFF cases
 }
 
-const QT_FOURCC: u32 = 0x71742020; // 'qt  ' - used to identify QuickTime format which has some differences from standard BMFF/MP4
 
 const MAX_BOX_DEPTH: usize = 32; // reasonable BMFF box depth, to prevent stack overflow
 
@@ -365,6 +364,29 @@ fn read_box_header_ext<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<(u8, u
     let flags = reader.read_u24::<BigEndian>()?;
     Ok((version, flags))
 }
+
+/// Detect whether a `meta` box omits the FullBox version/flags header.
+///
+/// Per ISO 14496-12 §8.11.1, `meta` is a FullBox whose first child must
+/// be `hdlr`. However, Apple QuickTime (and iOS AVAssetWriter even with
+/// `isom` brand) writes `meta` as a plain Box without the 4-byte
+/// version+flags field. We detect this by peeking at the next 8 bytes:
+/// if bytes 4..8 are `hdlr`, the data is already a child box header so
+/// no FullBox header is present. This matches the approach used by FFmpeg
+/// and Bento4.
+fn meta_box_lacks_fullbox_header<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<bool> {
+    let pos = reader.stream_position()?;
+    let mut buf = [0u8; 8];
+    let ok = reader.read_exact(&mut buf).is_ok();
+    reader.seek(SeekFrom::Start(pos))?;
+
+    if !ok {
+        return Ok(false);
+    }
+
+    Ok(&buf[4..8] == b"hdlr")
+}
+
 fn write_box_header_ext<W: Write>(w: &mut W, v: u8, f: u32) -> Result<u64> {
     w.write_u8(v)?;
     w.write_u24::<BigEndian>(f)?;
@@ -1343,9 +1365,9 @@ pub(crate) fn build_bmff_tree<R: Read + Seek + ?Sized>(
                     // FullBox has version and flags after the header, but for some boxes like QT "meta"
                     // the version and flags are not present even though it is technically a full box,
                     // so we need to conditionally read the extended header based on the box type and in
-                    // the case of "meta" the ftyp major brand of "qt  " indicates the QuickTime exception.
+                    // the case of "meta" we peek at the data to detect the QuickTime exception.
                     let (version, flags) = if BoxType::MetaBox == header.name
-                        && ftyp.major_brand == QT_FOURCC.into()
+                        && meta_box_lacks_fullbox_header(reader)?
                     {
                         (None, None)
                     } else {


### PR DESCRIPTION
## Problem

Apple's AVAssetWriter (and QuickTime) writes the BMFF `meta` box as a plain Box, omitting the 4-byte FullBox version+flags field that ISO 14496-12 requires. The parser currently only skips the FullBox header for QuickTime (`qt  `) major brands, so `isom`-branded MP4 files from iOS devices trigger:

> Box size extends beyond asset bounds

This prevents C2PA manifest extraction from any video recorded on iOS (and many Android devices that produce the same non-conformant `meta` box).

## Root cause

In `bmff_io.rs`, the existing check uses `ftyp.major_brand == QT_FOURCC` to decide whether to skip the FullBox header on the `meta` box. Apple's AVAssetWriter uses `isom` as the major brand (not `qt  `), so the check fails and the parser reads 4 phantom bytes as version+flags, corrupting the box tree.

## Fix

Replace the brand-based check with a peek heuristic: after reading the `meta` box header, peek at the next 8 bytes. If bytes 4..8 are `hdlr`, the data is already a child box header (the required first child per ISO 14496-12 §8.11.1), meaning no FullBox header is present.

This matches the approach used by:
- **FFmpeg** (`mov.c`): scans for `hdlr` after the meta box header
- **Bento4** (`Ap4ContainerAtom.cpp`): checks for a plausible child box size + `hdlr` FourCC

## Changes

Single file: `sdk/src/asset_handlers/bmff_io.rs`
- Removed the `QT_FOURCC` constant (no longer needed)
- Added `meta_box_lacks_fullbox_header()` helper that peeks 8 bytes and checks for `hdlr`
- Replaced the brand check with the new peek heuristic

## Testing

Tested against real-world videos from [divine.video](https://divine.video) (a video platform using C2PA via the Guardian Project's c2pa-flutter SDK):

- Verified parsing of iOS-recorded MP4s that previously failed
- Full C2PA manifest extracted: signer, assertions, ingredients, validation results
- Existing tests pass (the `test_bmff_jumbf_generation_qt` fixture failure is pre-existing and unrelated)

Test video (publicly available): `curl -O https://media.divine.video/f1e819b7e83bba0658440f691528896f2455ec713c41fa3bd947bb00d66d2257`