### PR TITLE
feat: don't spawn threads when computing hashes in a zkVM

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -375,7 +375,7 @@ where
         }
     };
 
-    if cfg!(target_arch = "wasm32") {
+    if cfg!(target_arch = "wasm32") || cfg!(target_os = "zkvm") {
         // hash the data for ranges
         for r in ranges {
             let start = r.start();


### PR DESCRIPTION
## Changes in this pull request
Extend the WASM fallback path in `hash_stream_by_alg` to also apply when targeting a `zkvm`. zkVM environments lack OS-level primitives like threading, so they require the same portable, sequential range-based read loop used for WASM.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
