### PR TITLE
fix: Harden BMFF Merkle tree hash processing code against integer underflow attack

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1884,7 +1884,7 @@ impl BmffHash {
         // generate leaves in the Merkle tree based on the box length and fixed or variable block sizes
         let mut leaves = Vec::new();
         if let Some(fixed_block_size) = merkle_map.fixed_block_size {
-            let mut block_start = box_info.start() + MDAT_EXCLUSION_SIZE;
+            let mut block_start = box_info.start().saturating_add(MDAT_EXCLUSION_SIZE);
             let mut bytes_left = box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE);
 
             // sanity check that fixed_block_size is greater than 0
@@ -1902,7 +1902,7 @@ impl BmffHash {
                 block_start += leaf_length;
             }
         } else if let Some(variable_block_sizes) = &merkle_map.variable_block_sizes {
-            let mut block_start = box_info.start() + MDAT_EXCLUSION_SIZE;
+            let mut block_start = box_info.start().saturating_add(MDAT_EXCLUSION_SIZE);
 
             // make sure variable_block_sizes == length of the box
             if box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE)
@@ -1923,7 +1923,7 @@ impl BmffHash {
         } else {
             // only one leaf, so just hash the entire box
             let hash_range = vec![HashRange::new(
-                box_info.start() + MDAT_EXCLUSION_SIZE,
+                box_info.start().saturating_add(MDAT_EXCLUSION_SIZE),
                 box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE),
             )];
             let leaf_hash = hash_stream_by_alg(alg, reader, Some(hash_range), false)?;
@@ -2066,7 +2066,7 @@ impl BmffHash {
         // find the hash ranges for each mdat
         for (index, (box_info, merkle_map)) in mdats.into_iter().zip(mm_vec).enumerate() {
             if let Some(fixed_block_size) = merkle_map.fixed_block_size {
-                let mut block_start = box_info.start() + MDAT_EXCLUSION_SIZE;
+                let mut block_start = box_info.start().saturating_add(MDAT_EXCLUSION_SIZE);
                 let mut bytes_left = box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE);
 
                 // sanity check that fixed_block_size is greater than 0
@@ -2086,7 +2086,7 @@ impl BmffHash {
                 }
                 mdat_ranges.insert(index, hash_ranges);
             } else if let Some(variable_block_sizes) = &merkle_map.variable_block_sizes {
-                let mut block_start = box_info.start() + MDAT_EXCLUSION_SIZE;
+                let mut block_start = box_info.start().saturating_add(MDAT_EXCLUSION_SIZE);
 
                 // make sure variable_block_sizes == length of the box
                 if box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE)
@@ -2108,7 +2108,7 @@ impl BmffHash {
                 mdat_ranges.insert(
                     index,
                     vec![HashRange::new(
-                        box_info.start() + MDAT_EXCLUSION_SIZE,
+                        box_info.start().saturating_add(MDAT_EXCLUSION_SIZE),
                         box_info.size().saturating_sub(MDAT_EXCLUSION_SIZE),
                     )],
                 );


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: Integer Underflow in `BmffHash` Merkle Hashing

## Issue

In `sdk/src/assertions/bmff_hash.rs`, two functions (`create_merkle_tree_for_merkle_map` and
`validate_merkle_maps_mdat_boxes`) compute the hashable payload of an mdat box using bare
subtraction (`box_info.size() - 16`) without validating that `size >= 16`.

If a crafted MP4/MOV file contains an mdat box with `size < 16`, the subtraction wraps to a
near-`u64::MAX` value, causing the hashing loop to attempt reading an astronomically large number
of bytes — a denial-of-service vector for any application that verifies BMFF-hashed C2PA content.
The same pattern existed in five locations across the two functions.

---

## Background: Why 16 bytes are always excluded

The C2PA spec exclusion list uses xpath to identify regions skipped during hashing. Because xpath
cannot distinguish a standard 8-byte BMFF header from a large-size 16-byte header, the spec
mandates excluding exactly 16 bytes from the start of every mdat box regardless of encoding. For a
standard-size mdat this means the 8-byte header plus the first 8 bytes of payload are both
excluded — intentional so that a single exclusion expression covers largesize boxes too.

---

## Fix

### Underflow: `saturating_sub` for payload size

Replaced all five bare `- 16` subtractions with `.saturating_sub(MDAT_EXCLUSION_SIZE)` across
both functions. When `size < 16`, `saturating_sub` returns 0 and the hashing loop does not
execute — no underflow, no out-of-bounds read. A named constant `MDAT_EXCLUSION_SIZE = 16`
replaces the magic number and documents the spec rationale at each use site.

### Overflow: `saturating_add` for `block_start`

All six `block_start` initialisations used bare `+` to add `MDAT_EXCLUSION_SIZE` to
`box_info.start()`. A crafted file whose mdat box begins within 16 bytes of `u64::MAX` would
cause the addition to wrap to a near-zero value in release mode, redirecting the Merkle hash
loop to the start of the file. Replaced all six with `.saturating_add(MDAT_EXCLUSION_SIZE)`,
which clamps to `u64::MAX` — always beyond any real file length — so the loop body is never
entered.

---

## Tests

### `bmff_hash_tests::test_create_merkle_tree_no_underflow_for_small_mdat_box`
Passes a `BoxInfoLite` with `size = 8` (standard header, no payload) to
`create_merkle_tree_for_merkle_map` and verifies no panic or arithmetic overflow occurs.

### `bmff_hash_tests::test_validate_merkle_maps_no_underflow_for_small_mdat_box`
Same `BoxInfoLite` passed through `validate_merkle_maps_mdat_boxes`; verifies no panic or
arithmetic overflow.

---

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
