### PR TITLE
fix: Harden riff chunk parser against forged size field memory attacks

### DIFF
--- a/sdk/src/asset_handlers/riff_io.rs
+++ b/sdk/src/asset_handlers/riff_io.rs
@@ -82,6 +82,15 @@ const AVIX_ID: ChunkId = ChunkId {
 
 const XMP_FLAG: u32 = 4;
 
+/// Returns the byte offset one past the end of `chunk`'s data
+/// (`chunk.offset() + 8 header bytes + chunk.len() data bytes`), or `None` on overflow.
+fn chunk_data_end(chunk: &Chunk) -> Option<u64> {
+    chunk
+        .offset()
+        .checked_add(8)?
+        .checked_add(chunk.len() as u64)
+}
+
 fn get_height_and_width(chunk_contents: &[ChunkContents]) -> Result<(u16, u16)> {
     if let Some(ChunkContents::Data(_id, chunk_data)) = chunk_contents.iter().find(|c| match c {
         ChunkContents::Data(id, _) => *id == VP8L_ID,
@@ -255,6 +264,14 @@ where
 
         Ok(ChunkContents::ChildrenNoType(id, children_contents))
     } else {
+        let stream_end = stream.seek(SeekFrom::End(0))?;
+        let chunk_end = chunk_data_end(chunk)
+            .ok_or_else(|| Error::InvalidAsset("RIFF chunk size overflow".to_string()))?;
+        if chunk_end > stream_end {
+            return Err(Error::InvalidAsset(
+                "RIFF chunk declared size exceeds file size".to_string(),
+            ));
+        }
         let contents = chunk
             .read_contents(stream)
             .map_err(|_| Error::InvalidAsset("RIFF handler could not parse file".to_string()))?;
@@ -284,6 +301,7 @@ fn get_manifest_pos(reader: &mut dyn CAIRead) -> Option<(u64, u32)> {
 
 impl CAIReader for RiffIO {
     fn read_cai(&self, input_stream: &mut dyn CAIRead) -> Result<Vec<u8>> {
+        let file_len = stream_len(input_stream)?;
         let mut chunk_reader = CAIReadWrapper {
             reader: input_stream,
         };
@@ -307,6 +325,13 @@ impl CAIReader for RiffIO {
                 result.map_err(|_| Error::InvalidAsset("Invalid RIFF format".to_string()))?;
 
             if chunk.id() == C2PA_CHUNK_ID {
+                let chunk_end = chunk_data_end(&chunk)
+                    .ok_or_else(|| Error::InvalidAsset("RIFF chunk size overflow".to_string()))?;
+                if chunk_end > file_len {
+                    return Err(Error::InvalidAsset(
+                        "RIFF chunk declared size exceeds file size".to_string(),
+                    ));
+                }
                 return Ok(chunk.read_contents(&mut chunk_reader)?);
             }
         }
@@ -316,6 +341,7 @@ impl CAIReader for RiffIO {
 
     // Get XMP block
     fn read_xmp(&self, input_stream: &mut dyn CAIRead) -> Option<String> {
+        let file_len = stream_len(input_stream).ok()?;
         let top_level_chunks = {
             let mut reader = CAIReadWrapper {
                 reader: input_stream,
@@ -334,6 +360,10 @@ impl CAIReader for RiffIO {
         for chunk in top_level_chunks.iter(&mut chunk_reader) {
             let chunk = chunk.ok()?;
             if chunk.id() == XMP_CHUNK_ID {
+                let chunk_end = chunk_data_end(&chunk)?;
+                if chunk_end > file_len {
+                    return None;
+                }
                 let output = chunk.read_contents(&mut chunk_reader).ok()?;
                 return Some(String::from_utf8_lossy(&output).to_string());
             }
@@ -759,6 +789,44 @@ pub mod tests {
             }
         }
         assert!(success)
+    }
+
+    #[test]
+    fn test_read_cai_forged_c2pa_chunk_size_returns_error() {
+        // A 20-byte RIFF file where the C2PA chunk claims 4 GB of data.
+        // Without the fix this causes a process abort from OOM (exit 134).
+        let mut data = Vec::new();
+        data.extend_from_slice(b"RIFF");
+        data.extend_from_slice(&12u32.to_le_bytes()); // RIFF data size (covers type + chunk hdr)
+        data.extend_from_slice(b"WAVE");
+        data.extend_from_slice(b"C2PA");
+        data.extend_from_slice(&u32::MAX.to_le_bytes()); // forged 4 GB declared size
+
+        let riff_io = RiffIO::new("wav");
+        let mut source = Cursor::new(data);
+        assert!(matches!(
+            riff_io.read_cai(&mut source),
+            Err(Error::InvalidAsset(_))
+        ));
+    }
+
+    #[test]
+    fn test_write_cai_forged_chunk_size_returns_error() {
+        // Same forged file fed to write_cai, which calls inject_c2pa internally.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"RIFF");
+        data.extend_from_slice(&12u32.to_le_bytes());
+        data.extend_from_slice(b"WAVE");
+        data.extend_from_slice(b"DATA");
+        data.extend_from_slice(&u32::MAX.to_le_bytes()); // forged 4 GB declared size
+
+        let riff_io = RiffIO::new("wav");
+        let mut source = Cursor::new(data);
+        let mut dest = Cursor::new(Vec::new());
+        assert!(matches!(
+            riff_io.write_cai(&mut source, &mut dest, b"manifest"),
+            Err(Error::InvalidAsset(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: RIFF Handler OOM Abort via Forged Chunk Size

## Issue

The `riff` crate's `Chunk::read_contents` allocates a buffer sized directly from the chunk's declared `u32` length field without validating it against the actual file size:

```rust
let mut data: Vec<u8> = vec![0; self.len.try_into().unwrap()];
stream.read_exact(&mut data)?;
```

A 20-byte RIFF file (WAV/WEBP/AVI) with a `C2PA` chunk claiming `u32::MAX` (4,294,967,295) bytes causes an unconditional process abort with "memory allocation of 4294967295 bytes failed" (exit code 134). This is not a catchable `panic!` — it is an allocator abort.


## Fix

Added bounds validation before each `read_contents` call. The check computes `chunk.offset() + 8 + chunk.len()` using saturating/checked arithmetic and compares against the actual stream length:

## Tests Added

| Test | Validates |
|------|-----------|
| `test_read_cai_forged_c2pa_chunk_size_returns_error` | `read_cai` returns `Err(InvalidAsset)` on 20-byte file with 4GB C2PA chunk |
| `test_write_cai_forged_chunk_size_returns_error` | `write_cai` returns `Err(InvalidAsset)` on 20-byte file with 4GB DATA chunk |

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
