### PR TITLE
fix: Add compatibility for source assets that report mdat box sizes that e…

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -21,7 +21,6 @@ use std::{
 
 use atree::{Arena, Token};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use mp4::Mp4Reader;
 
 use crate::{
     assertions::{BmffMerkleMap, ExclusionsMap},


### PR DESCRIPTION
…xtend beyond the end of the content.  This is a common practice for assets that may be pulled form a remote stream.  The asset may truncate the asset short of the actual byte counts listed.  

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
