### PR TITLE
fix: Multi rendition support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ c2pa = { path = "sdk", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost
-debug = 1              # line tables only for debugging - switch to 2 or debug for full symbols
+debug = 2              # symbols for debugging - switch to 1 to disable debug symbols
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -483,7 +483,7 @@ fn sign_fragmented(
     builder: &mut Builder,
     signer: &dyn Signer,
     init_pattern: &Path,
-    frag_pattern: &PathBuf,
+    frag_pattern: &Path,
     output_path: &Path,
 ) -> Result<()> {
     // search folders for init segments

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -494,9 +494,7 @@ fn sign_fragmented(
     let count = inits.count();
 
     if count > 0 {
-        builder
-            .sign_fragmented_files(signer, init_pattern, frag_pattern, output_path)
-            .map_err(anyhow::Error::from)?;
+        builder.sign_fragmented_files(signer, init_pattern, frag_pattern, output_path)?;
     } else {
         println!("No files matching pattern: {ip}");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -492,37 +492,16 @@ fn sign_fragmented(
         "could not parse source pattern".into(),
     ))?;
     let inits = glob::glob(ip).context("could not process glob pattern")?;
-    let mut count = 0;
-    for init in inits {
-        match init {
-            Ok(p) => {
-                let mut fragments = Vec::new();
-                let init_dir = p.parent().context("init segment had no parent dir")?;
-                let seg_glob = init_dir.join(frag_pattern); // segment match pattern
+    let count = inits.count();
 
-                // grab the fragments that go with this init segment
-                let seg_glob_str = seg_glob.to_str().context("fragment path not valid")?;
-                let seg_paths = glob::glob(seg_glob_str).context("fragment glob not valid")?;
-                for seg in seg_paths {
-                    match seg {
-                        Ok(f) => fragments.push(f),
-                        Err(_) => return Err(anyhow!("fragment path not valid")),
-                    }
-                }
-
-                println!("Adding manifest to: {p:?}");
-                let new_output_path =
-                    output_path.join(init_dir.file_name().context("invalid file name")?);
-                builder.sign_fragmented_files(signer, &p, &fragments, &new_output_path)?;
-
-                count += 1;
-            }
-            Err(_) => bail!("bad path to init segment"),
-        }
-    }
-    if count == 0 {
+    if count > 0 {
+        builder
+            .sign_fragmented_files(signer, init_pattern, frag_pattern, output_path)
+            .map_err(anyhow::Error::from)?;
+    } else {
         println!("No files matching pattern: {ip}");
     }
+
     Ok(())
 }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -116,6 +116,7 @@ coset = "0.4.0"
 der = { version = "0.7.9", features = ["alloc"] }
 extfmt = "0.2.0"
 getrandom = { version = "0.3.4", default-features = false, features = ["std"] }
+glob = "0.3.1"
 ecdsa = { version = "0.16.9", features = ["digest", "sha2"], optional = true }
 ed25519-dalek = { version = "2.1.1", features = [
     "alloc",
@@ -290,7 +291,6 @@ web-sys = { version = "0.3.58", features = [
 
 [dev-dependencies]
 anyhow = "1.0.97"
-glob = "0.3.1"
 hex-literal = "1.0.0"
 jumbf = "0.7.0"
 c2pa_macros = { path = "../macros" }

--- a/sdk/examples/fragmented_bmff.rs
+++ b/sdk/examples/fragmented_bmff.rs
@@ -96,7 +96,7 @@ mod cawg {
         builder: &mut Builder,
         signer: &dyn Signer,
         init_pattern: &Path,
-        frag_pattern: &PathBuf,
+        frag_pattern: &Path,
         output_path: &Path,
     ) -> Result<()> {
         builder

--- a/sdk/examples/fragmented_bmff.rs
+++ b/sdk/examples/fragmented_bmff.rs
@@ -24,7 +24,7 @@
 mod cawg {
     use std::path::{Path, PathBuf};
 
-    use anyhow::{anyhow, bail, Context as AnyhowContext, Result};
+    use anyhow::Result;
     use c2pa::{Builder, Settings, Signer};
     use serde_json::json;
 
@@ -99,43 +99,9 @@ mod cawg {
         frag_pattern: &PathBuf,
         output_path: &Path,
     ) -> Result<()> {
-        // search folders for init segments
-        let ip = init_pattern
-            .to_str()
-            .ok_or(anyhow!("could not parse source pattern"))?;
-        let inits = glob::glob(ip).context("could not process glob pattern")?;
-        let mut count = 0;
-        for init in inits {
-            match init {
-                Ok(p) => {
-                    let mut fragments = Vec::new();
-                    let init_dir = p.parent().context("init segment had no parent dir")?;
-                    let seg_glob = init_dir.join(frag_pattern); // segment match pattern
-
-                    // grab the fragments that go with this init segment
-                    let seg_glob_str = seg_glob.to_str().context("fragment path not valid")?;
-                    let seg_paths = glob::glob(seg_glob_str).context("fragment glob not valid")?;
-                    for seg in seg_paths {
-                        match seg {
-                            Ok(f) => fragments.push(f),
-                            Err(_) => return Err(anyhow!("fragment path not valid")),
-                        }
-                    }
-
-                    println!("Adding manifest to: {p:?}");
-                    let new_output_path =
-                        output_path.join(init_dir.file_name().context("invalid file name")?);
-                    builder.sign_fragmented_files(signer, &p, &fragments, &new_output_path)?;
-
-                    count += 1;
-                }
-                Err(_) => bail!("bad path to init segment"),
-            }
-        }
-        if count == 0 {
-            println!("No files matching pattern: {ip}");
-        }
-        Ok(())
+        builder
+            .sign_fragmented_files(signer, init_pattern, frag_pattern, output_path)
+            .map_err(anyhow::Error::from)
     }
 }
 

--- a/sdk/examples/fragmented_bmff.rs
+++ b/sdk/examples/fragmented_bmff.rs
@@ -22,7 +22,7 @@
 //! ```
 
 mod cawg {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use anyhow::Result;
     use c2pa::{Builder, Settings, Signer};

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1779,7 +1779,7 @@ impl BmffHash {
 
         let mut location_to_fragment_map: HashMap<usize, std::path::PathBuf> = HashMap::new();
 
-        // copy to destination and insert placeholder C2PA Merkle box
+        // copy fragment to destination and insert placeholder C2PA Merkle box
         for (location, seg) in (0_usize..).zip(fragment_paths.iter()) {
             let mut seg_reader = std::fs::File::open(seg)?;
 
@@ -1848,7 +1848,7 @@ impl BmffHash {
                 .write(true)
                 .open(&dest_path)?;
 
-            // UUID to insert into output asset
+            // UUID to insert into output fragment with placeholder proof (will be replaced with real proof after hashing)
             crate::utils::io_utils::insert_data_at(
                 &mut source,
                 &mut dest,
@@ -1860,7 +1860,7 @@ impl BmffHash {
             location_to_fragment_map.insert(location, dest_path);
         }
 
-        // fill in actual hashes now that we have inserted the C2PA box.
+        // fill in actual leaf hashes now that we have inserted the C2PA box.
         let bmff_exclusions = &self.exclusions;
         let mut leaves: Vec<crate::utils::merkle::MerkleNode> =
             Vec::with_capacity(fragment_paths.len());
@@ -1930,7 +1930,7 @@ impl BmffHash {
                     0,
                 )?;
 
-                // replace temp C2PA Merkle box
+                // replace temp C2PA Merkle box with final one containing the proof
                 if uuid_box_data.len() == bmff_mm_info.size() as usize {
                     fragment_stream.seek(std::io::SeekFrom::Start(bmff_mm_info.start()))?;
                     std::io::Write::write_all(&mut fragment_stream, &uuid_box_data)?;
@@ -1942,7 +1942,7 @@ impl BmffHash {
             }
         }
 
-        // save desired Merkle tree row (for now complete tree)
+        // save desired Merkle tree row
         let tree_row = std::cmp::min(max_proofs, m_tree.layers.len() - 1);
         let merkle_row = m_tree.layers[tree_row].clone();
         let mut hashes = Vec::new();
@@ -1957,7 +1957,7 @@ impl BmffHash {
             count: fragment_paths.len(),
             alg: Some(alg.to_owned()),
             init_hash: match alg {
-                // placeholder init hash to be filled once manifest is inserted
+                // placeholder init hash to be filled once manifest is inserted into init segment
                 "sha256" => Some(ByteBuf::from([0u8; 32].to_vec())),
                 "sha384" => Some(ByteBuf::from([0u8; 48].to_vec())),
                 "sha512" => Some(ByteBuf::from([0u8; 64].to_vec())),

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1760,7 +1760,7 @@ impl BmffHash {
         &mut self,
         max_proofs: usize,
         alg: &str,
-        fragment_paths: &Vec<std::path::PathBuf>,
+        fragment_paths: &[std::path::PathBuf],
         output_dir: &std::path::Path,
         local_id: usize,
         unique_id: usize,

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1760,7 +1760,6 @@ impl BmffHash {
         &mut self,
         max_proofs: usize,
         alg: &str,
-        asset_path: &std::path::Path,
         fragment_paths: &Vec<std::path::PathBuf>,
         output_dir: &std::path::Path,
         local_id: usize,

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -999,11 +999,16 @@ impl BmffHash {
     #[cfg(feature = "file_io")]
     pub fn update_fragmented_inithash(
         &mut self,
+        unique_id: usize,
+        local_id: usize,
         asset_path: &std::path::Path,
     ) -> crate::error::Result<()> {
         if let Some(mm) = &mut self.merkle {
             let mut init_stream = std::fs::File::open(asset_path)?;
-            let mpd_mm = mm.get_mut(0).ok_or(Error::NotFound)?;
+            let mpd_mm = mm
+                .iter_mut()
+                .find(|m| m.unique_id == unique_id && m.local_id == local_id)
+                .ok_or(Error::NotFound)?;
 
             let curr_alg = match &mpd_mm.alg {
                 Some(a) => a.clone(),
@@ -1759,7 +1764,7 @@ impl BmffHash {
         fragment_paths: &Vec<std::path::PathBuf>,
         output_dir: &std::path::Path,
         local_id: usize,
-        unique_id: Option<usize>,
+        unique_id: usize,
     ) -> crate::Result<()> {
         if !output_dir.exists() {
             std::fs::create_dir_all(output_dir)?;
@@ -1770,38 +1775,13 @@ impl BmffHash {
             }
         }
 
-        let mut fragments = Vec::new();
-
-        let unique_id = match unique_id {
-            Some(id) => id,
-            None => local_id,
-        };
-
-        // copy to output folder saving paths to fragments and init segments
-        for file_path in fragment_paths {
-            fragments.push(file_path.as_path());
-
-            let output_path = output_dir.join(
-                file_path
-                    .file_name()
-                    .ok_or(Error::BadParam("file name not found".to_string()))?,
-            );
-            std::fs::copy(file_path, output_path)?;
-        }
-        let output_path = output_dir.join(
-            asset_path
-                .file_name()
-                .ok_or(Error::BadParam("file name not found".to_string()))?,
-        );
-        std::fs::copy(asset_path, output_path)?;
-
         // create dummy tree to figure out the layout and proof size
-        let dummy_tree = C2PAMerkleTree::dummy_tree(fragments.len(), alg);
+        let dummy_tree = C2PAMerkleTree::dummy_tree(fragment_paths.len(), alg);
 
         let mut location_to_fragment_map: HashMap<usize, std::path::PathBuf> = HashMap::new();
 
         // copy to destination and insert placeholder C2PA Merkle box
-        for (location, seg) in (0_usize..).zip(fragments.iter()) {
+        for (location, seg) in (0_usize..).zip(fragment_paths.iter()) {
             let mut seg_reader = std::fs::File::open(seg)?;
 
             let c2pa_boxes = read_bmff_c2pa_boxes(&mut seg_reader)?;
@@ -1864,7 +1844,10 @@ impl BmffHash {
                 .to_string_lossy()
                 .into_owned();
             let dest_path = output_dir.join(&output_filename);
-            let mut dest = std::fs::OpenOptions::new().write(true).open(&dest_path)?;
+            let mut dest = std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&dest_path)?;
 
             // UUID to insert into output asset
             crate::utils::io_utils::insert_data_at(
@@ -1880,8 +1863,9 @@ impl BmffHash {
 
         // fill in actual hashes now that we have inserted the C2PA box.
         let bmff_exclusions = &self.exclusions;
-        let mut leaves: Vec<crate::utils::merkle::MerkleNode> = Vec::with_capacity(fragments.len());
-        for i in 0..fragments.len() {
+        let mut leaves: Vec<crate::utils::merkle::MerkleNode> =
+            Vec::with_capacity(fragment_paths.len());
+        for i in 0..fragment_paths.len() {
             if let Some(path) = location_to_fragment_map.get(&i) {
                 let mut fragment_stream = std::fs::File::open(path)?;
 
@@ -1902,7 +1886,7 @@ impl BmffHash {
 
         // gen final merkle tree
         let m_tree = C2PAMerkleTree::from_leaves(leaves, alg, false);
-        for i in 0..fragments.len() {
+        for i in 0..fragment_paths.len() {
             if let Some(dest_path) = location_to_fragment_map.get(&i) {
                 let mut fragment_stream = std::fs::OpenOptions::new()
                     .read(true)
@@ -1971,7 +1955,7 @@ impl BmffHash {
         let mm = MerkleMap {
             unique_id,
             local_id,
-            count: fragments.len(),
+            count: fragment_paths.len(),
             alg: Some(alg.to_owned()),
             init_hash: match alg {
                 // placeholder init hash to be filled once manifest is inserted
@@ -1984,7 +1968,13 @@ impl BmffHash {
             fixed_block_size: None,
             variable_block_sizes: None,
         };
-        self.merkle = Some(vec![mm]);
+
+        // add the MerkleMap to the merkle vector (create if needed)
+        if let Some(mm_vec) = self.merkle.as_mut() {
+            mm_vec.push(mm);
+        } else {
+            self.merkle = Some(vec![mm]);
+        }
 
         Ok(())
     }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3076,10 +3076,10 @@ impl Builder {
 
         let mut asset_paths = Vec::new();
         for entry in glob::glob(asset_path_str)
-            .map_err(|e| Error::BadParam(format!("Invalid glob pattern for asset path: {}", e)))?
+            .map_err(|e| Error::BadParam(format!("Invalid glob pattern for asset path: {e}")))?
         {
             let path = entry.map_err(|e| {
-                Error::BadParam(format!("Error occurred while reading asset path: {}", e))
+                Error::BadParam(format!("Error occurred while reading asset path: {e}"))
             })?;
             asset_paths.push(path);
         }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3015,8 +3015,10 @@ impl Builder {
     ///
     /// # Arguments
     /// * `signer` - The signer to use.
-    /// * `asset_path` - The path to the primary asset file.
-    /// * `fragment_glob` - The glob pattern to the fragmented files.
+    /// * `asset_path` - The path to the primary asset file or glob pattern if there are mulitple init segments in a set.
+    /// * `fragment_glob` - The glob pattern to the fragmented files. Do not full path, only the
+    /// *   pattern to find the fragmented files in the same directory as the asset file. For example,
+    /// *   if your fragmented files are named `video_1.m4s`, `video_2.m4s`, etc., then the glob pattern should be `video_*.m4s`.
     /// * `output_path` - The path to the output file.
     ///
     /// # Errors
@@ -3032,49 +3034,29 @@ impl Builder {
         // convert the manifest to a store
         let mut store = self.to_store()?;
 
+        let asset_path_str = asset_path.as_ref().to_str().ok_or(Error::BadParam(
+            "init glob pattern is not valid".to_string(),
+        ))?; // segment match pattern
+
+        let mut asset_paths = Vec::new();
+        for entry in glob::glob(asset_path_str)
+            .map_err(|e| Error::BadParam(format!("Invalid glob pattern for asset path: {}", e)))?
+        {
+            let path = entry.map_err(|e| {
+                Error::BadParam(format!("Error occurred while reading asset path: {}", e))
+            })?;
+            asset_paths.push(path);
+        }
+
         // sign and write our store to DASH content
         store.save_to_bmff_fragmented(
-            &[asset_path],
-            fragment_paths,
+            &asset_paths,
+            fragment_glob.as_ref(),
             output_path.as_ref(),
             signer,
             &self.context,
         )?;
-         Ok(())
-    }
-
-    /// Sign a set of renditions.
-    ///
-    /// Note: Currently this does not support files with existing C2PA manifest.
-    ///
-    /// # Arguments
-    /// * `signer` - The signer to use.
-    /// * `asset_paths` - The path to init segment for each rendition.
-    /// * `fragment_glob` - The glob pattern to the fragmented files.
-    /// * `output_path` - The path to the output file.
-    ///
-    /// # Errors
-    /// * Returns an [`Error`] if the manifest cannot be signed.
-    #[cfg(feature = "file_io")]
-    pub fn sign_renditions<P: AsRef<Path>>(
-        &mut self,
-        signer: &dyn Signer,
-        asset_paths: &[P],
-        fragment_glob: P,
-        output_path: P,
-    ) -> Result<()> {
-        // convert the manifest to a store
-        let mut store = self.to_store()?;
-
-        // sign and write our store to DASH content
-        store.save_to_bmff_fragmented(
-            asset_paths,
-            fragment_glob,
-            output_path.as_ref(),
-            signer,
-            &self.context,
-        )?;
-         Ok(())
+        Ok(())
     }
 
     #[cfg(feature = "file_io")]

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3056,8 +3056,8 @@ impl Builder {
     /// # Arguments
     /// * `signer` - The signer to use.
     /// * `asset_path` - The path to the primary asset file or glob pattern if there are mulitple init segments in a set.
-    /// * `fragment_glob` - The glob pattern to the fragmented files. Do not full path, only the
-    /// *   pattern to find the fragmented files in the same directory as the asset file. For example,
+    /// * `fragment_glob` - The glob pattern to the fragmented files. Do not use the full path, only the
+    /// *   pattern to find the fragmented files in the same directory/subdirectory as the asset file. For example,
     /// *   if your fragmented files are named `video_1.m4s`, `video_2.m4s`, etc., then the glob pattern should be `video_*.m4s`.
     /// * `output_path` - The path to the output file.
     ///

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3009,14 +3009,14 @@ impl Builder {
         Ok(())
     }
 
-    /// Sign a set of fragmented BMFF files.
+    /// Sign a set of fragmented BMFF files for a single rendition.
     ///
     /// Note: Currently this does not support files with existing C2PA manifest.
     ///
     /// # Arguments
     /// * `signer` - The signer to use.
     /// * `asset_path` - The path to the primary asset file.
-    /// * `fragment_paths` - The paths to the fragmented files.
+    /// * `fragment_glob` - The glob pattern to the fragmented files.
     /// * `output_path` - The path to the output file.
     ///
     /// # Errors
@@ -3026,41 +3026,55 @@ impl Builder {
         &mut self,
         signer: &dyn Signer,
         asset_path: P,
-        fragment_paths: &Vec<std::path::PathBuf>,
+        fragment_glob: P,
         output_path: P,
     ) -> Result<()> {
-        if !output_path.as_ref().exists() {
-            // ensure the path exists
-            std::fs::create_dir_all(output_path.as_ref())?;
-        } else {
-            // if the file exists, we need to remove it
-            if output_path.as_ref().is_file() {
-                return Err(crate::Error::BadParam(
-                    "output_path must be a folder".to_string(),
-                ));
-            } else {
-                let file_name = asset_path.as_ref().file_name().unwrap_or_default();
-                let mut output_file = output_path.as_ref().to_owned();
-                output_file = output_file.join(file_name);
-                if output_file.exists() {
-                    return Err(crate::Error::BadParam(
-                        "Destination file already exists".to_string(),
-                    ));
-                }
-            }
-        }
-
         // convert the manifest to a store
         let mut store = self.to_store()?;
 
         // sign and write our store to DASH content
         store.save_to_bmff_fragmented(
-            asset_path.as_ref(),
+            &[asset_path],
             fragment_paths,
             output_path.as_ref(),
             signer,
             &self.context,
-        )
+        )?;
+         Ok(())
+    }
+
+    /// Sign a set of renditions.
+    ///
+    /// Note: Currently this does not support files with existing C2PA manifest.
+    ///
+    /// # Arguments
+    /// * `signer` - The signer to use.
+    /// * `asset_paths` - The path to init segment for each rendition.
+    /// * `fragment_glob` - The glob pattern to the fragmented files.
+    /// * `output_path` - The path to the output file.
+    ///
+    /// # Errors
+    /// * Returns an [`Error`] if the manifest cannot be signed.
+    #[cfg(feature = "file_io")]
+    pub fn sign_renditions<P: AsRef<Path>>(
+        &mut self,
+        signer: &dyn Signer,
+        asset_paths: &[P],
+        fragment_glob: P,
+        output_path: P,
+    ) -> Result<()> {
+        // convert the manifest to a store
+        let mut store = self.to_store()?;
+
+        // sign and write our store to DASH content
+        store.save_to_bmff_fragmented(
+            asset_paths,
+            fragment_glob,
+            output_path.as_ref(),
+            signer,
+            &self.context,
+        )?;
+         Ok(())
     }
 
     #[cfg(feature = "file_io")]

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3009,7 +3009,7 @@ impl Builder {
         Ok(())
     }
 
-    /// Sign a set of fragmented BMFF files for a single rendition.
+    /// Sign rendition(s) containing fragmented BMFF files.
     ///
     /// Note: Currently this does not support files with existing C2PA manifest.
     ///

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2908,8 +2908,7 @@ impl Store {
             // ensure the path exists
             std::fs::create_dir_all(output_path).map_err(|e| {
                 Error::BadParam(format!(
-                    "failed to create output directory for fragments: {}",
-                    e
+                    "failed to create output directory for fragments: {e}"
                 ))
             })?;
         }
@@ -2947,14 +2946,13 @@ impl Store {
 
             // grab the fragments that go with this init segment
             for entry in glob::glob(frag_glob_str)
-                .map_err(|e| Error::BadParam(format!("glob pattern is not valid: {}", e)))?
+                .map_err(|e| Error::BadParam(format!("glob pattern is not valid: {e}")))?
             {
                 match entry {
                     Ok(path) => fragments.push(path),
                     Err(e) => {
                         return Err(Error::BadParam(format!(
-                            "error processing glob pattern: {}",
-                            e
+                            "error processing glob pattern: {e}"
                         )))
                     }
                 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2941,15 +2941,17 @@ impl Store {
 
             // add the Merkle tree map for this rendition
             // creating fragments in the output location
+            let unique_id = i + 1;
+            let local_id = i + 1;
             self.add_merkmap_for_rendition(
                 &fragments,
-                i + 1, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
-                i + 1, // unique id for this rendition
+                local_id, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
+                unique_id, // unique id for this rendition
                 &new_output_path,
                 context.settings(),
             )?;
 
-            output_map.insert(init_path.to_owned(), (i, i));
+            output_map.insert(init_path.to_owned(), (unique_id, local_id));
         }
 
         // now save the manifest to each output init segment (the manifest is the same for each segment per the spec to allow related rendtions to be validated as a set)
@@ -2976,12 +2978,9 @@ impl Store {
 
             let output_file = output_path.as_ref().join(init_dir).join(init_name);
 
-            // copy the init segment to the output location so we can modify it in place
-            std::fs::copy(init_path, &output_file)?;
-
             // add manifest a placeholder that will be replaced with the final manifest after signing,
             // but we need to add it now to properly calculate the BMFF hash for each init segment
-            save_jumbf_to_file(&unsigned_jumbf, &output_file, Some(&output_file))?;
+            save_jumbf_to_file(&unsigned_jumbf, init_path, Some(&output_file))?;
 
             // update the initHash for each init segment
             bmff_hash.update_fragmented_inithash(*unique_id, *local_id, &output_file)?;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2936,9 +2936,9 @@ impl Store {
             let mut fragments = Vec::new();
             let init_dir = init_path
                 .parent()
-                .ok_or(Error::BadParam(format!(
-                    "failed to get parent directory for init segment"
-                )))?
+                .ok_or(Error::BadParam(
+                    "failed to get parent directory for init segment".to_string(),
+                ))?
                 .to_path_buf();
             let frag_glob = init_dir.join(fragment_glob.as_ref());
             let frag_glob_str = frag_glob
@@ -2987,18 +2987,18 @@ impl Store {
         let unsigned_jumbf = self.to_jumbf_internal(signer.reserve_size())?;
         for (init_path, (unique_id, local_id)) in output_map.iter() {
             let init_name = PathBuf::from(init_path.file_name().ok_or(Error::BadParam(
-                format!("failed to get file name for init segment"),
+                "failed to get file name for init segment".to_string(),
             ))?);
             let init_dir = PathBuf::from(
                 init_path
                     .parent()
-                    .ok_or(Error::BadParam(format!(
-                        "failed to get parent directory for init segment"
-                    )))?
+                    .ok_or(Error::BadParam(
+                        "failed to get parent directory for init segment".to_string(),
+                    ))?
                     .file_name()
-                    .ok_or(Error::BadParam(format!(
-                        "failed to get file name for init segment"
-                    )))?,
+                    .ok_or(Error::BadParam(
+                        "failed to get file name for init segment".to_string(),
+                    ))?,
             );
 
             let output_file = output_path.as_ref().join(init_dir).join(init_name);
@@ -8329,8 +8329,8 @@ pub mod tests {
         )
         .unwrap()
         {
-            if init.is_ok() {
-                inits.push(init.unwrap());
+            if let Ok(item) = init {
+                inits.push(item);
             }
         }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2781,6 +2781,12 @@ impl Store {
         output_dir: &Path,
         settings: &Settings,
     ) -> Result<()> {
+        if fragments.is_empty() {
+            return Err(Error::BadParam(
+                "at least one fragment path must be provided".to_string(),
+            ));
+        }
+
         // get the provenance claim changing mutability
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
         pc.clear_data(); // clear since we are reusing an existing claim
@@ -2849,7 +2855,7 @@ impl Store {
 
     /// Embed the claims store as jumbf into fragmented assets.
     #[cfg(feature = "file_io")]
-    pub fn save_to_bmff_fragmented<P: AsRef<Path> + Copy>(
+    pub fn save_to_bmff_fragmented<P: AsRef<Path>>(
         &mut self,
         init_paths: &[PathBuf],
         fragment_glob: P,
@@ -2857,6 +2863,12 @@ impl Store {
         signer: &dyn Signer,
         context: &Context,
     ) -> Result<()> {
+        if init_paths.is_empty() {
+            return Err(Error::BadParam(
+                "at least one init segment path must be provided".to_string(),
+            ));
+        }
+
         let mut output_map = HashMap::new();
 
         // make sure output path is not a file
@@ -2869,7 +2881,7 @@ impl Store {
         // mak sure we can make the output folder
         if !output_path.as_ref().exists() {
             // ensure the path exists
-            std::fs::create_dir_all(output_path).map_err(|e| {
+            std::fs::create_dir_all(output_path.as_ref()).map_err(|e| {
                 Error::BadParam(format!(
                     "failed to create output directory for fragments: {e}"
                 ))
@@ -2931,8 +2943,8 @@ impl Store {
             // creating fragments in the output location
             self.add_merkmap_for_rendition(
                 &fragments,
-                i, // unique id for this rendition
-                i, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
+                i + 1, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
+                i + 1, // unique id for this rendition 
                 &new_output_path,
                 context.settings(),
             )?;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2944,7 +2944,7 @@ impl Store {
             self.add_merkmap_for_rendition(
                 &fragments,
                 i + 1, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
-                i + 1, // unique id for this rendition 
+                i + 1, // unique id for this rendition
                 &new_output_path,
                 context.settings(),
             )?;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2794,7 +2794,6 @@ impl Store {
     #[cfg(feature = "file_io")]
     fn add_merkmap_for_rendition(
         &mut self,
-        asset_path: &Path,
         fragments: &Vec<std::path::PathBuf>,
         local_id: usize,
         unique_id: usize,
@@ -2826,7 +2825,6 @@ impl Store {
         bmff_hash.add_merkle_for_fragmented(
             settings.core.merkle_tree_max_proofs,
             pc.alg(),
-            asset_path,
             fragments,
             output_dir,
             local_id,
@@ -2870,9 +2868,9 @@ impl Store {
 
     /// Embed the claims store as jumbf into fragmented assets.
     #[cfg(feature = "file_io")]
-    pub fn save_to_bmff_fragmented<P: AsRef<Path>>(
+    pub fn save_to_bmff_fragmented<P: AsRef<Path> + Copy>(
         &mut self,
-        init_paths: &[P],
+        init_paths: &[PathBuf],
         fragment_glob: P,
         output_path: P,
         signer: &dyn Signer,
@@ -2881,16 +2879,21 @@ impl Store {
         let mut output_map = HashMap::new();
 
         // make sure output path is not a file
-        if output_path.is_file() {
+        if output_path.as_ref().is_file() {
             return Err(crate::Error::BadParam(
                 "output_path must be a folder".to_string(),
             ));
         }
 
         // mak sure we can make the output folder
-        if !output_path.exists() {
+        if !output_path.as_ref().exists() {
             // ensure the path exists
-            std::fs::create_dir_all(output_path)?;
+            std::fs::create_dir_all(output_path).map_err(|e| {
+                Error::BadParam(format!(
+                    "failed to create output directory for fragments: {}",
+                    e
+                ))
+            })?;
         }
 
         // add dynamic assertions placeholders to the store
@@ -2913,7 +2916,12 @@ impl Store {
 
             // build the list of fragments for this init segment based on the glob pattern
             let mut fragments = Vec::new();
-            let init_dir = init_path.as_ref().parent().unwrap().to_path_buf();
+            let init_dir = init_path
+                .parent()
+                .ok_or(Error::BadParam(format!(
+                    "failed to get parent directory for init segment"
+                )))?
+                .to_path_buf();
             let frag_glob = init_dir.join(fragment_glob.as_ref());
             let frag_glob_str = frag_glob
                 .to_str()
@@ -2934,7 +2942,7 @@ impl Store {
                 }
             }
 
-            let new_output_path = output_path.join(
+            let new_output_path = output_path.as_ref().join(
                 init_dir
                     .file_name()
                     .ok_or(Error::BadParam("init segment bad file name".to_string()))?,
@@ -2943,7 +2951,6 @@ impl Store {
             // add the Merkle tree map for this rendition
             // creating fragments in the output location
             self.add_merkmap_for_rendition(
-                init_path.as_ref(),
                 &fragments,
                 i, // unique id for this rendition
                 i, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
@@ -2951,7 +2958,7 @@ impl Store {
                 context.settings(),
             )?;
 
-            output_map.insert(init_path.as_ref().to_owned(), (i, i));
+            output_map.insert(init_path.to_owned(), (i, i));
         }
 
         // now save the manifest to each output init segment (the manifest is the same for each segment per the spec to allow related rendtions to be validated as a set)
@@ -2960,12 +2967,23 @@ impl Store {
         let bmff_hashes = pc.bmff_hash_assertions();
         let mut bmff_hash = BmffHash::from_assertion(bmff_hashes[0].assertion())?;
         let unsigned_jumbf = self.to_jumbf_internal(signer.reserve_size())?;
-        for init_path in init_paths.iter() {
-            let init_name = PathBuf::from(init_path.file_name().unwrap_or_default());
-            let init_dir = PathBuf::from(init_path.parent().unwrap().file_name().unwrap());
+        for (init_path, (unique_id, local_id)) in output_map.iter() {
+            let init_name = PathBuf::from(init_path.file_name().ok_or(Error::BadParam(
+                format!("failed to get file name for init segment"),
+            ))?);
+            let init_dir = PathBuf::from(
+                init_path
+                    .parent()
+                    .ok_or(Error::BadParam(format!(
+                        "failed to get parent directory for init segment"
+                    )))?
+                    .file_name()
+                    .ok_or(Error::BadParam(format!(
+                        "failed to get file name for init segment"
+                    )))?,
+            );
 
-            let mut output_file = output_path.to_path_buf();
-            output_file = output_file.join(init_dir).join(init_name);
+            let output_file = output_path.as_ref().join(init_dir).join(init_name);
 
             // copy the init segment to the output location so we can modify it in place
             std::fs::copy(init_path, &output_file)?;
@@ -2975,7 +2993,6 @@ impl Store {
             save_jumbf_to_file(&unsigned_jumbf, &output_file, Some(&output_file))?;
 
             // update the initHash for each init segment
-            let (unique_id, local_id) = output_map.get(init_path).ok_or(Error::NotFound)?;
             bmff_hash.update_fragmented_inithash(*unique_id, *local_id, &output_file)?;
 
             output_files.push(output_file);
@@ -3497,27 +3514,6 @@ impl Store {
         Ok((sig, jumbf_bytes))
     }
 
-    #[cfg(feature = "file_io")]
-    fn finish_save(
-        &self,
-        mut jumbf_bytes: Vec<u8>,
-        output_path: &Path,
-        sig: Vec<u8>,
-        sig_placeholder: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>)> {
-        if sig_placeholder.len() != sig.len() {
-            return Err(Error::CoseSigboxTooSmall);
-        }
-
-        patch_bytes(&mut jumbf_bytes, sig_placeholder, &sig)
-            .map_err(|_| Error::JumbfCreationError)?;
-
-        // re-save to file
-        save_jumbf_to_file(&jumbf_bytes, output_path, Some(output_path))?;
-
-        Ok((sig, jumbf_bytes))
-    }
-
     /// Verify Store from an existing asset
     /// asset_path: path to input asset
     /// validation_log: If present all found errors are logged and returned, otherwise first error causes exit and is returned
@@ -3814,7 +3810,7 @@ impl Store {
         validation_log: &mut StatusTracker,
         context: &Context,
     ) -> Result<Store> {
-        let manifest_bytes = Store::load_jumbf_from_stream(format, &mut init_segment, context)?.0;
+        let manifest_bytes = Store::load_jumbf_from_stream(asset_type, init_segment, context)?.0;
 
         let store = Store::from_jumbf_with_context(&manifest_bytes, validation_log, context)?;
         let verify = context.settings().verify.verify_after_reading;
@@ -8334,7 +8330,7 @@ pub mod tests {
             .save_to_bmff_fragmented(
                 &inits,
                 &PathBuf::from("BigBuckBunny_2s*.m4s"),
-                output_path,
+                &output_path.to_path_buf(),
                 signer.as_ref(),
                 &context,
             )

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2792,30 +2792,35 @@ impl Store {
     }
 
     #[cfg(feature = "file_io")]
-    fn start_save_bmff_fragmented(
+    fn add_merkmap_for_rendition(
         &mut self,
         asset_path: &Path,
         fragments: &Vec<std::path::PathBuf>,
+        local_id: usize,
+        unique_id: usize,
         output_dir: &Path,
-        reserve_size: usize,
         settings: &Settings,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<()> {
         // get the provenance claim changing mutability
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
         pc.clear_data(); // clear since we are reusing an existing claim
 
-        let output_filename = asset_path.file_name().ok_or(Error::NotFound)?;
-        let dest_path = output_dir.join(output_filename);
+        // get the BMFF hash assertion if it exists or create a new one if not
+        let mut bmff_hash = if let Some(bmff_hash_assertion) = pc.bmff_hash_assertions().first() {
+            BmffHash::from_assertion(bmff_hash_assertion.assertion())?
+        } else {
+            let mut bmff_hash = BmffHash::new("jumbf manifest", pc.alg(), None);
 
-        let mut data;
+            bmff_hash.set_default_exclusions();
 
-        // 2) Get hash ranges if needed
-        let mut bmff_hash = Store::generate_bmff_data_hash_for_stream(pc.alg())?;
+            if pc.version() < 2 {
+                bmff_hash.set_bmff_version(2); // backcompat support
+            }
 
-        bmff_hash.clear_hash();
-        if pc.version() < 2 {
-            bmff_hash.set_bmff_version(2); // backcompat support
-        }
+            pc.add_assertion(&bmff_hash)?;
+            bmff_hash
+        };
+        bmff_hash.clear_hash(); // hash is not used when using fragmented Merkle tree approach
 
         // generate fragments and produce Merkle tree
         bmff_hash.add_merkle_for_fragmented(
@@ -2824,10 +2829,14 @@ impl Store {
             asset_path,
             fragments,
             output_dir,
-            1,
-            None,
+            local_id,
+            unique_id,
         )?;
 
+        // update the BMFF hash assertion with the new Merkle tree information
+        pc.update_bmff_hash(bmff_hash)?;
+
+        /*
         // add in the BMFF assertion
         pc.add_assertion(&bmff_hash)?;
 
@@ -2854,103 +2863,175 @@ impl Store {
         if jumbf_size != data.len() {
             return Err(Error::JumbfCreationError);
         }
+        */
 
-        Ok(data) // return JUMBF data
+        Ok(())
     }
 
     /// Embed the claims store as jumbf into fragmented assets.
     #[cfg(feature = "file_io")]
-    pub fn save_to_bmff_fragmented(
+    pub fn save_to_bmff_fragmented<P: AsRef<Path>>(
         &mut self,
-        asset_path: &Path,
-        fragments: &Vec<std::path::PathBuf>,
-        output_path: &Path,
+        init_paths: &[P],
+        fragment_glob: P,
+        output_path: P,
         signer: &dyn Signer,
         context: &Context,
     ) -> Result<()> {
-        match get_supported_file_extension(asset_path) {
-            Some(ext) => {
-                if !is_bmff_format(&ext) {
-                    return Err(Error::UnsupportedType);
-                }
-            }
-            None => return Err(Error::UnsupportedType),
+        let mut output_map = HashMap::new();
+
+        // make sure output path is not a file
+        if output_path.is_file() {
+            return Err(crate::Error::BadParam(
+                "output_path must be a folder".to_string(),
+            ));
         }
 
-        let output_filename = asset_path.file_name().ok_or(Error::NotFound)?;
-        let dest_path = output_path.join(output_filename);
+        // mak sure we can make the output folder
+        if !output_path.exists() {
+            // ensure the path exists
+            std::fs::create_dir_all(output_path)?;
+        }
 
-        let mut validation_log =
-            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
-
-        // add dynamic assertions to the store
+        // add dynamic assertions placeholders to the store
         let dynamic_assertions = signer.dynamic_assertions();
-        let _ = self.add_dynamic_assertion_placeholders(&dynamic_assertions)?;
-
-        // get temp store as JUMBF
-        let jumbf = self.to_jumbf(signer)?;
-
-        // use temp store so mulitple calls across renditions will work (the Store is not finalized this way)
-        let mut temp_store = Store::from_jumbf_with_context(&jumbf, &mut validation_log, context)?;
-
-        let mut jumbf_bytes = temp_store.start_save_bmff_fragmented(
-            asset_path,
-            fragments,
-            output_path,
-            signer.reserve_size(),
-            context.settings(),
-        )?;
-
-        let mut preliminary_claim = PartialClaim::default();
-        {
-            let pc = temp_store.provenance_claim().ok_or(Error::ClaimEncoding)?;
-            for assertion in pc.assertions() {
-                preliminary_claim.add_assertion(assertion);
-            }
+        if !dynamic_assertions.is_empty() {
+            self.add_dynamic_assertion_placeholders(&dynamic_assertions)?;
         }
 
-        // Now add the dynamic assertions and update the JUMBF.
-        let modified =
-            temp_store.write_dynamic_assertions(&dynamic_assertions, &mut preliminary_claim)?;
-
-        // update the JUMBF if modified with dynamic assertions
-        if modified {
-            let pc = temp_store.provenance_claim().ok_or(Error::ClaimEncoding)?;
-            match pc.remote_manifest() {
-                RemoteManifest::NoRemote | RemoteManifest::EmbedWithRemote(_) => {
-                    jumbf_bytes = temp_store.to_jumbf_internal(signer.reserve_size())?;
-
-                    // save the jumbf to the output path
-                    save_jumbf_to_file(&jumbf_bytes, &dest_path, Some(&dest_path))?;
-
-                    let pc = temp_store
-                        .provenance_claim_mut()
-                        .ok_or(Error::ClaimEncoding)?;
-                    // generate actual hash values
-                    let bmff_hashes = pc.bmff_hash_assertions();
-
-                    if !bmff_hashes.is_empty() {
-                        let mut bmff_hash = BmffHash::from_assertion(bmff_hashes[0].assertion())?;
-                        bmff_hash.update_fragmented_inithash(&dest_path)?;
-                        pc.update_bmff_hash(bmff_hash)?;
+        // add a Merkle tree map for each init segment and its associated fragments
+        for (i, init_path) in init_paths.iter().enumerate() {
+            // make sure it is a supported BMFF format
+            match get_supported_file_extension(init_path.as_ref()) {
+                Some(ext) => {
+                    if !is_bmff_format(&ext) {
+                        return Err(Error::UnsupportedType);
                     }
-
-                    // regenerate the jumbf because the cbor changed
-                    jumbf_bytes = temp_store.to_jumbf_internal(signer.reserve_size())?;
                 }
-                _ => (),
+                None => return Err(Error::UnsupportedType),
+            }
+
+            // build the list of fragments for this init segment based on the glob pattern
+            let mut fragments = Vec::new();
+            let init_dir = init_path.as_ref().parent().unwrap().to_path_buf();
+            let frag_glob = init_dir.join(fragment_glob.as_ref());
+            let frag_glob_str = frag_glob
+                .to_str()
+                .ok_or(Error::BadParam("glob pattern is not valid".to_string()))?; // segment match pattern
+
+            // grab the fragments that go with this init segment
+            for entry in glob::glob(frag_glob_str)
+                .map_err(|e| Error::BadParam(format!("glob pattern is not valid: {}", e)))?
+            {
+                match entry {
+                    Ok(path) => fragments.push(path),
+                    Err(e) => {
+                        return Err(Error::BadParam(format!(
+                            "error processing glob pattern: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+
+            let new_output_path = output_path.join(
+                init_dir
+                    .file_name()
+                    .ok_or(Error::BadParam("init segment bad file name".to_string()))?,
+            );
+
+            // add the Merkle tree map for this rendition
+            // creating fragments in the output location
+            self.add_merkmap_for_rendition(
+                init_path.as_ref(),
+                &fragments,
+                i, // unique id for this rendition
+                i, // local id for this rendition (same as unique since we are only doing one rendition per claim for now)
+                &new_output_path,
+                context.settings(),
+            )?;
+
+            output_map.insert(init_path.as_ref().to_owned(), (i, i));
+        }
+
+        // now save the manifest to each output init segment (the manifest is the same for each segment per the spec to allow related rendtions to be validated as a set)
+        let mut output_files = Vec::new();
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?; // reborrow to change mutability
+        let bmff_hashes = pc.bmff_hash_assertions();
+        let mut bmff_hash = BmffHash::from_assertion(bmff_hashes[0].assertion())?;
+        let unsigned_jumbf = self.to_jumbf_internal(signer.reserve_size())?;
+        for init_path in init_paths.iter() {
+            let init_name = PathBuf::from(init_path.file_name().unwrap_or_default());
+            let init_dir = PathBuf::from(init_path.parent().unwrap().file_name().unwrap());
+
+            let mut output_file = output_path.to_path_buf();
+            output_file = output_file.join(init_dir).join(init_name);
+
+            // copy the init segment to the output location so we can modify it in place
+            std::fs::copy(init_path, &output_file)?;
+
+            // add manifest a placeholder that will be replaced with the final manifest after signing,
+            // but we need to add it now to properly calculate the BMFF hash for each init segment
+            save_jumbf_to_file(&unsigned_jumbf, &output_file, Some(&output_file))?;
+
+            // update the initHash for each init segment
+            let (unique_id, local_id) = output_map.get(init_path).ok_or(Error::NotFound)?;
+            bmff_hash.update_fragmented_inithash(*unique_id, *local_id, &output_file)?;
+
+            output_files.push(output_file);
+        }
+
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?; // reborrow to change mutability
+
+        // update the BMFF hash in the final BMFFHash assertion containing the unique initHash values for each rendition
+        pc.update_bmff_hash(bmff_hash)?;
+
+        // Write dynamic assertions only if placeholders were added during placeholder generation.
+        // We check if the dynamic assertion labels exist in the claim - if not, placeholders
+        // weren't added and we should skip writing to avoid size mismatches.
+        let dynamic_assertions = signer.dynamic_assertions();
+        if !dynamic_assertions.is_empty() {
+            // Check if placeholders exist for these dynamic assertions
+            let has_placeholders = {
+                let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+                dynamic_assertions
+                    .iter()
+                    .all(|da| pc.assertion_hashed_uri_from_label(&da.label()).is_some())
             };
+
+            if has_placeholders {
+                let mut preliminary_claim = PartialClaim::default();
+                {
+                    let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+                    for assertion in pc.assertions() {
+                        preliminary_claim.add_assertion(assertion);
+                    }
+                }
+
+                self.write_dynamic_assertions(&dynamic_assertions, &mut preliminary_claim)?;
+            }
         }
 
         // sign the claim
-        let pc = temp_store.provenance_claim().ok_or(Error::ClaimEncoding)?;
-        let sig = temp_store.sign_claim(pc, signer, signer.reserve_size(), context.settings())?;
-        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+        let sig = self.sign_claim(pc, signer, signer.reserve_size(), context.settings())?;
 
-        match temp_store.finish_save(jumbf_bytes, &dest_path, sig, &sig_placeholder) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
+        // update the provenance claim with the signature so it gets saved in the manifest
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+        pc.set_signature_val(sig);
+
+        // regenerate the JUMBF with the signature
+        let final_jumbf = self.to_jumbf_internal(signer.reserve_size())?;
+        if final_jumbf.len() != unsigned_jumbf.len() {
+            return Err(Error::JumbfCreationError);
         }
+
+        // write the signed manifest to each output init segment
+        for output_file in output_files.iter() {
+            save_jumbf_to_file(&final_jumbf, output_file, Some(output_file))?;
+        }
+
+        Ok(())
     }
 
     /// Embed the claims store as JUMBF into a stream. Updates XMP with provenance
@@ -3733,8 +3814,10 @@ impl Store {
         validation_log: &mut StatusTracker,
         context: &Context,
     ) -> Result<Store> {
+        let manifest_bytes = Store::load_jumbf_from_stream(format, &mut init_segment, context)?.0;
+
+        let store = Store::from_jumbf_with_context(&manifest_bytes, validation_log, context)?;
         let verify = context.settings().verify.verify_after_reading;
-        let store = Self::from_stream(asset_type, &mut *init_segment, validation_log, context)?;
 
         // verify the store
         if verify {
@@ -8216,7 +8299,7 @@ pub mod tests {
     #[cfg(feature = "file_io")]
     fn test_fragmented_jumbf_generation() {
         let mut context = crate::context::Context::new();
-        context.settings_mut().verify.verify_after_reading = false;
+        context.settings_mut().verify.verify_after_reading = true;
 
         // test adding to actual image
 
@@ -8224,6 +8307,7 @@ pub mod tests {
         let output_path = tempdir.path();
 
         // search folders for init segments
+        let mut inits = Vec::new();
         for init in glob::glob(
             fixture_path("bunny/**/BigBuckBunny_2s_init.mp4")
                 .to_str()
@@ -8231,84 +8315,81 @@ pub mod tests {
         )
         .unwrap()
         {
-            match init {
-                Ok(p) => {
-                    let mut fragments = Vec::new();
-                    let init_dir = p.parent().unwrap();
-                    let seg_glob = init_dir.join("BigBuckBunny_2s*.m4s"); // segment match pattern
-
-                    // grab the fragments that go with this init segment
-                    for seg in glob::glob(seg_glob.to_str().unwrap()).unwrap().flatten() {
-                        fragments.push(seg);
-                    }
-
-                    // Create claims store.
-                    let mut store = Store::from_context(&context);
-
-                    // Create a new claim.
-                    let claim = create_test_claim().unwrap();
-                    store.commit_claim(claim).unwrap();
-
-                    // Do we generate JUMBF?
-                    let signer =
-                        test_cawg_signer(SigningAlg::Ps256, &[labels::SCHEMA_ORG]).unwrap();
-
-                    // Use Tempdir for automatic cleanup
-                    let new_subdir = tempfile::TempDir::new_in(output_path)
-                        .expect("Failed to create temp subdir");
-                    let new_output_path = new_subdir.path().join(init_dir.file_name().unwrap());
-                    store
-                        .save_to_bmff_fragmented(
-                            p.as_path(),
-                            &fragments,
-                            new_output_path.as_path(),
-                            signer.as_ref(),
-                            &context,
-                        )
-                        .unwrap();
-
-                    // verify the fragments
-                    let output_init = new_output_path.join(p.file_name().unwrap());
-                    let mut init_stream = std::fs::File::open(&output_init).unwrap();
-
-                    for entry in &fragments {
-                        let file_path = new_output_path.join(entry.file_name().unwrap());
-
-                        let mut validation_log = StatusTracker::default();
-
-                        let mut fragment_stream = std::fs::File::open(&file_path).unwrap();
-                        let _manifest = Store::load_fragment_from_stream(
-                            "mp4",
-                            &mut init_stream,
-                            &mut fragment_stream,
-                            &mut validation_log,
-                            &context,
-                        )
-                        .unwrap();
-                        init_stream.seek(std::io::SeekFrom::Start(0)).unwrap();
-                        assert!(!validation_log.has_any_error());
-                    }
-
-                    // test verifying all at once
-                    let mut output_fragments = Vec::new();
-                    for entry in &fragments {
-                        output_fragments.push(new_output_path.join(entry.file_name().unwrap()));
-                    }
-
-                    let mut validation_log = StatusTracker::default();
-                    let _manifest = Store::load_from_file_and_fragments(
-                        "mp4",
-                        &mut init_stream,
-                        &output_fragments,
-                        &mut validation_log,
-                        &context,
-                    )
-                    .unwrap();
-
-                    assert!(!validation_log.has_any_error());
-                }
-                Err(_) => panic!("test misconfigures"),
+            if init.is_ok() {
+                inits.push(init.unwrap());
             }
+        }
+
+        // Create claims store.
+        let mut store = Store::from_context(&context);
+
+        // Create a new claim.
+        let claim = create_test_claim().unwrap();
+        store.commit_claim(claim).unwrap();
+
+        // Do we generate JUMBF?
+        let signer = test_cawg_signer(SigningAlg::Ps256, &[labels::SCHEMA_ORG]).unwrap();
+
+        store
+            .save_to_bmff_fragmented(
+                &inits,
+                &PathBuf::from("BigBuckBunny_2s*.m4s"),
+                output_path,
+                signer.as_ref(),
+                &context,
+            )
+            .unwrap();
+
+        // verify the fragments
+        for init_path in &inits {
+            let init_name = PathBuf::from(init_path.file_name().unwrap_or_default());
+            let init_dir = PathBuf::from(init_path.parent().unwrap().file_name().unwrap());
+
+            let mut output_file = output_path.to_path_buf();
+            output_file = output_file.join(&init_dir).join(&init_name);
+
+            let mut init_stream = std::fs::File::open(&output_file).unwrap();
+
+            // build the list of fragments for this init segment based on the glob pattern
+            let mut fragments = Vec::new();
+            let frag_glob = output_path.join(&init_dir).join("BigBuckBunny_2s*.m4s");
+            let frag_glob_str = frag_glob.to_str().unwrap();
+
+            // grab the fragments that go with this init segment
+            for entry in glob::glob(frag_glob_str).unwrap() {
+                fragments.push(entry.unwrap());
+            }
+
+            // check fragments individually
+            for entry in &fragments {
+                let mut validation_log = StatusTracker::default();
+
+                let mut fragment_stream = std::fs::File::open(entry).unwrap();
+                let _manifest = Store::load_fragment_from_stream(
+                    "mp4",
+                    &mut init_stream,
+                    &mut fragment_stream,
+                    &mut validation_log,
+                    &context,
+                )
+                .unwrap();
+                init_stream.seek(std::io::SeekFrom::Start(0)).unwrap();
+                assert!(!validation_log.has_any_error());
+            }
+
+            // check all fragments together with the init
+            let mut validation_log = StatusTracker::default();
+            init_stream.rewind().unwrap();
+            let _manifest = Store::load_from_file_and_fragments(
+                "mp4",
+                &mut init_stream,
+                &fragments,
+                &mut validation_log,
+                &context,
+            )
+            .unwrap();
+
+            assert!(!validation_log.has_any_error());
         }
     }
 

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2812,7 +2812,7 @@ impl Store {
     #[cfg(feature = "file_io")]
     fn add_merkmap_for_rendition(
         &mut self,
-        fragments: &Vec<std::path::PathBuf>,
+        fragments: &[std::path::PathBuf],
         local_id: usize,
         unique_id: usize,
         output_dir: &Path,
@@ -8322,16 +8322,11 @@ pub mod tests {
 
         // search folders for init segments
         let mut inits = Vec::new();
-        for init in glob::glob(
-            fixture_path("bunny/**/BigBuckBunny_2s_init.mp4")
-                .to_str()
-                .unwrap(),
-        )
-        .unwrap()
+        for item in glob::glob(&fixture_path("bunny/**/BigBuckBunny_2s_init.mp4").to_string_lossy())
+            .unwrap()
+            .flatten()
         {
-            if let Ok(item) = init {
-                inits.push(item);
-            }
+            inits.push(item);
         }
 
         // Create claims store.

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -200,8 +200,9 @@ fn test_builder_sidecar_only() -> Result<()> {
 #[test]
 #[cfg(feature = "file_io")]
 fn test_builder_fragmented() -> Result<()> {
-    use common::tempdirectory;
     use std::path::PathBuf;
+
+    use common::tempdirectory;
 
     let context = test_context().into_shared();
 

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -197,6 +197,7 @@ fn test_builder_sidecar_only() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 #[cfg(feature = "file_io")]
 fn test_builder_fragmented() -> Result<()> {

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -200,19 +200,25 @@ fn test_builder_sidecar_only() -> Result<()> {
 
 #[test]
 #[cfg(feature = "file_io")]
-#[ignore = "generates a hash error, needs investigation"]
 fn test_builder_fragmented() -> Result<()> {
     use common::tempdirectory;
+    use std::path::PathBuf;
+
     let settings = Settings::new().with_toml(TEST_SETTINGS)?;
     let context = Context::new().with_settings(settings)?.into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
-    builder.set_intent(BuilderIntent::Edit);
+    builder.set_intent(BuilderIntent::Create(c2pa::DigitalSourceType::Empty));
     let tempdir = tempdirectory().expect("temp dir");
-    let output_path = tempdir.path();
+    let output_path = tempdir.path().to_path_buf();
     let mut init_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     init_path.push("tests/fixtures/bunny/**/BigBuckBunny_2s_init.mp4");
     let pattern = init_path.as_os_str().to_str().unwrap();
+
+    let frag_glob = PathBuf::from("BigBuckBunny_2s*.m4s");
+
+    builder.sign_fragmented_files(context.signer()?, &init_path, &frag_glob, &output_path)?;
+
     for init in glob::glob(pattern).unwrap() {
         match init {
             Ok(p) => {
@@ -228,35 +234,28 @@ fn test_builder_fragmented() -> Result<()> {
                     fragments.push(seg);
                 }
 
-                dbg!(&fragments);
                 // add manifest based on
-                let mut new_output_path =
-                    output_path.join(p.parent().unwrap().file_name().unwrap());
-                new_output_path.push(p.file_name().unwrap());
-
-                builder
-                    .sign_fragmented_files(
-                        &Settings::signer()?,
-                        p.as_path(),
-                        &fragments,
-                        new_output_path.as_path(),
-                    )
-                    .unwrap();
-
-                // verify the fragments
+                let new_output_path = output_path.join(p.parent().unwrap().file_name().unwrap());
                 let output_init = new_output_path.join(p.file_name().unwrap());
+
+                // verify all the fragments
                 let output_fragments = fragments
                     .into_iter()
                     .map(|f| new_output_path.join(f.file_name().unwrap()))
                     .collect();
-                let reader = Reader::from_fragmented_files(&output_init, &output_fragments)?;
+                let reader = Reader::from_shared_context(&context)
+                    .with_fragmented_files(&output_init, &output_fragments)?;
                 //println!("reader: {}", reader);
                 assert_eq!(reader.validation_status(), None);
 
                 // test a single fragment
                 let init_segment = std::fs::File::open(output_init)?;
                 let fragment = std::fs::File::open(output_fragments[0].as_path())?;
-                let reader = Reader::from_fragment("video/mp4", init_segment, fragment)?;
+                let reader = Reader::from_shared_context(&context).with_fragment(
+                    "video/mp4",
+                    init_segment,
+                    fragment,
+                )?;
                 assert_eq!(reader.validation_status(), None);
             }
             Err(e) => panic!("error = {e:?}"),

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -203,8 +203,7 @@ fn test_builder_fragmented() -> Result<()> {
     use common::tempdirectory;
     use std::path::PathBuf;
 
-    let settings = Settings::new().with_toml(TEST_SETTINGS)?;
-    let context = Context::new().with_settings(settings)?.into_shared();
+    let context = test_context().into_shared();
 
     let mut builder = Builder::from_shared_context(&context);
     builder.set_intent(BuilderIntent::Create(c2pa::DigitalSourceType::Empty));


### PR DESCRIPTION
## Changes in this pull request
The C2PA spec requires a single common manifest across all renditions in a set.  This PR generates  a single manifest that is is inserted into all init segments of the set.

Update the fragment signing APIs to accept either a single file or a glob pattern (to specify a set if rendition init segments).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
