### PR TITLE
feat: add ingredient archive FFI functions and relax Builder mutability

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -2009,6 +2009,87 @@ pub unsafe extern "C" fn c2pa_builder_to_archive(
     0 // returns 0 on success
 }
 
+/// Adds an ingredient to the C2paBuilder from a C2PA ingredient archive stream.
+///
+/// The stream must contain a C2PA ingredient archive produced by
+/// `c2pa_builder_write_ingredient_archive`. Use
+/// `c2pa_builder_add_ingredient_from_stream` for regular asset streams.
+///
+/// # Parameters
+/// * builder_ptr: pointer to a Builder.
+/// * stream: pointer to a readable, seekable C2paStream containing the ingredient archive.
+///
+/// # Errors
+/// Returns -1 if there were errors, otherwise returns 0.
+/// The error string can be retrieved by calling c2pa_error.
+///
+/// # Safety
+/// Pointers must be valid and non-NULL.
+///
+/// # Example
+/// ```c
+/// // Write the ingredient archive first
+/// C2paStream* archive = c2pa_create_stream(...);
+/// int result = c2pa_builder_write_ingredient_archive(ingredient_builder, "ingredient-id", archive);
+///
+/// // Rewind and add it to the parent builder
+/// c2pa_stream_seek(archive, 0, C2PA_SEEK_START);
+/// result = c2pa_builder_add_ingredient_from_archive(parent_builder, archive);
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_archive(
+    builder_ptr: *mut C2paBuilder,
+    stream: *mut C2paStream,
+) -> c_int {
+    let builder = deref_mut_or_return_int!(builder_ptr, C2paBuilder);
+    let stream = deref_mut_or_return_int!(stream, C2paStream);
+    let result = builder.add_ingredient_from_archive(&mut *stream);
+    ok_or_return_int!(result);
+    0 // returns 0 on success
+}
+
+/// Writes a single-ingredient C2PA archive to the destination stream.
+///
+/// The archive can later be loaded with `c2pa_builder_add_ingredient_from_archive`.
+/// This requires the `generate_c2pa_archive` builder setting to be enabled via
+/// `c2pa_builder_with_settings` / `c2pa_context_with_settings` before calling.
+///
+/// # Parameters
+/// * builder_ptr: pointer to a Builder.
+/// * ingredient_id: pointer to a C string identifying the ingredient within the builder.
+/// * stream: pointer to a writable C2paStream.
+///
+/// # Errors
+/// Returns -1 if there were errors, otherwise returns 0.
+/// The error string can be retrieved by calling c2pa_error.
+///
+/// # Safety
+/// Reads from NULL-terminated C strings. Pointers must be valid and non-NULL.
+///
+/// # Example
+/// ```c
+/// C2paStream* archive = c2pa_create_stream(...);
+/// int result = c2pa_builder_write_ingredient_archive(builder, "my-ingredient", archive);
+/// if (result < 0) {
+///     char* error = c2pa_error();
+///     printf("Error: %s\n", error);
+///     c2pa_string_free(error);
+/// }
+/// ```
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_builder_write_ingredient_archive(
+    builder_ptr: *mut C2paBuilder,
+    ingredient_id: *const c_char,
+    stream: *mut C2paStream,
+) -> c_int {
+    let builder = deref_mut_or_return_int!(builder_ptr, C2paBuilder);
+    let ingredient_id = cstr_or_return_int!(ingredient_id);
+    let stream = deref_mut_or_return_int!(stream, C2paStream);
+    let result = builder.write_ingredient_archive(&ingredient_id, &mut *stream);
+    ok_or_return_int!(result);
+    0 // returns 0 on success
+}
+
 /// Creates and writes signed manifest from the C2paBuilder to the destination stream.
 ///
 /// # Parameters
@@ -3546,6 +3627,67 @@ mod tests {
         let error = unsafe { c2pa_error() };
         let error_str = unsafe { CString::from_raw(error) };
         assert_eq!(error_str.to_str().unwrap(), "NullParameter: stream");
+        unsafe { c2pa_builder_free(builder) };
+    }
+
+    #[test]
+    fn test_c2pa_builder_add_ingredient_from_archive_null_stream() {
+        let manifest_def = CString::new("{}").unwrap();
+        let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
+        assert!(!builder.is_null());
+        let result =
+            unsafe { c2pa_builder_add_ingredient_from_archive(builder, std::ptr::null_mut()) };
+        assert_eq!(result, -1);
+        let error = unsafe { c2pa_error() };
+        let error_str = unsafe { CString::from_raw(error) };
+        assert_eq!(error_str.to_str().unwrap(), "NullParameter: stream");
+        unsafe { c2pa_builder_free(builder) };
+    }
+
+    #[test]
+    fn test_c2pa_builder_add_ingredient_from_archive_null_builder() {
+        let archive_bytes = include_bytes!(fixture_path!("cloud.jpg"));
+        let mut stream = TestStream::new(archive_bytes.to_vec());
+        let result = unsafe {
+            c2pa_builder_add_ingredient_from_archive(std::ptr::null_mut(), stream.as_ptr())
+        };
+        assert_eq!(result, -1);
+    }
+
+    #[test]
+    fn test_c2pa_builder_write_ingredient_archive_null_stream() {
+        let manifest_def = CString::new("{}").unwrap();
+        let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
+        assert!(!builder.is_null());
+        let ingredient_id = CString::new("test-ingredient").unwrap();
+        let result = unsafe {
+            c2pa_builder_write_ingredient_archive(
+                builder,
+                ingredient_id.as_ptr(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(result, -1);
+        let error = unsafe { c2pa_error() };
+        let error_str = unsafe { CString::from_raw(error) };
+        assert_eq!(error_str.to_str().unwrap(), "NullParameter: stream");
+        unsafe { c2pa_builder_free(builder) };
+    }
+
+    #[test]
+    fn test_c2pa_builder_write_ingredient_archive_null_ingredient_id() {
+        let manifest_def = CString::new("{}").unwrap();
+        let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
+        assert!(!builder.is_null());
+        let archive_bytes = vec![0u8; 0];
+        let mut stream = TestStream::new(archive_bytes);
+        let result = unsafe {
+            c2pa_builder_write_ingredient_archive(builder, std::ptr::null(), stream.as_ptr())
+        };
+        assert_eq!(result, -1);
+        let error = unsafe { c2pa_error() };
+        let error_str = unsafe { CString::from_raw(error) };
+        assert_eq!(error_str.to_str().unwrap(), "NullParameter: ingredient_id");
         unsafe { c2pa_builder_free(builder) };
     }
 

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1051,7 +1051,7 @@ impl Builder {
     /// * `stream` - A stream to write the zip into.
     /// # Errors
     /// * Returns an [`Error`] if the archive cannot be written.
-    fn old_to_archive(&mut self, stream: impl Write + Seek) -> Result<()> {
+    fn old_to_archive(&self, stream: impl Write + Seek) -> Result<()> {
         drop(
             // this drop seems to be required to force a flush before reading back.
             {
@@ -1223,7 +1223,7 @@ impl Builder {
     ///
     /// # Errors
     /// * Returns an [`Error`] if the archive cannot be written.
-    pub fn to_archive(&mut self, mut stream: impl Write + Seek) -> Result<()> {
+    pub fn to_archive(&self, mut stream: impl Write + Seek) -> Result<()> {
         if let Some(true) = self.context.settings().builder.generate_c2pa_archive {
             let c2pa_data = self.working_store_sign(ArchiveKind::Builder)?;
             stream.write_all(&c2pa_data)?;
@@ -1249,7 +1249,7 @@ impl Builder {
     /// # Errors
     /// * Returns [`Error::BadParam`] if the ingredient is not found, or JUMBF archives are disabled in settings.
     pub fn write_ingredient_archive(
-        &mut self,
+        &self,
         ingredient_id: &str,
         mut stream: impl Write + Seek,
     ) -> Result<()> {
@@ -2735,7 +2735,7 @@ impl Builder {
     /// # Errors
     /// * In Mode 2, returns an [`Error`] if no valid hard binding assertion exists.
     /// * Returns an [`Error`] if signing fails.
-    pub fn sign_embeddable(&mut self, format: &str) -> Result<Vec<u8>> {
+    pub fn sign_embeddable(&self, format: &str) -> Result<Vec<u8>> {
         let placeholder_jumbf_len = self.placeholder_jumbf_len;
 
         // Check that a valid hard binding exists in Mode 2 (no placeholder).
@@ -7045,7 +7045,7 @@ mod tests {
 
     #[test]
     fn test_with_archive() -> Result<()> {
-        let mut builder = Builder::default().with_definition(r#"{"title": "Test Image"}"#)?;
+        let builder = Builder::default().with_definition(r#"{"title": "Test Image"}"#)?;
 
         let mut archive = Cursor::new(Vec::new());
         builder.to_archive(&mut archive)?;
@@ -7145,7 +7145,7 @@ mod tests {
         // Test 1: New C2PA format (generate_c2pa_archive = true)
         let settings_new = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
         let context_new = Context::new().with_settings(settings_new)?;
-        let mut builder_new = Builder::from_context(context_new)
+        let builder_new = Builder::from_context(context_new)
             .with_definition(r#"{"title": "Test New Format"}"#)?;
 
         let mut archive_new = Cursor::new(Vec::new());
@@ -7167,7 +7167,7 @@ mod tests {
         let settings_old = Settings::new().with_value("builder.generate_c2pa_archive", false)?;
 
         let context_old = Context::new().with_settings(settings_old)?;
-        let mut builder_old = Builder::from_context(context_old)
+        let builder_old = Builder::from_context(context_old)
             .with_definition(r#"{"title": "Test Old Format"}"#)?;
 
         let mut archive_old = Cursor::new(Vec::new());
@@ -7202,7 +7202,7 @@ mod tests {
         let settings = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
 
         let context = Context::new().with_settings(settings.clone())?;
-        let mut builder =
+        let builder =
             Builder::from_context(context).with_definition(r#"{"title": "Test Self Signed"}"#)?;
 
         let mut archive = Cursor::new(Vec::new());


### PR DESCRIPTION
Summary
Adds two new C FFI functions for the ingredient archive workflow, and corrects unnecessary &mut self on several Builder methods.

New C FFI functions (c2pa_c_ffi)
c2pa_builder_add_ingredient_from_archive — reads a JUMBF ingredient archive from a C2paStream and appends the ingredient to the builder. Returns 0 on success, -1 on error (error string available via c2pa_error()).
c2pa_builder_write_ingredient_archive — writes a JUMBF ingredient archive for a named ingredient from the builder to a C2paStream. Returns 0 on success, -1 on error.
Both functions include null-parameter tests covering null builder, null stream, and null ingredient ID cases.

Builder mutability fixes (sdk)
The following Builder methods were taking &mut self but performed no mutation — all internal callees already operate on &self:

to_archive — read-only serialization to zip
write_ingredient_archive — delegates to working_store_sign(&self)
sign_embeddable — reads placeholder_jumbf_len, calls to_store(&self) and find_assertion(&self)
Changed all three to &self. This is a non-breaking relaxation: any caller that had &mut builder continues to compile, and callers holding only a shared reference can now call these methods without needing a mutable borrow.

