### PR TITLE
fix: Harden against deep linear ingredient chains with max limits

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -91,6 +91,15 @@ const MANIFEST_STORE_EXT: &str = "c2pa"; // file extension for external manifest
 #[cfg(feature = "fetch_remote_manifests")]
 const DEFAULT_MANIFEST_RESPONSE_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
+/// Maximum depth of nested ingredient references allowed during validation.
+///
+/// Prevents stack overflow when processing a manifest store that contains a deep
+/// linear chain of ingredient references (A → B → C → … → N). With the default
+/// 8 MB thread stack, ~3 000 levels causes an unrecoverable stack overflow (exit 134).
+/// A limit of 200 uses only ~540 KB of stack, providing a large safety margin while
+/// accommodating any realistic provenance chain depth.
+const MAX_INGREDIENT_DEPTH: usize = 200;
+
 pub(crate) struct ManifestHashes {
     pub manifest_box_hash: Vec<u8>,
     pub signature_box_hash: Vec<u8>,
@@ -1528,7 +1537,14 @@ impl Store {
         asset_data: &mut ClaimAssetData<'_>,
         validation_log: &mut StatusTracker,
         context: &Context,
+        depth: usize,
     ) -> Result<()> {
+        if depth >= MAX_INGREDIENT_DEPTH {
+            return Err(Error::InvalidAsset(format!(
+                "ingredient chain depth ({depth}) exceeds maximum ({MAX_INGREDIENT_DEPTH})"
+            )));
+        }
+
         let settings = context.settings();
 
         // Pre-count verifiable ingredients so we can emit accurate step/total values.
@@ -1722,6 +1738,7 @@ impl Store {
                         asset_data,
                         validation_log,
                         context,
+                        depth + 1,
                     )?;
                 } else {
                     log_item!(label.clone(), "ingredient not found", "ingredient_checks")
@@ -1756,7 +1773,14 @@ impl Store {
         asset_data: &mut ClaimAssetData<'_>,
         validation_log: &mut StatusTracker,
         context: &Context,
+        depth: usize,
     ) -> Result<()> {
+        if depth >= MAX_INGREDIENT_DEPTH {
+            return Err(Error::InvalidAsset(format!(
+                "ingredient chain depth ({depth}) exceeds maximum ({MAX_INGREDIENT_DEPTH})"
+            )));
+        }
+
         let settings = context.settings();
 
         let total_ingredients = claim
@@ -1954,6 +1978,7 @@ impl Store {
                         asset_data,
                         validation_log,
                         context,
+                        depth + 1,
                     ))
                     .await?;
                 } else {
@@ -2158,7 +2183,7 @@ impl Store {
                 context,
             )?;
 
-            Store::ingredient_checks(store, claim, &svi, asset_data, validation_log, context)?;
+            Store::ingredient_checks(store, claim, &svi, asset_data, validation_log, context, 0)?;
         } else {
             Claim::verify_claim_async(
                 claim,
@@ -2171,8 +2196,16 @@ impl Store {
             )
             .await?;
 
-            Store::ingredient_checks_async(store, claim, &svi, asset_data, validation_log, context)
-                .await?;
+            Store::ingredient_checks_async(
+                store,
+                claim,
+                &svi,
+                asset_data,
+                validation_log,
+                context,
+                0,
+            )
+            .await?;
         }
 
         Ok(())
@@ -3969,6 +4002,14 @@ impl Store {
         validation_log: &mut StatusTracker,
         claim_label_path: &mut Vec<&'a str>,
     ) -> Result<()> {
+        if claim_label_path.len() >= MAX_INGREDIENT_DEPTH {
+            return Err(Error::InvalidAsset(format!(
+                "ingredient chain depth ({}) exceeds maximum ({})",
+                claim_label_path.len(),
+                MAX_INGREDIENT_DEPTH
+            )));
+        }
+
         let claim_label = claim.label();
 
         if svi.manifest_map.contains_key(claim_label) {
@@ -8911,5 +8952,63 @@ pub mod tests {
 
         // Verify that flush was called
         assert!(flush_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_ingredient_depth_limit_get_claim_referenced_manifests() {
+        let store = Store::new();
+        let claim = Claim::new("depth_test", Some("contentauth"), 2);
+        let mut svi = StoreValidationInfo::default();
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
+
+        // Pre-fill claim_label_path to exactly MAX_INGREDIENT_DEPTH entries so the
+        // depth guard fires immediately without needing a real ingredient chain.
+        let labels: Vec<String> = (0..MAX_INGREDIENT_DEPTH)
+            .map(|i| format!("claim_{i}"))
+            .collect();
+        let mut claim_label_path: Vec<&str> = labels.iter().map(String::as_str).collect();
+
+        let result = Store::get_claim_referenced_manifests_impl(
+            &claim,
+            &store,
+            &mut svi,
+            true,
+            &mut validation_log,
+            &mut claim_label_path,
+        );
+
+        assert!(
+            matches!(result, Err(Error::InvalidAsset(_))),
+            "expected Err(InvalidAsset) for depth >= MAX_INGREDIENT_DEPTH, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_ingredient_depth_limit_ingredient_checks() {
+        use crate::{claim::ClaimAssetData, context::Context};
+
+        let store = Store::new();
+        let claim = Claim::new("depth_test", Some("contentauth"), 2);
+        let svi = StoreValidationInfo::default();
+        let mut asset_data = ClaimAssetData::Bytes(&[], "image/jpeg");
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
+        let context = Context::new();
+
+        let result = Store::ingredient_checks(
+            &store,
+            &claim,
+            &svi,
+            &mut asset_data,
+            &mut validation_log,
+            &context,
+            MAX_INGREDIENT_DEPTH,
+        );
+
+        assert!(
+            matches!(result, Err(Error::InvalidAsset(_))),
+            "expected Err(InvalidAsset) for depth >= MAX_INGREDIENT_DEPTH, got: {result:?}"
+        );
     }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1536,8 +1536,8 @@ impl Store {
         svi: &StoreValidationInfo,
         asset_data: &mut ClaimAssetData<'_>,
         validation_log: &mut StatusTracker,
-        context: &Context,
         depth: usize,
+        context: &Context,
     ) -> Result<()> {
         if depth >= MAX_INGREDIENT_DEPTH {
             return Err(Error::InvalidAsset(format!(
@@ -1737,8 +1737,8 @@ impl Store {
                         svi,
                         asset_data,
                         validation_log,
+                        depth.saturating_add(1),
                         context,
-                        depth + 1,
                     )?;
                 } else {
                     log_item!(label.clone(), "ingredient not found", "ingredient_checks")
@@ -1772,8 +1772,8 @@ impl Store {
         svi: &StoreValidationInfo<'_>,
         asset_data: &mut ClaimAssetData<'_>,
         validation_log: &mut StatusTracker,
-        context: &Context,
         depth: usize,
+        context: &Context,
     ) -> Result<()> {
         if depth >= MAX_INGREDIENT_DEPTH {
             return Err(Error::InvalidAsset(format!(
@@ -1977,8 +1977,8 @@ impl Store {
                         svi,
                         asset_data,
                         validation_log,
+                        depth.saturating_add(1),
                         context,
-                        depth + 1,
                     ))
                     .await?;
                 } else {
@@ -2183,7 +2183,7 @@ impl Store {
                 context,
             )?;
 
-            Store::ingredient_checks(store, claim, &svi, asset_data, validation_log, context, 0)?;
+            Store::ingredient_checks(store, claim, &svi, asset_data, validation_log, 0, context)?;
         } else {
             Claim::verify_claim_async(
                 claim,
@@ -2202,8 +2202,8 @@ impl Store {
                 &svi,
                 asset_data,
                 validation_log,
-                context,
                 0,
+                context,
             )
             .await?;
         }
@@ -4002,6 +4002,11 @@ impl Store {
         validation_log: &mut StatusTracker,
         claim_label_path: &mut Vec<&'a str>,
     ) -> Result<()> {
+        // `claim_label_path` is the chain of claims currently being walked
+        // recursively: each entry pushes on entry (line below) and pops on
+        // return (end of function), so its length is the current recursion
+        // depth — not the total number of ingredients seen. A claim with a
+        // million sibling ingredients still recurses at depth 1 per sibling.
         if claim_label_path.len() >= MAX_INGREDIENT_DEPTH {
             return Err(Error::InvalidAsset(format!(
                 "ingredient chain depth ({}) exceeds maximum ({})",
@@ -9002,8 +9007,8 @@ pub mod tests {
             &svi,
             &mut asset_data,
             &mut validation_log,
-            &context,
             MAX_INGREDIENT_DEPTH,
+            &context,
         );
 
         assert!(


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: Store Recursive Ingredient Traversal Stack Overflow (DoS)

## Vulnerability Issue

`get_claim_referenced_manifests_impl()`, `ingredient_checks()`, and
`ingredient_checks_async()` in `sdk/src/store.rs` walk the ingredient reference
graph recursively with no depth limit.

A crafted C2PA manifest store containing a linear chain of 3 000 ingredient
references (A → B → C → … → N) produces 3000 nested stack frames. With the
default 8 MB thread stack each frame consumes ~2.7 KB, exhausting the stack and
causing the process to terminate with exit code 134 (SIGABRT / stack overflow).

## Fix

Added module-level constant MAX_INGREDIENT_DEPTH of 200 to restrict the length of deep linear ingredient chain

## Tests Added

| Test | Validates |
|------|-----------|
| `test_ingredient_depth_limit_get_claim_referenced_manifests` | Returns `Err(InvalidAsset)` when `claim_label_path.len() >= MAX_INGREDIENT_DEPTH` |
| `test_ingredient_depth_limit_ingredient_checks` | Returns `Err(InvalidAsset)` when `depth >= MAX_INGREDIENT_DEPTH` |

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
