### PR TITLE
fix: Add API to read manifest bytes using reader+context

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -880,7 +880,6 @@ pub unsafe extern "C" fn c2pa_reader_with_stream(
 /// # Returns
 ///
 /// A pointer to a newly configured C2paReader, or NULL on error.
-/// ```
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
     reader: *mut C2paReader,


### PR DESCRIPTION
## Changes in this pull request
Add `c2pa_reader_with_manifest_data_and_stream`. 

Similar to `c2pa_reader_from_manifest_data_and_stream`, but adapted for Context APIS. Since Context has Settings, those would get reused when reading.

`from_manifest_data_and_stream` ([here](https://github.com/contentauth/c2pa-rs/blob/main/sdk/src/reader.rs#L436C12-L436C41) called by `c2pa_reader_from_manifest_data_and_stream` creates settings + context based on thread local settings if any ([here](https://github.com/contentauth/c2pa-rs/blob/main/sdk/src/reader.rs#L442-L443)).

The C FFI function uses existing Rust calls, but lets you pass in a contex (=> using `Reader::from_context(context).with_manifest_data_and_stream(c2pa_data, format, stream)`).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
