### PR TITLE
fix: regenerate JUMBF after dynamic assertions in save_to_stream

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3017,6 +3017,14 @@ impl Store {
         }?;
         let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
 
+        // Regenerate JUMBF after ALL claim modifications (including DataHash
+        // updates from save_jumbf_to_stream) so it matches what sign_claim signed.
+        // Without this, dynamic assertions cause jumbf_bytes to contain stale
+        // claim data from before DataHash finalization → claimSignature.mismatch.
+        if modified {
+            jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+        }
+
         intermediate_stream.rewind()?;
         output_stream.rewind()?;
         match self.finish_save_stream(


### PR DESCRIPTION
## Summary

Dynamic assertions (e.g., CAWG identity assertions via `AsyncDynamicAssertion`) produce `claimSignature.mismatch` when signed through the `save_to_stream` path (used by `Builder::sign_async`).

## Root Cause

In `save_to_stream`, after `write_dynamic_assertions` modifies the claim:

1. `to_jumbf_internal()` generates JUMBF with claim data **X**
2. `save_jumbf_to_stream()` embeds JUMBF into the asset — this updates the DataHash, changing the claim to **Y**
3. `sign_claim()` signs claim data **Y**
4. `finish_save_stream()` patches the signature into the JUMBF from step 1 (which still has stale claim data **X**)

The verifier reads claim data **X** from the JUMBF but the signature was computed over **Y** → `claimSignature.mismatch`.

The `sign_manifest` path (used by the embeddable API) is not affected because it generates JUMBF *after* signing.

## Fix

Regenerate `jumbf_bytes` via `to_jumbf_internal()` after `sign_claim` and before `finish_save_stream`, so the JUMBF matches the signed claim data. This only runs when dynamic assertions modified the claim (`if modified`).

## Reproduction

The existing `IdentityAssertion.spec.js` test in `c2pa-node-v2` passes because it only checks that `Reader.fromAsset()` doesn't throw — it never inspects `validation_status`. Adding a validation check reproduces the bug:

```typescript
const store = reader.json();
const integrityErrors = store.validation_status
  ?.filter(s => !s.code.startsWith("signingCredential."));
expect(integrityErrors).toHaveLength(0); // FAILS: claimSignature.mismatch
```

See: https://github.com/contentauth/c2pa-node-v2/issues/51

## Testing

Verified with a modified `IdentityAssertion.spec.ts` that checks `validation_status`:
- Before fix: `claimSignature.mismatch` on every configuration (directCoseHandling true/false, with/without ingredients)
- After fix: zero integrity errors, `cawg.identity` assertion present and valid