### PR TITLE
fix: Limit the maximum number of assertions allowed for C2PA Manifest

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -48,7 +48,7 @@ use crate::{
     jumbf_io,
     maybe_send_sync::MaybeSend,
     resource_store::{ResourceRef, ResourceResolver, ResourceStore},
-    settings::builder::TimeStampFetchScope,
+    settings::{builder::TimeStampFetchScope, MAX_ASSERTIONS},
     store::Store,
     utils::{hash_utils::hash_to_b64, merkle::MerkleAccumulator, mime::format_to_mime},
     AsyncSigner, ClaimGeneratorInfo, EphemeralSigner, HashRange, HashedUri, Ingredient,
@@ -803,9 +803,10 @@ impl Builder {
     /// Adds a CBOR assertion to the manifest.
     /// In most cases, use this function instead of `add_assertion_json`, unless the assertion must be stored in JSON format.
     fn check_assertion_limit(&self) -> Result<()> {
-        let max = self.context.settings().builder.max_assertions;
-        if self.definition.assertions.len() >= max {
-            return Err(Error::TooManyAssertions { max });
+        if self.definition.assertions.len() >= MAX_ASSERTIONS {
+            return Err(Error::TooManyAssertions {
+                max: MAX_ASSERTIONS,
+            });
         }
         Ok(())
     }
@@ -3396,7 +3397,7 @@ mod tests {
         crypto::raw_signature::SigningAlg,
         hash_stream_by_alg,
         maybe_send_sync::MaybeSend,
-        settings::{Settings, MAX_ASSERTIONS},
+        settings::Settings,
         utils::{
             hash_utils::HashRange,
             test::{test_context, write_bmff_placeholder_stream, write_jpeg_placeholder_stream},
@@ -7491,32 +7492,6 @@ mod tests {
                 max: MAX_ASSERTIONS
             }
         ));
-    }
-
-    #[test]
-    fn test_add_assertion_limit_is_configurable() {
-        let data = serde_json::json!({"value": 1});
-        let settings = Settings {
-            builder: crate::settings::builder::BuilderSettings {
-                max_assertions: 2,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let context = Context::new()
-            .with_settings(settings)
-            .expect("valid settings");
-        let mut builder = Builder::from_context(context);
-        builder
-            .add_assertion_json("org.test.a1", &data)
-            .expect("first assertion should succeed");
-        builder
-            .add_assertion_json("org.test.a2", &data)
-            .expect("second assertion should succeed");
-        let err = builder
-            .add_assertion_json("org.test.a3", &data)
-            .expect_err("third assertion should exceed limit of 2");
-        assert!(matches!(err, Error::TooManyAssertions { max: 2 }));
     }
 
     // Ensures that the future returned by `Builder::sign_async` implements `Send`, thus making it

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -74,7 +74,7 @@ use crate::{
     log_item,
     resource_store::UriOrResource,
     salt::{DefaultSalt, SaltGenerator},
-    settings::Settings,
+    settings::{Settings, MAX_ASSERTIONS},
     status_tracker::{ErrorBehavior, StatusTracker},
     store::StoreValidationInfo,
     utils::hash_utils::{hash_by_alg, vec_compare},
@@ -251,8 +251,6 @@ const ALG_SOFT_F: &str = "alg_soft";
 const METADATA_F: &str = "metadata";
 const CREATED_ASSERTIONS_F: &str = "created_assertions";
 const GATHERED_ASSERTIONS_F: &str = "gathered_assertions";
-
-use crate::settings::max_assertions;
 
 /// A `Claim` gathers together all the `Assertion`s about an asset
 /// from an actor at a given time, and may also include one or more
@@ -1431,10 +1429,9 @@ impl Claim {
     ) -> Result<C2PAAssertion> {
         // Enforce the per-manifest assertion limit to prevent resource exhaustion
         // regardless of how the claim is constructed.
-        let max_assertions = max_assertions();
-        if self.assertion_store.len() >= max_assertions {
+        if self.assertion_store.len() >= MAX_ASSERTIONS {
             return Err(Error::TooManyAssertions {
-                max: max_assertions,
+                max: MAX_ASSERTIONS,
             });
         }
 
@@ -4107,12 +4104,7 @@ pub mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use crate::{
-        assertions::{Action, Actions},
-        resource_store::UriOrResource,
-        settings,
-        utils::test::create_test_claim,
-    };
+    use crate::{resource_store::UriOrResource, utils::test::create_test_claim};
 
     #[test]
     fn test_build_claim() {
@@ -4291,33 +4283,5 @@ pub mod tests {
         }
 
         Ok(())
-    }
-
-    #[test]
-    fn test_add_assertion_default_limit_in_claim() {
-        // Use a small limit so the test runs quickly regardless of the default.
-        const TEST_LIMIT: usize = 5;
-        settings::set_settings_value("verify.max_assertions", TEST_LIMIT as u64).unwrap();
-
-        let mut claim = Claim::new("test_default_assertion_limit", Some("test"), 2);
-        let actions = Actions::new().add_action(Action::new("c2pa.created"));
-
-        // TEST_LIMIT assertions must succeed within the configured limit.
-        for _ in 0..TEST_LIMIT {
-            claim
-                .add_assertion(&actions)
-                .expect("assertion should succeed within the configured limit");
-        }
-
-        // The next one must be rejected.
-        let err = claim
-            .add_assertion(&actions)
-            .expect_err("assertion beyond limit should fail with TooManyAssertions");
-        assert!(
-            matches!(err, Error::TooManyAssertions { max: TEST_LIMIT }),
-            "expected TooManyAssertions {{ max: {TEST_LIMIT} }}, got {err:?}"
-        );
-
-        settings::reset_default_settings().unwrap();
     }
 }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -120,7 +120,7 @@ pub enum Error {
     #[error("more than one manifest store detected")]
     TooManyManifestStores,
 
-    #[error("assertion limit exceeded: maximum allowed is {max}; adjust verify.max_assertions in Settings to change this limit")]
+    #[error("assertion limit exceeded: maximum allowed is {max}")]
     TooManyAssertions { max: usize },
 
     #[error("manifest is not refernced by any ingredient")]

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -583,18 +583,6 @@ pub struct BuilderSettings {
     ///
     /// [`TimeStamp`]: crate::assertions::TimeStamp
     pub auto_timestamp_assertion: TimeStampSettings,
-    /// Maximum number of assertions that can be added to a single manifest.
-    ///
-    /// Limits resource consumption when processing untrusted manifests with a large number
-    /// of assertions. Calls to [`Builder::add_assertion`] or [`Builder::add_assertion_json`]
-    /// that would exceed this limit return [`Error::TooManyAssertions`].
-    ///
-    /// The default value is 100,000.
-    ///
-    /// [`Builder::add_assertion`]: crate::Builder::add_assertion
-    /// [`Builder::add_assertion_json`]: crate::Builder::add_assertion_json
-    /// [`Error::TooManyAssertions`]: crate::Error::TooManyAssertions
-    pub max_assertions: usize,
 }
 
 impl Default for BuilderSettings {
@@ -611,7 +599,6 @@ impl Default for BuilderSettings {
             prefer_box_hash: false,
             generate_c2pa_archive: Some(true),
             auto_timestamp_assertion: TimeStampSettings::default(),
-            max_assertions: crate::settings::MAX_ASSERTIONS,
         }
     }
 }

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -384,17 +384,6 @@ pub struct Verify {
     ///
     /// The default value is false.
     pub strict_v1_validation: bool,
-    /// Maximum number of assertions that will be parsed from a single manifest when reading
-    /// or validating an existing C2PA file.
-    ///
-    /// Limits resource consumption when processing untrusted manifests that embed an
-    /// arbitrarily large number of assertions. Parsing is aborted with
-    /// [`Error::TooManyAssertions`] if the assertion count in the file exceeds this limit.
-    ///
-    /// The default value is 100,000.
-    ///
-    /// [`Error::TooManyAssertions`]: crate::Error::TooManyAssertions
-    pub max_assertions: usize,
 }
 
 impl Default for Verify {
@@ -408,7 +397,6 @@ impl Default for Verify {
             remote_manifest_fetch: true,
             skip_ingredient_conflict_resolution: false,
             strict_v1_validation: false,
-            max_assertions: MAX_ASSERTIONS,
         }
     }
 }
@@ -989,19 +977,6 @@ pub(crate) fn get_thread_local_settings() -> Settings {
             .clone()
             .try_deserialize::<Settings>()
             .unwrap_or_default()
-    })
-}
-
-/// Returns the configured maximum number of assertions allowed per manifest.
-///
-/// Reads `verify.max_assertions` from thread-local settings. Returns the
-/// user-configured value when set, or [`MAX_ASSERTIONS`] (100,000) when
-/// no limit has been configured.
-pub(crate) fn max_assertions() -> usize {
-    SETTINGS.with_borrow(|config| {
-        config
-            .get::<usize>("verify.max_assertions")
-            .unwrap_or(MAX_ASSERTIONS)
     })
 }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -73,7 +73,7 @@ use crate::{
     log_item,
     manifest_store_report::ManifestStoreReport,
     maybe_send_sync::MaybeSend,
-    settings::{builder::OcspFetchScope, Settings},
+    settings::{builder::OcspFetchScope, Settings, MAX_ASSERTIONS},
     status_tracker::{ErrorBehavior, StatusTracker},
     utils::{
         hash_utils::HashRange,
@@ -109,8 +109,6 @@ pub(crate) struct StoreValidationInfo<'a> {
     pub manifest_store_range: Option<HashRange>, // range of the manifest store in the asset for data hash exclusions
     pub certificate_statuses: HashMap<String, Vec<Vec<u8>>>, // list of certificate status assertions for each serial
 }
-
-use crate::settings::max_assertions;
 
 /// A `Store` maintains a list of `Claim` structs.
 ///
@@ -1381,10 +1379,9 @@ impl Store {
 
             // Reject manifests that embed more assertions than the configured limit to
             // prevent unbounded memory and CPU consumption on untrusted input.
-            let max_assertions = max_assertions();
-            if num_assertions > max_assertions {
+            if num_assertions > MAX_ASSERTIONS {
                 return Err(Error::TooManyAssertions {
-                    max: max_assertions,
+                    max: MAX_ASSERTIONS,
                 });
             }
 


### PR DESCRIPTION
# Security Fix: Unbounded Assertion Count Allows Resource Exhaustion

## Issue

No limit exists on the number of assertions that can be added to a manifest across three distinct code paths:

1. **`Builder::add_assertion` / `add_assertion_json`** (`builder.rs`) — the public API for constructing manifests programmatically.
2. **`Claim::add_assertion`** (`claim.rs`) — the lower-level API callable directly, bypassing `Builder`.
3. **`Store::from_jumbf_impl`** (`store.rs`) — the parsing path that processes assertions from untrusted, existing C2PA files.

An attacker can exploit paths 1 and 2 by constructing a manifest with an arbitrarily large number of assertions, and path 3 by supplying a crafted C2PA file with excessive assertions. All three cause uncontrolled memory and CPU consumption — a DoS vector for any application that creates or reads C2PA content.

---

## Fix

### New error variant (`sdk/src/error.rs`)

```
TooManyAssertions { max: usize }
```

Returned by all three enforcement points when the limit is exceeded.

### Shared constant

`pub(crate) const MAX_ASSERTIONS: usize = 100_000` is declared once in `sdk/src/settings/mod.rs` and imported directly by all three enforcement points. There are no configurable settings fields or thread-local accessors — all modules use the constant directly for consistency.

### Limit enforcement

| File | Where | Limit source |
|---|---|---|
| `sdk/src/builder.rs` | `check_assertion_limit()` helper called by `add_assertion` and `add_assertion_json` | `MAX_ASSERTIONS` constant |
| `sdk/src/claim.rs` | `add_assertion_impl` | `MAX_ASSERTIONS` constant |
| `sdk/src/store.rs` | `from_jumbf_impl`, before the assertion parsing loop | `MAX_ASSERTIONS` constant |

Each point returns `Err(TooManyAssertions { max: MAX_ASSERTIONS })` before processing begins when the count meets or exceeds the limit.

---

## Tests

### `builder.rs` — `test_add_assertion_limit`
- Adds assertions up to `MAX_ASSERTIONS` — all succeed.
- Verifies the next one returns `TooManyAssertions { max: MAX_ASSERTIONS }`.
- Completes in ~0.02 seconds.

---
## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
