### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.78.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.78.3...c2pa-v0.78.4)
+_16 March 2026_
+
+### Fixed
+
+* Pin `atree` to 0.5.2 ([#1940](https://github.com/contentauth/c2pa-rs/pull/1940))
+* Remove exponential memory growth from nested claim reconstruction ([#1885](https://github.com/contentauth/c2pa-rs/pull/1885)) ([#1887](https://github.com/contentauth/c2pa-rs/pull/1887))
+
 ## [0.78.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.78.2...c2pa-v0.78.3)
 _13 March 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.78.3"
+version = "0.78.4"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.78.3"
+version = "0.78.4"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.78.3"
+version = "0.78.4"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.38"
+version = "0.26.39"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.78.3"
+version = "0.78.4"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2356,7 +2356,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.78.3"
+version = "0.78.4"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.78.3"
+version = "0.78.4"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.78.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.78.3...c2pa-c-ffi-v0.78.4)
+_16 March 2026_
+
 ## [0.78.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.78.2...c2pa-c-ffi-v0.78.3)
 _13 March 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.78.3", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.78.4", default-features = false, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.39](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.38...c2patool-v0.26.39)
+_16 March 2026_
+
+### Fixed
+
+* Pin `atree` to 0.5.2 ([#1940](https://github.com/contentauth/c2pa-rs/pull/1940))
+
 ## [0.26.38](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.37...c2patool-v0.26.38)
 _13 March 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.38"
+version = "0.26.39"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "=0.5.2"
-c2pa = { path = "../sdk", version = "0.78.3", features = [
+c2pa = { path = "../sdk", version = "0.78.4", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.78.3", features = [
+c2pa = { path = "../sdk", version = "0.78.4", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.78.3 -> 0.78.4 (✓ API compatible changes)
* `c2patool`: 0.26.38 -> 0.26.39
* `c2pa-c-ffi`: 0.78.3 -> 0.78.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.78.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.78.3...c2pa-v0.78.4)

_16 March 2026_

### Fixed

* Pin `atree` to 0.5.2 ([#1940](https://github.com/contentauth/c2pa-rs/pull/1940))
* Remove exponential memory growth from nested claim reconstruction ([#1885](https://github.com/contentauth/c2pa-rs/pull/1885)) ([#1887](https://github.com/contentauth/c2pa-rs/pull/1887))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.39](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.38...c2patool-v0.26.39)

_16 March 2026_

### Fixed

* Pin `atree` to 0.5.2 ([#1940](https://github.com/contentauth/c2pa-rs/pull/1940))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.78.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.78.3...c2pa-c-ffi-v0.78.4)

_16 March 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).