### PR TITLE
fix: handle meta box without FullBox header from Apple devices

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -44,7 +44,6 @@ pub struct BmffIO {
     bmff_format: String, // can be used for specialized BMFF cases
 }
 
-
 const MAX_BOX_DEPTH: usize = 32; // reasonable BMFF box depth, to prevent stack overflow
 
 const HEADER_SIZE: u64 = 8; // 4 byte type + 4 byte size
@@ -1272,6 +1271,7 @@ fn adjust_known_offsets<W: Write + CAIRead + ?Sized>(
     Ok(())
 }
 
+#[allow(clippy::only_used_in_recursion)]
 pub(crate) fn build_bmff_tree<R: Read + Seek + ?Sized>(
     reader: &mut R,
     end: u64,


### PR DESCRIPTION
## Changes

Apple's AVAssetWriter (and QuickTime) writes the BMFF `meta` box as a plain Box, omitting the 4-byte FullBox version+flags header, even when the file brand is `isom`. The current parser assumes `meta` always has a FullBox header per ISO 14496-12 §8.11.1, which causes `BoxSizeExceedsBounds` errors when reading C2PA manifests from these files.

This adds a `meta_box_lacks_fullbox_header()` peek that checks whether bytes 4..8 after the box header are `hdlr` — the required first child of `meta`. If so, the FullBox header is skipped. This matches the approach used by FFmpeg and Bento4.

Tested against real-world MP4 files from iOS devices uploaded to blossom servers via the [DiVine](https://divine.video) app.

## Checklist

- [x] This PR represents a single feature, fix, or change
- [x] All applicable changes have been documented
- [x] Any `TO DO` items have been entered as GitHub issues with links included in comments