### PR TITLE
fix: Prevent invalid validation_state when an ingredient's only failure code is signingCredential.untrusted

### DIFF
--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -217,10 +217,10 @@ impl ValidationResults {
                         })
                 })
             });
-            let ingredients_trusted = self.ingredient_deltas.as_ref().map_or(true, |deltas| {
-                deltas.iter().all(|idv| {
-                    idv.validation_deltas().success().iter().any(|status| {
-                        status.code() == validation_status::SIGNING_CREDENTIAL_TRUSTED
+            let ingredients_trusted = !self.ingredient_deltas.as_ref().is_some_and(|deltas| {
+                deltas.iter().any(|idv| {
+                    idv.validation_deltas().failure().iter().any(|status| {
+                        status.code() == validation_status::SIGNING_CREDENTIAL_UNTRUSTED
                     })
                 })
             });


### PR DESCRIPTION
## Changes in this pull request
This PR fixes an issue where the `validation_state` comes back as "Invalid" when an ingredient's only failure is SIGNING_CREDENTIAL_UNTRUSTED.  This status code is already filtered on the active manifest validity check.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
