### PR TITLE
fix: Harden RSA validators against invalid BER sequences

### DIFF
--- a/sdk/src/crypto/raw_signature/rust_native/validators/rsa_legacy_validator.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/validators/rsa_legacy_validator.rs
@@ -49,8 +49,15 @@ impl RawSignatureValidator for RsaLegacyValidator {
         let (_, seq) = parse_ber_sequence(spki.subject_public_key.raw_bytes())
             .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
 
-        let modulus = biguint_val(&seq[0]);
-        let exp = biguint_val(&seq[1]);
+        let seq_items = seq
+            .as_sequence()
+            .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
+        if seq_items.len() < 2 {
+            return Err(RawSignatureValidationError::InvalidPublicKey);
+        }
+
+        let modulus = biguint_val(&seq_items[0]);
+        let exp = biguint_val(&seq_items[1]);
 
         let public_key = RsaPublicKey::new(modulus, exp)
             .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
@@ -73,5 +80,62 @@ impl RawSignatureValidator for RsaLegacyValidator {
         };
 
         result.map_err(|_| RawSignatureValidationError::SignatureMismatch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::raw_signature::RawSignatureValidator;
+
+    // SPKI DER with rsaEncryption OID and an empty inner BER SEQUENCE.
+    // parse_ber_sequence succeeds (valid BER) but the guard rejects it because
+    // fewer than 2 elements (modulus + exponent) are present.
+    const RSA_SPKI_EMPTY_SEQUENCE: &[u8] = &[
+        0x30, 0x14, // SEQUENCE (20 bytes)
+        0x30, 0x0d, // AlgorithmIdentifier (13 bytes)
+        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // OID rsaEncryption
+        0x05, 0x00, // NULL parameters
+        0x03, 0x03, // BIT STRING (3 bytes)
+        0x00, // 0 unused bits
+        0x30, 0x00, // inner SEQUENCE — empty
+    ];
+
+    // Same structure but with one INTEGER only (modulus present, exponent missing).
+    const RSA_SPKI_SINGLE_ELEMENT_SEQUENCE: &[u8] = &[
+        0x30, 0x17, // SEQUENCE (23 bytes)
+        0x30, 0x0d, // AlgorithmIdentifier (13 bytes)
+        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // OID rsaEncryption
+        0x05, 0x00, // NULL parameters
+        0x03, 0x06, // BIT STRING (6 bytes)
+        0x00, // 0 unused bits
+        0x30, 0x03, // inner SEQUENCE (3 bytes, 1 element)
+        0x02, 0x01, 0x01, // INTEGER value 1 (modulus only)
+    ];
+
+    // 512 zero bytes: accepted by rsa::pkcs1v15::Signature::try_from (only empty slices
+    // are rejected); content correctness is checked at verify time, after our guard fires.
+    const DUMMY_SIG_512: &[u8] = &[0u8; 512];
+
+    const SAMPLE_DATA: &[u8] = b"some sample content to sign";
+
+    #[test]
+    fn rsa256_empty_sequence_public_key_rejected() {
+        assert_eq!(
+            RsaLegacyValidator::Rsa256
+                .validate(DUMMY_SIG_512, SAMPLE_DATA, RSA_SPKI_EMPTY_SEQUENCE)
+                .unwrap_err(),
+            RawSignatureValidationError::InvalidPublicKey
+        );
+    }
+
+    #[test]
+    fn rsa256_single_element_sequence_public_key_rejected() {
+        assert_eq!(
+            RsaLegacyValidator::Rsa256
+                .validate(DUMMY_SIG_512, SAMPLE_DATA, RSA_SPKI_SINGLE_ELEMENT_SEQUENCE)
+                .unwrap_err(),
+            RawSignatureValidationError::InvalidPublicKey
+        );
     }
 }

--- a/sdk/src/crypto/raw_signature/rust_native/validators/rsa_validator.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/validators/rsa_validator.rs
@@ -53,8 +53,15 @@ impl RawSignatureValidator for RsaValidator {
         let (_, seq) = parse_ber_sequence(spki.subject_public_key.raw_bytes())
             .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
 
-        let modulus = biguint_val(&seq[0]);
-        let exp = biguint_val(&seq[1]);
+        let seq_items = seq
+            .as_sequence()
+            .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
+        if seq_items.len() < 2 {
+            return Err(RawSignatureValidationError::InvalidPublicKey);
+        }
+
+        let modulus = biguint_val(&seq_items[0]);
+        let exp = biguint_val(&seq_items[1]);
 
         let public_key = RsaPublicKey::new(modulus, exp)
             .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
@@ -84,4 +91,61 @@ pub(super) fn biguint_val(ber_object: &BerObject) -> BigUint {
         .map(|x| x.to_u32_digits())
         .map(rsa::BigUint::new)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::raw_signature::RawSignatureValidator;
+
+    // SPKI DER with rsaEncryption OID and an empty inner BER SEQUENCE.
+    // parse_ber_sequence succeeds (valid BER) but the guard rejects it because
+    // fewer than 2 elements (modulus + exponent) are present.
+    const RSA_SPKI_EMPTY_SEQUENCE: &[u8] = &[
+        0x30, 0x14, // SEQUENCE (20 bytes)
+        0x30, 0x0d, // AlgorithmIdentifier (13 bytes)
+        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // OID rsaEncryption
+        0x05, 0x00, // NULL parameters
+        0x03, 0x03, // BIT STRING (3 bytes)
+        0x00, // 0 unused bits
+        0x30, 0x00, // inner SEQUENCE — empty
+    ];
+
+    // Same structure but with one INTEGER only (modulus present, exponent missing).
+    const RSA_SPKI_SINGLE_ELEMENT_SEQUENCE: &[u8] = &[
+        0x30, 0x17, // SEQUENCE (23 bytes)
+        0x30, 0x0d, // AlgorithmIdentifier (13 bytes)
+        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // OID rsaEncryption
+        0x05, 0x00, // NULL parameters
+        0x03, 0x06, // BIT STRING (6 bytes)
+        0x00, // 0 unused bits
+        0x30, 0x03, // inner SEQUENCE (3 bytes, 1 element)
+        0x02, 0x01, 0x01, // INTEGER value 1 (modulus only)
+    ];
+
+    // 512 zero bytes: accepted by rsa::pss::Signature::try_from (only empty slices are
+    // rejected); content correctness is checked at verify time, after our guard fires.
+    const DUMMY_SIG_512: &[u8] = &[0u8; 512];
+
+    const SAMPLE_DATA: &[u8] = b"some sample content to sign";
+
+    #[test]
+    fn ps256_empty_sequence_public_key_rejected() {
+        assert_eq!(
+            RsaValidator::Ps256
+                .validate(DUMMY_SIG_512, SAMPLE_DATA, RSA_SPKI_EMPTY_SEQUENCE)
+                .unwrap_err(),
+            RawSignatureValidationError::InvalidPublicKey
+        );
+    }
+
+    #[test]
+    fn ps256_single_element_sequence_public_key_rejected() {
+        assert_eq!(
+            RsaValidator::Ps256
+                .validate(DUMMY_SIG_512, SAMPLE_DATA, RSA_SPKI_SINGLE_ELEMENT_SEQUENCE)
+                .unwrap_err(),
+            RawSignatureValidationError::InvalidPublicKey
+        );
+    }
 }


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: RSA Validator Panic on Malformed BER Sequence (DoS)

## Vulnerability

`RsaValidator::validate()` and `RsaLegacyValidator::validate()` in
`sdk/src/crypto/raw_signature/rust_native/validators/` use the `Index<usize>`
operator on a `BerObject` to extract the RSA modulus and exponent:

```rust
let modulus = biguint_val(&seq[0]);
let exp = biguint_val(&seq[1]);
```

The `Index<usize>` implementation on `BerObject` **panics** with
`"Try to index BerObjectContent which is not constructed"` when the sequence
contains fewer than the requested number of elements.

An attacker embedding a certificate whose SubjectPublicKeyInfo BIT STRING
payload is a BER SEQUENCE with 0 or 1 elements causes the SDK to panic,
crashing any service processing the C2PA asset.

`parse_ber_sequence` does **not** protect against this: a 0-element or
1-element SEQUENCE is structurally valid BER and parses successfully. The
missing check is a semantic one — RSA public keys *must* contain exactly two
integers (modulus and exponent).

## Affected Files

| File | Lines | Prior guard | Risk |
|------|-------|-------------|------|
| `rsa_validator.rs` | 56-57 | None | Panic / process crash |
| `rsa_legacy_validator.rs` | 52-53 | None | Panic / process crash |

## Fix

Replace the direct indexing with a safe sequence extraction:

```rust
let seq_items = seq
    .as_sequence()
    .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
if seq_items.len() < 2 {
    return Err(RawSignatureValidationError::InvalidPublicKey);
}

let modulus = biguint_val(&seq_items[0]);
let exp = biguint_val(&seq_items[1]);
```

`as_sequence()` returns `Result<&[BerObject], BerError>` — it fails if the
object is not a constructed sequence. The length check then rejects any sequence
with fewer than 2 elements with `InvalidPublicKey` instead of panicking.

Both `rsa_validator.rs` and `rsa_legacy_validator.rs` received identical fixes.

## Tests Added

Tests live in `#[cfg(test)]` modules inside each fixed file so they run only
under the `rust_native_crypto` feature (the path that contains the fix):

| Test | File | Validates |
|------|------|-----------|
| `ps256_empty_sequence_public_key_rejected` | `rsa_validator.rs` | Returns `Err(InvalidPublicKey)` for 0-element sequence |
| `ps256_single_element_sequence_public_key_rejected` | `rsa_validator.rs` | Returns `Err(InvalidPublicKey)` for 1-element sequence |
| `rsa256_empty_sequence_public_key_rejected` | `rsa_legacy_validator.rs` | Returns `Err(InvalidPublicKey)` for 0-element sequence |
| `rsa256_single_element_sequence_public_key_rejected` | `rsa_legacy_validator.rs` | Returns `Err(InvalidPublicKey)` for 1-element sequence |

Each test uses a hand-crafted 22- or 25-byte SPKI DER with `rsaEncryption` OID
and a malformed inner BER SEQUENCE. The crafted keys pass `SubjectPublicKeyInfoRef::try_from`
and `parse_ber_sequence` (structurally valid), triggering only the new guard.# Security Fix: RSA Validator Panic on Malformed BER Sequence (DoS)

## Vulnerability

`RsaValidator::validate()` and `RsaLegacyValidator::validate()` in
`sdk/src/crypto/raw_signature/rust_native/validators/` use the `Index<usize>`
operator on a `BerObject` to extract the RSA modulus and exponent:

```rust
let modulus = biguint_val(&seq[0]);
let exp = biguint_val(&seq[1]);
```

The `Index<usize>` implementation on `BerObject` **panics** with
`"Try to index BerObjectContent which is not constructed"` when the sequence
contains fewer than the requested number of elements.

An attacker embedding a certificate whose SubjectPublicKeyInfo BIT STRING
payload is a BER SEQUENCE with 0 or 1 elements causes the SDK to panic,
crashing any service processing the C2PA asset.

`parse_ber_sequence` does **not** protect against this: a 0-element or
1-element SEQUENCE is structurally valid BER and parses successfully. The
missing check is a semantic one — RSA public keys *must* contain exactly two
integers (modulus and exponent).

## Affected Files

| File | Lines | Prior guard | Risk |
|------|-------|-------------|------|
| `rsa_validator.rs` | 56-57 | None | Panic / process crash |
| `rsa_legacy_validator.rs` | 52-53 | None | Panic / process crash |

## Fix

Replace the direct indexing with a safe sequence extraction:

```rust
let seq_items = seq
    .as_sequence()
    .map_err(|_| RawSignatureValidationError::InvalidPublicKey)?;
if seq_items.len() < 2 {
    return Err(RawSignatureValidationError::InvalidPublicKey);
}

let modulus = biguint_val(&seq_items[0]);
let exp = biguint_val(&seq_items[1]);
```

`as_sequence()` returns `Result<&[BerObject], BerError>` — it fails if the
object is not a constructed sequence. The length check then rejects any sequence
with fewer than 2 elements with `InvalidPublicKey` instead of panicking.

Both `rsa_validator.rs` and `rsa_legacy_validator.rs` received identical fixes.

## Tests Added

Tests live in `#[cfg(test)]` modules inside each fixed file so they run only
under the `rust_native_crypto` feature (the path that contains the fix):

| Test | File | Validates |
|------|------|-----------|
| `ps256_empty_sequence_public_key_rejected` | `rsa_validator.rs` | Returns `Err(InvalidPublicKey)` for 0-element sequence |
| `ps256_single_element_sequence_public_key_rejected` | `rsa_validator.rs` | Returns `Err(InvalidPublicKey)` for 1-element sequence |
| `rsa256_empty_sequence_public_key_rejected` | `rsa_legacy_validator.rs` | Returns `Err(InvalidPublicKey)` for 0-element sequence |
| `rsa256_single_element_sequence_public_key_rejected` | `rsa_legacy_validator.rs` | Returns `Err(InvalidPublicKey)` for 1-element sequence |

Each test uses a hand-crafted 22- or 25-byte SPKI DER with `rsaEncryption` OID
and a malformed inner BER SEQUENCE. The crafted keys pass `SubjectPublicKeyInfoRef::try_from`
and `parse_ber_sequence` (structurally valid), triggering only the new guard.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
