### PR TITLE
fix: remove hardcoded debug file write from v2_api_integration test

### DIFF
--- a/sdk/tests/v2_api_integration.rs
+++ b/sdk/tests/v2_api_integration.rs
@@ -188,14 +188,6 @@ mod integration_v2 {
             dest
         };
 
-        #[cfg(not(target_os = "wasi"))]
-        {
-            // write dest to file for debugging
-            let debug_path = format!("{}/../target/v2_test.jpg", env!("CARGO_MANIFEST_DIR"));
-            std::fs::write(debug_path, dest.get_ref())?;
-            dest.rewind()?;
-        }
-
         let reader = Reader::from_stream(format, &mut dest)?;
 
         // extract a thumbnail image from the ManifestStore


### PR DESCRIPTION
The `test_v2_integration` test unconditionally writes a debug JPEG to `$CARGO_MANIFEST_DIR/../target/v2_test.jpg`, which fails with `No such file or directory` whenever the workspace target directory is relocated (custom `CARGO_TARGET_DIR`, out-of-tree builds, or any setup where `<repo>/target` isn't the active target dir). The write exists only as a dev aid; the test logic reads from the in-memory `Cursor` regardless, so removing the block makes the test hermetic without affecting coverage.