### PR TITLE
chore: Deprecate thread-local settings APIs in favor of explicit Context

### DIFF
--- a/c2pa_c_ffi/cbindgen.toml
+++ b/c2pa_c_ffi/cbindgen.toml
@@ -73,7 +73,7 @@ after_includes = """
 [fn]
 prefix = "C2PA_API extern"
 deprecated = "C2PA_DEPRECATED"
-deprecated_with_note = "C2PA_DEPRECATED_MSG"
+deprecated_with_note = "C2PA_DEPRECATED_MSG({})"
 
 [export]
 # Exclude internal functions from C API

--- a/c2pa_c_ffi/cbindgen.toml
+++ b/c2pa_c_ffi/cbindgen.toml
@@ -52,13 +52,17 @@ after_includes = """
     #endif
 #endif
 
-/* Deprecation macros: produce compiler warnings when deprecated C2PA functions are called. */
-#if defined(__cplusplus) && __cplusplus >= 201402L
-    #define C2PA_DEPRECATED [[deprecated]]
-    #define C2PA_DEPRECATED_MSG(msg) [[deprecated(msg)]]
-#elif defined(__GNUC__) || defined(__clang__)
+/* Deprecation macros: produce compiler warnings when deprecated C2PA functions are called.
+ * GCC/Clang __attribute__ is checked first because it is position-flexible
+ * (works after 'extern'), whereas C++ [[deprecated]] is only valid at the
+ * very start of a declaration and cbindgen emits the annotation after the
+ * 'extern' keyword. */
+#if defined(__GNUC__) || defined(__clang__)
     #define C2PA_DEPRECATED __attribute__((deprecated))
     #define C2PA_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#elif defined(__cplusplus) && __cplusplus >= 201402L
+    #define C2PA_DEPRECATED [[deprecated]]
+    #define C2PA_DEPRECATED_MSG(msg) [[deprecated(msg)]]
 #elif defined(_MSC_VER)
     #define C2PA_DEPRECATED __declspec(deprecated)
     #define C2PA_DEPRECATED_MSG(msg) __declspec(deprecated(msg))

--- a/c2pa_c_ffi/cbindgen.toml
+++ b/c2pa_c_ffi/cbindgen.toml
@@ -52,11 +52,28 @@ after_includes = """
     #endif
 #endif
 
+/* Deprecation macros: produce compiler warnings when deprecated C2PA functions are called. */
+#if defined(__cplusplus) && __cplusplus >= 201402L
+    #define C2PA_DEPRECATED [[deprecated]]
+    #define C2PA_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__) || defined(__clang__)
+    #define C2PA_DEPRECATED __attribute__((deprecated))
+    #define C2PA_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+    #define C2PA_DEPRECATED __declspec(deprecated)
+    #define C2PA_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#else
+    #define C2PA_DEPRECATED
+    #define C2PA_DEPRECATED_MSG(msg)
+#endif
+
 
 """
 
 [fn]
 prefix = "C2PA_API extern"
+deprecated = "C2PA_DEPRECATED"
+deprecated_with_note = "C2PA_DEPRECATED_MSG"
 
 [export]
 # Exclude internal functions from C API

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -930,6 +930,10 @@ pub unsafe extern "C" fn c2pa_context_cancel(ctx: *mut C2paContext) -> c_int {
 /// and it is no longer valid after that call.
 #[cfg(feature = "file_io")]
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_reader_from_context() with an explicit context for new implementations."
+)]
+#[allow(deprecated)]
 pub unsafe extern "C" fn c2pa_read_file(
     path: *const c_char,
     data_dir: *const c_char,
@@ -957,6 +961,9 @@ pub unsafe extern "C" fn c2pa_read_file(
 /// and it is no longer valid after that call.
 #[cfg(feature = "file_io")]
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_builder_add_ingredient_from_stream() with an explicit context for new implementations."
+)]
 #[allow(deprecated)]
 pub unsafe extern "C" fn c2pa_read_ingredient_file(
     path: *const c_char,
@@ -998,6 +1005,10 @@ pub struct C2paSignerInfo {
 /// and it is no longer valid after that call.
 #[cfg(feature = "file_io")]
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_builder_from_context() with c2pa_builder_sign_to_stream() for new implementations."
+)]
+#[allow(deprecated)]
 pub unsafe extern "C" fn c2pa_sign_file(
     source_path: *const c_char,
     dest_path: *const c_char,
@@ -1024,12 +1035,12 @@ pub unsafe extern "C" fn c2pa_sign_file(
 }
 
 /// Frees a string allocated by Rust.
-/// Deprecated, use c2pa_free instead
 ///
 /// # Safety
 /// The string must not have been modified in C.
 /// The string can only be freed once and is invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_release_string(s: *mut c_char) {
     cimpl_free!(s);
 }
@@ -1101,6 +1112,7 @@ pub unsafe extern "C" fn c2pa_free(ptr: *const c_void) -> c_int {
 /// The string must not have been modified in C.
 /// The string can only be freed once and is invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_string_free(s: *mut c_char) {
     cimpl_free!(s);
 }
@@ -1124,6 +1136,7 @@ pub unsafe extern "C" fn c2pa_free_string_array(ptr: *const *const c_char, count
 
     let mut_ptr = ptr as *mut *mut c_char;
     // Free each string directly using the pointer.
+    #[allow(deprecated)]
     for i in 0..count {
         c2pa_string_free(*mut_ptr.add(i));
     }
@@ -1431,6 +1444,7 @@ pub unsafe extern "C" fn c2pa_reader_from_manifest_data_and_stream(
 /// # Safety
 /// The C2paReader can only be freed once and is invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_reader_free(reader_ptr: *mut C2paReader) {
     cimpl_free!(reader_ptr);
 }
@@ -1653,6 +1667,7 @@ pub unsafe extern "C" fn c2pa_builder_supported_mime_types(
 /// # Safety
 /// The C2paBuilder can only be freed once and is invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_builder_free(builder_ptr: *mut C2paBuilder) {
     cimpl_free!(builder_ptr);
 }
@@ -2098,6 +2113,7 @@ pub unsafe extern "C" fn c2pa_builder_sign_context(
 /// # Safety
 /// The bytes can only be freed once and are invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_manifest_bytes_free(manifest_bytes_ptr: *const c_uchar) {
     cimpl_free!(manifest_bytes_ptr);
 }
@@ -2712,6 +2728,7 @@ pub unsafe extern "C" fn c2pa_signer_reserve_size(signer_ptr: *mut C2paSigner) -
 /// # Safety
 /// The C2paSigner can only be freed once and is invalid after this call.
 #[no_mangle]
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_signer_free(signer_ptr: *const C2paSigner) {
     cimpl_free!(signer_ptr);
 }
@@ -2744,6 +2761,7 @@ pub unsafe extern "C" fn c2pa_ed25519_sign(
 ///
 /// # Safety
 /// The signature can only be freed once and is invalid after this call.
+#[deprecated(note = "Use c2pa_free() instead, which works for all pointer types.")]
 pub unsafe extern "C" fn c2pa_signature_free(signature_ptr: *const u8) {
     cimpl_free!(signature_ptr);
 }

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -522,13 +522,18 @@ pub unsafe extern "C" fn c2pa_error_set_last(error_str: *const c_char) -> c_int 
 /// # Safety
 /// Reads from NULL-terminated C strings.
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_settings_new() and c2pa_context_builder_set_settings() to configure a context explicitly."
+)]
 pub unsafe extern "C" fn c2pa_load_settings(
     settings: *const c_char,
     format: *const c_char,
 ) -> c_int {
     let settings = cstr_or_return_int!(settings);
     let format = cstr_or_return_int!(format);
-    // we use the legacy from_string function to set thread-local settings for backward compatibility
+    // The C API is inherently stateful: callers invoke c2pa_load_settings once and subsequent
+    // C API calls inherit those settings via thread-local storage. This is by design.
+    #[allow(deprecated)]
     let result = C2paSettings::from_string(&settings, &format);
     ok_or_return_int!(result);
     0 // returns 0 on success
@@ -952,12 +957,14 @@ pub unsafe extern "C" fn c2pa_read_file(
 /// and it is no longer valid after that call.
 #[cfg(feature = "file_io")]
 #[no_mangle]
+#[allow(deprecated)]
 pub unsafe extern "C" fn c2pa_read_ingredient_file(
     path: *const c_char,
     data_dir: *const c_char,
 ) -> *mut c_char {
     let path = cstr_or_return_null!(path);
     let data_dir = cstr_or_return_null!(data_dir);
+    // Legacy C API: uses thread-local settings. Use c2pa_reader_from_context for new implementations.
     let result = Ingredient::from_file_with_folder(path, data_dir).map_err(Error::from_c2pa_error);
     let ingredient = ok_or_return_null!(result);
     let json = serde_json::to_string(&ingredient).unwrap_or_default();
@@ -1195,6 +1202,9 @@ pub unsafe extern "C" fn c2pa_reader_from_context(context: *mut C2paContext) -> 
 /// format must be a valid NULL-terminated C string pointer.
 /// stream must be a valid pointer to a C2paStream.
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_reader_from_context() with an explicit context instead of relying on thread-local settings."
+)]
 pub unsafe extern "C" fn c2pa_reader_from_stream(
     format: *const c_char,
     stream: *mut C2paStream,
@@ -1202,6 +1212,9 @@ pub unsafe extern "C" fn c2pa_reader_from_stream(
     let format = cstr_or_return_null!(format);
     let stream = deref_mut_or_return_null!(stream, C2paStream);
 
+    // Legacy C API: inherits thread-local settings set by c2pa_load_settings.
+    // Prefer c2pa_reader_from_context for new C API usage.
+    #[allow(deprecated)]
     let result = C2paReader::from_stream(&format, stream);
     let result = ok_or_return_null!(post_validate(result));
     box_tracked!(result)
@@ -1362,8 +1375,13 @@ pub unsafe extern "C" fn c2pa_reader_with_fragment(
 /// ```
 #[cfg(feature = "file_io")]
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_reader_from_context() with an explicit context instead of relying on thread-local settings."
+)]
+#[allow(deprecated)]
 pub unsafe fn c2pa_reader_from_file(path: *const c_char) -> *mut C2paReader {
     let path = cstr_or_return_null!(path);
+    // Legacy C API: inherits thread-local settings set by c2pa_load_settings.
     let result = C2paReader::from_file(&path);
     box_tracked!(ok_or_return_null!(post_validate(result)))
 }
@@ -1385,6 +1403,9 @@ pub unsafe fn c2pa_reader_from_file(path: *const c_char) -> *mut C2paReader {
 /// The returned value MUST be released by calling c2pa_free
 /// and it is no longer valid after that call.
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_reader_from_context() then c2pa_reader_with_manifest_data_and_stream() instead."
+)]
 pub unsafe extern "C" fn c2pa_reader_from_manifest_data_and_stream(
     format: *const c_char,
     stream: *mut C2paStream,
@@ -1396,6 +1417,8 @@ pub unsafe extern "C" fn c2pa_reader_from_manifest_data_and_stream(
 
     let manifest_bytes = bytes_or_return_null!(manifest_data, manifest_size, "manifest_data");
 
+    // Legacy C API: inherits thread-local settings set by c2pa_load_settings.
+    #[allow(deprecated)]
     let result = C2paReader::from_manifest_data_and_stream(manifest_bytes, &format, stream);
     box_tracked!(ok_or_return_null!(post_validate(result)))
 }
@@ -1537,8 +1560,12 @@ pub unsafe extern "C" fn c2pa_reader_supported_mime_types(
 /// }
 /// ```
 #[no_mangle]
+#[deprecated(note = "Use c2pa_builder_from_context() then c2pa_builder_set_definition() instead.")]
 pub unsafe extern "C" fn c2pa_builder_from_json(manifest_json: *const c_char) -> *mut C2paBuilder {
     let manifest_json = cstr_or_return_null!(manifest_json);
+    // Legacy C API: inherits thread-local settings set by c2pa_load_settings.
+    // Prefer c2pa_builder_from_context for new C API usage.
+    #[allow(deprecated)]
     let result = C2paBuilder::from_json(&manifest_json);
     let result = ok_or_return_null!(result);
     box_tracked!(result)
@@ -1593,6 +1620,8 @@ pub unsafe extern "C" fn c2pa_builder_from_context(context: *mut C2paContext) ->
 /// }
 /// ```
 #[no_mangle]
+#[deprecated(note = "Use c2pa_builder_from_context() then c2pa_builder_with_archive() instead.")]
+#[allow(deprecated)]
 pub unsafe extern "C" fn c2pa_builder_from_archive(stream: *mut C2paStream) -> *mut C2paBuilder {
     let stream = deref_mut_or_return_null!(stream, C2paStream);
     box_tracked!(ok_or_return_null!(C2paBuilder::from_archive(
@@ -2646,7 +2675,12 @@ pub unsafe extern "C" fn c2pa_signer_from_info(signer_info: &C2paSignerInfo) -> 
 /// The returned value MUST be released by calling c2pa_free
 /// and it is no longer valid after that call.
 #[no_mangle]
+#[deprecated(
+    note = "Use c2pa_context_builder_set_signer() to configure a signer on a context instead."
+)]
 pub unsafe extern "C" fn c2pa_signer_from_settings() -> *mut C2paSigner {
+    // Legacy C API: reads signer configuration from thread-local settings (set by c2pa_load_settings).
+    #[allow(deprecated)]
     let signer = ok_or_return_null!(C2paSettings::signer());
     box_tracked!(C2paSigner {
         signer: Box::new(signer),
@@ -2752,6 +2786,7 @@ unsafe fn c2pa_mime_types_to_c_array(strs: Vec<String>, count: *mut usize) -> *c
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::{ffi::CString, io::Seek, panic::catch_unwind};
 

--- a/c2pa_c_ffi/src/json_api.rs
+++ b/c2pa_c_ffi/src/json_api.rs
@@ -19,7 +19,9 @@ use crate::{Error, Result, SignerInfo};
 ///
 /// If data_dir is provided, any thumbnail or c2pa data will be written to that folder.
 /// Any Validation errors will be reported in the validation_status field.
+#[allow(deprecated)]
 pub fn read_file(path: &str, data_dir: Option<String>) -> Result<String> {
+    // Legacy JSON API: inherits thread-local settings set by c2pa_load_settings.
     let mut reader = Reader::from_file(path).map_err(Error::from_c2pa_error)?;
 
     #[cfg(target_arch = "wasm32")]
@@ -53,6 +55,7 @@ pub fn read_file(path: &str, data_dir: Option<String>) -> Result<String> {
 /// Signer information must also be supplied
 ///
 /// Any file paths in the manifest will be read relative to the source file
+#[allow(deprecated)]
 pub fn sign_file(
     source: &str,
     dest: &str,
@@ -60,6 +63,7 @@ pub fn sign_file(
     signer_info: &SignerInfo,
     data_dir: Option<String>,
 ) -> Result<Vec<u8>> {
+    // Legacy JSON API: inherits thread-local settings set by c2pa_load_settings.
     let mut builder = c2pa::Builder::from_json(manifest_json).map_err(Error::from_c2pa_error)?;
 
     // if data_dir is provided, set the base path for the manifest
@@ -86,6 +90,7 @@ pub fn sign_file(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::{ffi::CString, fs::remove_dir_all, path::PathBuf};
 

--- a/cli/src/info.rs
+++ b/cli/src/info.rs
@@ -23,6 +23,7 @@ pub fn info(path: &Path) -> Result<()> {
             None
         }
     }
+    #[allow(deprecated)]
     let ingredient = c2pa::Ingredient::from_file_with_options(path, &Options {})?;
     println!("Information for {}", ingredient.title().unwrap_or_default());
     let mut is_cloud_manifest = false;
@@ -60,7 +61,7 @@ pub fn info(path: &Path) -> Result<()> {
         } else {
             println!("Validated");
         }
-        let reader = Reader::from_file(path)?;
+        let reader = Reader::default().with_file(path)?;
 
         let manifests: Vec<_> = reader.iter_manifests().collect();
         match manifests.len() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,12 +24,14 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Arc,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
 use c2pa::{
     format_from_path, identity::validator::CawgValidator, settings::Settings, Builder,
-    ClaimGeneratorInfo, Error, Ingredient, ManifestDefinition, Reader, Signer,
+    ClaimGeneratorInfo, Context as C2paContext, Error, Ingredient, ManifestDefinition, Reader,
+    Signer,
 };
 use clap::{Parser, Subcommand};
 use etcetera::BaseStrategy;
@@ -277,7 +279,9 @@ fn load_ingredient(path: &Path) -> Result<Ingredient> {
         }
         Ok(ingredient)
     } else {
-        Ok(Ingredient::from_file(path)?)
+        #[allow(deprecated)]
+        let result = Ingredient::from_file(path)?;
+        Ok(result)
     }
 }
 
@@ -392,10 +396,12 @@ fn blocking_get(url: &str) -> Result<String> {
     }
 }
 
-fn configure_sdk(args: &CliArgs) -> Result<()> {
-    if args.settings.exists() {
-        Settings::from_file(&args.settings)?;
-    }
+fn configure_sdk(args: &CliArgs) -> Result<Settings> {
+    let mut settings = if args.settings.exists() {
+        Settings::new().with_file(&args.settings)?
+    } else {
+        Settings::default()
+    };
 
     let mut enable_trust_checks = false;
 
@@ -409,12 +415,13 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
             debug!("Using trust anchors from {trust_list:?}");
 
             let data = load_trust_resource(trust_list)?;
-            Settings::from_toml(
+            settings.update_from_str(
                 &toml::toml! {
                     [trust]
                     trust_anchors = data
                 }
                 .to_string(),
+                "toml",
             )?;
 
             enable_trust_checks = true;
@@ -424,12 +431,13 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
             debug!("Using allowed list from {allowed_list:?}");
 
             let data = load_trust_resource(allowed_list)?;
-            Settings::from_toml(
+            settings.update_from_str(
                 &toml::toml! {
                     [trust]
                     allowed_list = data
                 }
                 .to_string(),
+                "toml",
             )?;
 
             enable_trust_checks = true;
@@ -439,12 +447,13 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
             debug!("Using trust config from {trust_config:?}");
 
             let data = load_trust_resource(trust_config)?;
-            Settings::from_toml(
+            settings.update_from_str(
                 &toml::toml! {
                     [trust]
                     trust_config = data
                 }
                 .to_string(),
+                "toml",
             )?;
 
             enable_trust_checks = true;
@@ -454,27 +463,17 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
     // if any trust setting is provided enable the trust checks
     // there is no disabling of default setting only the ability to enable if they were internally disabled
     if enable_trust_checks {
-        Settings::from_toml(
+        settings.update_from_str(
             &toml::toml! {
                 [verify]
                 verify_trust = true
             }
             .to_string(),
+            "toml",
         )?;
     }
 
-    // enable or disable verification after signing
-    {
-        Settings::from_toml(
-            &toml::toml! {
-                [trust]
-                verify_after_sign = (!args.no_signing_verify)
-            }
-            .to_string(),
-        )?;
-    }
-
-    Ok(())
+    Ok(settings)
 }
 
 fn sign_fragmented(
@@ -523,7 +522,11 @@ fn sign_fragmented(
     Ok(())
 }
 
-fn verify_fragmented(init_pattern: &Path, frag_pattern: &Path) -> Result<Vec<Reader>> {
+fn verify_fragmented(
+    init_pattern: &Path,
+    frag_pattern: &Path,
+    context: &Arc<C2paContext>,
+) -> Result<Vec<Reader>> {
     let mut readers = Vec::new();
 
     let ip = init_pattern
@@ -551,7 +554,8 @@ fn verify_fragmented(init_pattern: &Path, frag_pattern: &Path) -> Result<Vec<Rea
                 }
 
                 println!("Verifying manifest: {p:?}");
-                let reader = Reader::from_fragmented_files(p, &fragments)?;
+                let reader =
+                    Reader::from_shared_context(context).with_fragmented_files(p, &fragments)?;
                 if let Some(vs) = reader.validation_status() {
                     if let Some(e) = vs.iter().find(|v| !v.passed()) {
                         eprintln!("Error validating segments: {e:?}");
@@ -588,7 +592,7 @@ fn validate_cawg(reader: &mut Reader) -> Result<()> {
     }
 }
 
-fn reader_from_args(args: &CliArgs) -> Result<Reader> {
+fn reader_from_args(args: &CliArgs, context: &Arc<C2paContext>) -> Result<Reader> {
     if let Some(external_manifest) = &args.external_manifest {
         let c2pa_data = fs::read(external_manifest)?;
         let format = match c2pa::format_from_path(&args.path) {
@@ -597,12 +601,13 @@ fn reader_from_args(args: &CliArgs) -> Result<Reader> {
                 bail!("Format for {:?} is unrecognized", args.path);
             }
         };
-        Ok(
-            Reader::from_manifest_data_and_stream(&c2pa_data, &format, File::open(&args.path)?)
-                .map_err(special_errs)?,
-        )
+        Ok(Reader::from_shared_context(context)
+            .with_manifest_data_and_stream(&c2pa_data, &format, File::open(&args.path)?)
+            .map_err(special_errs)?)
     } else {
-        Ok(Reader::from_file(&args.path).map_err(special_errs)?)
+        Ok(Reader::from_shared_context(context)
+            .with_file(&args.path)
+            .map_err(special_errs)?)
     }
 }
 
@@ -642,7 +647,9 @@ fn main() -> Result<()> {
     }
 
     if args.cert_chain {
-        let reader = Reader::from_file(path).map_err(special_errs)?;
+        let reader = Reader::from_context(C2paContext::new())
+            .with_file(path)
+            .map_err(special_errs)?;
         // todo: add cawg certs here??
         if let Some(manifest) = reader.active_manifest() {
             if let Some(si) = manifest.signature_info() {
@@ -665,7 +672,8 @@ fn main() -> Result<()> {
     );
 
     // configure the SDK
-    configure_sdk(&args).context("Could not configure c2pa-rs")?;
+    let mut settings = configure_sdk(&args).context("Could not configure c2pa-rs")?;
+    let context = Arc::new(C2paContext::new().with_settings(&settings)?);
 
     // Remove manifest needs to also remove XMP provenance
     // if args.remove_manifest {
@@ -707,7 +715,7 @@ fn main() -> Result<()> {
 
         // read the manifest information
         let manifest_def: ManifestDef = serde_json::from_slice(json.as_bytes())?;
-        let mut builder = Builder::from_json(&json)?;
+        let mut builder = Builder::from_shared_context(&context).with_definition(&json)?;
         let mut manifest = manifest_def.manifest;
 
         // add claim_tool generator so we know this was created using this tool
@@ -751,6 +759,7 @@ fn main() -> Result<()> {
         // note: This could be treated as an update manifest eventually since the image is the same
         let has_parent = builder.definition.ingredients.iter().any(|i| i.is_parent());
         if !has_parent && !is_fragment {
+            #[allow(deprecated)]
             let mut source_ingredient = Ingredient::from_file(&args.path)?;
             if source_ingredient.manifest_data().is_some() {
                 source_ingredient.set_is_parent();
@@ -779,12 +788,15 @@ fn main() -> Result<()> {
             let signer = CallbackSigner::new(process_runner, cb_config);
 
             Box::new(signer)
-        } else {
-            match Settings::signer() {
-                Ok(signer) => signer,
-                Err(Error::MissingSignerSettings) => sign_config.signer()?,
-                Err(err) => Err(err)?,
+        } else if let Some(signer_cfg) = settings.signer.take() {
+            let c2pa_signer = signer_cfg.c2pa_signer()?;
+            if let Some(cawg_cfg) = settings.cawg_x509_signer.take() {
+                cawg_cfg.cawg_signer(c2pa_signer)?
+            } else {
+                c2pa_signer
             }
+        } else {
+            sign_config.signer()?
         };
 
         if let Some(output) = args.output {
@@ -858,7 +870,9 @@ fn main() -> Result<()> {
                 }
 
                 // generate a report on the output file
-                let mut reader = Reader::from_file(&output).map_err(special_errs)?;
+                let mut reader = Reader::from_shared_context(&context)
+                    .with_file(&output)
+                    .map_err(special_errs)?;
                 validate_cawg(&mut reader)?;
                 print_reader(&reader, args.detailed, args.crjson)?;
             }
@@ -880,13 +894,16 @@ fn main() -> Result<()> {
         }
         create_dir_all(&output)?;
         if args.ingredient {
+            #[allow(deprecated)]
             let report = Ingredient::from_file_with_folder(&args.path, &output)
                 .map_err(special_errs)?
                 .to_string();
             File::create(output.join("ingredient.json"))?.write_all(&report.into_bytes())?;
             println!("Ingredient report written to the directory {:?}", &output);
         } else {
-            let mut reader = Reader::from_file(&args.path).map_err(special_errs)?;
+            let mut reader = Reader::from_shared_context(&context)
+                .with_file(&args.path)
+                .map_err(special_errs)?;
             validate_cawg(&mut reader)?;
             reader.to_folder(&output)?;
             let report = reader.to_string();
@@ -900,15 +917,14 @@ fn main() -> Result<()> {
             println!("Manifest report written to the directory {:?}", &output);
         }
     } else if args.ingredient {
-        println!(
-            "{}",
-            Ingredient::from_file(&args.path).map_err(special_errs)?
-        )
+        #[allow(deprecated)]
+        let ingredient = Ingredient::from_file(&args.path).map_err(special_errs)?;
+        println!("{}", ingredient)
     } else if let Some(Commands::Fragment {
         fragments_glob: Some(fg),
     }) = &args.command
     {
-        let mut stores = verify_fragmented(&args.path, fg)?;
+        let mut stores = verify_fragmented(&args.path, fg, &context)?;
         if stores.len() == 1 {
             validate_cawg(&mut stores[0])?;
             println!("{}", stores[0]);
@@ -919,7 +935,7 @@ fn main() -> Result<()> {
             println!("{} Init manifests validated", stores.len());
         }
     } else {
-        let mut reader = reader_from_args(&args)?;
+        let mut reader = reader_from_args(&args, &context)?;
         validate_cawg(&mut reader)?;
         print_reader(&reader, args.detailed, args.crjson)?;
     }
@@ -957,6 +973,7 @@ pub mod tests {
         return tempfile::tempdir().map_err(Into::into);
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_manifest_config() {
         const SOURCE_PATH: &str = "tests/fixtures/earth_apollo17.jpg";

--- a/cli/src/tree.rs
+++ b/cli/src/tree.rs
@@ -79,7 +79,7 @@ pub fn tree<P: AsRef<Path>>(path: P) -> Result<String> {
         .ok_or_else(|| crate::Error::BadParam("bad filename".to_string()))?;
     let asset_name = os_filename.to_string_lossy().into_owned();
 
-    let reader = Reader::from_file(path)?;
+    let reader = Reader::default().with_file(path)?;
 
     // walk through the manifests and show the contents
     Ok(if let Some(manifest_label) = reader.active_label() {

--- a/make_test_images/src/compare_manifests.rs
+++ b/make_test_images/src/compare_manifests.rs
@@ -83,11 +83,11 @@ pub fn compare_image_manifests<P: AsRef<Path>, Q: AsRef<Path>>(
 ) -> Result<Vec<String>> {
     let manifest_store1 = match m1.as_ref().extension() {
         Some(ext) if ext == "json" => Reader::from_json(&fs::read_to_string(m1)?),
-        _ => Reader::from_file(m1.as_ref()),
+        _ => Reader::default().with_file(m1.as_ref()),
     };
     let manifest_store2 = match m2.as_ref().extension() {
         Some(ext) if ext == "json" => Reader::from_json(&fs::read_to_string(m2)?),
-        _ => Reader::from_file(m2.as_ref()),
+        _ => Reader::default().with_file(m2.as_ref()),
     };
 
     match (manifest_store1, manifest_store2) {

--- a/make_test_images/src/make_test_images.rs
+++ b/make_test_images/src/make_test_images.rs
@@ -23,7 +23,6 @@ use anyhow::{Context, Result};
 use c2pa::{
     create_signer,
     jumbf_io::{load_jumbf_from_stream, save_jumbf_to_stream},
-    settings::Settings,
     Builder, Error, Ingredient, Reader, Relationship, Signer, SigningAlg,
 };
 use memchr::memmem;
@@ -226,6 +225,8 @@ impl MakeTestImages {
             .into_owned();
         let format = extension_to_mime(&extension).unwrap_or("image/jpeg");
 
+        // TODO: replace with a context-based Ingredient factory once one is available publicly
+        #[allow(deprecated)]
         let mut parent = Ingredient::from_stream(format, &mut source)?;
         parent.set_relationship(relationship);
         parent.set_title(name);
@@ -275,7 +276,7 @@ impl MakeTestImages {
         })
         .to_string();
 
-        let mut builder = Builder::from_json(&manifest_def)?;
+        let mut builder = Builder::default().with_definition(&manifest_def)?;
 
         // keep track of ingredient instances so we don't duplicate them
         let mut ingredient_table = HashMap::new();
@@ -499,7 +500,7 @@ impl MakeTestImages {
         let src_path = &self.make_path(src);
         let mut source = fs::File::open(src_path).context("opening ingredient")?;
 
-        let mut builder = Builder::from_json(&json)?;
+        let mut builder = Builder::default().with_definition(&json)?;
 
         let parent_name = file_name(&dst_path).ok_or(Error::BadParam("no filename".to_string()))?;
         builder.add_ingredient_from_stream(
@@ -618,16 +619,7 @@ impl MakeTestImages {
 
     /// Runs a list of recipes
     pub fn run(&self) -> Result<()> {
-        // Verify after sign is causing hash errors here, I don't know why yet.
-        // This is a temporary fix to allow the tests to run.
-        Settings::from_toml(
-            &toml::toml! {
-                [verify]
-                verify_after_sign = false
-            }
-            .to_string(),
-        )
-        .expect("failed to set verify settings");
+        // verify_after_sign defaults to false in Settings::default(), so no override needed.
 
         if !self.output_dir.exists() {
             std::fs::create_dir_all(&self.output_dir).context("Can't create output folder")?;
@@ -654,7 +646,7 @@ impl MakeTestImages {
                     .extension()
                     .and_then(|s| s.to_str())
                     .unwrap_or("jpg");
-                let reader = Reader::from_stream(format, &mut file)?;
+                let reader = Reader::default().with_stream(format, &mut file)?;
                 let json = reader.json();
 
                 let json_path = json_dir
@@ -691,6 +683,7 @@ pub mod tests {
         ]
     }"#;
 
+    #[allow(deprecated)]
     #[test]
     fn test_make_images() {
         use c2pa::settings::Settings;

--- a/sdk/benches/read.rs
+++ b/sdk/benches/read.rs
@@ -10,7 +10,7 @@ fn read_jpeg(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.jpg (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -22,7 +22,7 @@ fn read_png(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.png (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -34,7 +34,7 @@ fn read_gif(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.gif (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -46,7 +46,7 @@ fn read_tiff(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.tiff (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -58,7 +58,7 @@ fn read_svg(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.svg (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -72,7 +72,7 @@ fn read_svg(c: &mut Criterion) {
 //     c.bench_function("read 100kb-signed.pdf (with manifest)", |b| {
 //         b.iter(|| {
 //             let mut stream = Cursor::new(data);
-//             Reader::from_stream(format, &mut stream)
+//             Reader::default().with_stream(format, &mut stream)
 //         })
 //     });
 // }
@@ -84,7 +84,7 @@ fn read_mp3(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.mp3 (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -96,7 +96,7 @@ fn read_mp4(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.mp4 (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }
@@ -108,7 +108,7 @@ fn read_wav(c: &mut Criterion) {
     c.bench_function("read 100kb-signed.wav (with manifest)", |b| {
         b.iter(|| {
             let mut stream = Cursor::new(data);
-            Reader::from_stream(format, &mut stream)
+            Reader::default().with_stream(format, &mut stream)
         })
     });
 }

--- a/sdk/benches/sign.rs
+++ b/sdk/benches/sign.rs
@@ -14,7 +14,9 @@ fn create_signer() -> CallbackSigner {
 }
 
 fn create_builder() -> Builder {
-    Builder::from_json(MANIFEST_JSON).expect("failed to create builder from manifest JSON")
+    Builder::default()
+        .with_definition(MANIFEST_JSON)
+        .expect("failed to create builder from manifest JSON")
 }
 
 fn sign_jpeg(c: &mut Criterion) {

--- a/sdk/examples/client/client.rs
+++ b/sdk/examples/client/client.rs
@@ -105,6 +105,7 @@ pub fn main() -> Result<()> {
     let source = PathBuf::from(src);
     let dest = PathBuf::from(dst);
     // if a filepath was provided on the command line, read it as a parent file
+    #[allow(deprecated)]
     let mut parent = Ingredient::from_file(source.as_path())?;
     parent.set_relationship(Relationship::ParentOf);
 
@@ -140,7 +141,7 @@ pub fn main() -> Result<()> {
     )?;
 
     // create a new Manifest
-    let mut builder = Builder::new();
+    let mut builder = Builder::default();
     builder.definition.claim_version = Some(2);
     let mut generator = ClaimGeneratorInfo::new(GENERATOR);
     generator.set_version("0.1");
@@ -159,7 +160,7 @@ pub fn main() -> Result<()> {
 
     builder.sign_file(&*signer, &source, &dest)?;
 
-    let reader = Reader::from_file(&dest)?;
+    let reader = Reader::default().with_file(&dest)?;
 
     // example of how to print out the whole manifest as json
     println!("{reader}\n");

--- a/sdk/examples/data_hash.rs
+++ b/sdk/examples/data_hash.rs
@@ -103,7 +103,7 @@ fn user_data_hash_with_placeholder_api() -> Result<()> {
     output_stream.write_all(&final_manifest)?;
 
     output_stream.rewind()?;
-    let reader = Reader::from_stream("image/jpeg", &mut output_stream)?;
+    let reader = Reader::default().with_stream("image/jpeg", &mut output_stream)?;
 
     println!("Manifest with placeholder API (supports dynamic assertions):");
     println!("{reader}\n");

--- a/sdk/examples/show.rs
+++ b/sdk/examples/show.rs
@@ -13,12 +13,12 @@
 
 //! Example App that generates a manifest store listing for a given file
 use anyhow::Result;
-use c2pa::{Context, Reader};
+use c2pa::Reader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 {
-        let ms = Reader::from_context(Context::new()).with_file(&args[1])?;
+        let ms = Reader::default().with_file(&args[1])?;
         println!("{ms}");
     } else {
         println!("Prints a manifest report (requires a file path argument)")

--- a/sdk/examples/v2show.rs
+++ b/sdk/examples/v2show.rs
@@ -34,21 +34,21 @@ fn main() -> Result<()> {
         let format = format_from_path(&path).ok_or(Error::UnsupportedType)?;
         let mut file = std::fs::File::open(&path)?;
 
-        let reader = match Reader::from_stream(&format, &mut file) {
+        let reader = match Reader::default().with_stream(&format, &mut file) {
             Ok(reader) => Ok(reader),
             Err(Error::RemoteManifestUrl(url)) => {
                 println!("Fetching remote manifest from {url}");
                 let mut c2pa_data = Vec::new();
                 let resp = ureq::get(&url).call()?;
                 resp.into_body().into_reader().read_to_end(&mut c2pa_data)?;
-                Reader::from_manifest_data_and_stream(&c2pa_data, &format, &mut file)
+                Reader::default().with_manifest_data_and_stream(&c2pa_data, &format, &mut file)
             }
             Err(Error::JumbfNotFound) => {
                 // if not embedded or cloud, check for sidecar first and load if it exists
                 let potential_sidecar_path = path.with_extension("c2pa");
                 if potential_sidecar_path.exists() {
                     let manifest_data = std::fs::read(potential_sidecar_path)?;
-                    Ok(Reader::from_manifest_data_and_stream(
+                    Ok(Reader::default().with_manifest_data_and_stream(
                         &manifest_data,
                         &format,
                         &mut file,

--- a/sdk/src/assertions/exif.rs
+++ b/sdk/src/assertions/exif.rs
@@ -133,7 +133,7 @@ pub mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use crate::builder::Builder;
+    use crate::Builder;
 
     const SPEC_EXAMPLE: &str = r#"{
         "@context" : {
@@ -170,7 +170,7 @@ pub mod tests {
 
     #[test]
     fn exif_new() {
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
 
         let original = Exif::new()
             .insert("exif:GPSLatitude", "39,21.102N")
@@ -185,7 +185,7 @@ pub mod tests {
 
     #[test]
     fn exif_from_json() {
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         let original = Exif::from_json_str(SPEC_EXAMPLE).expect("from_json");
         builder
             .add_assertion(Exif::LABEL, &original)

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -981,7 +981,10 @@ pub mod tests {
     use byteorder::WriteBytesExt;
 
     use super::*;
-    use crate::utils::io_utils::tempdirectory;
+    use crate::{
+        utils::{io_utils::tempdirectory, test::test_context},
+        Builder, CallbackSigner, Reader, SigningAlg,
+    };
 
     /// Public test helper: builds a minimal JPEG XL container for use in integration tests.
     pub fn build_test_jxl_container() -> Vec<u8> {
@@ -2090,21 +2093,21 @@ pub mod tests {
     ///      `C2PA_BOXHASH` label; all non-excluded, non-CAI boxes carry a
     ///      non-empty hash.
     #[test]
-    fn test_e2e_jpegxl_sign_read_validate() -> crate::error::Result<()> {
+    fn test_e2e_jpegxl_sign_read_validate() -> Result<()> {
         // ── Test fixtures ────────────────────────────────────────────────────────
         static SAMPLE_JXL: &[u8] = include_bytes!("../../tests/fixtures/sample1.jxl");
         static CERTS: &[u8] = include_bytes!("../../tests/fixtures/certs/ed25519.pub");
         static PRIVATE_KEY: &[u8] = include_bytes!("../../tests/fixtures/certs/ed25519.pem");
 
         // Ed25519 signing helper (same pattern used in v2_api_integration.rs)
-        fn ed_sign(data: &[u8], private_key: &[u8]) -> crate::error::Result<Vec<u8>> {
+        fn ed_sign(data: &[u8], private_key: &[u8]) -> Result<Vec<u8>> {
             use ed25519_dalek::{Signature, Signer, SigningKey};
             use pem::parse;
-            let pem = parse(private_key).map_err(|e| crate::Error::OtherError(Box::new(e)))?;
+            let pem = parse(private_key).map_err(|e| Error::OtherError(Box::new(e)))?;
             // Ed25519 PKCS#8 private key: skip the 16-byte ASN.1 prefix.
             let key_bytes = &pem.contents()[16..];
-            let signing_key = SigningKey::try_from(key_bytes)
-                .map_err(|e| crate::Error::OtherError(Box::new(e)))?;
+            let signing_key =
+                SigningKey::try_from(key_bytes).map_err(|e| Error::OtherError(Box::new(e)))?;
             let signature: Signature = signing_key.sign(data);
             Ok(signature.to_bytes().to_vec())
         }
@@ -2113,10 +2116,10 @@ pub mod tests {
 
         // Load the test trust anchors and verification settings so that the
         // Ed25519 test certificate is trusted during read-back.
-        crate::Settings::from_toml(include_str!("../../tests/fixtures/test_settings.toml"))?;
+        let context = test_context().into_shared();
 
         let signer_fn = |_ctx: *const (), data: &[u8]| ed_sign(data, PRIVATE_KEY);
-        let signer = crate::CallbackSigner::new(signer_fn, crate::SigningAlg::Ed25519, CERTS);
+        let signer = CallbackSigner::new(signer_fn, SigningAlg::Ed25519, CERTS);
 
         let manifest_json = serde_json::json!({
             "title": "E2E JPEG XL Integration Test",
@@ -2155,7 +2158,8 @@ pub mod tests {
             ]
         });
 
-        let mut builder = crate::Builder::from_json(&manifest_json.to_string())?;
+        let mut builder =
+            Builder::from_shared_context(&context).with_definition(manifest_json.to_string())?;
 
         let mut source = Cursor::new(SAMPLE_JXL);
         let mut signed = Cursor::new(Vec::new());
@@ -2164,12 +2168,12 @@ pub mod tests {
         // ── Phase 2: Read back and validate manifest claims ──────────────────────
 
         signed.rewind().unwrap();
-        let reader = crate::Reader::from_stream("image/jxl", &mut signed)?;
+        let reader = Reader::from_shared_context(&context).with_stream("image/jxl", &mut signed)?;
 
         // Active manifest must be present.
         let manifest = reader
             .active_manifest()
-            .ok_or_else(|| crate::Error::ClaimEncoding)?;
+            .ok_or_else(|| Error::ClaimEncoding)?;
 
         assert_eq!(
             manifest.title().unwrap_or_default(),

--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -1130,7 +1130,7 @@ pub mod tests {
             "title": "Large AVI Test"
         }"#;
 
-        let mut builder = Builder::from_json(manifest_json).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json).unwrap();
         let mut source = File::open(test_file).unwrap();
         let mut dest = Cursor::new(Vec::new());
 

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -496,7 +496,7 @@ impl Builder {
     /// # Returns
     /// * A new [`Builder`].
     #[deprecated(
-        note = "Use `Builder::default()` for default settings, or `Builder::from_context(context)` to pass an explicit `Context`."
+        note = "Use `Builder::default()` for default settings, or `Builder::from_context(context)` and pass settings in the `Context`."
     )]
     pub fn new() -> Self {
         // Legacy behavior: explicitly get global settings for backward compatibility

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -466,9 +466,16 @@ impl AsRef<Builder> for Builder {
 }
 
 impl Builder {
-    /// Creates a new [`Builder`] struct.
+    /// Creates a new [`Builder`] struct using thread-local settings.
+    ///
+    /// Use [`Builder::default()`](Builder::default) for a builder with default settings, or
+    /// [`Builder::from_context(context)`](Builder::from_context) to pass an explicit
+    /// [`Context`](crate::Context).
     /// # Returns
     /// * A new [`Builder`].
+    #[deprecated(
+        note = "Use `Builder::default()` for default settings, or `Builder::from_context(context)` to pass an explicit `Context`."
+    )]
     pub fn new() -> Self {
         // Legacy behavior: explicitly get global settings for backward compatibility
         // at some point we should remove this and require a Context to be passed in.
@@ -485,6 +492,9 @@ impl Builder {
     /// This method takes ownership of the Context and wraps it in an Arc internally.
     /// Use this for single-use contexts where you don't need to share the context.
     ///
+    /// Use [`Builder::default()`] when no special configuration is needed.
+    /// Use [`Builder::from_shared_context`] to share a context across multiple builders.
+    ///
     /// # Arguments
     /// * `context` - The [`Context`] to use for this [`Builder`].
     ///
@@ -495,6 +505,10 @@ impl Builder {
     /// ```
     /// # use c2pa::{Context, Builder, Result};
     /// # fn main() -> Result<()> {
+    /// // With default settings (no explicit context needed):
+    /// let builder = Builder::default();
+    ///
+    /// // With custom settings:
     /// let context = Context::new().with_settings(r#"{"verify": {"verify_after_sign": true}}"#)?;
     /// let builder = Builder::from_context(context);
     /// # Ok(())
@@ -593,7 +607,10 @@ impl Builder {
         intent
     }
 
-    /// Creates a new [`Builder`] from a JSON [`ManifestDefinition`] string.
+    /// Creates a new [`Builder`] from a JSON [`ManifestDefinition`] string using thread-local settings.
+    ///
+    /// Use [`Builder::from_context(context).with_definition(json)`](Builder::with_definition) instead,
+    /// passing an explicit [`Context`](crate::Context) rather than relying on thread-local settings.
     ///
     /// # Arguments
     /// * `json` - A JSON string representing the [`ManifestDefinition`].
@@ -601,6 +618,9 @@ impl Builder {
     /// * A new [`Builder`].
     /// # Errors
     /// * Returns an [`Error`] if the JSON is malformed or incorrect.
+    #[deprecated(
+        note = "Use `Builder::from_context(context).with_definition(json)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
     pub fn from_json(json: &str) -> Result<Self> {
         // Legacy behavior: explicitly get global settings for backward compatibility
         let settings = crate::settings::get_thread_local_settings();
@@ -929,7 +949,7 @@ impl Builder {
         let ingredient: Ingredient = Ingredient::from_json(&ingredient_json.into())?;
 
         if format == "c2pa" || format == "application/c2pa" {
-            let reader = Reader::from_stream(format, stream)?;
+            let reader = Reader::from_shared_context(&self.context).with_stream(format, stream)?;
             let parent_ingredient = self.add_ingredient_from_reader(&reader)?;
             parent_ingredient.merge(&ingredient);
             return self
@@ -1235,16 +1255,19 @@ impl Builder {
         })
     }
 
-    /// Create a [`Builder`] from an archive stream.
+    /// Create a [`Builder`] from an archive stream using thread-local settings.
     ///
     /// Archives contain unsigned working stores (signed with BoxHash placeholder),
     /// so validation is skipped.
+    ///
+    /// Use [`Builder::from_context(context).with_archive(stream)`](Builder::with_archive) instead,
+    /// passing an explicit [`Context`](crate::Context) rather than relying on thread-local settings.
     ///
     /// # Arguments
     /// * `stream` - The stream to read the archive from.
     ///
     /// # Returns
-    /// A new Builder with default context.
+    /// A new Builder with thread-local context.
     ///
     /// # Errors
     /// Returns an [`Error`] if the archive cannot be read.
@@ -1260,6 +1283,10 @@ impl Builder {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        note = "Use `Builder::from_context(context).with_archive(stream)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub fn from_archive(stream: impl Read + Seek + Send) -> Result<Self> {
         Builder::new().with_archive(stream)
     }
@@ -3231,7 +3258,10 @@ mod tests {
         settings::Settings,
         utils::{
             hash_utils::HashRange,
-            test::{test_context, write_bmff_placeholder_stream, write_jpeg_placeholder_stream},
+            test::{
+                setup_logger, test_context, write_bmff_placeholder_stream,
+                write_jpeg_placeholder_stream,
+            },
             test_signer::{async_test_signer, test_signer},
         },
         validation_results::ValidationState,
@@ -3400,7 +3430,7 @@ mod tests {
         // strip whitespace so we can compare later
         let mut stripped_json = manifest_json();
         stripped_json.retain(|c| !c.is_whitespace());
-        let mut builder = Builder::from_json(&stripped_json).unwrap();
+        let mut builder = Builder::default().with_definition(&stripped_json).unwrap();
         builder.resources.add("5678", "12345").unwrap();
         let definition = &builder.definition;
         assert_eq!(definition.vendor, Some("test".to_string()));
@@ -3433,7 +3463,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json().to_string(), format, &mut source)
             .unwrap();
@@ -3466,7 +3496,7 @@ mod tests {
 
         // unzip the manifest builder from the zipped stream
         zipped.rewind().unwrap();
-        let mut builder = Builder::from_archive(&mut zipped).unwrap();
+        let mut builder = Builder::default().with_archive(&mut zipped).unwrap();
 
         // sign and write to the output stream
         let signer = test_signer(SigningAlg::Ps256);
@@ -3476,7 +3506,9 @@ mod tests {
 
         // read and validate the signed manifest store
         dest.rewind().unwrap();
-        let manifest_store = Reader::from_stream(format, &mut dest).expect("from_bytes");
+        let manifest_store = Reader::default()
+            .with_stream(format, &mut dest)
+            .expect("from_bytes");
 
         println!("{manifest_store}");
         assert_ne!(manifest_store.validation_state(), ValidationState::Invalid);
@@ -3494,67 +3526,67 @@ mod tests {
     // The second is not referenced and should get one.
     #[test]
     fn test_builder_one_placed_action_via_ingredient_id_ref() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
-
-        Settings::from_toml(
-            &toml::toml! {
-                [builder]
-                actions.auto_placed_action.enabled = true
-            }
-            .to_string(),
-        )
-        .unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder]
+                    actions.auto_placed_action.enabled = true
+                }
+                .to_string(),
+            )
+            .unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut output = Cursor::new(Vec::new());
-        let mut builder = Builder::from_json(
-            &json!({
-                "title": "Test Manifest",
-                "format": "image/jpeg",
-                "ingredients": [
-                    {
-                        "title": "First Ingredient",
-                        "format": "image/jpeg",
-                        "relationship": "componentOf",
-                        "instance_id": "123"
-                    },
-                    {
-                        "title": "Second Ingredient",
-                        "format": "image/png",
-                        "relationship": "componentOf",
-                        "instance_id": "456"
-                    }
-                ],
-                "assertions": [
-                    {
-                        "label": "c2pa.actions",
-                        "data": {
-                            "actions": [
-                                {
-                                    "action": "c2pa.placed",
-                                    "instanceId": "123"
-                                }
-                            ]
+        let mut builder = Builder::from_context(context)
+            .with_definition(
+                json!({
+                    "title": "Test Manifest",
+                    "format": "image/jpeg",
+                    "ingredients": [
+                        {
+                            "title": "First Ingredient",
+                            "format": "image/jpeg",
+                            "relationship": "componentOf",
+                            "instance_id": "123"
+                        },
+                        {
+                            "title": "Second Ingredient",
+                            "format": "image/png",
+                            "relationship": "componentOf",
+                            "instance_id": "456"
                         }
-                    },
-                ]
-            })
-            .to_string(),
-        )
-        .unwrap();
-
-        builder.set_intent(BuilderIntent::Create(DigitalSourceType::DigitalCapture));
-        builder
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
+                    ],
+                    "assertions": [
+                        {
+                            "label": "c2pa.actions",
+                            "data": {
+                                "actions": [
+                                    {
+                                        "action": "c2pa.placed",
+                                        "instanceId": "123"
+                                    }
+                                ]
+                            }
+                        },
+                    ]
+                })
+                .to_string(),
             )
             .unwrap();
 
+        builder.set_intent(BuilderIntent::Create(DigitalSourceType::DigitalCapture));
+        builder
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
+            .unwrap();
+
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
         let actions: Actions = reader
             .active_manifest()
             .unwrap()
@@ -3587,20 +3619,20 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut output = Cursor::new(Vec::new());
         Builder::from_context(context)
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3627,7 +3659,10 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut builder = Builder::from_context(context);
         builder
@@ -3636,16 +3671,13 @@ mod tests {
 
         let mut output = Cursor::new(Vec::new());
         builder
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3699,7 +3731,10 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut builder = Builder::from_context(context);
         builder
@@ -3729,16 +3764,13 @@ mod tests {
 
         let mut output = Cursor::new(Vec::new());
         builder
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3798,20 +3830,20 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut output = Cursor::new(Vec::new());
         Builder::from_context(context)
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3846,20 +3878,20 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut output = Cursor::new(Vec::new());
         Builder::from_context(context)
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3910,20 +3942,20 @@ mod tests {
             )
             .unwrap();
 
-        let context = Context::new().with_settings(settings).unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_signer(test_signer(SigningAlg::Ps256));
 
         let mut output = Cursor::new(Vec::new());
         Builder::from_context(context)
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut output,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut output)
             .unwrap();
 
         output.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", output).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
 
         let actions: Actions = reader
             .active_manifest()
@@ -3953,14 +3985,14 @@ mod tests {
     #[cfg(feature = "file_io")]
     fn test_builder_sign_file() {
         use crate::utils::io_utils::tempdirectory;
-        crate::utils::test::setup_logger();
+        setup_logger();
 
         let source = "tests/fixtures/CA.jpg";
         let dir = tempdirectory().unwrap();
         let dest = dir.path().join("test_file.jpg");
         let mut parent = std::fs::File::open(source).unwrap();
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json(), "image/jpeg", &mut parent)
             .unwrap();
@@ -3974,7 +4006,7 @@ mod tests {
         builder.sign_file(signer.as_ref(), source, &dest).unwrap();
 
         // read and validate the signed manifest store
-        let manifest_store = Reader::from_file(&dest).expect("from_bytes");
+        let manifest_store = Reader::default().with_file(&dest).expect("from_bytes");
 
         println!("{manifest_store}");
         assert_eq!(manifest_store.validation_state(), ValidationState::Trusted);
@@ -4013,7 +4045,7 @@ mod tests {
             let mut source = std::fs::File::open(path).unwrap();
             let mut dest = Cursor::new(Vec::new());
 
-            let mut builder = Builder::from_json(&manifest_json()).unwrap();
+            let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
             builder
                 .add_ingredient_from_stream(parent_json(), format, &mut source)
                 .unwrap();
@@ -4030,7 +4062,9 @@ mod tests {
 
             // read and validate the signed manifest store
             dest.rewind().unwrap();
-            let manifest_store = Reader::from_stream(format, &mut dest).expect("from_bytes");
+            let manifest_store = Reader::default()
+                .with_stream(format, &mut dest)
+                .expect("from_bytes");
 
             //println!("{}", manifest_store);
             if format != "c2pa" {
@@ -4059,7 +4093,9 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE_CLEAN);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
         builder.remote_url = Some("http://my_remote_url".to_string());
         builder.no_embed = true;
 
@@ -4071,11 +4107,14 @@ mod tests {
 
         // check to make sure we have a remote url and no manifest data
         dest.set_position(0);
-        let _err = Reader::from_stream("image/jpeg", &mut dest).expect_err("from_bytes");
+        let _err = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .expect_err("from_bytes");
 
         // now validate the manifest against the written asset
         dest.set_position(0);
-        let reader = Reader::from_manifest_data_and_stream(&manifest_data, "image/jpeg", &mut dest)
+        let reader = Reader::default()
+            .with_manifest_data_and_stream(&manifest_data, "image/jpeg", &mut dest)
             .expect("from_bytes");
 
         println!("{}", reader.json());
@@ -4089,7 +4128,9 @@ mod tests {
 
         let signer = test_signer(SigningAlg::Ps256);
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         // get a placeholder the manifest
         let placeholder = builder
@@ -4135,16 +4176,20 @@ mod tests {
 
         output_stream.rewind().unwrap();
 
-        let reader = crate::Reader::from_stream("image/jpeg", output_stream).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", output_stream)
+            .unwrap();
         println!("{reader}");
         assert_eq!(reader.validation_status(), None);
     }
 
     #[test]
     fn test_builder_data_hashed_embeddable_min() -> Result<()> {
-        let signer = Settings::signer().unwrap();
+        let signer = test_signer(SigningAlg::Ps256);
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         // get a placeholder the manifest
         let placeholder = builder
@@ -4171,7 +4216,9 @@ mod tests {
 
         let output_stream = Cursor::new(signed_manifest);
 
-        let reader = crate::Reader::from_stream("application/c2pa", output_stream).unwrap();
+        let reader = Reader::default()
+            .with_stream("application/c2pa", output_stream)
+            .unwrap();
         println!("{reader}");
         assert_eq!(reader.validation_status(), None);
         Ok(())
@@ -4180,7 +4227,9 @@ mod tests {
     #[test]
     fn test_placeholder_auto_adds_data_hash() -> Result<()> {
         // Create a builder without any hash assertions
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         // Verify no DataHash exists initially
         assert!(builder.find_assertion::<DataHash>(DataHash::LABEL).is_err());
@@ -4202,7 +4251,9 @@ mod tests {
     #[test]
     fn test_placeholder_auto_adds_bmff_hash() -> Result<()> {
         // Create a builder without any hash assertions
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         // Verify no BmffHash exists initially
         assert!(builder.find_assertion::<BmffHash>(BmffHash::LABEL).is_err());
@@ -4223,7 +4274,9 @@ mod tests {
     #[test]
     fn test_placeholder_respects_existing_hash() -> Result<()> {
         // Create a builder with a custom DataHash
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
         let mut custom_dh = DataHash::new("my_custom_hash", "sha512");
         custom_dh.add_exclusion(HashRange::new(100, 200));
         builder.add_assertion(DataHash::LABEL, &custom_dh)?;
@@ -4243,7 +4296,9 @@ mod tests {
     #[test]
     fn test_placeholder_rejects_multiple_hashes() -> Result<()> {
         // Create a builder with both DataHash and BmffHash
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         let dh = DataHash::new("data_hash", "sha256");
         builder.add_assertion(DataHash::LABEL, &dh)?;
@@ -4265,7 +4320,9 @@ mod tests {
     #[test]
     fn test_placeholder_with_box_hash() -> Result<()> {
         // Create a builder with BoxHash
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         let mut reader = Cursor::new("");
         let c2pa_io = jumbf_io::get_assetio_handler("application/c2pa").unwrap();
@@ -4360,7 +4417,7 @@ mod tests {
         embedded.extend_from_slice(&TEST_IMAGE_CLEAN[2..]); // rest of JPEG
 
         let mut embedded_stream = Cursor::new(embedded);
-        let reader = Reader::from_stream("image/jpeg", &mut embedded_stream)?;
+        let reader = Reader::default().with_stream("image/jpeg", &mut embedded_stream)?;
         assert_eq!(
             reader.validation_state(),
             ValidationState::Trusted,
@@ -4400,7 +4457,7 @@ mod tests {
 
     #[test]
     fn test_hash_type() -> Result<()> {
-        let builder = Builder::from_json(&simple_manifest_json())?;
+        let builder = Builder::default().with_definition(simple_manifest_json())?;
 
         // Non-BMFF formats default to DataHash.
         assert_eq!(builder.hash_type("image/jpeg"), HashType::Data);
@@ -4447,7 +4504,7 @@ mod tests {
 
     #[test]
     fn test_hash_type_with_existing_box_hash_assertion() -> Result<()> {
-        let mut builder = Builder::from_json(&simple_manifest_json())?;
+        let mut builder = Builder::default().with_definition(simple_manifest_json())?;
 
         let bh = BoxHash::default();
         builder.add_assertion(BoxHash::LABEL, &bh)?;
@@ -4463,7 +4520,7 @@ mod tests {
     fn test_hash_type_consistent_with_needs_placeholder() -> Result<()> {
         // When needs_placeholder returns false, hash_type must be BoxHash.
         // When needs_placeholder returns true, hash_type must be DataHash or BmffHash.
-        let builder = Builder::from_json(&simple_manifest_json())?;
+        let builder = Builder::default().with_definition(simple_manifest_json())?;
         for format in &["image/jpeg", "image/png", "video/mp4", "image/avif"] {
             let needs = builder.needs_placeholder(format);
             let ht = builder.hash_type(format);
@@ -4490,7 +4547,7 @@ mod tests {
         use std::io::{Seek, SeekFrom, Write};
 
         // 1. Setup - Create builder with simple manifest
-        let mut builder = Builder::from_json(&simple_manifest_json())?;
+        let mut builder = Builder::default().with_definition(simple_manifest_json())?;
 
         // 2. Create placeholder (adds DataHash to builder).
         //    placeholder() now returns composed bytes directly (no separate composed_manifest call needed).
@@ -4538,8 +4595,7 @@ mod tests {
         output_stream.write_all(&signed_manifest)?;
 
         output_stream.rewind()?;
-        let reader =
-            Reader::from_context(Context::new()).with_stream("image/jpeg", output_stream)?;
+        let reader = Reader::default().with_stream("image/jpeg", output_stream)?;
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
         // 7. Workflow complete. Reader::from_stream loads the asset but the manifest assertion
@@ -4555,7 +4611,7 @@ mod tests {
         use std::io::{Seek, SeekFrom, Write};
 
         // 1. Build a simple manifest for an MP4 asset.
-        let mut builder = Builder::from_json(&simple_manifest_json())?;
+        let mut builder = Builder::default().with_definition(simple_manifest_json())?;
 
         // 2. Call placeholder() for a BMFF format.
         //    Returns composed bytes (C2PA UUID box) ready to embed; raw JUMBF is
@@ -4599,7 +4655,7 @@ mod tests {
 
         // 8. Validate the final asset.
         output_stream.rewind()?;
-        let reader = Reader::from_stream("video/mp4", &mut output_stream)?;
+        let reader = Reader::default().with_stream("video/mp4", &mut output_stream)?;
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
 
@@ -4716,7 +4772,7 @@ mod tests {
 
         // 10. Validate the final asset.
         output_stream.rewind()?;
-        let reader = Reader::from_stream("video/mp4", &mut output_stream)?;
+        let reader = Reader::default().with_stream("video/mp4", &mut output_stream)?;
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
 
@@ -4734,10 +4790,12 @@ mod tests {
         // And generate the box hashes
         //bh.generate_box_hash_from_stream(&mut reader, "sha256", box_mapper, true).unwrap();
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
         builder.add_assertion(labels::BOX_HASH, &bh).unwrap();
 
-        let signer = Settings::signer().unwrap();
+        let signer = test_signer(SigningAlg::Ps256);
 
         let manifest_bytes = builder
             .sign_box_hashed_embeddable(signer.as_ref(), "application/c2pa")
@@ -4745,7 +4803,9 @@ mod tests {
 
         let output_stream = Cursor::new(manifest_bytes);
 
-        let reader = crate::Reader::from_stream("application/c2pa", output_stream).unwrap();
+        let reader = Reader::default()
+            .with_stream("application/c2pa", output_stream)
+            .unwrap();
         println!("{reader}");
         assert_eq!(reader.validation_status(), None);
     }
@@ -4765,7 +4825,9 @@ mod tests {
         // get saved box hash settings
         let box_hash: BoxHash = serde_json::from_slice(BOX_HASH).unwrap();
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         builder.add_assertion(labels::BOX_HASH, &box_hash).unwrap();
 
@@ -4807,7 +4869,8 @@ mod tests {
 
         out_stream.rewind().unwrap();
 
-        let _reader = crate::Reader::from_stream_async("image/jpeg", out_stream)
+        let _reader = Reader::default()
+            .with_stream_async("image/jpeg", out_stream)
             .await
             .unwrap();
         //println!("{reader}");
@@ -4829,7 +4892,9 @@ mod tests {
         // get saved box hash settings
         let box_hash: BoxHash = serde_json::from_slice(BOX_HASH).unwrap();
 
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         builder.add_assertion(labels::BOX_HASH, &box_hash).unwrap();
 
@@ -4871,7 +4936,8 @@ mod tests {
 
         out_stream.rewind().unwrap();
 
-        let _reader = crate::Reader::from_stream_async("image/jpeg", out_stream)
+        let _reader = Reader::default()
+            .with_stream_async("image/jpeg", out_stream)
             .await
             .unwrap();
         //println!("{reader}");
@@ -4887,7 +4953,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE_CLEAN);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder.set_base_path("tests/fixtures");
         builder
             .add_ingredient_from_stream(parent_json().to_string(), "image/jpeg", &mut source)
@@ -4899,7 +4965,7 @@ mod tests {
 
         // unzip the manifest builder from the zipped stream
         zipped.rewind().unwrap();
-        let mut builder = Builder::from_archive(&mut zipped).unwrap();
+        let mut builder = Builder::default().with_archive(&mut zipped).unwrap();
 
         // sign the Builder and write it to the output stream
         let signer = test_signer(SigningAlg::Ps256);
@@ -4909,7 +4975,9 @@ mod tests {
 
         // read and validate the signed manifest store
         dest.rewind().unwrap();
-        let reader = Reader::from_stream("image/jpeg", &mut dest).expect("from_bytes");
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .expect("from_bytes");
 
         //println!("{}", reader);
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
@@ -5052,11 +5120,10 @@ mod tests {
     #[test]
     /// tests and illustrates how to add assets to a non-file based manifest by using a stream
     fn from_json_with_stream_full_resources() {
-        use crate::utils::test::setup_logger;
         setup_logger();
         use crate::assertions::Relationship;
 
-        let mut builder = Builder::from_json(MANIFEST_JSON).unwrap();
+        let mut builder = Builder::default().with_definition(MANIFEST_JSON).unwrap();
         // add binary resources to manifest and ingredients giving matching the identifiers given in JSON
         builder
             .add_resource("IMG_0003.jpg", Cursor::new(b"jpeg data"))
@@ -5082,7 +5149,9 @@ mod tests {
             .expect("builder sign");
 
         output.set_position(0);
-        let reader = Reader::from_stream("jpeg", &mut output).expect("from_bytes");
+        let reader = Reader::default()
+            .with_stream("jpeg", &mut output)
+            .expect("from_bytes");
         let m = reader.active_manifest().unwrap();
 
         //println!("after = {m}");
@@ -5209,7 +5278,8 @@ mod tests {
 
         output.set_position(0);
 
-        let reader = Reader::from_stream_async("jpeg", &mut output)
+        let reader = Reader::default()
+            .with_stream_async("jpeg", &mut output)
             .await
             .expect("from_bytes");
         let m = reader.active_manifest().unwrap();
@@ -5235,7 +5305,7 @@ mod tests {
         let redacted_uri =
             crate::jumbf::labels::to_assertion_uri(parent_manifest_label, ASSERTION_LABEL);
 
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Edit);
         builder.definition.redactions = Some(vec![redacted_uri.clone()]);
 
@@ -5255,7 +5325,9 @@ mod tests {
 
         output.set_position(0);
 
-        let reader = Reader::from_stream("image/jpeg", &mut output).expect("from_bytes");
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .expect("from_bytes");
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
         let m = reader.active_manifest().unwrap();
@@ -5273,7 +5345,8 @@ mod tests {
 
         let mut input = Cursor::new(TEST_IMAGE);
 
-        let parent = Reader::from_stream_async("image/jpeg", &mut input)
+        let parent = Reader::default()
+            .with_stream_async("image/jpeg", &mut input)
             .await
             .expect("from_stream");
         let parent_manifest_label = parent.active_label().unwrap();
@@ -5302,7 +5375,8 @@ mod tests {
 
         output.set_position(0);
 
-        let reader = Reader::from_stream_async("image/jpeg", &mut output)
+        let reader = Reader::default()
+            .with_stream_async("image/jpeg", &mut output)
             .await
             .expect("from_bytes");
         //println!("{reader}");
@@ -5318,13 +5392,10 @@ mod tests {
 
     #[test]
     fn test_redaction_two_ingredients() {
-        use crate::{
-            assertions::{c2pa_action, Action, Actions},
-            utils::test::setup_logger,
-        };
+        use crate::assertions::{c2pa_action, Action, Actions};
 
-        Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
         setup_logger();
+        let context = test_context().into_shared();
 
         const ASSERTION_LABEL: &str = "stds.schema-org.CreativeWork";
 
@@ -5454,7 +5525,9 @@ mod tests {
 
         // Verify
         output.set_position(0);
-        let reader = Reader::from_stream("jpeg", &mut output).expect("read combined");
+        let reader = Reader::from_shared_context(&context)
+            .with_stream("jpeg", &mut output)
+            .expect("read combined");
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
 
@@ -5483,10 +5556,9 @@ mod tests {
     /// this first creates a manifest with an assertion we will later redact
     /// then creates an update manifest that redacts the assertion
     fn test_redaction2() {
-        use crate::{assertions::Action, utils::test::setup_logger};
-        Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
-
+        use crate::assertions::Action;
         setup_logger();
+        let context = test_context().into_shared();
         // the label of the assertion we are going to redact
         const ASSERTION_LABEL: &str = "stds.schema-org.CreativeWork";
 
@@ -5533,7 +5605,9 @@ mod tests {
             .unwrap();
 
         dest1.set_position(0);
-        let reader = Reader::from_stream("jpeg", &mut dest1).expect("from_bytes");
+        let reader = Reader::from_shared_context(&context)
+            .with_stream("jpeg", &mut dest1)
+            .expect("from_bytes");
         //println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
         let parent_manifest_label = reader.active_label().unwrap();
@@ -5582,7 +5656,9 @@ mod tests {
         output.set_position(0);
         //std::fs::write("redaction2.jpg", output.get_ref()).unwrap();
 
-        let reader = Reader::from_stream("jpeg", &mut output).expect("from_bytes");
+        let reader = Reader::from_shared_context(&context)
+            .with_stream("jpeg", &mut output)
+            .expect("from_bytes");
         //println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
         let m = reader.active_manifest().unwrap();
@@ -5595,14 +5671,16 @@ mod tests {
     fn test_redact_actions_returns_invalid_redaction() {
         let mut input = Cursor::new(TEST_IMAGE);
 
-        let parent = Reader::from_stream("image/jpeg", &mut input).expect("from_stream");
+        let parent = Reader::default()
+            .with_stream("image/jpeg", &mut input)
+            .expect("from_stream");
         let parent_manifest_label = parent.active_label().unwrap();
 
         // Try to redact the actions assertion, which is not allowed per the spec.
         let redacted_uri =
             crate::jumbf::labels::to_assertion_uri(parent_manifest_label, "c2pa.actions");
 
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Edit);
         builder.definition.redactions = Some(vec![redacted_uri]);
 
@@ -5616,7 +5694,9 @@ mod tests {
     fn test_redact_nonexistent_assertion_returns_not_found() {
         let mut input = Cursor::new(TEST_IMAGE);
 
-        let parent = Reader::from_stream("image/jpeg", &mut input).expect("from_stream");
+        let parent = Reader::default()
+            .with_stream("image/jpeg", &mut input)
+            .expect("from_stream");
         let parent_manifest_label = parent.active_label().unwrap();
 
         // Try to redact an assertion that doesn't exist in the parent manifest.
@@ -5625,7 +5705,7 @@ mod tests {
             "stds.schema-org.DoesNotExist",
         );
 
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Edit);
         builder.definition.redactions = Some(vec![redacted_uri]);
 
@@ -5696,7 +5776,7 @@ mod tests {
         let parent_manifest_label = v1_reader.active_label().unwrap();
         let redacted_uri = crate::jumbf::labels::to_databox_uri(parent_manifest_label, "c2pa.data");
 
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Edit);
         builder.definition.redactions = Some(vec![redacted_uri.clone()]);
 
@@ -5713,7 +5793,9 @@ mod tests {
             .expect("redaction builder sign");
 
         output.set_position(0);
-        let reader = Reader::from_stream("image/jpeg", &mut output).expect("from_bytes");
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .expect("from_bytes");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
 
         let m = reader.active_manifest().unwrap();
@@ -5747,7 +5829,9 @@ mod tests {
     #[cfg(all(feature = "add_thumbnails", feature = "file_io"))]
     #[test]
     fn test_to_archive_and_from_archive_with_ingredient_thumbnail() {
-        let mut builder = Builder::from_json(&simple_manifest_json()).unwrap();
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
 
         let mut thumbnail = Cursor::new(TEST_THUMBNAIL);
         let mut source = Cursor::new(TEST_IMAGE_CLEAN);
@@ -5762,7 +5846,7 @@ mod tests {
         let mut archive = Cursor::new(Vec::new());
         assert!(builder.to_archive(&mut archive).is_ok());
 
-        let mut builder = Builder::from_archive(archive).unwrap();
+        let mut builder = Builder::default().with_archive(archive).unwrap();
 
         let mut output = Cursor::new(Vec::new());
 
@@ -5770,7 +5854,8 @@ mod tests {
             .sign(&signer, "image/jpeg", &mut source, &mut output)
             .is_ok());
 
-        let reader_json = Reader::from_stream("image/jpeg", &mut output)
+        let reader_json = Reader::default()
+            .with_stream("image/jpeg", &mut output)
             .unwrap()
             .json();
         println!("{reader_json}");
@@ -5780,8 +5865,7 @@ mod tests {
 
     #[test]
     fn test_with_archive() -> Result<()> {
-        let mut builder =
-            Builder::from_context(Context::new()).with_definition(r#"{"title": "Test Image"}"#)?;
+        let mut builder = Builder::default().with_definition(r#"{"title": "Test Image"}"#)?;
 
         let mut archive = Cursor::new(Vec::new());
         builder.to_archive(&mut archive)?;
@@ -5844,14 +5928,14 @@ mod tests {
 
         // Test 3: Verify both can be read back
         archive_new.rewind()?;
-        let loaded_new = Builder::from_archive(archive_new)?;
+        let loaded_new = Builder::default().with_archive(archive_new)?;
         assert_eq!(
             loaded_new.definition.title,
             Some("Test New Format".to_string())
         );
 
         archive_old.rewind()?;
-        let loaded_old = Builder::from_archive(archive_old)?;
+        let loaded_old = Builder::default().with_archive(archive_old)?;
         assert_eq!(
             loaded_old.definition.title,
             Some("Test Old Format".to_string())
@@ -5892,7 +5976,7 @@ mod tests {
     /// Test Builder add_action with a serde_json::Value
     #[test]
     fn test_builder_add_action_with_value() {
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         let action = json!({
             "action": "com.example.test-action",
             "parameters": {
@@ -5909,7 +5993,7 @@ mod tests {
     #[test]
     fn test_builder_add_action_with_struct() {
         use crate::assertions::Action;
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         let action = Action::new("com.example.test-action")
             .set_parameter("key1", "value1")
             .unwrap()
@@ -5923,7 +6007,7 @@ mod tests {
     #[cfg(feature = "file_io")]
     #[test]
     fn test_builder_set_base_path() {
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
 
         let ingredient_folder = fixture_path("ingredient");
@@ -5944,7 +6028,7 @@ mod tests {
             .sign(&signer, "image/jpeg", &mut source, &mut dest)
             .unwrap();
 
-        let reader = Reader::from_stream("jpeg", &mut dest).unwrap();
+        let reader = Reader::default().with_stream("jpeg", &mut dest).unwrap();
         let active_manifest = reader.active_manifest().unwrap();
         let ingredient = active_manifest.ingredients().first().unwrap();
         assert_eq!(ingredient.title(), Some("C.jpg"));
@@ -5965,16 +6049,15 @@ mod tests {
         // if one is not otherwise added.
         let mut builder = Builder::from_shared_context(&context);
         builder.set_intent(BuilderIntent::Edit);
-        let signer = &Settings::signer()?;
-        // We have a different options here. We can embed the manifest into a destination file
+        // We have different options here. We can embed the manifest into a destination file
         // or we can bypass the embedding and just get the manifest data back.
         // you can also output to null if you just want the manifest data.
         // Here we embed the manifest into a destination file.
-        let _c2pa_data = builder.sign(signer, format, &mut source, &mut dest)?;
+        let _c2pa_data = builder.save_to_stream(format, &mut source, &mut dest)?;
 
         dest.rewind()?;
         // use read_from_manifest_data_and_stream to validate if not embedded.
-        let reader = Reader::from_stream(format, &mut dest)?;
+        let reader = Reader::default().with_stream(format, &mut dest)?;
         println!("first: {reader}");
 
         // create a new builder and add our ingredient from the reader.
@@ -5984,9 +6067,9 @@ mod tests {
         println!("\nbuilder2:{builder2}");
         source.rewind()?;
         let dest2 = &mut Cursor::new(Vec::new());
-        builder2.sign(signer, format, &mut source, dest2)?;
+        builder2.save_to_stream(format, &mut source, dest2)?;
         dest2.rewind()?;
-        let reader2 = Reader::from_stream(format, dest2)?;
+        let reader2 = Reader::default().with_stream(format, dest2)?;
         println!("\nreader2:{reader2}");
         assert_eq!(reader2.active_manifest().unwrap().ingredients().len(), 1);
         Ok(())
@@ -6262,9 +6345,10 @@ mod tests {
     //         .expect("should load settings");
 
     //     // This should panic in debug mode
-    //     let _builder = Builder::new();
+    //     let _builder = Builder::default();
     // }
 
+    #[allow(deprecated)]
     #[test]
     fn test_builder_new_succeeds_without_global_settings() {
         // Clean slate
@@ -6283,7 +6367,7 @@ mod tests {
     #[test]
     fn actions_created_assertion() {
         let mut dest = Cursor::new(Vec::new());
-        Builder::new()
+        Builder::from_context(test_context())
             .with_definition(
                 json!({
                   "assertions": [
@@ -6304,17 +6388,14 @@ mod tests {
                 .to_string(),
             )
             .unwrap()
-            .sign(
-                &Settings::signer().unwrap(),
-                "image/jpeg",
-                &mut Cursor::new(TEST_IMAGE),
-                &mut dest,
-            )
+            .save_to_stream("image/jpeg", &mut Cursor::new(TEST_IMAGE), &mut dest)
             .unwrap();
 
         dest.rewind().unwrap();
 
-        let reader = Reader::from_stream("image/jpeg", &mut dest).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .unwrap();
         let active_manifest = reader.active_manifest().unwrap();
 
         let actions_assertion = active_manifest
@@ -6331,7 +6412,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE_TIFF);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         builder.set_intent(BuilderIntent::Create(DigitalSourceType::DigitalCapture));
 
         let signer = test_signer(SigningAlg::Ps256);
@@ -6341,7 +6422,9 @@ mod tests {
 
         // read and validate the signed manifest store
         dest.rewind().unwrap();
-        let reader = Reader::from_stream(format, &mut dest).expect("from_stream");
+        let reader = Reader::default()
+            .with_stream(format, &mut dest)
+            .expect("from_stream");
 
         // Verify there is no data hash mismatch error in validation status
         if let Some(status) = reader.validation_status() {
@@ -6364,7 +6447,7 @@ mod tests {
         fn assert_send<T: MaybeSend>(_: T) {}
 
         let signer = async_test_signer(SigningAlg::Ps256);
-        let mut builder = Builder::new();
+        let mut builder = Builder::default();
         let mut src = io::empty();
         let mut dst = io::empty();
 

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3402,6 +3402,7 @@ impl std::fmt::Display for Builder {
 mod tests {
     #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]
+    #![allow(deprecated)]
     use std::{
         io::{self, Cursor},
         vec,

--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -802,11 +802,10 @@ impl Context {
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+    #[cfg(not(target_arch = "wasm32"))]
+    use crate::utils::test_signer::async_test_signer;
     use crate::{
-        utils::{
-            test::test_context,
-            test_signer::{async_test_signer, test_signer},
-        },
+        utils::{test::test_context, test_signer::test_signer},
         SigningAlg,
     };
 

--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -802,6 +802,13 @@ impl Context {
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+    use crate::{
+        utils::{
+            test::test_context,
+            test_signer::{async_test_signer, test_signer},
+        },
+        SigningAlg,
+    };
 
     #[test]
     fn test_into_settings_from_settings() {
@@ -843,9 +850,7 @@ mod tests {
 
     #[test]
     fn test_signer_from_settings() {
-        // Create a context with signer settings from the test_settings.toml file
-        let toml = include_str!("../tests/fixtures/test_settings.toml");
-        let context = Context::new().with_settings(toml).unwrap();
+        let context = test_context();
 
         // Verify that signer can be created from the settings
         let signer = context.signer();
@@ -854,7 +859,7 @@ mod tests {
         // Verify the signer has the expected algorithm
         let signer = signer.unwrap();
         assert!(
-            signer.alg() == crate::SigningAlg::Ps256,
+            signer.alg() == SigningAlg::Ps256,
             "Signer from settings should have Ps256 algorithm"
         );
 
@@ -901,7 +906,7 @@ mod tests {
     #[test]
     fn test_custom_signer() {
         // Create a custom test signer
-        let custom_signer = crate::utils::test_signer::test_signer(crate::SigningAlg::Es256);
+        let custom_signer = test_signer(SigningAlg::Es256);
 
         // Create a context with the custom signer
         let context = Context::new().with_signer(custom_signer);
@@ -909,7 +914,7 @@ mod tests {
         // Verify the custom signer is returned with the expected algorithm
         let signer = context.signer().unwrap();
         assert!(
-            signer.alg() == crate::SigningAlg::Es256,
+            signer.alg() == SigningAlg::Es256,
             "Custom signer should have Es256 algorithm"
         );
     }
@@ -917,10 +922,8 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_custom_async_signer() {
-        use crate::utils::test_signer::async_test_signer;
-
         // Create a custom async signer using the test utility
-        let custom_async_signer = async_test_signer(crate::SigningAlg::Es256);
+        let custom_async_signer = async_test_signer(SigningAlg::Es256);
 
         // Create a context with the custom async signer
         let context = Context::new().with_async_signer(custom_async_signer);
@@ -929,7 +932,7 @@ mod tests {
         let async_signer = context.async_signer().unwrap();
         assert_eq!(
             async_signer.alg(),
-            crate::SigningAlg::Es256,
+            SigningAlg::Es256,
             "Custom async signer should have Es256 algorithm"
         );
 
@@ -1334,10 +1337,8 @@ mod tests {
 
     #[test]
     fn test_set_signer() {
-        use crate::SigningAlg;
-
         // Create a custom test signer (Es256)
-        let custom_signer = crate::utils::test_signer::test_signer(SigningAlg::Es256);
+        let custom_signer = test_signer(SigningAlg::Es256);
 
         // Create a context and mutate it with set_signer
         let mut context = Context::new();
@@ -1362,10 +1363,8 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_set_async_signer() {
-        use crate::SigningAlg;
-
         // Create a custom async test signer (Es256)
-        let custom_signer = crate::utils::test_signer::async_test_signer(SigningAlg::Es256);
+        let custom_signer = async_test_signer(SigningAlg::Es256);
 
         // Create a context and mutate it with set_async_signer
         let mut context = Context::new();
@@ -1396,10 +1395,8 @@ mod tests {
 
     #[test]
     fn test_set_methods_replace_previous_values() {
-        use crate::SigningAlg;
-
         // Create a context with initial signer (Ps256)
-        let initial_signer = crate::utils::test_signer::test_signer(SigningAlg::Ps256);
+        let initial_signer = test_signer(SigningAlg::Ps256);
         let mut context = Context::new().with_signer(initial_signer);
 
         // Verify initial signer
@@ -1411,7 +1408,7 @@ mod tests {
         );
 
         // Replace with new signer (Es256) using set_signer
-        let new_signer = crate::utils::test_signer::test_signer(SigningAlg::Es256);
+        let new_signer = test_signer(SigningAlg::Es256);
         context.set_signer(new_signer).unwrap();
 
         // Verify signer was replaced

--- a/sdk/src/crjson.rs
+++ b/sdk/src/crjson.rs
@@ -839,7 +839,8 @@ mod tests {
 
     #[test]
     fn test_jpeg_trust_reader_from_stream() -> Result<()> {
-        let reader = Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
+        let reader = Reader::default()
+            .with_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
 
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
         Ok(())
@@ -847,7 +848,8 @@ mod tests {
 
     #[test]
     fn test_jpeg_trust_format_json() -> Result<()> {
-        let reader = Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
+        let reader = Reader::default()
+            .with_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
 
         let json_value = reader.to_crjson_value()?;
 
@@ -906,7 +908,7 @@ mod tests {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_cr_json_reader_from_file() -> Result<()> {
-        let reader = Reader::from_file("tests/fixtures/CA.jpg")?;
+        let reader = Reader::default().with_file("tests/fixtures/CA.jpg")?;
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
 
         let json = reader.crjson();
@@ -920,7 +922,7 @@ mod tests {
     #[cfg(feature = "file_io")]
     fn test_claim_signature_decoding() -> Result<()> {
         // Test that signature (manifest-level) is decoded with full certificate details
-        let reader = Reader::from_file("tests/fixtures/CA.jpg")?;
+        let reader = Reader::default().with_file("tests/fixtures/CA.jpg")?;
 
         let json_value = reader.to_crjson_value()?;
         let manifests = json_value["manifests"].as_array().unwrap();
@@ -974,7 +976,7 @@ mod tests {
     #[cfg(feature = "file_io")]
     fn test_cawg_identity_x509_signature_decoding() -> Result<()> {
         // Test that cawg.identity with X.509 signature is fully decoded
-        let reader = Reader::from_file("tests/fixtures/C_with_CAWG_data.jpg")?;
+        let reader = Reader::default().with_file("tests/fixtures/C_with_CAWG_data.jpg")?;
 
         let json_value = reader.to_crjson_value()?;
         let manifests = json_value["manifests"].as_array().unwrap();
@@ -1051,7 +1053,8 @@ mod tests {
             "identity/tests/fixtures/claim_aggregation/adobe_connected_identities.jpg"
         );
 
-        let reader = Reader::from_stream("image/jpeg", std::io::Cursor::new(&test_image[..]))?;
+        let reader =
+            Reader::default().with_stream("image/jpeg", std::io::Cursor::new(&test_image[..]))?;
 
         let json_value = reader.to_crjson_value()?;
         let manifests = json_value["manifests"].as_array().unwrap();
@@ -1133,7 +1136,7 @@ mod tests {
             return Ok(());
         }
 
-        let reader = Reader::from_file(path)?;
+        let reader = Reader::default().with_file(path)?;
         let json_value = reader.to_crjson_value()?;
 
         let manifests = json_value["manifests"]

--- a/sdk/src/identity/builder/identity_assertion_builder.rs
+++ b/sdk/src/identity/builder/identity_assertion_builder.rs
@@ -330,7 +330,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json(), format, &mut source)
             .unwrap();
@@ -352,7 +352,7 @@ mod tests {
         // Read back the Manifest that was generated.
         dest.rewind().unwrap();
 
-        let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+        let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
         let manifest = manifest_store.active_manifest().unwrap();
@@ -383,7 +383,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream_async(parent_json(), format, &mut source)
             .await
@@ -407,7 +407,7 @@ mod tests {
         // Read back the Manifest that was generated.
         dest.rewind().unwrap();
 
-        let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+        let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
         let manifest = manifest_store.active_manifest().unwrap();

--- a/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
+++ b/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
@@ -186,8 +186,9 @@ mod tests {
             x509::AsyncX509CredentialHolder,
             IdentityAssertion, SignerPayload, ValidationError,
         },
+        settings::Settings,
         status_tracker::StatusTracker,
-        Builder, HashedUri, Reader, SigningAlg,
+        Builder, Context, HashedUri, Reader, SigningAlg,
     };
 
     const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
@@ -266,7 +267,10 @@ mod tests {
 
     #[c2pa_test_async]
     async fn adobe_connected_identities() {
-        crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
+        let settings = Settings::new()
+            .with_value("verify.verify_trust", false)
+            .unwrap();
+        let context = Context::new().with_settings(settings).unwrap();
 
         let format = "image/jpeg";
         let test_image =
@@ -274,7 +278,7 @@ mod tests {
 
         let mut test_image = Cursor::new(test_image);
 
-        let reader = Reader::default()
+        let reader = Reader::from_context(context)
             .with_stream(format, &mut test_image)
             .unwrap();
         assert_eq!(reader.validation_status(), None);

--- a/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
+++ b/sdk/src/identity/identity_assertion/built_in_signature_verifier.rs
@@ -199,7 +199,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json(), format, &mut source)
             .unwrap();
@@ -234,7 +234,7 @@ mod tests {
         // Read back the Manifest that was generated.
         dest.rewind().unwrap();
 
-        let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+        let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
         let manifest = manifest_store.active_manifest().unwrap();
@@ -274,7 +274,9 @@ mod tests {
 
         let mut test_image = Cursor::new(test_image);
 
-        let reader = Reader::from_stream(format, &mut test_image).unwrap();
+        let reader = Reader::default()
+            .with_stream(format, &mut test_image)
+            .unwrap();
         assert_eq!(reader.validation_status(), None);
 
         let manifest = reader.active_manifest().unwrap();
@@ -364,7 +366,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json(), format, &mut source)
             .unwrap();
@@ -386,7 +388,7 @@ mod tests {
         // Read back the Manifest that was generated.
         dest.rewind().unwrap();
 
-        let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+        let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
         let manifest = manifest_store.active_manifest().unwrap();

--- a/sdk/src/identity/tests/claim_aggregation/interop.rs
+++ b/sdk/src/identity/tests/claim_aggregation/interop.rs
@@ -25,20 +25,24 @@ use crate::{
         claim_aggregation::{IcaSignatureVerifier, IdentityProvider, VerifiedIdentity},
         IdentityAssertion, SignerPayload,
     },
+    settings::Settings,
     status_tracker::StatusTracker,
-    HashedUri, Reader,
+    Context, HashedUri, Reader,
 };
 
 #[c2pa_test_async]
 async fn adobe_connected_identities() {
-    crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
+    let settings = Settings::new()
+        .with_value("verify.verify_trust", false)
+        .unwrap();
+    let context = Context::new().with_settings(settings).unwrap();
 
     let format = "image/jpeg";
     let test_image = include_bytes!("../fixtures/claim_aggregation/adobe_connected_identities.jpg");
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::default()
+    let reader = Reader::from_context(context)
         .with_stream(format, &mut test_image)
         .unwrap();
     assert_eq!(reader.validation_status(), None);
@@ -119,14 +123,17 @@ async fn adobe_connected_identities() {
 
 #[c2pa_test_async]
 async fn ims_multiple_manifests() {
-    crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
+    let settings = Settings::new()
+        .with_value("verify.verify_trust", false)
+        .unwrap();
+    let context = Context::new().with_settings(settings).unwrap();
 
     let format = "image/jpeg";
     let test_image = include_bytes!("../fixtures/claim_aggregation/ims_multiple_manifests.jpg");
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::default()
+    let reader = Reader::from_context(context)
         .with_stream(format, &mut test_image)
         .unwrap();
     assert_eq!(reader.validation_status(), None);

--- a/sdk/src/identity/tests/claim_aggregation/interop.rs
+++ b/sdk/src/identity/tests/claim_aggregation/interop.rs
@@ -38,7 +38,9 @@ async fn adobe_connected_identities() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -124,7 +126,9 @@ async fn ims_multiple_manifests() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Check the summary report for the entire manifest store.

--- a/sdk/src/identity/tests/claim_aggregation/validation.rs
+++ b/sdk/src/identity/tests/claim_aggregation/validation.rs
@@ -54,7 +54,9 @@ async fn success_case() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -118,7 +120,9 @@ async fn invalid_cose_sign1() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -198,7 +202,9 @@ async fn invalid_cose_sign_alg() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -260,7 +266,9 @@ async fn missing_cose_sign_alg() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -323,7 +331,9 @@ async fn invalid_content_type() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -386,7 +396,9 @@ async fn invalid_content_type_assigned() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -448,7 +460,9 @@ async fn missing_content_type() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -522,7 +536,9 @@ async fn missing_vc() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -580,7 +596,9 @@ async fn invalid_vc() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -647,7 +665,9 @@ async fn invalid_issuer_did() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -712,7 +732,9 @@ async fn unsupported_did_method() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -775,7 +797,9 @@ async fn unresolvable_did() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -838,7 +862,9 @@ async fn did_doc_without_assertion_method() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -914,7 +940,9 @@ async fn signature_mismatch() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -982,7 +1010,9 @@ async fn valid_time_stamp() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1069,7 +1099,9 @@ async fn invalid_time_stamp() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1138,7 +1170,9 @@ async fn valid_from_missing() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1206,7 +1240,9 @@ async fn valid_from_in_future() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1279,7 +1315,9 @@ async fn valid_from_after_time_stamp() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1375,7 +1413,9 @@ async fn valid_until_in_future() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1444,7 +1484,9 @@ async fn valid_until_in_past() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();
@@ -1532,7 +1574,9 @@ async fn signer_payload_mismatch() {
 
     let mut test_image = Cursor::new(test_image);
 
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     let manifest = reader.active_manifest().unwrap();

--- a/sdk/src/identity/tests/examples/x509_signing.rs
+++ b/sdk/src/identity/tests/examples/x509_signing.rs
@@ -41,7 +41,7 @@ async fn x509_signing() {
     let mut source = Cursor::new(TEST_IMAGE);
     let mut dest = Cursor::new(Vec::new());
 
-    let mut builder = Builder::from_json(&manifest_json()).unwrap();
+    let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
     builder
         .add_ingredient_from_stream(parent_json(), format, &mut source)
         .unwrap();
@@ -85,7 +85,7 @@ async fn x509_signing() {
 
     dest.rewind().unwrap();
 
-    let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+    let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
     assert_eq!(manifest_store.validation_status(), None);
 
     let manifest = manifest_store.active_manifest().unwrap();

--- a/sdk/src/identity/tests/validation_method/continue_when_possible.rs
+++ b/sdk/src/identity/tests/validation_method/continue_when_possible.rs
@@ -41,7 +41,9 @@ async fn malformed_cbor() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find malformed CBOR error.
@@ -81,7 +83,9 @@ async fn extra_fields() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find malformed CBOR error.
@@ -137,7 +141,9 @@ async fn assertion_not_in_claim_v1() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -249,7 +255,9 @@ async fn duplicate_assertion_reference() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -350,7 +358,9 @@ async fn no_hard_binding() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -460,7 +470,9 @@ mod invalid_sig_type {
         let mut test_image = Cursor::new(test_image);
 
         // Initial read with default `Reader` should pass without issues.
-        let reader = Reader::from_stream(format, &mut test_image).unwrap();
+        let reader = Reader::default()
+            .with_stream(format, &mut test_image)
+            .unwrap();
         assert_eq!(reader.validation_status(), None);
 
         // Re-parse with identity assertion code should find extra assertion error.
@@ -534,7 +546,9 @@ mod invalid_sig_type {
         let mut test_image = Cursor::new(test_image);
 
         // Initial read with default `Reader` should pass without issues.
-        let reader = Reader::from_stream(format, &mut test_image).unwrap();
+        let reader = Reader::default()
+            .with_stream(format, &mut test_image)
+            .unwrap();
         assert_eq!(reader.validation_status(), None);
 
         // Re-parse with identity assertion code should find extra assertion error.
@@ -609,7 +623,9 @@ async fn pad1_invalid() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find invalid pad error.
@@ -699,7 +715,9 @@ async fn pad2_invalid() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find invalid pad error.

--- a/sdk/src/identity/tests/validation_method/stop_on_error.rs
+++ b/sdk/src/identity/tests/validation_method/stop_on_error.rs
@@ -40,7 +40,9 @@ async fn malformed_cbor() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find malformed CBOR error.
@@ -80,7 +82,9 @@ async fn extra_fields() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find malformed CBOR error.
@@ -135,7 +139,9 @@ async fn assertion_not_in_claim_v1() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -221,7 +227,9 @@ async fn duplicate_assertion_reference() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -297,7 +305,9 @@ async fn no_hard_binding() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find extra assertion error.
@@ -384,7 +394,9 @@ mod invalid_sig_type {
         let mut test_image = Cursor::new(test_image);
 
         // Initial read with default `Reader` should pass without issues.
-        let reader = Reader::from_stream(format, &mut test_image).unwrap();
+        let reader = Reader::default()
+            .with_stream(format, &mut test_image)
+            .unwrap();
         assert_eq!(reader.validation_status(), None);
 
         // Re-parse with identity assertion code should find extra assertion error.
@@ -459,7 +471,9 @@ mod invalid_sig_type {
         let mut test_image = Cursor::new(test_image);
 
         // Initial read with default `Reader` should pass without issues.
-        let reader = Reader::from_stream(format, &mut test_image).unwrap();
+        let reader = Reader::default()
+            .with_stream(format, &mut test_image)
+            .unwrap();
         assert_eq!(reader.validation_status(), None);
 
         // Re-parse with identity assertion code should find extra assertion error.
@@ -537,7 +551,9 @@ async fn pad1_invalid() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find invalid pad error.
@@ -601,7 +617,9 @@ async fn pad2_invalid() {
     let mut test_image = Cursor::new(test_image);
 
     // Initial read with default `Reader` should pass without issues.
-    let reader = Reader::from_stream(format, &mut test_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(format, &mut test_image)
+        .unwrap();
     assert_eq!(reader.validation_status(), None);
 
     // Re-parse with identity assertion code should find invalid pad error.

--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -78,7 +78,8 @@ mod tests {
 
         let mut stream = Cursor::new(CONNECTED_IDENTITIES_VALID);
 
-        let reader = Reader::from_stream_async("image/jpeg", &mut stream)
+        let reader = Reader::default()
+            .with_stream_async("image/jpeg", &mut stream)
             .await
             .unwrap();
 
@@ -104,7 +105,8 @@ mod tests {
 
         let mut stream = Cursor::new(MULTIPLE_IDENTITIES_VALID);
 
-        let reader = Reader::from_stream_async("image/jpeg", &mut stream)
+        let reader = Reader::default()
+            .with_stream_async("image/jpeg", &mut stream)
             .await
             .unwrap();
 
@@ -126,7 +128,8 @@ mod tests {
     async fn test_cawg_validate_with_hard_binding_missing() {
         let mut stream = Cursor::new(NO_HARD_BINDING);
 
-        let reader = Reader::from_stream_async("image/jpeg", &mut stream)
+        let reader = Reader::default()
+            .with_stream_async("image/jpeg", &mut stream)
             .await
             .unwrap();
 

--- a/sdk/src/identity/x509/x509_signature_verifier.rs
+++ b/sdk/src/identity/x509/x509_signature_verifier.rs
@@ -186,7 +186,7 @@ mod tests {
         let mut source = Cursor::new(TEST_IMAGE);
         let mut dest = Cursor::new(Vec::new());
 
-        let mut builder = Builder::from_json(&manifest_json()).unwrap();
+        let mut builder = Builder::default().with_definition(manifest_json()).unwrap();
         builder
             .add_ingredient_from_stream(parent_json(), format, &mut source)
             .unwrap();
@@ -219,7 +219,7 @@ mod tests {
         // Read back the Manifest that was generated.
         dest.rewind().unwrap();
 
-        let manifest_store = Reader::from_stream(format, &mut dest).unwrap();
+        let manifest_store = Reader::default().with_stream(format, &mut dest).unwrap();
         assert_eq!(manifest_store.validation_status(), None);
 
         let manifest = manifest_store.active_manifest().unwrap();

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -704,13 +704,25 @@ impl Ingredient {
     }
 
     #[cfg(feature = "file_io")]
-    /// Creates an `Ingredient` from a file path.
+    /// Creates an `Ingredient` from a file path using thread-local settings.
+    ///
+    /// Use [`Ingredient::from_file_with_options`] with an explicit context instead.
+    #[deprecated(
+        note = "Use `Ingredient::from_file_with_options` with an explicit `Context` instead of relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         Self::from_file_with_options(path.as_ref(), &DefaultOptions { base: None })
     }
 
     #[cfg(feature = "file_io")]
-    /// Creates an `Ingredient` from a file path.
+    /// Creates an `Ingredient` from a file path using thread-local settings.
+    ///
+    /// Use [`Ingredient::from_file_with_options`] with an explicit context instead.
+    #[deprecated(
+        note = "Use `Ingredient::from_file_with_options` with an explicit `Context` instead of relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub fn from_file_with_folder<P: AsRef<Path>>(path: P, folder: P) -> Result<Self> {
         Self::from_file_with_options(
             path.as_ref(),
@@ -725,8 +737,15 @@ impl Ingredient {
         (assertion.content_type(), assertion.data())
     }
 
-    /// Creates an `Ingredient` from a file path and options.
+    /// Creates an `Ingredient` from a file path and options, using thread-local settings.
+    ///
+    /// Pass an explicit [`Context`](crate::Context) to `from_file_impl` directly, or use
+    /// the [`Builder`](crate::Builder) API with [`Builder::from_context`](crate::Builder::from_context)
+    /// to avoid relying on thread-local settings.
     #[cfg(feature = "file_io")]
+    #[deprecated(
+        note = "Rely on `Builder::from_context` with an explicit `Context` instead of using thread-local settings."
+    )]
     pub fn from_file_with_options<P: AsRef<Path>>(
         path: P,
         options: &dyn IngredientOptions,
@@ -816,19 +835,28 @@ impl Ingredient {
         Ok(ingredient)
     }
 
-    /// Creates an `Ingredient` from a memory buffer.
+    /// Creates an `Ingredient` from a memory buffer using thread-local settings.
     ///
     /// This does not set title or hash.
     /// Thumbnail will be set only if one can be retrieved from a previous valid manifest.
+    ///
+    /// Use [`Ingredient::from_stream`] with an explicit [`Context`](crate::Context) instead.
+    #[deprecated(
+        note = "Use `Ingredient::from_stream` with an explicit `Context` instead of relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub fn from_memory(format: &str, buffer: &[u8]) -> Result<Self> {
         let mut stream = Cursor::new(buffer);
         Self::from_stream(format, &mut stream)
     }
 
-    /// Creates an `Ingredient` from a stream.
+    /// Creates an `Ingredient` from a stream using thread-local settings.
     ///
     /// This does not set title or hash.
     /// Thumbnail will be set only if one can be retrieved from a previous valid manifest.
+    ///
+    /// Pass an explicit [`Context`](crate::Context) via `add_stream_internal` instead.
+    #[deprecated(note = "Pass an explicit `Context` instead of relying on thread-local settings.")]
     pub fn from_stream(format: &str, stream: &mut dyn CAIRead) -> Result<Self> {
         // Legacy behavior: explicitly get global settings for backward compatibility
         let settings = crate::settings::get_thread_local_settings();
@@ -971,19 +999,30 @@ impl Ingredient {
         Ok(self)
     }
 
-    /// Creates an `Ingredient` from a memory buffer (async version).
+    /// Creates an `Ingredient` from a memory buffer (async version) using thread-local settings.
     ///
     /// This does not set title or hash.
     /// Thumbnail will be set only if one can be retrieved from a previous valid manifest.
+    ///
+    /// Use [`Builder::from_context`](crate::Builder::from_context) with an explicit [`Context`](crate::Context) instead.
+    #[deprecated(
+        note = "Use `Builder::from_context(context)` with an explicit `Context` instead of relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub async fn from_memory_async(format: &str, buffer: &[u8]) -> Result<Self> {
         let mut stream = Cursor::new(buffer);
         Self::from_stream_async(format, &mut stream).await
     }
 
-    /// Creates an `Ingredient` from a stream (async version).
+    /// Creates an `Ingredient` from a stream (async version) using thread-local settings.
     ///
     /// This does not set title or hash.
     /// Thumbnail will be set only if one can be retrieved from a previous valid manifest.
+    ///
+    /// Use [`Builder::from_context`](crate::Builder::from_context) with an explicit [`Context`](crate::Context) instead.
+    #[deprecated(
+        note = "Use `Builder::from_context(context)` with an explicit `Context` instead of relying on thread-local settings."
+    )]
     pub async fn from_stream_async(format: &str, stream: &mut dyn CAIRead) -> Result<Self> {
         // Legacy behavior: explicitly get global settings for backward compatibility
         let settings = crate::settings::get_thread_local_settings();
@@ -1408,7 +1447,11 @@ impl Ingredient {
         Ok(self)
     }
 
-    /// Asynchronously create an Ingredient from a binary manifest (.c2pa) and asset bytes.
+    /// Asynchronously create an Ingredient from a binary manifest (.c2pa) and asset bytes,
+    /// using thread-local settings.
+    ///
+    /// Use [`Ingredient::from_manifest_and_asset_stream_async`] with an explicit
+    /// [`Context`](crate::Context) instead.
     ///
     /// # Example: Create an Ingredient from a binary manifest (.c2pa) and asset bytes
     /// ```
@@ -1429,6 +1472,10 @@ impl Ingredient {
     /// #    Ok(())
     /// }
     /// ```
+    #[deprecated(
+        note = "Pass an explicit `Context` via `from_manifest_and_asset_stream_async` instead of relying on thread-local settings."
+    )]
+    #[allow(deprecated)]
     pub async fn from_manifest_and_asset_bytes_async<M: Into<Vec<u8>>>(
         manifest_bytes: M,
         format: &str,
@@ -1438,7 +1485,11 @@ impl Ingredient {
         Self::from_manifest_and_asset_stream_async(manifest_bytes, format, &mut stream).await
     }
 
-    /// Asynchronously create an Ingredient from a binary manifest (.c2pa) and asset.
+    /// Asynchronously create an Ingredient from a binary manifest (.c2pa) and asset,
+    /// using thread-local settings.
+    ///
+    /// Pass an explicit [`Context`](crate::Context) instead of relying on thread-local settings.
+    #[deprecated(note = "Pass an explicit `Context` instead of relying on thread-local settings.")]
     pub async fn from_manifest_and_asset_stream_async<M: Into<Vec<u8>>>(
         manifest_bytes: M,
         format: &str,
@@ -1626,6 +1677,7 @@ impl IngredientOptions for DefaultOptions {
 mod tests {
     #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]
+    #![allow(deprecated)]
 
     use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
@@ -1870,6 +1922,7 @@ mod tests {
 mod tests_file_io {
     #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]
+    #![allow(deprecated)]
 
     use super::*;
     use crate::{assertion::AssertionData, utils::test::fixture_path};

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -127,6 +127,9 @@ impl Reader {
     /// This method takes ownership of the [`Context`] and wraps it in an [`Arc`] internally.
     /// Use this for single-use contexts where you don't need to share the context.
     ///
+    /// Use [`Reader::default()`] when no special configuration is needed.
+    /// Use [`Reader::from_shared_context`] to share a context across multiple readers.
+    ///
     /// # Arguments
     /// * `context` - The [`Context`] to use for the Reader
     ///
@@ -138,6 +141,10 @@ impl Reader {
     /// ```
     /// # use c2pa::{Context, Reader, Result};
     /// # fn main() -> Result<()> {
+    /// // With default settings (no explicit context needed):
+    /// let reader = Reader::default();
+    ///
+    /// // With custom settings:
     /// let context = Context::new().with_settings(r#"{"verify": {"verify_after_sign": true}}"#)?;
     /// let reader = Reader::from_context(context);
     /// # Ok(())
@@ -228,6 +235,9 @@ impl Reader {
     /// A [`Reader`] for the manifest store.
     /// # Note
     /// [CAWG identity assertions](https://cawg.io/identity/) require async calls for validation.
+    #[deprecated(
+        note = "Use `Reader::from_context(context).with_stream(format, stream)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
     #[async_generic]
     pub fn from_stream(format: &str, stream: impl Read + Seek + MaybeSend) -> Result<Reader> {
         // Legacy behavior: explicitly get global settings for backward compatibility
@@ -263,7 +273,7 @@ impl Reader {
     /// ```no_run
     /// use c2pa::{Context, Reader};
     /// # fn main() -> c2pa::Result<()> {
-    /// let reader = Reader::from_context(Context::new()).with_file("path/to/file.jpg")?;
+    /// let reader = Reader::default().with_file("path/to/file.jpg")?;
     /// # Ok(())
     /// # }
     /// ```
@@ -355,6 +365,9 @@ impl Reader {
     /// # Note
     /// [CAWG identity assertions](https://cawg.io/identity/) require async calls for validation.
     #[cfg(feature = "file_io")]
+    #[deprecated(
+        note = "Use `Reader::from_context(context).with_file(path)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
     #[async_generic]
     pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> Result<Reader> {
         // Legacy behavior: explicitly get thread-local settings for backward compatibility
@@ -436,6 +449,9 @@ impl Reader {
     /// # Errors
     /// This function returns an [`Error`] ef the c2pa_data is not valid, or severe errors occur in validation.
     /// You must check validation status for non-severe errors.
+    #[deprecated(
+        note = "Use `Reader::from_context(context).with_manifest_data_and_stream(c2pa_data, format, stream)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
     #[async_generic]
     pub fn from_manifest_data_and_stream(
         c2pa_data: &[u8],
@@ -519,9 +535,9 @@ impl Reader {
         fragment: impl Read + Seek + MaybeSend,
     ) -> Result<Self> {
         if _sync {
-            Reader::from_context(Context::new()).with_fragment(format, stream, fragment)
+            Reader::default().with_fragment(format, stream, fragment)
         } else {
-            Reader::from_context(Context::new())
+            Reader::default()
                 .with_fragment_async(format, stream, fragment)
                 .await
         }
@@ -569,6 +585,9 @@ impl Reader {
     /// would be used to load and validate fragmented MP4 files that span
     /// multiple separate asset files.
     #[cfg(feature = "file_io")]
+    #[deprecated(
+        note = "Use `Reader::from_context(context).with_fragmented_files(path, fragments)` instead, passing a `Context` explicitly rather than relying on thread-local settings."
+    )]
     pub fn from_fragmented_files<P: AsRef<std::path::Path>>(
         path: P,
         fragments: &Vec<std::path::PathBuf>,
@@ -837,9 +856,7 @@ impl Reader {
     /// use c2pa::{Context, Reader};
     /// // Create a Reader from an in-memory stream (placeholder bytes shown here).
     /// let input = Cursor::new(Vec::new());
-    /// let reader = Reader::from_context(Context::new())
-    ///     .with_stream("image/jpeg", input)
-    ///     .unwrap();
+    /// let reader = Reader::default().with_stream("image/jpeg", input).unwrap();
     ///
     /// // Get a resource identifier from the active manifest (e.g., a thumbnail).
     /// let manifest = reader.active_manifest().unwrap();
@@ -1362,7 +1379,8 @@ pub mod tests {
 
     #[test]
     fn test_reader_embedded() -> Result<()> {
-        let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+        let reader =
+            Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
         assert_eq!(reader.remote_url(), None);
         assert!(reader.is_embedded());
 
@@ -1388,7 +1406,8 @@ pub mod tests {
     #[test]
     #[cfg(feature = "fetch_remote_manifests")]
     fn test_reader_remote_url() -> Result<()> {
-        let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_REMOTE_MANIFEST))?;
+        let reader =
+            Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_REMOTE_MANIFEST))?;
         let remote_url = reader.remote_url();
         assert_eq!(remote_url, Some("https://cai-manifests.adobe.com/manifests/adobe-urn-uuid-5f37e182-3687-462e-a7fb-573462780391"));
         assert!(!reader.is_embedded());
@@ -1399,7 +1418,7 @@ pub mod tests {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_reader_from_file_no_manifest() -> Result<()> {
-        let result = Reader::from_file("tests/fixtures/IMG_0003.jpg");
+        let result = Reader::default().with_file("tests/fixtures/IMG_0003.jpg");
         assert!(matches!(result, Err(Error::JumbfNotFound)));
         Ok(())
     }
@@ -1407,7 +1426,7 @@ pub mod tests {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_reader_from_file_validation_err() -> Result<()> {
-        let reader = Reader::from_file("tests/fixtures/XCA.jpg")?;
+        let reader = Reader::default().with_file("tests/fixtures/XCA.jpg")?;
         assert!(reader.validation_status().is_some());
         assert_eq!(
             reader.validation_status().unwrap()[0].code(),
@@ -1503,8 +1522,8 @@ pub mod tests {
     #[test]
     /// Test that the reader can validate a file with nested assertion errors
     fn test_reader_nested_resource() -> Result<()> {
-        let reader =
-            Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
+        let reader = Reader::default()
+            .with_stream("image/jpeg", std::io::Cursor::new(IMAGE_COMPLEX_MANIFEST))?;
         assert_eq!(reader.validation_status(), None);
         assert_eq!(reader.manifests.len(), 3);
         let manifest = reader.active_manifest().unwrap();
@@ -1527,7 +1546,7 @@ pub mod tests {
         }
 
         use crate::utils::{io_utils::tempdirectory, test::temp_dir_path};
-        let reader = Reader::from_stream(
+        let reader = Reader::default().with_stream(
             "image/jpeg",
             std::io::Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST),
         )?;
@@ -1556,7 +1575,7 @@ pub mod tests {
     #[cfg(feature = "file_io")]
     /// Test that the reader can validate a file with nested assertion errors
     fn test_reader_detailed_json() -> Result<()> {
-        let reader = Reader::from_file("tests/fixtures/CACAE-uri-CA.jpg")?;
+        let reader = Reader::default().with_file("tests/fixtures/CACAE-uri-CA.jpg")?;
         let json = reader.json();
         let detailed_json = reader.detailed_json();
         let parsed_json: Value = serde_json::from_str(json.as_str())?;
@@ -1587,8 +1606,8 @@ pub mod tests {
     fn test_reader_post_validate() -> Result<()> {
         use crate::{log_item, status_tracker::StatusTracker};
 
-        let mut reader =
-            Reader::from_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
+        let mut reader = Reader::default()
+            .with_stream("image/jpeg", std::io::Cursor::new(IMAGE_WITH_MANIFEST))?;
 
         struct TestValidator;
         impl PostValidator for TestValidator {

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -466,7 +466,7 @@ mod tests {
             }]
         }"#;
 
-        let mut builder = Builder::from_json(json).expect("from json");
+        let mut builder = Builder::default().with_definition(json).expect("from json");
         builder
             .add_resource("abc123", Cursor::new(value))
             .expect("add_resource");
@@ -490,7 +490,9 @@ mod tests {
             .expect("sign");
 
         output_image.set_position(0);
-        let reader = Reader::from_stream("jpeg", &mut output_image).expect("from_bytes");
+        let reader = Reader::default()
+            .with_stream("jpeg", &mut output_image)
+            .expect("from_bytes");
         let _json = reader.json();
         println!("{_json}");
     }

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -436,8 +436,14 @@ pub struct Settings {
 impl Settings {
     #[cfg(feature = "file_io")]
     /// Load thread-local [Settings] from a file.
-    /// to be deprecated - use [Settings::with_file] instead
+    ///
+    /// Use [`Settings::new().with_file()`](Settings::with_file) instead,
+    /// which does not modify thread-local state.
     #[doc(hidden)]
+    #[deprecated(
+        note = "Use `Settings::new().with_file(path)` instead, which does not modify thread-local state."
+    )]
+    #[allow(deprecated)]
     pub fn from_file<P: AsRef<Path>>(settings_path: P) -> Result<Self> {
         let ext = settings_path
             .as_ref()
@@ -451,8 +457,14 @@ impl Settings {
 
     /// Load thread-local [Settings] from string representation of the configuration.
     /// Format of configuration must be supplied (json or toml).
-    /// to be deprecated - use [Settings::with_json] or [Settings::with_toml] instead
+    ///
+    /// Use [`Settings::new().with_json()`](Settings::with_json) or
+    /// [`Settings::new().with_toml()`](Settings::with_toml) instead,
+    /// which do not modify thread-local state.
     #[doc(hidden)]
+    #[deprecated(
+        note = "Use `Settings::new().with_json(str)` or `Settings::new().with_toml(str)` instead, which do not modify thread-local state."
+    )]
     pub fn from_string(settings_str: &str, format: &str) -> Result<Self> {
         let f = match format.to_lowercase().as_str() {
             "json" => FileFormat::Json,
@@ -490,8 +502,14 @@ impl Settings {
         }
     }
 
-    /// Set the thread-local [Settings] from a toml file.
-    /// to be deprecated use [Settings::with_toml] instead
+    /// Set the thread-local [Settings] from a toml string.
+    ///
+    /// Use [`Settings::new().with_toml()`](Settings::with_toml) instead,
+    /// which does not modify thread-local state.
+    #[deprecated(
+        note = "Use `Settings::new().with_toml(toml)` instead, which does not modify thread-local state."
+    )]
+    #[allow(deprecated)]
     pub fn from_toml(toml: &str) -> Result<()> {
         Settings::from_string(toml, "toml").map(|_| ())
     }
@@ -772,23 +790,39 @@ impl Settings {
     }
 
     /// Serializes the thread-local [Settings] into a toml string.
+    ///
+    /// Use `toml::to_string(&settings)` on a [`Settings`] instance instead.
     #[doc(hidden)]
+    #[deprecated(
+        note = "Use `toml::to_string(&settings)` on a `Settings` instance instead of reading from thread-local state."
+    )]
     pub fn to_toml() -> Result<String> {
         let settings = get_thread_local_settings();
         Ok(toml::to_string(&settings)?)
     }
 
     /// Serializes the thread-local [Settings] into a pretty (formatted) toml string.
+    ///
+    /// Use `toml::to_string_pretty(&settings)` on a [`Settings`] instance instead.
     #[doc(hidden)]
+    #[deprecated(
+        note = "Use `toml::to_string_pretty(&settings)` on a `Settings` instance instead of reading from thread-local state."
+    )]
     pub fn to_pretty_toml() -> Result<String> {
         let settings = get_thread_local_settings();
         Ok(toml::to_string_pretty(&settings)?)
     }
 
-    /// Returns the constructed signer from the `signer` field.
+    /// Returns the constructed signer from the thread-local `signer` settings field.
     ///
     /// If the signer settings aren't specified, this function will return [Error::MissingSignerSettings].
+    ///
+    /// Configure the signer via a [`Context`](crate::Context) passed explicitly to
+    /// [`Builder::from_context`](crate::Builder::from_context) instead.
     #[inline]
+    #[deprecated(
+        note = "Configure the signer via `Context` and pass it to `Builder::from_context` instead of using thread-local signer settings."
+    )]
     pub fn signer() -> Result<crate::BoxedSigner> {
         SignerSettings::signer()
     }
@@ -1015,86 +1049,30 @@ pub mod tests {
         std::fs::write(settings_path, settings_json.as_bytes()).map_err(Error::IoError)
     }
 
+    /// Legacy test: verifies the thread-local settings API reads defaults and round-trips values.
     #[test]
-    fn test_get_defaults() {
+    fn test_thread_local_settings() {
+        // Verify defaults are accessible via thread-local
         let settings = get_thread_local_settings();
-
         assert_eq!(settings.core, Core::default());
         assert_eq!(settings.trust, Trust::default());
-        assert_eq!(settings.cawg_trust, Trust::default());
         assert_eq!(settings.verify, Verify::default());
         assert_eq!(settings.builder, BuilderSettings::default());
 
-        reset_default_settings().unwrap();
-    }
-
-    #[test]
-    fn test_get_val_by_direct_path() {
-        // you can do this for all values but if these sanity checks pass they all should if the path is correct
+        // Verify individual values can be read by path
         assert_eq!(
             get_settings_value::<bool>("builder.thumbnail.enabled").unwrap(),
             BuilderSettings::default().thumbnail.enabled
         );
         assert_eq!(
-            get_settings_value::<Option<String>>("trust.user_anchors").unwrap(),
-            Trust::default().user_anchors
-        );
-
-        // test getting full objects
-        assert_eq!(get_settings_value::<Core>("core").unwrap(), Core::default());
-        assert_eq!(
-            get_settings_value::<Verify>("verify").unwrap(),
-            Verify::default()
-        );
-        assert_eq!(
-            get_settings_value::<BuilderSettings>("builder").unwrap(),
-            BuilderSettings::default()
-        );
-        assert_eq!(
-            get_settings_value::<Trust>("trust").unwrap(),
-            Trust::default()
-        );
-
-        // test implicit deserialization
-        let remote_manifest_fetch: bool =
-            get_settings_value("verify.remote_manifest_fetch").unwrap();
-        let auto_thumbnail: bool = get_settings_value("builder.thumbnail.enabled").unwrap();
-        let user_anchors: Option<String> = get_settings_value("trust.user_anchors").unwrap();
-
-        assert_eq!(
-            remote_manifest_fetch,
+            get_settings_value::<bool>("verify.remote_manifest_fetch").unwrap(),
             Verify::default().remote_manifest_fetch
         );
-        assert_eq!(auto_thumbnail, BuilderSettings::default().thumbnail.enabled);
-        assert_eq!(user_anchors, Trust::default().user_anchors);
 
-        // test implicit deserialization on objects
-        let core: Core = get_settings_value("core").unwrap();
-        let verify: Verify = get_settings_value("verify").unwrap();
-        let builder: BuilderSettings = get_settings_value("builder").unwrap();
-        let trust: Trust = get_settings_value("trust").unwrap();
-
-        assert_eq!(core, Core::default());
-        assert_eq!(verify, Verify::default());
-        assert_eq!(builder, BuilderSettings::default());
-        assert_eq!(trust, Trust::default());
-
-        reset_default_settings().unwrap();
-    }
-
-    #[test]
-    fn test_set_val_by_direct_path() {
-        let ts = include_bytes!("../../tests/fixtures/certs/trust/test_cert_root_bundle.pem");
-
-        // test updating values
+        // Verify set/get round-trip via thread-local API
         Settings::set_thread_local_value("core.merkle_tree_chunk_size_in_kb", 10).unwrap();
         Settings::set_thread_local_value("verify.remote_manifest_fetch", false).unwrap();
         Settings::set_thread_local_value("builder.thumbnail.enabled", false).unwrap();
-        Settings::set_thread_local_value(
-            "trust.user_anchors",
-            Some(String::from_utf8(ts.to_vec()).unwrap()),
-        )
-        .unwrap();
 
         assert_eq!(
             get_settings_value::<usize>("core.merkle_tree_chunk_size_in_kb").unwrap(),
@@ -1102,22 +1080,6 @@ pub mod tests {
         );
         assert!(!get_settings_value::<bool>("verify.remote_manifest_fetch").unwrap());
         assert!(!get_settings_value::<bool>("builder.thumbnail.enabled").unwrap());
-        assert_eq!(
-            get_settings_value::<Option<String>>("trust.user_anchors").unwrap(),
-            Some(String::from_utf8(ts.to_vec()).unwrap())
-        );
-
-        // the current config should be different from the defaults
-        assert_ne!(get_settings_value::<Core>("core").unwrap(), Core::default());
-        assert_ne!(
-            get_settings_value::<Verify>("verify").unwrap(),
-            Verify::default()
-        );
-        assert_ne!(
-            get_settings_value::<BuilderSettings>("builder").unwrap(),
-            BuilderSettings::default()
-        );
-        assert!(get_settings_value::<Trust>("trust").unwrap() == Trust::default());
 
         reset_default_settings().unwrap();
     }
@@ -1130,74 +1092,21 @@ pub mod tests {
 
         save_settings_as_json(&op).unwrap();
 
-        Settings::from_file(&op).unwrap();
-        let settings = get_thread_local_settings();
-
+        let settings = Settings::new().with_file(&op).unwrap();
         assert_eq!(settings, Settings::default());
-
-        reset_default_settings().unwrap();
-    }
-
-    #[cfg(feature = "file_io")]
-    #[test]
-    fn test_save_load_from_string() {
-        let temp_dir = tempdirectory().unwrap();
-        let op = crate::utils::test::temp_dir_path(&temp_dir, "sdk_config.json");
-
-        save_settings_as_json(&op).unwrap();
-
-        let setting_buf = std::fs::read(&op).unwrap();
-
-        {
-            let settings_str: &str = &String::from_utf8_lossy(&setting_buf);
-            Settings::from_string(settings_str, "json").map(|_| ())
-        }
-        .unwrap();
-        let settings = get_thread_local_settings();
-
-        assert_eq!(settings, Settings::default());
-
-        reset_default_settings().unwrap();
     }
 
     #[test]
-    fn test_partial_loading() {
-        // we support just changing the fields you are interested in changing
-        // here is an example of incomplete structures only overriding specific
-        // fields
-
-        let modified_core = toml::toml! {
-            [core]
-            debug = true
-            hash_alg = "sha512"
-            max_memory_usage = 123456
-        }
-        .to_string();
-
-        Settings::from_toml(&modified_core).unwrap();
-
-        // see if updated values match
-        assert!(get_settings_value::<bool>("core.debug").unwrap());
-        assert_eq!(
-            get_settings_value::<String>("core.hash_alg").unwrap(),
-            "sha512".to_string()
-        );
-        assert_eq!(
-            get_settings_value::<u32>("core.max_memory_usage").unwrap(),
-            123456u32
-        );
-
-        // check a few defaults to make sure they are still there
-        assert_eq!(
-            get_settings_value::<bool>("builder.thumbnail.enabled").unwrap(),
-            BuilderSettings::default().thumbnail.enabled
-        );
-
-        reset_default_settings().unwrap();
+    fn test_settings_from_json_str() {
+        // Verify that Settings round-trips through JSON without touching thread-local state.
+        let json = serde_json::to_string(&Settings::default()).unwrap();
+        let settings = Settings::new().with_json(&json).unwrap();
+        assert_eq!(settings, Settings::default());
     }
 
     #[test]
     fn test_bad_setting() {
+        // Verify that type-invalid TOML values are rejected without touching thread-local state.
         let modified_core = toml::toml! {
             [core]
             merkle_tree_chunk_size_in_kb = true
@@ -1206,12 +1115,15 @@ pub mod tests {
         }
         .to_string();
 
-        assert!(Settings::from_toml(&modified_core).is_err());
-
-        reset_default_settings().unwrap();
+        assert!(Settings::new().with_toml(&modified_core).is_err());
     }
+
+    /// Legacy test: verifies arbitrary (hidden) keys can be stored and retrieved via the
+    /// thread-local Figment config. This is not possible with the instance-based API since
+    /// unknown keys are not part of the `Settings` struct.
     #[test]
-    fn test_hidden_setting() {
+    #[allow(deprecated)]
+    fn test_thread_local_hidden_setting() {
         let secret = toml::toml! {
             [hidden]
             test1 = true
@@ -1236,45 +1148,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_all_setting() {
-        let all_settings = toml::toml! {
-            version = 1
-
-            [trust]
-
-            [Core]
-            debug = false
-            hash_alg = "sha256"
-            salt_jumbf_boxes = true
-            prefer_bmff_merkle_tree = false
-            compress_manifests = true
-
-            [Builder]
-            prefer_box_hash = false
-
-            [Verify]
-            verify_after_reading = true
-            verify_after_sign = true
-            verify_trust = true
-            ocsp_fetch = false
-            remote_manifest_fetch = true
-            skip_ingredient_conflict_resolution = false
-            strict_v1_validation = false
-        }
-        .to_string();
-
-        Settings::from_toml(&all_settings).unwrap();
-
-        reset_default_settings().unwrap();
-    }
-
-    #[test]
     fn test_load_settings_from_sample_toml() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
-
         let toml = include_bytes!("../../examples/c2pa.toml");
-        Settings::from_toml(std::str::from_utf8(toml).unwrap()).unwrap();
+        Settings::new()
+            .with_toml(std::str::from_utf8(toml).unwrap())
+            .unwrap();
     }
 
     #[test]

--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -311,6 +311,7 @@ impl Signer for RemoteSigner {
 #[cfg(test)]
 pub mod tests {
     #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
 
     use crate::{settings::Settings, utils::test_signer, SigningAlg};
 
@@ -325,32 +326,34 @@ pub mod tests {
         })
     }
 
+    /// Legacy test verifying the deprecated thread-local signer API still works.
     #[test]
-    fn test_make_test_signer() {
-        // Makes a default test signer.
+    #[allow(deprecated)]
+    fn test_thread_local_signer() {
         assert!(Settings::signer().is_ok());
     }
 
     #[test]
     fn test_make_local_signer() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
-
-        // Testing with a different alg than the default test signer.
         let alg = SigningAlg::Ps384;
         let (sign_cert, private_key) = test_signer::cert_chain_and_private_key_for_alg(alg);
-        Settings::from_toml(
-            &toml::toml! {
-                [signer.local]
-                alg = (alg.to_string())
-                sign_cert = (String::from_utf8(sign_cert.to_vec()).unwrap())
-                private_key = (String::from_utf8(private_key.to_vec()).unwrap())
-            }
-            .to_string(),
-        )
-        .unwrap();
 
-        let signer = Settings::signer().unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [signer.local]
+                    alg = (alg.to_string())
+                    sign_cert = (String::from_utf8(sign_cert.to_vec()).unwrap())
+                    private_key = (String::from_utf8(private_key.to_vec()).unwrap())
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        // Test the settings signer path directly (context.signer() uses a custom test
+        // signer in test mode, so we test SignerSettings::c2pa_signer() directly here)
+        let signer_settings = settings.signer.expect("signer settings should be present");
+        let signer = signer_settings.c2pa_signer().unwrap();
         assert_eq!(signer.alg(), alg);
         assert_eq!(signer.time_authority_url(), None);
         assert!(signer.sign(&[1, 2, 3]).is_ok());
@@ -363,9 +366,6 @@ pub mod tests {
 
         use crate::create_signer;
 
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
-
         let alg = SigningAlg::Ps384;
         let (sign_cert, private_key) = test_signer::cert_chain_and_private_key_for_alg(alg);
 
@@ -375,18 +375,22 @@ pub mod tests {
         let server = MockServer::start();
         let mock = remote_signer_mock_server(&server, &signed_bytes);
 
-        Settings::from_toml(
-            &toml::toml! {
-                [signer.remote]
-                url = (server.base_url())
-                alg = (alg.to_string())
-                sign_cert = (String::from_utf8(sign_cert.to_vec()).unwrap())
-            }
-            .to_string(),
-        )
-        .unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [signer.remote]
+                    url = (server.base_url())
+                    alg = (alg.to_string())
+                    sign_cert = (String::from_utf8(sign_cert.to_vec()).unwrap())
+                }
+                .to_string(),
+            )
+            .unwrap();
 
-        let signer = Settings::signer().unwrap();
+        // Test the settings signer path directly (context.signer() uses a custom test
+        // signer in test mode, so we test SignerSettings::c2pa_signer() directly here)
+        let signer_settings = settings.signer.expect("signer settings should be present");
+        let signer = signer_settings.c2pa_signer().unwrap();
         assert_eq!(signer.alg(), alg);
         assert_eq!(signer.time_authority_url(), None);
         assert_eq!(signer.sign(&[1, 2, 3]).unwrap(), signed_bytes);

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -8321,7 +8321,9 @@ pub mod tests {
             .sign(&signer, "image/png", &mut Cursor::new(png), &mut dst)
             .unwrap();
 
-        let reader = crate::Reader::from_stream("image/png", &mut dst).unwrap();
+        let reader = crate::Reader::default()
+            .with_stream("image/png", &mut dst)
+            .unwrap();
 
         assert_eq!(reader.validation_state(), crate::ValidationState::Invalid);
     }

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -407,26 +407,21 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_bytes_from_stream() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    prefer_smallest_format = false
+                    ignore_errors = false
+                }
+                .to_string(),
+            )
+            .unwrap();
 
-        Settings::from_toml(
-            &toml::toml! {
-                [builder.thumbnail]
-                prefer_smallest_format = false
-                ignore_errors = false
-            }
-            .to_string(),
-        )
-        .unwrap();
-
-        let (format, bytes) = make_thumbnail_bytes_from_stream(
-            "image/jpeg",
-            Cursor::new(TEST_JPEG),
-            &Settings::default(),
-        )
-        .unwrap()
-        .unwrap();
+        let (format, bytes) =
+            make_thumbnail_bytes_from_stream("image/jpeg", Cursor::new(TEST_JPEG), &settings)
+                .unwrap()
+                .unwrap();
 
         assert!(matches!(format, ThumbnailFormat::Jpeg));
 
@@ -437,26 +432,21 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_with_prefer_smallest_format() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    prefer_smallest_format = true
+                    ignore_errors = false
+                }
+                .to_string(),
+            )
+            .unwrap();
 
-        Settings::from_toml(
-            &toml::toml! {
-                [builder.thumbnail]
-                prefer_smallest_format = true
-                ignore_errors = false
-            }
-            .to_string(),
-        )
-        .unwrap();
-
-        let (format, bytes) = make_thumbnail_bytes_from_stream(
-            "image/png",
-            Cursor::new(TEST_PNG),
-            &Settings::default(),
-        )
-        .unwrap()
-        .unwrap();
+        let (format, bytes) =
+            make_thumbnail_bytes_from_stream("image/png", Cursor::new(TEST_PNG), &settings)
+                .unwrap()
+                .unwrap();
 
         assert!(matches!(format, ThumbnailFormat::Jpeg));
 
@@ -504,24 +494,19 @@ pub mod tests {
 
     #[test]
     fn test_make_thumbnail_and_ignore_errors() {
-        #[cfg(target_os = "wasi")]
-        Settings::reset().unwrap();
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    ignore_errors = true
+                }
+                .to_string(),
+            )
+            .unwrap();
 
-        Settings::from_toml(
-            &toml::toml! {
-                [builder.thumbnail]
-                ignore_errors = true
-            }
-            .to_string(),
-        )
-        .unwrap();
-
-        let thumbnail = make_thumbnail_bytes_from_stream(
-            "image/png",
-            Cursor::new(Vec::new()),
-            &Settings::default(),
-        )
-        .unwrap();
+        let thumbnail =
+            make_thumbnail_bytes_from_stream("image/png", Cursor::new(Vec::new()), &settings)
+                .unwrap();
         assert!(thumbnail.is_none());
     }
 }

--- a/sdk/tests/common/mod.rs
+++ b/sdk/tests/common/mod.rs
@@ -20,12 +20,33 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use c2pa::{format_from_path, Reader, Result};
+use c2pa::{format_from_path, Context, Reader, Result, Settings};
 pub use compare_readers::compare_readers;
 #[allow(unused)] // different code path for WASI
 use tempfile::{tempdir, TempDir};
 #[allow(unused)]
 pub use test_signer::test_signer;
+
+/// Returns a [`Settings`] instance loaded from the standard test fixture TOML.
+///
+/// Use this instead of `Settings::new().with_toml(include_str!(...))` in test code.
+#[allow(unused, clippy::expect_used)]
+pub fn test_settings() -> Settings {
+    Settings::new()
+        .with_toml(include_str!("../fixtures/test_settings.toml"))
+        .expect("built-in test_settings.toml should be valid")
+}
+
+/// Returns a [`Context`] configured with the standard test settings.
+///
+/// Use this instead of manually constructing `Settings` + `Context` in test code.
+/// Call `.into_shared()` on the result if you need an `Arc<Context>`.
+#[allow(unused, clippy::expect_used)]
+pub fn test_context() -> Context {
+    Context::new()
+        .with_settings(test_settings())
+        .expect("test_settings should always be valid")
+}
 
 #[allow(unused_macros)]
 macro_rules! assert_err {
@@ -50,7 +71,7 @@ pub fn known_good_path<P: AsRef<Path>>(file_name: P) -> std::path::PathBuf {
 /// get a file from path without requiring file_io feature enabled in the c2pa crate
 pub fn reader_from_file<P: AsRef<Path>>(path: P) -> Result<Reader> {
     let format = format_from_path(&path).ok_or(c2pa::Error::UnsupportedType)?;
-    Reader::from_stream(&format, &mut fs::File::open(&path)?)
+    Reader::default().with_stream(&format, &mut fs::File::open(&path)?)
 }
 
 #[allow(unused)]
@@ -85,7 +106,7 @@ pub fn compare_stream_to_known_good<P: AsRef<Path>, S: Read + Seek + Send>(
 ) -> Result<()> {
     let known = read_known_good(&known_file)?;
     let reader1 = Reader::from_json(&known)?;
-    let reader2 = Reader::from_stream(format, stream)?;
+    let reader2 = Reader::default().with_stream(format, stream)?;
     let result = compare_readers(&reader1, &reader2)?;
     assert!(result.is_empty(), "{}", result.join("\n"));
     Ok(())

--- a/sdk/tests/crjson/asset_hash.rs
+++ b/sdk/tests/crjson/asset_hash.rs
@@ -22,7 +22,7 @@ const IMAGE_WITH_MANIFEST: &[u8] = include_bytes!("../fixtures/CA.jpg");
 
 #[test]
 fn test_cr_json_omits_asset_info_content_metadata() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
 
     let json_value = reader.to_crjson_value()?;
 
@@ -50,7 +50,7 @@ fn test_cr_json_omits_asset_info_content_metadata() -> Result<()> {
 #[test]
 #[cfg(feature = "file_io")]
 fn test_cr_json_from_file_omits_asset_info_content_metadata() -> Result<()> {
-    let reader = Reader::from_file("tests/fixtures/CA.jpg")?;
+    let reader = Reader::default().with_file("tests/fixtures/CA.jpg")?;
 
     let json_value = reader.to_crjson_value()?;
 

--- a/sdk/tests/crjson/created_gathered.rs
+++ b/sdk/tests/crjson/created_gathered.rs
@@ -15,17 +15,17 @@
 
 use std::io::Cursor;
 
-use c2pa::{Builder, Context, Reader, Result, Settings};
+use c2pa::{Builder, Reader, Result};
+
+use super::super::common::test_context;
 
 const TEST_IMAGE: &[u8] = include_bytes!("../fixtures/CA.jpg");
-const TEST_SETTINGS: &str = include_str!("../fixtures/test_settings.toml");
 
 #[test]
 fn test_created_and_gathered_assertions_separated() -> Result<()> {
     use serde_json::json;
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let format = "image/jpeg";
     let mut source = Cursor::new(TEST_IMAGE);
@@ -62,7 +62,7 @@ fn test_created_and_gathered_assertions_separated() -> Result<()> {
 
     // Now read it with Reader
     dest.set_position(0);
-    let reader = Reader::from_stream(format, dest)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, dest)?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array
@@ -179,8 +179,7 @@ fn test_created_and_gathered_assertions_separated() -> Result<()> {
 fn test_hash_assertions_in_created() -> Result<()> {
     use serde_json::json;
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let format = "image/jpeg";
     let mut source = Cursor::new(TEST_IMAGE);
@@ -206,7 +205,7 @@ fn test_hash_assertions_in_created() -> Result<()> {
 
     // Now read it with Reader
     dest.set_position(0);
-    let reader = Reader::from_stream(format, dest)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, dest)?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array

--- a/sdk/tests/crjson/hash_assertions.rs
+++ b/sdk/tests/crjson/hash_assertions.rs
@@ -19,7 +19,7 @@ const IMAGE_WITH_MANIFEST: &[u8] = include_bytes!("../fixtures/C.jpg");
 
 /// Load a fixture and return the crJSON value for the first manifest's assertions object.
 fn first_assertions() -> Result<serde_json::Value> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json = reader.to_crjson_value()?;
     let manifest = json["manifests"][0].clone();
     Ok(manifest["assertions"].clone())
@@ -82,7 +82,8 @@ fn test_hash_data_not_filtered() -> Result<()> {
     );
 
     // Confirm it is absent from the standard Manifest JSON format.
-    let standard_reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let standard_reader =
+        Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let standard_json = serde_json::to_value(standard_reader)?;
     let standard_assertions = standard_json["manifests"]
         .as_object()

--- a/sdk/tests/crjson/ingredients.rs
+++ b/sdk/tests/crjson/ingredients.rs
@@ -21,7 +21,7 @@ const IMAGE_WITH_INGREDIENT: &[u8] = include_bytes!("../fixtures/CA.jpg");
 
 #[test]
 fn test_ingredient_assertions_included() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array
@@ -82,7 +82,7 @@ fn test_ingredient_assertions_included() -> Result<()> {
 
 #[test]
 fn test_ingredient_count_matches() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array
@@ -114,7 +114,7 @@ fn test_ingredient_count_matches() -> Result<()> {
 
 #[test]
 fn test_ingredient_referenced_in_claim() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array
@@ -203,7 +203,7 @@ fn test_ingredient_referenced_in_claim() -> Result<()> {
 
 #[test]
 fn test_ingredient_in_actions_parameter() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     // Get manifests array
@@ -247,7 +247,7 @@ fn test_multiple_ingredients_have_instances() -> Result<()> {
     // For files with multiple ingredients, they would be labeled:
     // c2pa.ingredient__1, c2pa.ingredient__2, etc.
 
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     let manifests = json_value["manifests"]
@@ -278,7 +278,7 @@ fn test_multiple_ingredients_have_instances() -> Result<()> {
 
 #[test]
 fn test_ingredient_label_matches_version() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     let manifests = json_value["manifests"]

--- a/sdk/tests/crjson/schema_compliance.rs
+++ b/sdk/tests/crjson/schema_compliance.rs
@@ -77,7 +77,7 @@ fn assert_schema_valid(value: &serde_json::Value) {
 /// The full crJSON output must pass JSON Schema validation.
 #[test]
 fn test_crjson_passes_schema_validation() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
     maybe_write_crjson_output(
         "CA.jpg.json",
@@ -90,7 +90,7 @@ fn test_crjson_passes_schema_validation() -> Result<()> {
 /// Root document must have exactly the required top-level fields.
 #[test]
 fn test_root_required_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     assert!(json_value.get("@context").is_some(), "@context is required");
@@ -127,7 +127,7 @@ fn test_root_required_fields() -> Result<()> {
 /// `jsonGenerator` must have `name` and `version` (SemVer) but not `date`.
 #[test]
 fn test_json_generator_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     let jg = json_value
@@ -157,7 +157,7 @@ fn test_json_generator_fields() -> Result<()> {
 /// `manifests` must be an array; active manifest must be first.
 #[test]
 fn test_manifests_is_array_active_first() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     let manifests = json_value["manifests"]
@@ -170,7 +170,7 @@ fn test_manifests_is_array_active_first() -> Result<()> {
 /// Every manifest must have the required fields and exactly one of `claim` / `claim.v2`.
 #[test]
 fn test_manifest_required_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -229,7 +229,7 @@ fn test_manifest_required_fields() -> Result<()> {
 /// Assertion keys must use `__N` double-underscore instance notation (not `_N`).
 #[test]
 fn test_assertion_instance_labeling() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -251,7 +251,7 @@ fn test_assertion_instance_labeling() -> Result<()> {
 /// Binary assertions (thumbnails, embedded data) must use the reference object form.
 #[test]
 fn test_binary_assertions_use_ref_format() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -282,7 +282,7 @@ fn test_binary_assertions_use_ref_format() -> Result<()> {
 /// Hash fields in assertions must be base64 strings, not integer arrays.
 #[test]
 fn test_hash_fields_are_base64_strings() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     fn check_no_byte_array_hashes(value: &serde_json::Value, path: &str) {
@@ -344,7 +344,7 @@ fn test_hash_fields_are_base64_strings() -> Result<()> {
 /// signature, assertions (array of hashedUriMap), dc:format, instanceID.
 #[test]
 fn test_claim_v1_required_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -403,7 +403,7 @@ fn test_claim_v1_required_fields() -> Result<()> {
 /// signature, created_assertions (array of hashedUriMap).
 #[test]
 fn test_claim_v2_required_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -467,7 +467,7 @@ fn test_claim_v2_required_fields() -> Result<()> {
 /// An empty object `{}` is permitted when signature data is unavailable.
 #[test]
 fn test_signature_structure() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -531,7 +531,7 @@ fn test_signature_structure() -> Result<()> {
 /// a `specVersion` of "2.3", and a required `validationTime` RFC 3339 string.
 #[test]
 fn test_validation_results_structure() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {
@@ -582,7 +582,7 @@ fn test_validation_results_structure() -> Result<()> {
 /// `validationResults` must NOT contain unknown fields (negative test).
 #[test]
 fn test_validation_results_no_extra_fields() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let json_value = reader.to_crjson_value()?;
 
     let allowed = [
@@ -610,7 +610,7 @@ fn test_validation_results_no_extra_fields() -> Result<()> {
 /// `specVersion` must not be absent or set to a wrong value (negative test).
 #[test]
 fn test_validation_results_spec_version_wrong_value() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;
     let mut json_value = reader.to_crjson_value()?;
 
     // Mutate the first manifest's specVersion to something wrong and verify our
@@ -638,7 +638,7 @@ fn test_validation_results_spec_version_wrong_value() -> Result<()> {
 /// Ingredient assertions must use Dublin Core field names (`dc:title`, `dc:format`).
 #[test]
 fn test_ingredient_uses_dc_field_names() -> Result<()> {
-    let reader = Reader::from_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
+    let reader = Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT))?;
     let json_value = reader.to_crjson_value()?;
 
     for manifest in json_value["manifests"].as_array().unwrap() {

--- a/sdk/tests/crjson_tests.rs
+++ b/sdk/tests/crjson_tests.rs
@@ -14,4 +14,5 @@
 //! CrJSON integration tests.
 //! Tests are organized in the crjson/ subfolder.
 
+mod common;
 mod crjson;

--- a/sdk/tests/integration.rs
+++ b/sdk/tests/integration.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+mod common;
+
 /// Complete functional integration test with parent and ingredients.
 // Isolate from wasm by wrapping in module.
 #[cfg(feature = "file_io")]
@@ -24,6 +26,8 @@ mod integration_1 {
     use c2pa_macros::c2pa_test_async;
     #[allow(unused)] // different code path for WASI
     use tempfile::{tempdir, TempDir};
+
+    use super::common::test_context;
 
     /// Returns the path to a fixture file.
     fn fixture_path(file_name: &str) -> PathBuf {
@@ -50,9 +54,7 @@ mod integration_1 {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_embed_manifest() -> Result<()> {
-        let settings =
-            Settings::new().with_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
-        let context = Context::new().with_settings(settings)?.into_shared();
+        let context = test_context().into_shared();
 
         // set up parent and destination paths
         let temp_dir = tempdirectory()?;
@@ -97,6 +99,7 @@ mod integration_1 {
         );
 
         // add an ingredient
+        #[allow(deprecated)]
         let ingredient = Ingredient::from_file(&ingredient_path)?;
 
         // add an action assertion stating that we imported this file
@@ -133,7 +136,7 @@ mod integration_1 {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_embed_json_manifest() -> Result<()> {
-        Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+        let context = test_context().into_shared();
 
         // set up parent and destination paths
         let temp_dir = tempdirectory()?;
@@ -144,15 +147,15 @@ mod integration_1 {
 
         let json = std::fs::read_to_string(manifest_path)?;
 
-        let mut builder = Builder::from_json(&json)?;
+        let mut builder = Builder::from_shared_context(&context).with_definition(&json)?;
         builder.set_base_path(fixture_path(""));
 
         // sign and embed into the target file
-        let signer = Settings::signer()?;
-        builder.sign_file(signer.as_ref(), &parent_path, &output_path)?;
+        let signer = context.signer()?;
+        builder.sign_file(signer, &parent_path, &output_path)?;
 
         // read our new file with embedded manifest
-        let reader = Reader::from_file(&output_path)?;
+        let reader = Reader::from_shared_context(&context).with_file(&output_path)?;
 
         println!("{reader}");
         // std::fs::copy(&output_path, "test_file.jpg")?; // for debugging to get copy of the file
@@ -170,9 +173,7 @@ mod integration_1 {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_embed_bmff_manifest() -> Result<()> {
-        let settings =
-            Settings::new().with_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
-        let context = Context::new().with_settings(settings)?.into_shared();
+        let context = test_context().into_shared();
 
         // set up parent and destination paths
         let temp_dir = tempdirectory()?;
@@ -207,9 +208,7 @@ mod integration_1 {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_asset_reference_assertion() -> Result<()> {
-        let settings =
-            Settings::new().with_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
-        let context = Context::new().with_settings(settings)?.into_shared();
+        let context = test_context().into_shared();
 
         // set up parent and destination paths
         let temp_dir = tempdirectory()?;
@@ -234,7 +233,7 @@ mod integration_1 {
         builder.sign_file(signer, &parent_path, &output_path)?;
 
         // read our new file with embedded manifest
-        let reader = Reader::from_file(&output_path)?;
+        let reader = Reader::from_shared_context(&context).with_file(&output_path)?;
 
         println!("{reader}");
 
@@ -253,9 +252,7 @@ mod integration_1 {
     #[test]
     #[cfg(feature = "file_io")]
     fn test_metadata_assertion() -> Result<()> {
-        let settings =
-            Settings::new().with_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
-        let context = Context::new().with_settings(settings)?.into_shared();
+        let context = test_context().into_shared();
 
         // set up parent and destination paths
         let temp_dir = tempdirectory()?;

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -760,8 +760,7 @@ fn test_ingredient_arbitrary_metadata_fields() -> Result<()> {
 
 #[test]
 fn test_builder_unsupported_format() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = Context::new().with_settings(test_settings())?.into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
@@ -787,8 +786,7 @@ fn test_builder_unsupported_format() -> Result<()> {
 
 #[test]
 fn test_builder_unsupported_format_no_embed_required() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = Context::new().with_settings(test_settings())?.into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
@@ -809,8 +807,7 @@ fn test_builder_unsupported_format_no_embed_required() -> Result<()> {
 
 #[test]
 fn test_builder_unsupported_format_remote_url_rejected() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = Context::new().with_settings(test_settings())?.into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -23,15 +23,12 @@ use c2pa::{
 mod common;
 #[cfg(all(feature = "add_thumbnails", feature = "file_io"))]
 use common::compare_stream_to_known_good;
-use common::test_signer;
-
-const TEST_SETTINGS: &str = include_str!("../tests/fixtures/test_settings.toml");
+use common::{test_context, test_settings, test_signer};
 
 #[test]
 #[cfg(all(feature = "add_thumbnails", feature = "file_io"))]
 fn test_builder_ca_jpg() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
     let format = "image/jpeg";
@@ -70,8 +67,7 @@ fn test_builder_ca_jpg() -> Result<()> {
 // Source: https://github.com/contentauth/c2pa-rs/issues/530
 #[test]
 fn test_builder_riff() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
     let mut source = Cursor::new(include_bytes!("fixtures/sample1.wav"));
     let format = "audio/wav";
 
@@ -90,8 +86,7 @@ fn test_builder_riff() -> Result<()> {
 // Source: https://github.com/contentauth/c2pa-rs/issues/1554
 #[test]
 fn test_builder_cyclic_ingredient() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let mut source = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
     let format = "image/jpeg";
@@ -121,11 +116,13 @@ fn test_builder_cyclic_ingredient() -> Result<()> {
     dest.rewind()?;
     ingredient.rewind()?;
 
-    let active_manifest_uri = Reader::from_stream(format, &mut dest)?
+    let active_manifest_uri = Reader::default()
+        .with_stream(format, &mut dest)?
         .active_label()
         .unwrap()
         .to_owned();
-    let ingredient_uri = Reader::from_stream(format, ingredient)?
+    let ingredient_uri = Reader::default()
+        .with_stream(format, ingredient)?
         .active_label()
         .unwrap()
         .to_owned();
@@ -151,7 +148,7 @@ fn test_builder_cyclic_ingredient() -> Result<()> {
     // Attempt to read the manifest with a cyclical ingredient.
     let mut cyclic_ingredient = Cursor::new(bytes);
     assert!(matches!(
-        Reader::from_stream(format, &mut cyclic_ingredient),
+        Reader::default().with_stream(format, &mut cyclic_ingredient),
         Err(Error::CyclicIngredients { .. })
     ));
 
@@ -175,8 +172,7 @@ fn test_builder_cyclic_ingredient() -> Result<()> {
 
 #[test]
 fn test_builder_sidecar_only() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
     let mut source = Cursor::new(include_bytes!("fixtures/earth_apollo17.jpg"));
     let format = "image/jpeg";
 
@@ -185,7 +181,8 @@ fn test_builder_sidecar_only() -> Result<()> {
     builder.set_no_embed(true);
     let c2pa_data = builder.sign(context.signer()?, format, &mut source, &mut io::empty())?;
 
-    let reader1 = Reader::from_manifest_data_and_stream(&c2pa_data, format, &mut source)?;
+    let reader1 =
+        Reader::default().with_manifest_data_and_stream(&c2pa_data, format, &mut source)?;
     println!("reader1: {reader1}");
 
     let builder2: Builder = reader1.try_into()?;
@@ -203,8 +200,7 @@ fn test_builder_sidecar_only() -> Result<()> {
 #[ignore = "generates a hash error, needs investigation"]
 fn test_builder_fragmented() -> Result<()> {
     use common::tempdirectory;
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
@@ -236,7 +232,7 @@ fn test_builder_fragmented() -> Result<()> {
 
                 builder
                     .sign_fragmented_files(
-                        &Settings::signer()?,
+                        context.signer()?,
                         p.as_path(),
                         &fragments,
                         new_output_path.as_path(),
@@ -249,7 +245,8 @@ fn test_builder_fragmented() -> Result<()> {
                     .into_iter()
                     .map(|f| new_output_path.join(f.file_name().unwrap()))
                     .collect();
-                let reader = Reader::from_fragmented_files(&output_init, &output_fragments)?;
+                let reader = Reader::from_shared_context(&context)
+                    .with_fragmented_files(&output_init, &output_fragments)?;
                 //println!("reader: {}", reader);
                 assert_eq!(reader.validation_status(), None);
 
@@ -267,7 +264,7 @@ fn test_builder_fragmented() -> Result<()> {
 
 #[test]
 fn test_builder_remote_url_no_embed() -> Result<()> {
-    let mut settings = Settings::new().with_toml(TEST_SETTINGS)?;
+    let mut settings = test_settings();
     // disable remote fetching for this test
     settings = settings.with_value("verify.remote_manifest_fetch", false)?;
     let context = Context::new().with_settings(settings)?.into_shared();
@@ -299,8 +296,7 @@ fn test_builder_remote_url_no_embed() -> Result<()> {
 
 #[test]
 fn test_builder_embedded_v1_otgp() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let mut source = Cursor::new(include_bytes!("fixtures/XCA.jpg"));
     let format = "image/jpeg";
@@ -419,8 +415,7 @@ fn test_dynamic_assertions_builder() -> Result<()> {
         }
     }
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     //let manifest_def = std::fs::read_to_string(fixtures_path("simple_manifest.json"))?;
     let mut builder = Builder::from_shared_context(&context);
@@ -452,8 +447,7 @@ fn test_dynamic_assertions_builder() -> Result<()> {
 fn test_assertion_created_field() -> Result<()> {
     use serde_json::json;
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
     let format = "image/jpeg";
@@ -544,8 +538,7 @@ fn test_assertion_created_field() -> Result<()> {
 
 #[test]
 fn test_metadata_formats_json_manifest() -> Result<()> {
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let manifest_json = r#"
     {
@@ -621,9 +614,7 @@ fn test_metadata_formats_json_manifest() -> Result<()> {
 /// Test that path traversal attempts in archive resources are blocked
 #[test]
 fn test_archive_path_traversal_protection() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
-
-    let mut builder = Builder::new();
+    let mut builder = Builder::default();
     builder.set_intent(BuilderIntent::Edit);
 
     // Try to add a resource with a path traversal attempt
@@ -672,8 +663,7 @@ fn test_archive_path_traversal_protection() -> Result<()> {
 fn test_ingredient_arbitrary_metadata_fields() -> Result<()> {
     use serde_json::json;
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     // Create an ingredient with custom metadata fields
     let manifest_json = json!({

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -15,9 +15,11 @@ use std::io::{self, Cursor, Seek};
 
 #[cfg(not(target_arch = "wasm32"))]
 use c2pa::identity::validator::CawgValidator;
+#[cfg(not(target_arch = "wasm32"))]
+use c2pa::Settings;
 use c2pa::{
     validation_status, Builder, BuilderIntent, Context, Error, ManifestAssertionKind, Reader,
-    Result, Settings, ValidationState,
+    Result, ValidationState,
 };
 
 mod common;

--- a/sdk/tests/test_failures.rs
+++ b/sdk/tests/test_failures.rs
@@ -2,15 +2,15 @@ mod common;
 use std::io::Cursor;
 
 use c2pa::{
-    assertions::DataHash, settings::Settings, validation_status, Builder, BuilderIntent, Error,
-    HashRange, Reader, Result,
+    assertions::DataHash, validation_status, Builder, BuilderIntent, Error, HashRange, Reader,
+    Result,
 };
-use common::fixture_stream;
+use common::{fixture_stream, test_context};
 
 #[test]
 fn test_reader_ts_changed() -> Result<()> {
     let (format, mut stream) = fixture_stream("CA_ct.jpg")?;
-    let reader = Reader::from_stream(&format, &mut stream).unwrap();
+    let reader = Reader::default().with_stream(&format, &mut stream).unwrap();
     // in the older validation statuses, this was an error, but now it is informational
     assert_eq!(
         reader
@@ -28,13 +28,13 @@ fn test_reader_ts_changed() -> Result<()> {
 
 #[test]
 fn test_bad_data_hash() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context().into_shared();
 
     const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
     let format = "image/jpeg";
     let mut source = Cursor::new(TEST_IMAGE);
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
 
     use c2pa::assertions::Action;
@@ -65,7 +65,7 @@ fn test_bad_data_hash() -> Result<()> {
 
     let mut dest = Cursor::new(Vec::new());
 
-    let result = builder.sign(&Settings::signer()?, format, &mut source, &mut dest);
+    let result = builder.sign(context.signer()?, format, &mut source, &mut dest);
     assert!(matches!(result, Err(Error::HashMismatch(..))));
 
     Ok(())

--- a/sdk/tests/test_nested_ingredients_de_serialization.rs
+++ b/sdk/tests/test_nested_ingredients_de_serialization.rs
@@ -6,10 +6,13 @@
 
 use std::io::{Cursor, Seek};
 
-use c2pa::{
-    assertions::DigitalSourceType, settings::Settings, Builder, BuilderIntent, Ingredient, Reader,
-    Result,
-};
+use c2pa::{assertions::DigitalSourceType, Builder, BuilderIntent, Reader, Result, Signer};
+
+mod common;
+
+fn test_context() -> std::sync::Arc<c2pa::Context> {
+    common::test_context().into_shared()
+}
 
 /// Test that nested ingredients are properly reconstructed from a manifest store
 /// when undergoing multiple serialize-deserialize cycles.
@@ -20,17 +23,17 @@ use c2pa::{
 /// - Second edit with first edit as ingredient (level 2, so with nested ingredient)
 #[test]
 fn test_nested_ingredients_reconstruction_from_store() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
 
     let format = "image/jpeg";
     let mut base_image = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
 
     // Top level of nesting
     let mut level1_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level1_output,
@@ -40,10 +43,10 @@ fn test_nested_ingredients_reconstruction_from_store() -> Result<()> {
     // When using Edit intent, the source automatically becomes the parent ingredient
     level1_output.rewind()?;
     let mut level2_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut level1_output,
         &mut level2_output,
@@ -53,10 +56,10 @@ fn test_nested_ingredients_reconstruction_from_store() -> Result<()> {
     // When using Edit intent, the source automatically becomes the parent ingredient
     level2_output.rewind()?;
     let mut level3_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut level2_output,
         &mut level3_output,
@@ -64,7 +67,7 @@ fn test_nested_ingredients_reconstruction_from_store() -> Result<()> {
 
     // Now read the level 3 output and verify nested ingredients are properly reconstructed
     level3_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut level3_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut level3_output)?;
 
     // Verify we have an active manifest
     let active_manifest = reader
@@ -115,17 +118,17 @@ fn test_nested_ingredients_reconstruction_from_store() -> Result<()> {
 /// Test that converting a Reader to Builder preserves nested ingredients.
 #[test]
 fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
 
     let format = "image/jpeg";
     let mut base_image = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
 
     // Create a 3-level ingredient hierarchy
     let mut level1_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level1_output,
@@ -134,7 +137,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
     base_image.rewind()?;
     level1_output.rewind()?;
     let mut level2_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.add_ingredient_from_stream(
         serde_json::json!({"title": "L1"}).to_string(),
@@ -142,7 +145,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
         &mut level1_output,
     )?;
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level2_output,
@@ -151,7 +154,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
     base_image.rewind()?;
     level2_output.rewind()?;
     let mut level3_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.add_ingredient_from_stream(
         serde_json::json!({"title": "L2"}).to_string(),
@@ -159,7 +162,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
         &mut level2_output,
     )?;
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level3_output,
@@ -167,7 +170,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
 
     // Read the level 3 output
     level3_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut level3_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut level3_output)?;
 
     // Convert Reader to Builder
     let mut builder_from_reader = reader.into_builder()?;
@@ -176,7 +179,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
     base_image.rewind()?;
     let mut level4_output = Cursor::new(Vec::new());
     builder_from_reader.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level4_output,
@@ -184,7 +187,7 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
 
     // Read the level 4 output and verify nested ingredients are preserved
     level4_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut level4_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut level4_output)?;
 
     let active_manifest = reader
         .active_manifest()
@@ -212,17 +215,17 @@ fn test_reader_to_builder_preserves_nested_ingredients() -> Result<()> {
 /// Test that ingredient manifest_data properly includes nested ingredients.
 #[test]
 fn test_ingredient_manifest_data_includes_nested_ingredients() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
 
     let format = "image/jpeg";
     let mut base_image = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
 
     // Create a 2-level hierarchy
     let mut level1_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level1_output,
@@ -231,7 +234,7 @@ fn test_ingredient_manifest_data_includes_nested_ingredients() -> Result<()> {
     base_image.rewind()?;
     level1_output.rewind()?;
     let mut level2_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.add_ingredient_from_stream(
         serde_json::json!({"title": "Test ingredient"}).to_string(),
@@ -239,7 +242,7 @@ fn test_ingredient_manifest_data_includes_nested_ingredients() -> Result<()> {
         &mut level1_output,
     )?;
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level2_output,
@@ -247,7 +250,7 @@ fn test_ingredient_manifest_data_includes_nested_ingredients() -> Result<()> {
 
     // Read and convert to Builder
     level2_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut level2_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut level2_output)?;
     let builder = reader.into_builder()?;
 
     // Verify the ingredient has manifest_data in its own resources too
@@ -275,17 +278,17 @@ fn test_ingredient_manifest_data_includes_nested_ingredients() -> Result<()> {
 /// Test that deeply nested ingredients are properly handled.
 #[test]
 fn test_deeply_nested_ingredients() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
 
     let format = "image/jpeg";
     let mut base_image = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
 
     // Create a deeper ingredient hierarchy (5 levels)
     let mut current_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut current_output,
@@ -296,25 +299,20 @@ fn test_deeply_nested_ingredients() -> Result<()> {
         base_image.rewind()?;
         current_output.rewind()?;
         let mut next_output = Cursor::new(Vec::new());
-        let mut builder = Builder::new();
+        let mut builder = Builder::from_shared_context(&context);
         builder.set_intent(BuilderIntent::Edit);
         builder.add_ingredient_from_stream(
             serde_json::json!({"title": format!("Level {}", level)}).to_string(),
             format,
             &mut current_output,
         )?;
-        builder.sign(
-            &Settings::signer()?,
-            format,
-            &mut base_image,
-            &mut next_output,
-        )?;
+        builder.sign(context.signer()?, format, &mut base_image, &mut next_output)?;
         current_output = next_output;
     }
 
     // Read the final output
     current_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut current_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut current_output)?;
 
     // Walk down the ingredient hierarchy and verify all levels are present
     let mut current_manifest = reader
@@ -351,17 +349,17 @@ fn test_deeply_nested_ingredients() -> Result<()> {
 /// Test that empty/missing nested ingredients don't cause crashes or issues.
 #[test]
 fn test_ingredient_without_nested_ingredients() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
 
     let format = "image/jpeg";
     let mut base_image = Cursor::new(include_bytes!("fixtures/no_manifest.jpg"));
 
     // Create a 2-level hierarchy (level 1 has no ingredients)
     let mut level1_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level1_output,
@@ -370,7 +368,7 @@ fn test_ingredient_without_nested_ingredients() -> Result<()> {
     base_image.rewind()?;
     level1_output.rewind()?;
     let mut level2_output = Cursor::new(Vec::new());
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Edit);
     builder.add_ingredient_from_stream(
         serde_json::json!({"title": "Simple ingredient"}).to_string(),
@@ -378,7 +376,7 @@ fn test_ingredient_without_nested_ingredients() -> Result<()> {
         &mut level1_output,
     )?;
     builder.sign(
-        &Settings::signer()?,
+        context.signer()?,
         format,
         &mut base_image,
         &mut level2_output,
@@ -386,7 +384,7 @@ fn test_ingredient_without_nested_ingredients() -> Result<()> {
 
     // Read and verify...
     level2_output.rewind()?;
-    let reader = Reader::from_stream(format, &mut level2_output)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut level2_output)?;
 
     let active_manifest = reader
         .active_manifest()
@@ -413,10 +411,11 @@ fn test_sign_manifest(
     builder: &mut Builder,
     format: &str,
     source: &mut Cursor<&[u8]>,
+    signer: &dyn Signer,
 ) -> Result<Cursor<Vec<u8>>> {
     let mut output = Cursor::new(Vec::new());
     source.rewind()?;
-    builder.sign(&Settings::signer()?, format, source, &mut output)?;
+    builder.sign(signer, format, source, &mut output)?;
     output.rewind()?;
     Ok(output)
 }
@@ -434,18 +433,19 @@ fn test_sign_manifest(
 /// because A appeared in both B's and C's ingredient trees.
 #[test]
 fn test_diamond_topology_read() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
+    let signer = context.signer()?;
 
     let format = "image/jpeg";
     let mut source = Cursor::new(include_bytes!("fixtures/no_manifest.jpg").as_slice());
 
     // A: base manifest
-    let mut builder_a = Builder::new();
+    let mut builder_a = Builder::from_shared_context(&context);
     builder_a.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
-    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source)?;
+    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source, signer)?;
 
     // B: has A as ingredient
-    let mut builder_b = Builder::new();
+    let mut builder_b = Builder::from_shared_context(&context);
     builder_b.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
     builder_b.add_ingredient_from_stream(
@@ -453,10 +453,10 @@ fn test_diamond_topology_read() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source)?;
+    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source, signer)?;
 
     // C: also has A as ingredient (independent of B)
-    let mut builder_c = Builder::new();
+    let mut builder_c = Builder::from_shared_context(&context);
     builder_c.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
     builder_c.add_ingredient_from_stream(
@@ -464,10 +464,10 @@ fn test_diamond_topology_read() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source)?;
+    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source, signer)?;
 
     // D: combines B and C (diamond — both share A as ancestor)
-    let mut builder_d = Builder::new();
+    let mut builder_d = Builder::from_shared_context(&context);
     builder_d.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_b.rewind()?;
     builder_d.add_ingredient_from_stream(
@@ -476,13 +476,15 @@ fn test_diamond_topology_read() -> Result<()> {
         &mut output_b,
     )?;
     output_c.rewind()?;
-    let mut ingredient_c = Ingredient::from_stream(format, &mut output_c)?;
-    ingredient_c.set_title("C");
-    builder_d.add_ingredient(ingredient_c);
-    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source)?;
+    builder_d.add_ingredient_from_stream(
+        serde_json::json!({"title": "C"}).to_string(),
+        format,
+        &mut output_c,
+    )?;
+    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source, signer)?;
 
     // Read D — this must complete without exponential memory growth
-    let reader = Reader::from_stream(format, &mut output_d)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut output_d)?;
 
     let active = reader
         .active_manifest()
@@ -519,19 +521,20 @@ fn test_diamond_topology_read() -> Result<()> {
 /// This verifies `build_ingredient_store` resolves both via the fallback chain.
 #[test]
 fn test_mixed_v2_v3_ingredient_versions() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
+    let signer = context.signer()?;
 
     let format = "image/jpeg";
     let mut source = Cursor::new(include_bytes!("fixtures/no_manifest.jpg").as_slice());
 
     // A: base manifest (v1 claim so it can be an ingredient of both v1 and v2 claims)
-    let mut builder_a = Builder::new();
+    let mut builder_a = Builder::from_shared_context(&context);
     builder_a.definition.claim_version = Some(1);
     builder_a.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
-    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source)?;
+    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source, signer)?;
 
     // B: claim_version=1 → v2 ingredient assertions (c2pa_manifest field)
-    let mut builder_b = Builder::new();
+    let mut builder_b = Builder::from_shared_context(&context);
     builder_b.definition.claim_version = Some(1);
     builder_b.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
@@ -540,10 +543,10 @@ fn test_mixed_v2_v3_ingredient_versions() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source)?;
+    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source, signer)?;
 
     // C: default claim_version (2) → v3 ingredient assertions (active_manifest field)
-    let mut builder_c = Builder::new();
+    let mut builder_c = Builder::from_shared_context(&context);
     builder_c.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
     builder_c.add_ingredient_from_stream(
@@ -551,10 +554,10 @@ fn test_mixed_v2_v3_ingredient_versions() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source)?;
+    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source, signer)?;
 
     // D: combines B (v2 ingredients) and C (v3 ingredients)
-    let mut builder_d = Builder::new();
+    let mut builder_d = Builder::from_shared_context(&context);
     builder_d.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_b.rewind()?;
     builder_d.add_ingredient_from_stream(
@@ -563,19 +566,21 @@ fn test_mixed_v2_v3_ingredient_versions() -> Result<()> {
         &mut output_b,
     )?;
     output_c.rewind()?;
-    let mut ingredient_c = Ingredient::from_stream(format, &mut output_c)?;
-    ingredient_c.set_title("C");
-    builder_d.add_ingredient(ingredient_c);
-    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source)?;
+    builder_d.add_ingredient_from_stream(
+        serde_json::json!({"title": "C"}).to_string(),
+        format,
+        &mut output_c,
+    )?;
+    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source, signer)?;
 
     // Read D, convert to builder (exercises build_ingredient_store), re-sign as E
-    let reader = Reader::from_stream(format, &mut output_d)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut output_d)?;
     let mut builder_e = reader.into_builder()?;
     builder_e.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
-    let mut output_e = test_sign_manifest(&mut builder_e, format, &mut source)?;
+    let mut output_e = test_sign_manifest(&mut builder_e, format, &mut source, signer)?;
 
     // Read E and verify structure is preserved despite mixed ingredient versions
-    let reader_e = Reader::from_stream(format, &mut output_e)?;
+    let reader_e = Reader::from_shared_context(&context).with_stream(format, &mut output_e)?;
     let active_e = reader_e
         .active_manifest()
         .expect("E should have active manifest");
@@ -608,17 +613,18 @@ fn test_mixed_v2_v3_ingredient_versions() -> Result<()> {
 /// to a Builder and re-signs to verify the round-trip preserves structure.
 #[test]
 fn test_diamond_topology_into_builder_round_trip() -> Result<()> {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml"))?;
+    let context = test_context();
+    let signer = context.signer()?;
 
     let format = "image/jpeg";
     let mut source = Cursor::new(include_bytes!("fixtures/no_manifest.jpg").as_slice());
 
     // Build diamond: A -> B, A -> C, B+C -> D
-    let mut builder_a = Builder::new();
+    let mut builder_a = Builder::from_shared_context(&context);
     builder_a.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
-    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source)?;
+    let mut output_a = test_sign_manifest(&mut builder_a, format, &mut source, signer)?;
 
-    let mut builder_b = Builder::new();
+    let mut builder_b = Builder::from_shared_context(&context);
     builder_b.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
     builder_b.add_ingredient_from_stream(
@@ -626,9 +632,9 @@ fn test_diamond_topology_into_builder_round_trip() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source)?;
+    let mut output_b = test_sign_manifest(&mut builder_b, format, &mut source, signer)?;
 
-    let mut builder_c = Builder::new();
+    let mut builder_c = Builder::from_shared_context(&context);
     builder_c.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_a.rewind()?;
     builder_c.add_ingredient_from_stream(
@@ -636,9 +642,9 @@ fn test_diamond_topology_into_builder_round_trip() -> Result<()> {
         format,
         &mut output_a,
     )?;
-    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source)?;
+    let mut output_c = test_sign_manifest(&mut builder_c, format, &mut source, signer)?;
 
-    let mut builder_d = Builder::new();
+    let mut builder_d = Builder::from_shared_context(&context);
     builder_d.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
     output_b.rewind()?;
     builder_d.add_ingredient_from_stream(
@@ -647,20 +653,22 @@ fn test_diamond_topology_into_builder_round_trip() -> Result<()> {
         &mut output_b,
     )?;
     output_c.rewind()?;
-    let mut ingredient_c = Ingredient::from_stream(format, &mut output_c)?;
-    ingredient_c.set_title("C");
-    builder_d.add_ingredient(ingredient_c);
-    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source)?;
+    builder_d.add_ingredient_from_stream(
+        serde_json::json!({"title": "C"}).to_string(),
+        format,
+        &mut output_c,
+    )?;
+    let mut output_d = test_sign_manifest(&mut builder_d, format, &mut source, signer)?;
 
     // Read D, convert to builder, re-sign as E
-    let reader = Reader::from_stream(format, &mut output_d)?;
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut output_d)?;
     let mut builder_e = reader.into_builder()?;
     // Prevent auto-capture of source as additional ingredient (test_settings has intent=edit)
     builder_e.set_intent(BuilderIntent::Create(DigitalSourceType::Empty));
-    let mut output_e = test_sign_manifest(&mut builder_e, format, &mut source)?;
+    let mut output_e = test_sign_manifest(&mut builder_e, format, &mut source, signer)?;
 
     // Read E and verify structure is preserved
-    let reader_e = Reader::from_stream(format, &mut output_e)?;
+    let reader_e = Reader::from_shared_context(&context).with_stream(format, &mut output_e)?;
     let active_e = reader_e
         .active_manifest()
         .expect("E should have active manifest");

--- a/sdk/tests/test_reader.rs
+++ b/sdk/tests/test_reader.rs
@@ -24,7 +24,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 #[cfg(feature = "file_io")]
 fn test_reader_not_found() -> Result<()> {
-    let result = Reader::from_file("not_found.png");
+    let result = Reader::default().with_file("not_found.png");
     assert_err!(result, Err(Error::IoError(_)));
     Ok(())
 }
@@ -32,7 +32,7 @@ fn test_reader_not_found() -> Result<()> {
 #[test]
 fn test_reader_no_jumbf() -> Result<()> {
     let (format, mut stream) = fixture_stream("sample1.png")?;
-    let result = Reader::from_stream(&format, &mut stream);
+    let result = Reader::default().with_stream(&format, &mut stream);
     assert_err!(result, Err(Error::JumbfNotFound));
     Ok(())
 }
@@ -40,14 +40,14 @@ fn test_reader_no_jumbf() -> Result<()> {
 #[test]
 fn test_reader_ca_jpg() -> Result<()> {
     let (format, mut stream) = fixture_stream("CA.jpg")?;
-    let reader = Reader::from_stream(&format, &mut stream)?;
+    let reader = Reader::default().with_stream(&format, &mut stream)?;
     compare_to_known_good(&reader, "CA.json")
 }
 
 #[test]
 fn test_reader_c_jpg() -> Result<()> {
     let (format, mut stream) = fixture_stream("C.jpg")?;
-    let reader = Reader::from_stream(&format, &mut stream)?;
+    let reader = Reader::default().with_stream(&format, &mut stream)?;
     compare_to_known_good(&reader, "C.json")
 }
 
@@ -82,11 +82,12 @@ fn test_reader_xca_jpg() -> Result<()> {
 #[cfg(feature = "fetch_remote_manifests")]
 #[c2pa_test_async]
 async fn test_reader_remote_url_async() -> Result<()> {
-    let reader = Reader::from_stream_async(
-        "image/jpeg",
-        std::io::Cursor::new(include_bytes!("./fixtures/cloud.jpg")),
-    )
-    .await?;
+    let reader = Reader::default()
+        .with_stream_async(
+            "image/jpeg",
+            std::io::Cursor::new(include_bytes!("./fixtures/cloud.jpg")),
+        )
+        .await?;
     let remote_url = reader.remote_url();
     assert_eq!(remote_url, Some("https://cai-manifests.adobe.com/manifests/adobe-urn-uuid-5f37e182-3687-462e-a7fb-573462780391"));
     assert!(!reader.is_embedded());

--- a/sdk/tests/timestamp_assertion.rs
+++ b/sdk/tests/timestamp_assertion.rs
@@ -15,11 +15,11 @@ use std::io::{Cursor, Seek};
 
 use c2pa::{
     assertions::{self, TimeStamp},
-    settings::Settings,
-    Builder, BuilderIntent, Reader, Result, Signer,
+    Builder, BuilderIntent, Context, Reader, Result, Signer,
 };
 
 mod common;
+use common::test_settings;
 
 const TEST_IMAGE: &[u8] = include_bytes!("fixtures/no_manifest.jpg");
 const FORMAT: &str = "image/jpeg";
@@ -53,11 +53,12 @@ impl Signer for WrappedTsaSigner {
 // as a timestamp assertion in the main manifest.
 #[test]
 fn timestamp_assertion_parent_scope() {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
+    let base_settings = test_settings();
+    let child_context = Context::new().with_settings(base_settings).unwrap();
 
     let mut child_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_context(child_context);
     builder
         .sign(
             &WrappedTsaSigner(Box::new(common::test_signer())),
@@ -67,22 +68,26 @@ fn timestamp_assertion_parent_scope() {
         )
         .unwrap();
 
-    Settings::from_toml(
-        &toml::toml! {
-            [builder.auto_timestamp_assertion]
-            enabled = true
-            skip_existing = false
-            fetch_scope = "parent"
-        }
-        .to_string(),
-    )
-    .unwrap();
+    let mut parent_settings = test_settings();
+    parent_settings
+        .update_from_str(
+            &toml::toml! {
+                [builder.auto_timestamp_assertion]
+                enabled = true
+                skip_existing = false
+                fetch_scope = "parent"
+            }
+            .to_string(),
+            "toml",
+        )
+        .unwrap();
 
     child_image.rewind().unwrap();
 
     let mut parent_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let parent_context = Context::new().with_settings(parent_settings).unwrap();
+    let mut builder = Builder::from_context(parent_context);
     builder.set_intent(BuilderIntent::Update);
     builder
         .sign(
@@ -95,7 +100,7 @@ fn timestamp_assertion_parent_scope() {
 
     parent_image.rewind().unwrap();
 
-    let reader = Reader::from_stream(FORMAT, parent_image).unwrap();
+    let reader = Reader::default().with_stream(FORMAT, parent_image).unwrap();
     let timestamp_assertion: TimeStamp = reader
         .active_manifest()
         .unwrap()
@@ -114,11 +119,12 @@ fn timestamp_assertion_parent_scope() {
 // as a timestamp assertion in the main manifest.
 #[test]
 fn timestamp_assertion_all_scope() {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
+    let base_settings = test_settings();
+    let child_context = Context::new().with_settings(base_settings).unwrap();
 
     let mut child_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_context(child_context);
     builder
         .sign(
             &WrappedTsaSigner(Box::new(common::test_signer())),
@@ -128,22 +134,26 @@ fn timestamp_assertion_all_scope() {
         )
         .unwrap();
 
-    Settings::from_toml(
-        &toml::toml! {
-            [builder.auto_timestamp_assertion]
-            enabled = true
-            skip_existing = false
-            fetch_scope = "all"
-        }
-        .to_string(),
-    )
-    .unwrap();
+    let mut parent_settings = test_settings();
+    parent_settings
+        .update_from_str(
+            &toml::toml! {
+                [builder.auto_timestamp_assertion]
+                enabled = true
+                skip_existing = false
+                fetch_scope = "all"
+            }
+            .to_string(),
+            "toml",
+        )
+        .unwrap();
 
     child_image.rewind().unwrap();
 
     let mut parent_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let parent_context = Context::new().with_settings(parent_settings).unwrap();
+    let mut builder = Builder::from_context(parent_context);
     builder.set_intent(BuilderIntent::Update);
     builder
         .sign(
@@ -156,7 +166,7 @@ fn timestamp_assertion_all_scope() {
 
     parent_image.rewind().unwrap();
 
-    let reader = Reader::from_stream(FORMAT, parent_image).unwrap();
+    let reader = Reader::default().with_stream(FORMAT, parent_image).unwrap();
     let timestamp_assertion: TimeStamp = reader
         .active_manifest()
         .unwrap()
@@ -179,11 +189,12 @@ fn timestamp_assertion_all_scope() {
 // as a timestamp assertion in the main manifest.
 #[test]
 fn timestamp_assertion_explicit_builder() {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
+    let settings = test_settings();
+    let context = Context::new().with_settings(settings).unwrap();
 
     let mut child_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_context(context);
     builder
         .sign(
             &WrappedTsaSigner(Box::new(common::test_signer())),
@@ -195,11 +206,13 @@ fn timestamp_assertion_explicit_builder() {
 
     let mut parent_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::default();
     builder.set_intent(BuilderIntent::Update);
 
     child_image.rewind().unwrap();
-    let reader = Reader::from_stream(FORMAT, &mut child_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(FORMAT, &mut child_image)
+        .unwrap();
     builder.add_timestamp(reader.active_label().unwrap());
     child_image.rewind().unwrap();
 
@@ -214,7 +227,7 @@ fn timestamp_assertion_explicit_builder() {
 
     parent_image.rewind().unwrap();
 
-    let reader = Reader::from_stream(FORMAT, parent_image).unwrap();
+    let reader = Reader::default().with_stream(FORMAT, parent_image).unwrap();
     let timestamp_assertion: TimeStamp = reader
         .active_manifest()
         .unwrap()
@@ -233,11 +246,12 @@ fn timestamp_assertion_explicit_builder() {
 // again and skip timestamping all existing timestamped manifests.
 #[test]
 fn timestamp_assertion_skip_existing() {
-    Settings::from_toml(include_str!("../tests/fixtures/test_settings.toml")).unwrap();
+    let settings = test_settings();
 
     let mut child_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder =
+        Builder::from_context(Context::new().with_settings(settings.clone()).unwrap());
     builder
         .sign(
             &WrappedTsaSigner(Box::new(common::test_signer())),
@@ -251,7 +265,7 @@ fn timestamp_assertion_skip_existing() {
 
     let mut parent_image = Cursor::new(Vec::new());
 
-    let mut builder = Builder::new();
+    let mut builder = Builder::default();
     builder.set_intent(BuilderIntent::Update);
     builder
         .sign(
@@ -262,23 +276,26 @@ fn timestamp_assertion_skip_existing() {
         )
         .unwrap();
 
-    Settings::from_toml(
-        &toml::toml! {
-            [builder.auto_timestamp_assertion]
-            enabled = true
-            skip_existing = true
-            fetch_scope = "all"
-        }
-        .to_string(),
-    )
-    .unwrap();
+    let mut skip_settings = settings;
+    skip_settings
+        .update_from_str(
+            &toml::toml! {
+                [builder.auto_timestamp_assertion]
+                enabled = true
+                skip_existing = true
+                fetch_scope = "all"
+            }
+            .to_string(),
+            "toml",
+        )
+        .unwrap();
 
     parent_image.rewind().unwrap();
 
     let mut parent_parent_image = Cursor::new(Vec::new());
 
     // Sign it one last time to ensure the original child manifest isn't timestamped again.
-    let mut builder = Builder::new();
+    let mut builder = Builder::from_context(Context::new().with_settings(skip_settings).unwrap());
     builder.set_intent(BuilderIntent::Update);
     builder
         .sign(
@@ -291,7 +308,9 @@ fn timestamp_assertion_skip_existing() {
 
     parent_parent_image.rewind().unwrap();
 
-    let reader = Reader::from_stream(FORMAT, parent_parent_image).unwrap();
+    let reader = Reader::default()
+        .with_stream(FORMAT, parent_parent_image)
+        .unwrap();
     let timestamp_assertion: TimeStamp = reader
         .active_manifest()
         .unwrap()

--- a/sdk/tests/v2_api_integration.rs
+++ b/sdk/tests/v2_api_integration.rs
@@ -11,16 +11,18 @@
 // specific language governing permissions and limitations under
 // each license.
 
+mod common;
+
 /// Complete functional integration test with acquisitions and ingredients.
 //  Isolate from wasm by wrapping in module.
 mod integration_v2 {
     use std::io::{Cursor, Seek};
 
     use anyhow::Result;
-    use c2pa::{
-        crypto::raw_signature::SigningAlg, settings::Settings, Builder, CallbackSigner, Reader,
-    };
+    use c2pa::{crypto::raw_signature::SigningAlg, Builder, CallbackSigner, Reader};
     use serde_json::json;
+
+    use super::common::test_context;
 
     const PARENT_JSON: &str = r#"
     {
@@ -155,9 +157,7 @@ mod integration_v2 {
 
         // don't try to verify on wasm since it doesn't support ed25519 yet
 
-        Settings::from_toml(include_str!("fixtures/test_settings.toml"))?;
-
-        let mut builder = Builder::from_json(&json)?;
+        let mut builder = Builder::from_context(test_context()).with_definition(&json)?;
         builder.add_ingredient_from_stream(PARENT_JSON, format, &mut source)?;
 
         // add a manifest thumbnail ( just reuse the image for now )
@@ -178,7 +178,7 @@ mod integration_v2 {
         let mut dest = {
             let ed_signer = |_context: *const _, data: &[u8]| ed_sign(data, PRIVATE_KEY);
             let signer = CallbackSigner::new(ed_signer, SigningAlg::Ed25519, CERTS);
-            let mut builder = Builder::from_archive(&mut zipped)?;
+            let mut builder = Builder::default().with_archive(&mut zipped)?;
             // sign the ManifestStoreBuilder and write it to the output stream
             let mut dest = Cursor::new(Vec::new());
             builder.sign(&signer, format, &mut source, &mut dest)?;
@@ -196,7 +196,7 @@ mod integration_v2 {
             dest.rewind()?;
         }
 
-        let reader = Reader::from_stream(format, &mut dest)?;
+        let reader = Reader::default().with_stream(format, &mut dest)?;
 
         // extract a thumbnail image from the ManifestStore
         let mut thumbnail = Cursor::new(Vec::new());

--- a/sdk/tests/v2_api_integration.rs
+++ b/sdk/tests/v2_api_integration.rs
@@ -196,7 +196,7 @@ mod integration_v2 {
             dest.rewind()?;
         }
 
-        let reader = Reader::default().with_stream(format, &mut dest)?;
+        let reader = Reader::from_context(test_context()).with_stream(format, &mut dest)?;
 
         // extract a thumbnail image from the ManifestStore
         let mut thumbnail = Cursor::new(Vec::new());


### PR DESCRIPTION
Deprecate thread-local settings APIs in favor of explicit Context
This PR deprecates the legacy thread-local configuration APIs across the SDK and C FFI, replacing them with context-aware equivalents that accept an explicit Context object. No breaking changes — all deprecated methods retain their original behavior.

What's deprecated

SDK:
Builder::new(), Builder::from_json(), Builder::from_archive() → Builder::default().with_*()
Reader::from_stream(), Reader::from_file(), Reader::from_manifest_data_and_stream() → Reader::default().with_*()
Settings::from_toml(), Settings::signer() → Settings::new().with_*()
All public Ingredient constructors (none are context-aware)

C FFI:
c2pa_load_settings, c2pa_reader_from_stream, c2pa_reader_from_manifest_data_and_stream, c2pa_builder_from_json, c2pa_builder_from_archive, c2pa_signer_from_settings
c2pa_read_file, c2pa_read_ingredient_file, c2pa_sign_file
Type-specific free functions (c2pa_reader_free, c2pa_builder_free, c2pa_string_free, etc.) → c2pa_free()

Key changes
Builder::default() and Reader::default() are now the idiomatic way to construct with a default context (replacing the wordy Builder::from_context(Context::new()))
Builder::sign() replaced with save_to_stream() in tests where the signer is already configured on the context
cbindgen.toml configured to propagate Rust #[deprecated] to C/C++ headers via portable deprecation macros
Added test_context() and test_settings() test helpers to reduce boilerplate across ~50 test files
Tests updated throughout: deprecated APIs restricted to #[allow(deprecated)] blocks in their declaring modules; all other tests use the new context-based patterns

