### PR TITLE
fix: add new `http` feature for `c2pa_c_ffi` in Windows build script

### DIFF
--- a/make_release.ps1
+++ b/make_release.ps1
@@ -86,7 +86,7 @@ Write-Host "`nEnvironment setup complete. You can now run 'make release'."
 Write-Host "Building Rust project with msvc and clang toolchain ..."
 rustup update stable-$arch-pc-windows-msvc
 rustup target add $arch-pc-windows-msvc
-cargo build --target="$arch-pc-windows-msvc" -p c2pa-c-ffi --release --no-default-features --features "rust_native_crypto, file_io"
+cargo build --target="$arch-pc-windows-msvc" -p c2pa-c-ffi --release --no-default-features --features "rust_native_crypto, file_io, http"
 
 
 # generate zip file with version and platform and add to artifacts folder


### PR DESCRIPTION
Adds the new `http` feature to `c2pa_c_ffi` introduced in #1886 for Emscripten support for the Windows build scripts.

We should consider unifying the Makefile and Windows build script if possible.