### PR TITLE
fix: Handle more thumbnail redaction edge cases

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1269,7 +1269,6 @@ impl Builder {
     /// Copies binary resources from `store` into this builder when the id is not already present.
     fn merge_resources_from_store(&mut self, store: &ResourceStore) -> Result<()> {
         for (id, data) in store.resources() {
-            dbg!(&id);
             let _sanitized_id = sanitize_archive_path(id)?;
             if !self.resources.exists(id) {
                 self.resources.add(id, data.clone())?;

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1348,10 +1348,17 @@ impl Ingredient {
             // pass through `to_absolute_uri` unchanged and keep pointing at their own
             // nested manifest. Either way, the extracted manifest label is compared
             // against `thumbnail_redacted_manifests` to decide whether to drop it.
+            // A thumbnail whose resolved manifest label equals the claim being built is a
+            // self-reference to the outer archive manifest: it is always stale after re-signing
+            // and must be suppressed unconditionally.  Other thumbnails are suppressed only when
+            // the redaction list explicitly targets their source manifest.
             let thumbnail_is_redacted = jumbf::labels::manifest_label_from_uri(
                 &jumbf::labels::to_absolute_uri(claim.label(), &thumb_ref.identifier),
             )
-            .is_some_and(|label| thumbnail_redacted_manifests.contains(&label));
+            .is_some_and(|label| {
+                label == claim.label() || thumbnail_redacted_manifests.contains(&label)
+            });
+
 
             if !thumbnail_is_redacted {
                 // if we have a hash, just build the hashed uri

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1262,8 +1262,7 @@ impl Ingredient {
             })
         };
 
-        // Collect the redacted thumbnail URIs (already in absolute JUMBF form).
-        // We compare thumbnail URIs directly rather than extracting and comparing manifest labels.
+        // Collect the redacted thumbnail URIs, use them for comparison.
         let redacted_thumbnail_uris: std::collections::HashSet<String> = redactions
             .as_deref()
             .unwrap_or_default()
@@ -1342,14 +1341,12 @@ impl Ingredient {
         // If the ingredient defines a thumbnail, add it to the claim,
         // unless the thumbnail URI is explicitly listed in the redactions.
         if let Some(thumb_ref) = self.thumbnail_ref() {
-            // A relative self#jumbf= URI (e.g. "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient",
-            // starts with "self#jumbf=" but NOT "self#jumbf=/") on an ingredient that already
-            // has manifest_data is a stale reference from the outer archive manifest being
-            // rebuilt. That assertion no longer exists after re-signing and all references and
-            // resources related to it must be dropped.
+            // A relative self#jumbf= URI on an ingredient that already
+            // has manifest_data is a stale reference from the outer (archive) manifest being
+            // rebuilt. Due to staleness, resources might need to be removed if stale/redacted.
             // Ingredients without manifest_data may also carry relative self#jumbf= thumbnail
-            // identifiers (written by the archive format for freshly-generated thumbnails),
-            // those are valid resources in the builder's resource store and must NOT be suppressed.
+            // identifiers (e.g. written by the archive format for freshly-generated thumbnails),
+            // those are valid resources in the builder's resource store and must be kept.
             let is_stale_outer_ref = self.manifest_data_ref().is_some()
                 && thumb_ref.identifier.starts_with("self#jumbf=")
                 && !thumb_ref.identifier.starts_with("self#jumbf=/");
@@ -1364,8 +1361,23 @@ impl Ingredient {
                     jumbf::labels::to_absolute_uri(active_label, &thumb_ref.identifier)
                 })
                 .unwrap_or_else(|| thumb_ref.identifier.clone());
-            let thumbnail_is_redacted =
-                is_stale_outer_ref || redacted_thumbnail_uris.contains(abs_thumb_uri.as_str());
+
+            // For ingredients with embedded manifest data, a freshly-generated thumbnail
+            // (e.g. an XMP-IID filename from maybe_add_thumbnail) may exist even when the
+            // manifest's own claim thumbnail failed validation. If any thumbnail from
+            // this ingredient's manifest chain is being redacted, suppress the fresh
+            // thumbnail too, it represents the same provenance (edge case for thumbnails
+            // added from files).
+            let active_manifest_label = self.active_manifest.as_deref().unwrap_or("");
+            let fresh_thumb_is_suppressed = self.manifest_data_ref().is_some()
+                && !active_manifest_label.is_empty()
+                && redacted_thumbnail_uris
+                    .iter()
+                    .any(|uri| uri.contains(active_manifest_label));
+
+            let thumbnail_is_redacted = is_stale_outer_ref
+                || redacted_thumbnail_uris.contains(abs_thumb_uri.as_str())
+                || fresh_thumb_is_suppressed;
 
             if !thumbnail_is_redacted {
                 // if we have a hash, just build the hashed uri

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1262,17 +1262,16 @@ impl Ingredient {
             })
         };
 
-        // Needed so no thumbnails is generated if thumbnail got redacted.
-        // Both claim thumbnails (c2pa.thumbnail.claim) and ingredient thumbnails
-        // (c2pa.thumbnail.ingredient) stored in any manifest must be suppressible via redactions.
-        let thumbnail_redacted_manifests: std::collections::HashSet<String> = redactions
+        // Collect the redacted thumbnail URIs (already in absolute JUMBF form).
+        // We compare thumbnail URIs directly rather than extracting and comparing manifest labels.
+        let redacted_thumbnail_uris: std::collections::HashSet<String> = redactions
             .as_deref()
             .unwrap_or_default()
             .iter()
             .filter(|r| {
                 r.contains(labels::CLAIM_THUMBNAIL) || r.contains(labels::INGREDIENT_THUMBNAIL)
             })
-            .filter_map(|r| jumbf::labels::manifest_label_from_uri(r))
+            .cloned()
             .collect();
 
         // add the ingredient manifest_data to the claim
@@ -1304,20 +1303,23 @@ impl Ingredient {
                 let signature_uri = jumbf::labels::to_signature_uri(manifest_label);
 
                 // Use the parent claim thumbnail if validation passed and it was not redacted.
-                let thumbnail_not_redacted = !thumbnail_redacted_manifests.contains(manifest_label);
                 let is_valid = self
                     .validation_results()
                     .is_some_and(|v| v.validation_state() != crate::ValidationState::Invalid);
-                if thumbnail_not_redacted && is_valid {
+                if is_valid {
                     thumbnail = ingredient_active_claim
                         .assertions()
                         .iter()
                         .find(|hashed_uri| hashed_uri.url().contains(labels::CLAIM_THUMBNAIL))
-                        .map(|t| {
+                        .and_then(|t| {
                             // convert ingredient uris to absolute when adding them
                             // since this uri references a different manifest
                             let url = jumbf::labels::to_absolute_uri(manifest_label, &t.url());
-                            HashedUri::new(url, t.alg(), &t.hash())
+                            if redacted_thumbnail_uris.contains(url.as_str()) {
+                                None
+                            } else {
+                                Some(HashedUri::new(url, t.alg(), &t.hash()))
+                            }
                         });
                 }
                 // generate c2pa_manifest hashed_uris
@@ -1338,22 +1340,32 @@ impl Ingredient {
         };
 
         // If the ingredient defines a thumbnail, add it to the claim,
-        // unless the source claim thumbnail was redacted...
-        // (that is why we kept thumbnail_redacted_manifests around).
+        // unless the thumbnail URI is explicitly listed in the redactions.
         if let Some(thumb_ref) = self.thumbnail_ref() {
-            // The extracted manifest label is compared
-            // against `thumbnail_redacted_manifests` to decide if to be skipped.
-            // A thumbnail whose resolved manifest label equals the claim being built is a
-            // self-reference to the outer archive manifest: it is stale after re-signing
-            // and must be suppressed. Other thumbnails are suppressed only when
-            // the redaction list explicitly targets their source manifest.
-            let thumbnail_is_redacted = jumbf::labels::manifest_label_from_uri(
-                &jumbf::labels::to_absolute_uri(claim.label(), &thumb_ref.identifier),
-            )
-            .is_some_and(|label| {
-                label == claim.label() || thumbnail_redacted_manifests.contains(&label)
-            });
+            // A relative self#jumbf= URI (e.g. "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient",
+            // starts with "self#jumbf=" but NOT "self#jumbf=/") on an ingredient that already
+            // has manifest_data is a stale reference from the outer archive manifest being
+            // rebuilt. That assertion no longer exists after re-signing and all references and
+            // resources related to it must be dropped.
+            // Ingredients without manifest_data may also carry relative self#jumbf= thumbnail
+            // identifiers (written by the archive format for freshly-generated thumbnails),
+            // those are valid resources in the builder's resource store and must NOT be suppressed.
+            let is_stale_outer_ref = self.manifest_data_ref().is_some()
+                && thumb_ref.identifier.starts_with("self#jumbf=")
+                && !thumb_ref.identifier.starts_with("self#jumbf=/");
 
+            // Resolve the thumbnail identifier to an absolute JUMBF URI using the ingredient's
+            // own manifest label (self.active_manifest), then check directly against the
+            // redacted URI set...
+            let abs_thumb_uri = self
+                .active_manifest
+                .as_deref()
+                .map(|active_label| {
+                    jumbf::labels::to_absolute_uri(active_label, &thumb_ref.identifier)
+                })
+                .unwrap_or_else(|| thumb_ref.identifier.clone());
+            let thumbnail_is_redacted =
+                is_stale_outer_ref || redacted_thumbnail_uris.contains(abs_thumb_uri.as_str());
 
             if !thumbnail_is_redacted {
                 // if we have a hash, just build the hashed uri

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1341,16 +1341,11 @@ impl Ingredient {
         // unless the source claim thumbnail was redacted...
         // (that is why we kept thumbnail_redacted_manifests around).
         if let Some(thumb_ref) = self.thumbnail_ref() {
-            // Resolve the thumbnail identifier to an absolute JUMBF URI using the outer
-            // claim's label as the base. Relative `self#jumbf=...` identifiers reference
-            // assertions in the outer manifest currently being built (i.e. `claim`), so
-            // that is the correct base. Absolute identifiers (`self#jumbf=/c2pa/...`)
-            // pass through `to_absolute_uri` unchanged and keep pointing at their own
-            // nested manifest. Either way, the extracted manifest label is compared
-            // against `thumbnail_redacted_manifests` to decide whether to drop it.
+            // The extracted manifest label is compared
+            // against `thumbnail_redacted_manifests` to decide if to be skipped.
             // A thumbnail whose resolved manifest label equals the claim being built is a
-            // self-reference to the outer archive manifest: it is always stale after re-signing
-            // and must be suppressed unconditionally.  Other thumbnails are suppressed only when
+            // self-reference to the outer archive manifest: it is stale after re-signing
+            // and must be suppressed. Other thumbnails are suppressed only when
             // the redaction list explicitly targets their source manifest.
             let thumbnail_is_redacted = jumbf::labels::manifest_label_from_uri(
                 &jumbf::labels::to_absolute_uri(claim.label(), &thumb_ref.identifier),

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1263,11 +1263,15 @@ impl Ingredient {
         };
 
         // Needed so no thumbnails is generated if thumbnail got redacted.
+        // Both claim thumbnails (c2pa.thumbnail.claim) and ingredient thumbnails
+        // (c2pa.thumbnail.ingredient) stored in any manifest must be suppressible via redactions.
         let thumbnail_redacted_manifests: std::collections::HashSet<String> = redactions
             .as_deref()
             .unwrap_or_default()
             .iter()
-            .filter(|r| r.contains(labels::CLAIM_THUMBNAIL))
+            .filter(|r| {
+                r.contains(labels::CLAIM_THUMBNAIL) || r.contains(labels::INGREDIENT_THUMBNAIL)
+            })
             .filter_map(|r| jumbf::labels::manifest_label_from_uri(r))
             .collect();
 
@@ -1337,18 +1341,26 @@ impl Ingredient {
         // unless the source claim thumbnail was redacted...
         // (that is why we kept thumbnail_redacted_manifests around).
         if let Some(thumb_ref) = self.thumbnail_ref() {
+            // A relative self#jumbf URI (e.g. "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient",
+            // which starts with "self#jumbf=" but NOT "self#jumbf=/") points to an assertion in the
+            // outer manifest currently being rebuilt, not in any nested ingredient manifest.  Such
+            // thumbnails are stale once the manifest is re-signed and must always be suppressed.
+            let is_stale_outer_ref = thumb_ref.identifier.starts_with("self#jumbf=")
+                && !thumb_ref.identifier.starts_with("self#jumbf=/");
+
             // Normalize the identifier to an absolute JUMBF URI using the ingredient's
             // active manifest label as the base (a no-op for identifiers that are already
             // absolute), then extract the manifest label from the result so we can check
             // whether that manifest's thumbnails are being redacted.
-            let thumbnail_is_redacted = self
-                .active_manifest
-                .as_deref()
-                .map(|active_label| {
-                    jumbf::labels::to_absolute_uri(active_label, &thumb_ref.identifier)
-                })
-                .and_then(|abs_uri| jumbf::labels::manifest_label_from_uri(&abs_uri))
-                .is_some_and(|label| thumbnail_redacted_manifests.contains(&label));
+            let thumbnail_is_redacted = is_stale_outer_ref
+                || self
+                    .active_manifest
+                    .as_deref()
+                    .map(|active_label| {
+                        jumbf::labels::to_absolute_uri(active_label, &thumb_ref.identifier)
+                    })
+                    .and_then(|abs_uri| jumbf::labels::manifest_label_from_uri(&abs_uri))
+                    .is_some_and(|label| thumbnail_redacted_manifests.contains(&label));
 
             if !thumbnail_is_redacted {
                 // if we have a hash, just build the hashed uri

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1341,26 +1341,17 @@ impl Ingredient {
         // unless the source claim thumbnail was redacted...
         // (that is why we kept thumbnail_redacted_manifests around).
         if let Some(thumb_ref) = self.thumbnail_ref() {
-            // A relative self#jumbf URI (e.g. "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient",
-            // which starts with "self#jumbf=" but NOT "self#jumbf=/") points to an assertion in the
-            // outer manifest currently being rebuilt, not in any nested ingredient manifest.  Such
-            // thumbnails are stale once the manifest is re-signed and must always be suppressed.
-            let is_stale_outer_ref = thumb_ref.identifier.starts_with("self#jumbf=")
-                && !thumb_ref.identifier.starts_with("self#jumbf=/");
-
-            // Normalize the identifier to an absolute JUMBF URI using the ingredient's
-            // active manifest label as the base (a no-op for identifiers that are already
-            // absolute), then extract the manifest label from the result so we can check
-            // whether that manifest's thumbnails are being redacted.
-            let thumbnail_is_redacted = is_stale_outer_ref
-                || self
-                    .active_manifest
-                    .as_deref()
-                    .map(|active_label| {
-                        jumbf::labels::to_absolute_uri(active_label, &thumb_ref.identifier)
-                    })
-                    .and_then(|abs_uri| jumbf::labels::manifest_label_from_uri(&abs_uri))
-                    .is_some_and(|label| thumbnail_redacted_manifests.contains(&label));
+            // Resolve the thumbnail identifier to an absolute JUMBF URI using the outer
+            // claim's label as the base. Relative `self#jumbf=...` identifiers reference
+            // assertions in the outer manifest currently being built (i.e. `claim`), so
+            // that is the correct base. Absolute identifiers (`self#jumbf=/c2pa/...`)
+            // pass through `to_absolute_uri` unchanged and keep pointing at their own
+            // nested manifest. Either way, the extracted manifest label is compared
+            // against `thumbnail_redacted_manifests` to decide whether to drop it.
+            let thumbnail_is_redacted = jumbf::labels::manifest_label_from_uri(
+                &jumbf::labels::to_absolute_uri(claim.label(), &thumb_ref.identifier),
+            )
+            .is_some_and(|label| thumbnail_redacted_manifests.contains(&label));
 
             if !thumbnail_is_redacted {
                 // if we have a hash, just build the hashed uri


### PR DESCRIPTION
## Changes in this pull request
As in title. Some providers handle thumbnails differently, this change is to handle that.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
