### PR TITLE
fix: panic when validating boxes hash with no names

### DIFF
--- a/sdk/src/assertions/box_hash.rs
+++ b/sdk/src/assertions/box_hash.rs
@@ -126,7 +126,15 @@ impl BoxHash {
 
         // check to see we source index starts at PNGh and skip if not included in the hash list
         if let Some(first_expected_bms) = source_bms.get(source_index) {
-            if first_expected_bms.names[0] == "PNGh" && self.boxes[0].names[0] != "PNGh" {
+            if first_expected_bms
+                .names
+                .first()
+                .is_some_and(|name| name == "PNGh")
+                && self.boxes[0]
+                    .names
+                    .first()
+                    .is_some_and(|name| name != "PNGh")
+            {
                 source_index += 1;
             }
         } else {
@@ -673,5 +681,30 @@ mod tests {
         assert_eq!(bh.boxes[0].names[0], "test");
         assert_eq!(bh.boxes[1].names[0], "C2PA");
         assert_eq!(bh.boxes[2].names[0], "test1");
+    }
+
+    #[test]
+    fn test_verify_stream_hash_with_empty_names() {
+        let ap = fixture_path("libpng-test.png");
+        let bhp = get_assetio_handler_from_path(&ap)
+            .unwrap()
+            .asset_box_hash_ref()
+            .unwrap();
+        let mut input = File::open(&ap).unwrap();
+
+        let malicious_bh = BoxHash {
+            boxes: vec![BoxMap {
+                names: vec![],
+                alg: Some("sha256".to_string()),
+                hash: ByteBuf::from(vec![0]),
+                excluded: None,
+                pad: ByteBuf::from(vec![]),
+                range_start: 0,
+                range_len: 0,
+            }],
+        };
+
+        // This shouldn't crash.
+        let _ = malicious_bh.verify_stream_hash(&mut input, Some("sha256"), bhp);
     }
 }


### PR DESCRIPTION
Boxes hash validation currently panics when validating boxes with no names. This PR fixes that.