### PR TITLE
fix: Harden against image decompression bomb attacks in building thumbnail

### DIFF
--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -21,7 +21,7 @@ use image::{
         jpeg::JpegEncoder,
         png::{CompressionType, FilterType, PngEncoder},
     },
-    DynamicImage, ImageDecoder, ImageFormat, ImageReader,
+    DynamicImage, ImageDecoder, ImageFormat, ImageReader, Limits,
 };
 
 use crate::{
@@ -142,18 +142,23 @@ where
     R: BufRead + Seek,
     W: Write + Seek,
 {
-    let mut decoder = ImageReader::with_format(input, input_format.into()).into_decoder()?;
+    // Apply the image crate's own `Limits` (default `max_alloc` = 512 MiB) so
+    // decoders that honor them reject crafted inputs internally.
+    let mut reader = ImageReader::with_format(input, input_format.into());
+    reader.limits(Limits::default());
+    let mut decoder = reader.into_decoder()?;
     let orientation = decoder.orientation()?;
 
-    // Guard against decompression bombs: reject images whose raw decoded size would
-    // exceed 512 MB before allocating any pixel buffer. 512 MB matches the default
-    // `Limits::max_alloc` in the `image` crate (image-0.25, src/io/limits.rs line 54),
-    // covering all legitimate inputs including 16-bit 50 MP professional images (~302 MB).
+    // Defense-in-depth against decompression bombs: `DynamicImage::from_decoder`
+    // allocates the pixel buffer directly via `vec![0u8; total_bytes]`, which
+    // bypasses `Limits::max_alloc`. Reject decoded sizes over 512 MiB ourselves
+    // before that allocation runs. 512 MiB covers all legitimate inputs incl.
+    // 16-bit 50 MP professional images (~302 MB) and matches `Limits::default`.
     const MAX_IMAGE_BYTES: u64 = 512 * 1024 * 1024;
     let total_bytes = decoder.total_bytes();
     if total_bytes > MAX_IMAGE_BYTES {
         return Err(Error::InvalidAsset(format!(
-            "image decoded size ({total_bytes} bytes) exceeds the maximum allowed (512 MB)"
+            "image decoded size ({total_bytes} bytes) exceeds the maximum allowed (512 MiB)"
         )));
     }
 
@@ -506,10 +511,11 @@ pub mod tests {
 
     /// Regression test for decompression bomb via oversized PNG dimensions.
     ///
-    /// A malicious PNG can claim 16384×16384 RGBA dimensions (1 GB decoded) while
-    /// compressing to ~65 bytes. Before the fix, `DynamicImage::from_decoder` would
-    /// attempt the full 1 GB allocation. After the fix, `total_bytes()` is checked
-    /// against the 512 MB limit before any allocation occurs, returning `InvalidAsset`.
+    /// A malicious PNG can claim 16384×16384 RGBA dimensions (1 GB decoded)
+    /// while compressing to ~65 bytes. Before the fix, `DynamicImage::from_decoder`
+    /// would attempt the full 1 GB allocation. After the fix, we explicitly
+    /// check `decoder.total_bytes()` against 512 MiB before that allocation
+    /// runs and return `Error::InvalidAsset`.
     #[test]
     fn test_make_thumbnail_rejects_decompression_bomb() {
         // Minimal valid PNG: IHDR declares 16384×16384 RGBA (total_bytes = 1 GB).
@@ -537,10 +543,11 @@ pub mod tests {
             make_thumbnail_bytes_from_stream("image/png", Cursor::new(bomb_png), &settings);
 
         // Before the fix: attempts to allocate 1 GB, crashing containers.
-        // After the fix: returns Err(InvalidAsset) without any large allocation.
+        // After the fix: total_bytes check returns Err(InvalidAsset) before
+        // any large allocation occurs.
         assert!(
             matches!(result, Err(Error::InvalidAsset(_))),
-            "expected Err(InvalidAsset) for decompression bomb, got: {result:?}"
+            "expected Err(InvalidAsset), got: {result:?}"
         );
     }
 

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -145,6 +145,18 @@ where
     let mut decoder = ImageReader::with_format(input, input_format.into()).into_decoder()?;
     let orientation = decoder.orientation()?;
 
+    // Guard against decompression bombs: reject images whose raw decoded size would
+    // exceed 512 MB before allocating any pixel buffer. 512 MB matches the default
+    // `Limits::max_alloc` in the `image` crate (image-0.25, src/io/limits.rs line 54),
+    // covering all legitimate inputs including 16-bit 50 MP professional images (~302 MB).
+    const MAX_IMAGE_BYTES: u64 = 512 * 1024 * 1024;
+    let total_bytes = decoder.total_bytes();
+    if total_bytes > MAX_IMAGE_BYTES {
+        return Err(Error::InvalidAsset(format!(
+            "image decoded size ({total_bytes} bytes) exceeds the maximum allowed (512 MB)"
+        )));
+    }
+
     let mut image = DynamicImage::from_decoder(decoder)?;
     image.apply_orientation(orientation);
 
@@ -490,6 +502,46 @@ pub mod tests {
             .decode()
             .unwrap();
         assert!(image.width() == 100 || image.height() == 100);
+    }
+
+    /// Regression test for decompression bomb via oversized PNG dimensions.
+    ///
+    /// A malicious PNG can claim 16384×16384 RGBA dimensions (1 GB decoded) while
+    /// compressing to ~65 bytes. Before the fix, `DynamicImage::from_decoder` would
+    /// attempt the full 1 GB allocation. After the fix, `total_bytes()` is checked
+    /// against the 512 MB limit before any allocation occurs, returning `InvalidAsset`.
+    #[test]
+    fn test_make_thumbnail_rejects_decompression_bomb() {
+        // Minimal valid PNG: IHDR declares 16384×16384 RGBA (total_bytes = 1 GB).
+        // Signature + IHDR + minimal IDAT + IEND; CRC values are correct.
+        let bomb_png: &[u8] = &[
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+            0x00, 0x00, 0x00, 0x0d, // IHDR length = 13
+            0x49, 0x48, 0x44, 0x52, // "IHDR"
+            0x00, 0x00, 0x40, 0x00, // width  = 16384
+            0x00, 0x00, 0x40, 0x00, // height = 16384
+            0x08, 0x06, 0x00, 0x00, 0x00, // 8-bit RGBA, no interlace
+            0xa9, 0xc8, 0x10, 0x84, // IHDR CRC
+            0x00, 0x00, 0x00, 0x08, // IDAT length = 8
+            0x49, 0x44, 0x41, 0x54, // "IDAT"
+            0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, // minimal zlib-compressed data
+            0x48, 0x06, 0x89, 0xd2, // IDAT CRC
+            0x00, 0x00, 0x00, 0x00, // IEND length = 0
+            0x49, 0x45, 0x4e, 0x44, // "IEND"
+            0xae, 0x42, 0x60, 0x82, // IEND CRC
+        ];
+
+        let mut settings = Settings::default();
+        settings.builder.thumbnail.ignore_errors = false;
+        let result =
+            make_thumbnail_bytes_from_stream("image/png", Cursor::new(bomb_png), &settings);
+
+        // Before the fix: attempts to allocate 1 GB, crashing containers.
+        // After the fix: returns Err(InvalidAsset) without any large allocation.
+        assert!(
+            matches!(result, Err(Error::InvalidAsset(_))),
+            "expected Err(InvalidAsset) for decompression bomb, got: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request

# Security Fix: Thumbnail Decompression Bomb (PNG/TIFF/etc. Oversized Dimensions)

## Vulnerability

`make_thumbnail_from_stream` in `sdk/src/utils/thumbnail.rs` calls
`DynamicImage::from_decoder(decoder)` without first validating the image's declared
decoded size against any limit.

`ImageDecoder::into_decoder()` reads only the image header (e.g. PNG IHDR), which
contains attacker-controlled width/height fields. `from_decoder` then allocates a pixel
buffer of `width × height × bytes_per_pixel` bytes unconditionally:

1. A malicious PNG declares `16384 × 16384 RGBA` (1 GB decoded) in a ~65-byte file
2. `from_decoder` attempts to allocate 1 GB for the pixel buffer
3. Any application running in a container with < 1 GB available memory is killed (exit 137)
   or the process aborts with an allocation failure

The attack vector is any code path that calls thumbnail generation on untrusted input
(e.g. processing C2PA ingredients with thumbnails enabled).


## Fix

Two layered protections against decompression bombs:

1. **Apply the `image` crate's own `Limits`** via `ImageReader::limits()` — for
   decoders that honour limits internally.
2. **Explicit `decoder.total_bytes()` check** before `DynamicImage::from_decoder`
   — defense-in-depth for the path the `image` crate doesn't cover (see below).

**Why both layers are needed.** `Limits::default()` sets `max_alloc = 512 MiB` and
that budget is stored on the decoder by `set_limits()`, but `DynamicImage::from_decoder`
calls `decoder_to_image` which allocates the pixel buffer directly via
`vec![0u8; total_bytes as usize]` — that allocation does not consult
`Limits::max_alloc`. A 16384×16384 RGBA PNG (1 GiB) or an 8192×8192 RGBA32F TIFF
(1 GiB) would still allocate 1 GiB before `Limits` had a chance to act. The
explicit `total_bytes()` check closes this gap on the only path that allocates.


## Test Added

| Test | Validates |
|------|-----------|
| `test_make_thumbnail_rejects_decompression_bomb` | `make_thumbnail_bytes_from_stream` returns `Err(InvalidAsset)` for a 65-byte PNG claiming 16384×16384 RGBA (1 GB decoded). Uses `matches!(result, Err(Error::InvalidAsset(_)))`. |

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
