### PR TITLE
feat!: Store ClaimGeneratorInfo strings as Arc<str> for thread-shared identity

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -716,8 +716,8 @@ fn main() -> Result<()> {
         // add claim_tool generator so we know this was created using this tool
         let mut tool_generator = ClaimGeneratorInfo::new(env!("CARGO_PKG_NAME"));
         tool_generator.set_version(env!("CARGO_PKG_VERSION"));
-        if !manifest.claim_generator_info.is_empty()
-            || manifest.claim_generator_info[0].name == "c2pa-rs"
+        if manifest.claim_generator_info.is_empty()
+            || &*manifest.claim_generator_info[0].name == "c2pa-rs"
         {
             manifest.claim_generator_info = vec![tool_generator];
         } else {

--- a/sdk/benches/sign.rs
+++ b/sdk/benches/sign.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
-use c2pa::{Builder, CallbackSigner, SigningAlg};
-use criterion::{criterion_group, criterion_main, Criterion};
+use c2pa::{Builder, CallbackSigner, ClaimGeneratorInfo, SigningAlg};
+use criterion::{criterion_group, criterion_main, black_box, Criterion};
 
 const CERTS: &[u8] = include_bytes!("../tests/fixtures/certs/ed25519.pub");
 const PRIVATE_KEY: &[u8] = include_bytes!("../tests/fixtures/certs/ed25519.pem");
@@ -172,7 +172,42 @@ fn sign_wav(c: &mut Criterion) {
     });
 }
 
+fn claim_generator_info_clone(c: &mut Criterion) {
+    let mut info = ClaimGeneratorInfo::new("benchmark_generator");
+    info.set_version("1.0.0").set_operating_system("linux-x86_64");
+
+    c.bench_function("claim_generator_info clone", |b| {
+        b.iter(|| {
+            black_box(info.clone());
+        })
+    });
+}
+
+fn claim_generator_info_vec_clone(c: &mut Criterion) {
+    let mut info = ClaimGeneratorInfo::new("benchmark_generator");
+    info.set_version("1.0.0").set_operating_system("linux-x86_64");
+    let vec = vec![info, ClaimGeneratorInfo::default()];
+
+    c.bench_function("claim_generator_info vec<2> clone", |b| {
+        b.iter(|| {
+            black_box(vec.clone());
+        })
+    });
+}
+
+fn claim_generator_info_deserialize(c: &mut Criterion) {
+    let json = r#"{"name":"benchmark_generator","version":"1.0.0","operating_system":"linux-x86_64"}"#;
+
+    c.bench_function("claim_generator_info deserialize json", |b| {
+        b.iter(|| {
+            let info: ClaimGeneratorInfo =
+                serde_json::from_str(black_box(json)).expect("deserialize");
+            black_box(info);
+        })
+    });
+}
+
 criterion_group!(
-    benches, sign_jpeg, sign_png, sign_gif, sign_tiff, sign_svg, sign_mp3, sign_mp4, sign_wav
+    benches, sign_jpeg, sign_png, sign_gif, sign_tiff, sign_svg, sign_mp3, sign_mp4, sign_wav, claim_generator_info_clone, claim_generator_info_vec_clone, claim_generator_info_deserialize
 );
 criterion_main!(benches);

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -5286,8 +5286,8 @@ mod tests {
 
         // validate the claim_generator_info
         let cgi = m.claim_generator_info.as_ref().unwrap();
-        assert_eq!(cgi[0].name, "test");
-        assert_eq!(cgi[0].version.as_ref().unwrap(), "1.0");
+        assert_eq!(&*cgi[0].name, "test");
+        assert_eq!(cgi[0].version.as_deref(), Some("1.0"));
         match cgi[0].icon().unwrap() {
             crate::resource_store::UriOrResource::ResourceRef(resource) => {
                 assert_eq!(resource.format, "image/svg+xml");

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -4169,7 +4169,7 @@ pub mod tests {
         let mut claim = create_test_claim().expect("create test claim");
 
         let mut info = ClaimGeneratorInfo::new("test app");
-        info.version = Some("2.3.4".to_string());
+        info.set_version("2.3.4");
         info.icon = Some(UriOrResource::HashedUri(HashedUri::new(
             "self#jumbf=c2pa.databoxes.data_box".to_string(),
             None,
@@ -4181,7 +4181,7 @@ pub mod tests {
 
         let cgi = claim.claim_generator_info().unwrap();
 
-        assert_eq!(&cgi[0].name, "test app");
+        assert_eq!(&*cgi[0].name, "test app");
         assert_eq!(cgi[0].version.as_deref(), Some("2.3.4"));
         if let UriOrResource::HashedUri(r) = cgi[1].icon.as_ref().unwrap() {
             assert_eq!(r.hash(), b"hashed");

--- a/sdk/src/claim_generator_info.rs
+++ b/sdk/src/claim_generator_info.rs
@@ -11,7 +11,10 @@
 // specific language governing permissions and limitations under
 
 // each license.
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
 #[cfg(feature = "json_schema")]
 use schemars::JsonSchema;
@@ -20,37 +23,136 @@ use serde_json::Value;
 
 use crate::resource_store::UriOrResource;
 
+mod arc_str_serde {
+    use std::{fmt, sync::Arc};
+
+    use serde::{
+        de::{Deserializer, Error, Visitor},
+        Deserialize, Serializer,
+    };
+
+    pub(super) struct ArcStrVisitor;
+
+    impl<'de> Visitor<'de> for ArcStrVisitor {
+        type Value = Arc<str>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string")
+        }
+
+        fn visit_str<E: Error>(self, v: &str) -> Result<Arc<str>, E> {
+            Ok(Arc::from(v))
+        }
+
+        fn visit_borrowed_str<E: Error>(self, v: &'de str) -> Result<Arc<str>, E> {
+            Ok(Arc::from(v))
+        }
+
+        fn visit_string<E: Error>(self, v: String) -> Result<Arc<str>, E> {
+            Ok(Arc::from(v))
+        }
+    }
+
+    pub fn serialize<S: Serializer>(value: &Arc<str>, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(value)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Arc<str>, D::Error> {
+        deserializer.deserialize_str(ArcStrVisitor)
+    }
+
+    #[derive(Debug)]
+    pub(super) struct ArcStrWrapper(pub Arc<str>);
+
+    impl<'de> Deserialize<'de> for ArcStrWrapper {
+        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            d.deserialize_str(ArcStrVisitor).map(ArcStrWrapper)
+        }
+    }
+}
+
+mod arc_str_opt_serde {
+    use std::sync::Arc;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use super::arc_str_serde::ArcStrWrapper;
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<Arc<str>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => serializer.serialize_str(v),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Arc<str>>, D::Error> {
+        Option::<ArcStrWrapper>::deserialize(deserializer).map(|opt| opt.map(|w| w.0))
+    }
+}
+
 /// Description of the claim generator, or the software used in generating the claim.
 ///
-/// This structure is also used for actions softwareAgent
+/// String fields are stored as `Arc<str>` so one `ClaimGeneratorInfo` can be shared
+/// across threads and builders without re-allocating the backing strings on each
+/// clone. This is intended for multi-threaded signing pipelines (batch image
+/// signing, per-frame video workflows) where the generator identity is constant
+/// for the lifetime of the application.
+///
+/// This structure is also used for actions softwareAgent.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 pub struct ClaimGeneratorInfo {
     /// A human readable string naming the claim_generator
-    pub name: String,
+    #[serde(with = "arc_str_serde")]
+    #[cfg_attr(feature = "json_schema", schemars(with = "String"))]
+    pub name: Arc<str>,
     /// A human readable string of the product's version
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
+    #[serde(
+        default,
+        with = "arc_str_opt_serde",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[cfg_attr(feature = "json_schema", schemars(with = "Option<String>"))]
+    pub version: Option<Arc<str>>,
     /// hashed URI to the icon (either embedded or remote)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<UriOrResource>,
     /// A human readable string of the OS the claim generator is running on.
     /// CrJSON schema uses `operating_system`; C2PA CBOR may use `schema.org.SoftwareApplication.operatingSystem`.
     #[serde(
+        default,
+        with = "arc_str_opt_serde",
         alias = "schema.org.SoftwareApplication.operatingSystem",
         skip_serializing_if = "Option::is_none"
     )]
-    pub operating_system: Option<String>,
+    #[cfg_attr(feature = "json_schema", schemars(with = "Option<String>"))]
+    pub operating_system: Option<Arc<str>>,
     // Any other values that are not part of the standard
     #[serde(flatten)]
     pub(crate) other: HashMap<String, Value>,
 }
 
+fn interned_defaults() -> &'static (Arc<str>, Arc<str>) {
+    static DEFAULTS: OnceLock<(Arc<str>, Arc<str>)> = OnceLock::new();
+    DEFAULTS.get_or_init(|| {
+        (
+            Arc::from(crate::NAME),
+            Arc::from(env!("CARGO_PKG_VERSION")),
+        )
+    })
+}
+
 impl Default for ClaimGeneratorInfo {
     fn default() -> Self {
+        let (name, version) = interned_defaults();
         Self {
-            name: crate::NAME.to_string(),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            name: Arc::clone(name),
+            version: Some(Arc::clone(version)),
             icon: None,
             operating_system: None,
             other: HashMap::new(),
@@ -59,7 +161,7 @@ impl Default for ClaimGeneratorInfo {
 }
 
 impl ClaimGeneratorInfo {
-    pub fn new<S: Into<String>>(name: S) -> Self {
+    pub fn new<S: Into<Arc<str>>>(name: S) -> Self {
         Self {
             name: name.into(),
             version: None,
@@ -74,8 +176,14 @@ impl ClaimGeneratorInfo {
         self.icon.as_ref()
     }
 
+    /// Sets the name of the generator.
+    pub fn set_name<S: Into<Arc<str>>>(&mut self, name: S) -> &mut Self {
+        self.name = name.into();
+        self
+    }
+
     /// Sets the version of the generator.
-    pub fn set_version<S: Into<String>>(&mut self, version: S) -> &mut Self {
+    pub fn set_version<S: Into<Arc<str>>>(&mut self, version: S) -> &mut Self {
         self.version = Some(version.into());
         self
     }
@@ -83,6 +191,12 @@ impl ClaimGeneratorInfo {
     /// Sets the icon of the generator.
     pub fn set_icon<S: Into<UriOrResource>>(&mut self, uri_or_resource: S) -> &mut Self {
         self.icon = Some(uri_or_resource.into());
+        self
+    }
+
+    /// Sets the operating system of the generator.
+    pub fn set_operating_system<S: Into<Arc<str>>>(&mut self, os: S) -> &mut Self {
+        self.operating_system = Some(os.into());
         self
     }
 
@@ -106,6 +220,8 @@ impl ClaimGeneratorInfo {
 pub mod tests {
     #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]
+
+    use std::{sync::Arc, thread};
 
     use super::*;
     use crate::{hashed_uri::HashedUri, resource_store::ResourceRef};
@@ -141,5 +257,100 @@ pub mod tests {
             serde_json::from_str(&json).expect("Failed to deserialize");
 
         assert_eq!(g, result);
+    }
+
+    #[test]
+    fn test_shared_across_threads() {
+        let mut with_version = ClaimGeneratorInfo::new("shared_generator");
+        with_version.set_version("2.3.1");
+
+        let shared = Arc::new(with_version);
+        let expected_name = Arc::clone(&shared.name);
+        let expected_version = Arc::clone(shared.version.as_ref().expect("version set above"));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let info = Arc::clone(&shared);
+                let expected_name = Arc::clone(&expected_name);
+                let expected_version = Arc::clone(&expected_version);
+                thread::spawn(move || {
+                    let cloned = (*info).clone();
+                    assert_eq!(&*cloned.name, "shared_generator");
+                    assert_eq!(cloned.version.as_deref(), Some("2.3.1"));
+                    assert!(
+                        Arc::ptr_eq(&cloned.name, &expected_name),
+                        "name should be refcount-shared, not duplicated"
+                    );
+                    assert!(
+                        Arc::ptr_eq(
+                            cloned.version.as_ref().expect("version preserved"),
+                            &expected_version
+                        ),
+                        "version should be refcount-shared, not duplicated"
+                    );
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("worker panicked");
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_byte_stable_json() {
+        let mut g = ClaimGeneratorInfo::new("stability_test");
+        g.set_version("1.0.0").set_operating_system("linux");
+
+        let first = serde_json::to_vec(&g).expect("serialize");
+        let parsed: ClaimGeneratorInfo = serde_json::from_slice(&first).expect("deserialize");
+        let second = serde_json::to_vec(&parsed).expect("re-serialize");
+
+        assert_eq!(first, second, "JSON serialization is not byte-stable");
+    }
+
+    #[test]
+    fn test_roundtrip_byte_stable_cbor() {
+        let mut g = ClaimGeneratorInfo::new("stability_test");
+        g.set_version("1.0.0").set_operating_system("linux");
+
+        let first = c2pa_cbor::ser::to_vec(&g).expect("cbor serialize");
+        let parsed: ClaimGeneratorInfo =
+            c2pa_cbor::from_slice(&first).expect("cbor deserialize");
+        let second = c2pa_cbor::ser::to_vec(&parsed).expect("cbor re-serialize");
+
+        assert_eq!(first, second, "CBOR serialization is not byte-stable");
+        assert_eq!(g, parsed);
+    }
+
+    #[test]
+    fn test_operating_system_alias_deserialize() {
+        let json = r#"{"name":"alias_test","schema.org.SoftwareApplication.operatingSystem":"macos"}"#;
+        let parsed: ClaimGeneratorInfo =
+            serde_json::from_str(json).expect("deserialize with alias key");
+        assert_eq!(parsed.operating_system.as_deref(), Some("macos"));
+    }
+
+    #[test]
+    fn test_deserialize_missing_optional_fields() {
+        let json = r#"{"name":"minimal"}"#;
+        let parsed: ClaimGeneratorInfo =
+            serde_json::from_str(json).expect("deserialize minimal");
+        assert_eq!(&*parsed.name, "minimal");
+        assert!(parsed.version.is_none());
+        assert!(parsed.operating_system.is_none());
+        assert!(parsed.icon.is_none());
+        assert!(parsed.other.is_empty());
+    }
+
+    #[test]
+    fn test_default_memoized() {
+        let a = ClaimGeneratorInfo::default();
+        let b = ClaimGeneratorInfo::default();
+        assert!(Arc::ptr_eq(&a.name, &b.name));
+        assert!(Arc::ptr_eq(
+            a.version.as_ref().unwrap(),
+            b.version.as_ref().unwrap()
+        ));
     }
 }

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -198,15 +198,15 @@ impl TryFrom<ClaimGeneratorInfoSettings> for ClaimGeneratorInfo {
 
     fn try_from(value: ClaimGeneratorInfoSettings) -> Result<Self> {
         Ok(ClaimGeneratorInfo {
-            name: value.name,
-            version: value.version,
+            name: value.name.into(),
+            version: value.version.map(Into::into),
             icon: value.icon.map(UriOrResource::ResourceRef),
             operating_system: {
                 value.operating_system.map(|os| match os {
                     ClaimGeneratorInfoOperatingSystem::Auto => {
-                        format!("{}-unknown-{}", consts::ARCH, consts::OS)
+                        format!("{}-unknown-{}", consts::ARCH, consts::OS).into()
                     }
-                    ClaimGeneratorInfoOperatingSystem::Other(name) => name,
+                    ClaimGeneratorInfoOperatingSystem::Other(name) => name.into(),
                 })
             },
             other: value
@@ -227,8 +227,8 @@ impl TryFrom<&ClaimGeneratorInfoSettings> for ClaimGeneratorInfo {
 
     fn try_from(value: &ClaimGeneratorInfoSettings) -> Result<Self> {
         Ok(ClaimGeneratorInfo {
-            name: value.name.clone(),
-            version: value.version.clone(),
+            name: value.name.as_str().into(),
+            version: value.version.as_deref().map(Into::into),
             icon: value
                 .icon
                 .as_ref()
@@ -236,9 +236,9 @@ impl TryFrom<&ClaimGeneratorInfoSettings> for ClaimGeneratorInfo {
             operating_system: {
                 value.operating_system.as_ref().map(|os| match os {
                     ClaimGeneratorInfoOperatingSystem::Auto => {
-                        format!("{}-unknown-{}", consts::ARCH, consts::OS)
+                        format!("{}-unknown-{}", consts::ARCH, consts::OS).into()
                     }
-                    ClaimGeneratorInfoOperatingSystem::Other(name) => name.clone(),
+                    ClaimGeneratorInfoOperatingSystem::Other(name) => name.as_str().into(),
                 })
             },
             other: value
@@ -665,8 +665,8 @@ pub mod tests {
             other: HashMap::new(),
         };
         let info = ClaimGeneratorInfo::try_from(settings).unwrap();
-        assert_eq!(info.name, "Test Generator");
-        assert_eq!(info.version, Some("1.0.0".to_string()));
+        assert_eq!(&*info.name, "Test Generator");
+        assert_eq!(info.version.as_deref(), Some("1.0.0"));
 
         // Test with auto OS detection
         let settings = ClaimGeneratorInfoSettings {
@@ -695,8 +695,8 @@ pub mod tests {
         };
         let info = ClaimGeneratorInfo::try_from(settings).unwrap();
         assert_eq!(
-            info.operating_system,
-            Some("x86_64-pc-windows-msvc".to_string())
+            info.operating_system.as_deref(),
+            Some("x86_64-pc-windows-msvc")
         );
         assert!(matches!(info.icon, Some(UriOrResource::ResourceRef(_))));
         assert_eq!(info.other.len(), 1);
@@ -710,7 +710,7 @@ pub mod tests {
             other: HashMap::new(),
         };
         let info = ClaimGeneratorInfo::try_from(&settings).unwrap();
-        assert_eq!(info.name, "Test Generator");
+        assert_eq!(&*info.name, "Test Generator");
         assert_eq!(settings.name, "Test Generator"); // Original still valid
     }
 

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -221,7 +221,7 @@ pub fn create_min_test_claim() -> Result<Claim> {
     let mut claim = Claim::new("contentauth unit test", Some("contentauth"), 2);
 
     let mut cg_info = ClaimGeneratorInfo::new("test app");
-    cg_info.version = Some("2.3.4".to_string());
+    cg_info.set_version("2.3.4");
     claim.add_claim_generator_info(cg_info);
 
     let created_action = Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty);
@@ -241,7 +241,7 @@ pub fn create_test_claim() -> Result<Claim> {
     let icon_ref = claim.add_assertion(&icon)?;
 
     let mut cg_info = ClaimGeneratorInfo::new("test app");
-    cg_info.version = Some("2.3.4".to_string());
+    cg_info.set_version("2.3.4");
     cg_info.icon = Some(UriOrResource::HashedUri(icon_ref));
     cg_info.insert("something", "else");
 


### PR DESCRIPTION
Closes #2034. Following the pattern from #1680 (Context → `Arc`), this converts `ClaimGeneratorInfo`'s string fields (`name`, `version`, `operating_system`) from `String` to `Arc<str>` so a single generator identity can be shared across builders and workers without duplicating its backing strings on every clone. Wire format is unchanged — `Arc<str>` serializes identically to `String` for both JSON and CBOR via a visitor-based `deserialize_str` path that allocates the `Arc<str>` buffer directly (no intermediate `String`), and the byte-stable roundtrip tests assert signature stability. Scope is limited to `ClaimGeneratorInfo`; per-manifest assertions hold mostly dynamic values and wouldn't benefit. Constructors continue to accept `impl Into<Arc<str>>`, so `&str`/`String`/`Arc<str>` all work at call sites; `Default::default()` interns its name and version strings via a single `OnceLock` so repeat calls allocate zero strings. Also folds in a one-line fix for a pre-existing panic in `cli/src/main.rs` where `!is_empty()` on the `||` short-circuit path made `[0]` indexing unreachable only in the non-empty case, leaving the empty case as an unconditional out-of-bounds panic.

Microbenchmarks in `sdk/benches/sign.rs` show `ClaimGeneratorInfo::clone` drops from 43.8 ns → 12.7 ns (3.4x) and `Vec<ClaimGeneratorInfo>` clone from 90.4 ns → 36.8 ns (2.5x). Deserialization is a small trade: 132.2 ns → 136.8 ns (3.5% slower) because `Arc<str>` has an intrinsic 16-byte refcount header vs `String`'s inline layout — acceptable since typical workflows deserialize once and clone many times, and the end-to-end `sign 100kb jpeg` bench lands within noise (277.7 µs → 273.1 µs). The real benefit is enabling the shared-identity pattern without per-worker string duplication; `cargo test -p c2pa --lib` passes all 702 tests, with new coverage for `Arc::ptr_eq`-verified thread sharing, JSON and CBOR byte-stable roundtrips, `#[serde(alias)]` handling with the custom serializer, missing optional field deserialization, and `Default` memoization verified by pointer identity.