### PR TITLE
fix: Harden bmff parsing against integer overflow attack

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1302,7 +1302,10 @@ pub(crate) fn build_bmff_tree<R: Read + Seek + ?Sized>(
             break;
         }
 
-        if current + s > end {
+        let box_end = current
+            .checked_add(s)
+            .ok_or_else(|| Error::InvalidAsset("BMFF box size overflow".to_string()))?;
+        if box_end > end {
             if BoxType::MdatBox == header.name {
                 // for mdat boxes that extend beyond the end of the file we will just set the size to the remaining bytes in the file since
                 // some files have malformed mdat sizes but we can still hash the content by treating it as a truncated box
@@ -2933,5 +2936,30 @@ pub mod tests {
             Err(Error::JumbfNotFound) => (),
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn test_bmff_large_size_overflow_does_not_panic() {
+        // Craft a 32-byte MP4: 16-byte ftyp box followed by a 16-byte large-size box
+        // that claims 0xFFFFFFFFFFFFFFF0 bytes. When current=16 (after ftyp), the
+        // unchecked addition 16 + 0xFFFFFFFFFFFFFFF0 overflows u64 in debug mode
+        // (panic exit 101) and silently wraps to bypass the bounds check in release mode.
+        let mut data: Vec<u8> = Vec::new();
+        // ftyp box (16 bytes): size=16, type='ftyp', major_brand='mp41', minor_version=0
+        data.extend_from_slice(&16u32.to_be_bytes());
+        data.extend_from_slice(b"ftyp");
+        data.extend_from_slice(b"mp41");
+        data.extend_from_slice(&0u32.to_be_bytes());
+        // large-size box (16 bytes): size=1 signals largesize, type='mdat', largesize=MAX-15
+        data.extend_from_slice(&1u32.to_be_bytes());
+        data.extend_from_slice(b"mdat");
+        data.extend_from_slice(&0xfffffffffffffff0u64.to_be_bytes());
+
+        let bmff_io = BmffIO::new("mp4");
+        let mut source = Cursor::new(data);
+        assert!(matches!(
+            bmff_io.read_cai(&mut source),
+            Err(Error::InvalidAsset(_))
+        ));
     }
 }


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: BMFF Large-Size Box u64 Addition Overflow

## Issue

In `build_bmff_tree` (`sdk/src/asset_handlers/bmff_io.rs`, line 1305), the bounds check
used unchecked u64 addition:

```rust
if current + s > end {
```

- `current: u64` — stream offset at the start of the current box (e.g. `16` after ftyp)
- `s: u64` — `header.size`, which for large-size boxes is the raw 8-byte value from the
  file (attacker-controlled; e.g. `0xFFFFFFFFFFFFFFF0`)
- `end: u64` — actual file size

With a 32-byte MP4 (16-byte `ftyp` + 16-byte large-size box):

| Build | Behaviour |
|-------|-----------|
| Debug | `16 + 0xFFFFFFFFFFFFFFF0` panics: "attempt to add with overflow" (exit 101) |
| Release | Wraps to `0`; `0 > 32` is false → **bounds check silently bypassed** |

**Severity:** High — a 32-byte crafted file causes an unconditional crash in debug builds and
a bounds-check bypass in release builds. Affects all BMFF-based formats (MP4, MOV, HEIC, …).

## Fix

Replace the unchecked addition with `checked_add`, returning `Err(InvalidAsset)` on overflow:

## Tests Added

| Test | Validates |
|------|-----------|
| `test_bmff_large_size_overflow_does_not_panic` | `read_cai` returns `Err(InvalidAsset)` on a 32-byte file with `largesize=0xFFFFFFFFFFFFFFF0` |


## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
