### PR TITLE
Add compatibility check workflow

### DIFF
--- a/.github/workflows/compatibility-check.yml
+++ b/.github/workflows/compatibility-check.yml
@@ -1,0 +1,99 @@
+name: Compatibility Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - v1_api
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+  push:
+    branches:
+      - main
+      - v1_api
+
+jobs:
+  compatibility:
+    name: ${{ matrix.direction.name }}
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+      contains(github.event.pull_request.labels.*.name, 'check-release')
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        direction:
+          - name: Forward compatibility
+            signer_dir: base
+            verifier_dir: pr
+            output_file: signed-forward.jpg
+          - name: Backward compatibility
+            signer_dir: pr
+            verifier_dir: base
+            output_file: signed-backward.jpg
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: pr
+
+      - name: Checkout base code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache PR Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: pr
+
+      - name: Cache base Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: base
+
+      - name: Build PR c2patool
+        working-directory: pr
+        run: cargo build --locked --release -p c2patool
+
+      - name: Build base c2patool
+        working-directory: base
+        run: cargo build --locked --release -p c2patool
+
+      - name: Run compatibility check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p compat
+
+          "./${{ matrix.direction.signer_dir }}/target/release/c2patool" \
+            "./${{ matrix.direction.signer_dir }}/cli/sample/image.jpg" \
+            -m "./${{ matrix.direction.signer_dir }}/cli/sample/test.json" \
+            -o "./compat/${{ matrix.direction.output_file }}" \
+            -f
+
+          "./${{ matrix.direction.verifier_dir }}/target/release/c2patool" \
+            "./compat/${{ matrix.direction.output_file }}" \
+            --info
+
+          "./${{ matrix.direction.verifier_dir }}/target/release/c2patool" \
+            "./compat/${{ matrix.direction.output_file }}" \
+            > "./compat/report.json"
+
+          grep -q "My Title" "./compat/report.json"


### PR DESCRIPTION
## Changes in this pull request
I have added a new Github Action workflow to perform conpatibility checks between the base branch and the pull request branch.

Related Issue: #1911 

I'm aware there was earlier work in #513 .
My understanding is that the previous approach aimed for a much stricter comparison, including format-level checks with multiple asset types.
This PR intentionally takes a lighter approach. Instead of enforcing exact snapshot matches, it uses `c2patool` to run practical forward and backward compatibility checks.

One possible concern with the previous PR is that the workflow may fail if compatibility is broken due to spec changes.
That is also part of the motivation for this work.
If a spec or implementation change causes compatibility to break, that should be handled as a critical event.
And this is need to be detected as early as possible, before it impacts downstream solutions built on this repository.

There are two behavior for compatibility.
- Forward compatibility: `base` signs a sample asset, `PR` reads it.
- Backward compatibility: `PR` signs a sample asset, `base` reads it.

This PR uses trigger conditions similar to `tier-1a`, but I'm happy to adjust if needed.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
