### PR TITLE
Update fetch.rs

### DIFF
--- a/sdk/src/crypto/ocsp/fetch.rs
+++ b/sdk/src/crypto/ocsp/fetch.rs
@@ -153,7 +153,7 @@ pub(crate) fn fetch_ocsp_response(certs: &[Vec<u8>], context: &Context) -> Optio
         context
             .check_progress(ProgressPhase::FetchingOCSP, step, requests_len)
             .ok()?;
-        let req_url = request_data.url.join(&request_data.request_str).ok()?;
+        let req_url = request_data.url.join(&request_data.request_str.trim_start_matches('/')).ok()?;
 
         let mut request = http::Request::get(req_url.to_string());
         if let Some(host) = req_url.host() {


### PR DESCRIPTION
At line 156, URL builder function was replacing the path of the URL because of the leading Slash in the request.str

## Changes in this pull request
Improved the URL builder function by using trim method

## Checklist
- [ ] This PR represents an update in the URL builder function at Line 149 in https://github.com/contentauth/c2pa-rs/blob/main/sdk/src/crypto/ocsp/fetch.rs

