### PR TITLE
chore: Ignore `rand` advisory as it doesn't apply to our feature set

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,7 @@ yanked = "deny"
 ignore = [
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
   "RUSTSEC-2024-0370", # proc-macro-error
-  "RUSTSEC-2026-0097", # rand unsound with custom logger
+  "RUSTSEC-2026-0097", # rand unsound with custom logger (https://github.com/contentauth/c2pa-rs/issues/2045)
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@ yanked = "deny"
 ignore = [
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
   "RUSTSEC-2024-0370", # proc-macro-error
+  "RUSTSEC-2026-0097", # rand unsound with custom logger
 ]
 
 [bans]


### PR DESCRIPTION
Our dependency `rand` is reporting an ["unsound error"](https://github.com/contentauth/c2pa-rs/actions/runs/24354271956/job/71116890612) with `cargo-deny` on all branches. We can't update it because our dependency `ed25519-dalek` still depends on an older version of `rand_core`, at least until they cut a new release (https://github.com/dalek-cryptography/curve25519-dalek/issues/876). Luckily, this error doesn't apply to us because we don't enable the `log` features of `rand`, so we can add an entry to ignore it in the `deny.toml`.