### PR TITLE
fix: Harden against empty certificates during OCSP certificate validation

### DIFF
--- a/sdk/src/crypto/cose/ocsp.rs
+++ b/sdk/src/crypto/cose/ocsp.rs
@@ -361,12 +361,16 @@ fn check_stapled_ocsp_response(
 
     // If we get a valid response, validate the certs.
     if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
+        let Some(first_cert) = ocsp_certs.first() else {
+            return Ok(OcspResponse::default());
+        };
+
         // make sure this is an OCSP signing EKU
         let mut new_ctp = ctp.clone();
         new_ctp.clear_ekus();
         new_ctp.add_valid_ekus(OCSP_OID_STR.as_bytes()); // ocsp signing EKU
         if check_end_entity_certificate_profile(
-            &ocsp_certs[0],
+            first_cert,
             &new_ctp,
             validation_log,
             tst_info.as_ref(),
@@ -378,11 +382,7 @@ fn check_stapled_ocsp_response(
 
         // validate the trust
         if new_ctp
-            .check_certificate_trust(
-                ocsp_certs,
-                &ocsp_certs[0],
-                signing_time.map(|t| t.timestamp()),
-            )
+            .check_certificate_trust(ocsp_certs, first_cert, signing_time.map(|t| t.timestamp()))
             .is_err()
         {
             return Ok(OcspResponse::default());
@@ -457,13 +457,16 @@ pub(crate) fn fetch_and_check_ocsp_response(
 
     // If we get a valid response validate the certs.
     if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
+        let Some(first_cert) = ocsp_certs.first() else {
+            return Ok(OcspResponse::default());
+        };
+
         // make sure this is an OCSP signing EKU
         let mut new_ctp = ctp.clone();
         new_ctp.clear_ekus();
         new_ctp.add_valid_ekus(OCSP_OID_STR.as_bytes()); // ocsp signing EKU
 
-        if check_end_entity_certificate_profile(&ocsp_certs[0], &new_ctp, validation_log, None)
-            .is_err()
+        if check_end_entity_certificate_profile(first_cert, &new_ctp, validation_log, None).is_err()
         {
             return Ok(OcspResponse::default());
         }

--- a/sdk/src/crypto/ocsp/mod.rs
+++ b/sdk/src/crypto/ocsp/mod.rs
@@ -131,9 +131,12 @@ impl OcspResponse {
                 return Ok(output);
             };
 
-            // grab the signing key
+            // grab the signing key from the first cert; reject if certs is empty
+            let Some(first_cert) = ocsp_certs.first() else {
+                return Ok(output);
+            };
             let Ok(signing_key_der) =
-                rasn::der::encode(&ocsp_certs[0].tbs_certificate.subject_public_key_info)
+                rasn::der::encode(&first_cert.tbs_certificate.subject_public_key_info)
             else {
                 return Ok(output);
             };
@@ -471,6 +474,60 @@ mod tests {
         assert!(ocsp_data.revoked_at.is_none());
         assert!(validation_log.has_any_error());
         assert!(validation_log.has_status(SIGNING_CREDENTIAL_OCSP_UNKNOWN));
+    }
+
+    /// Crafted OcspResponse DER with `certs = Some([])` (present but empty).
+    ///
+    /// Structure:
+    ///   OcspResponse { status=successful, responseBytes = BasicOcspResponse {
+    ///     tbs_response_data = ResponseData { responderID=byKey(zeros),
+    ///                                        producedAt="20230101000000Z",
+    ///                                        responses=[] },
+    ///     signature_algorithm = sha256WithRSA,
+    ///     signature = dummy bytes,
+    ///     certs = [0] EXPLICIT SEQUENCE OF Certificate {}  ← empty
+    ///   }}
+    ///
+    /// This is syntactically valid DER.  The old code panicked at `ocsp_certs[0]`
+    /// when `basic_response.certs = Some([])` and all earlier guards passed.
+    /// The fix uses `.first()` and returns early when the vec is empty.
+    const OCSP_EMPTY_CERTS_DER: &[u8] = &[
+        0x30, 0x5d, // OcspResponse SEQUENCE (93 bytes)
+        0x0a, 0x01, 0x00, // status ENUMERATED 0 (successful)
+        0xa0, 0x58, // [0] EXPLICIT responseBytes (88 bytes)
+        0x30, 0x56, // ResponseBytes SEQUENCE (86 bytes)
+        0x06, 0x09, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x30, 0x01,
+        0x01, // id-pkix-ocsp-basic
+        0x04, 0x49, // OCTET STRING — BasicOcspResponse DER (73 bytes)
+        0x30, 0x47, // BasicOcspResponse SEQUENCE (71 bytes)
+        0x30, 0x2b, // ResponseData SEQUENCE (43 bytes)
+        0xa2, 0x16, // responderID [2] EXPLICIT byKey (22 bytes)
+        0x04, 0x14, // KeyHash OCTET STRING (20 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 20-byte placeholder
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18,
+        0x0f, // producedAt GeneralizedTime (15 bytes)
+        0x32, 0x30, 0x32, 0x33, 0x30, 0x31, 0x30, 0x31, // "20230101"
+        0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x5a, // "000000Z"
+        0x30, 0x00, // responses SEQUENCE OF SingleResponse (empty)
+        0x30, 0x0d, // AlgorithmIdentifier sha256WithRSA (15 bytes)
+        0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, // OID
+        0x05, 0x00, // NULL params
+        0x03, 0x05, // BIT STRING signature (5 bytes content)
+        0x00, 0xde, 0xad, 0xbe, 0xef, // 0 unused bits + 4 dummy bytes
+        0xa0, 0x02, // certs [0] EXPLICIT (2 bytes content)
+        0x30, 0x00, // SEQUENCE OF Certificate — empty
+    ];
+
+    #[test]
+    fn from_der_checked_empty_certs_returns_default_not_panic() {
+        // Regression: old code panicked at `ocsp_certs[0]` when
+        // `basic_response.certs = Some([])`.  The fix uses `.first()` and
+        // returns Ok(output) (with ocsp_certs = None) instead of panicking.
+        let mut log = StatusTracker::default();
+        let result = OcspResponse::from_der_checked(OCSP_EMPTY_CERTS_DER, None, &mut log);
+        assert!(result.is_ok());
+        // certs were empty so no cert data flows through
+        assert!(result.unwrap().ocsp_certs.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: OCSP Empty-Certs DoS (index-out-of-bounds panic)

## Vulnerability

The c2pa-rs SDK panics with `index out of bounds` when validating a COSE
signature whose unprotected header contains an OCSP response with a
present-but-empty `certs` field (`certs = Some([])`).

Because the unprotected header is **not covered by the COSE signature**, an
attacker can inject a crafted OCSP DER blob without any signing keys. This
turns certificate-revocation checking into a remote DoS vector: any validator
processing attacker-supplied content panics.

### Root cause

`OcspResponse::from_der_checked` in `sdk/src/crypto/ocsp/mod.rs` guarded
against `certs = None` with `if let Some(ocsp_certs) = ...`, but did not
guard against an empty `Vec`. The first element was then accessed with a
direct index `ocsp_certs[0]`, which panics when the vec is present but empty:

```rust
// Vulnerable code — panics when certs = Some([])
if let Some(ocsp_certs) = basic_response.certs {
    ...
    let signing_key_der =
        rasn::der::encode(&ocsp_certs[0].tbs_certificate.subject_public_key_info)?;
    //                    ^^^^^^^^^^^^ index out of bounds if vec is empty
```

The same pattern appeared as defense-in-depth access sites in
`sdk/src/crypto/cose/ocsp.rs` (`check_stapled_ocsp_response` and
`fetch_and_check_ocsp_response`).

### Attack surface

The OCSP DER is read from the COSE `rVals`/`ocspVals` unprotected header
field, which is not authenticated by the COSE signature. Any attacker who can
present a crafted C2PA asset to a validator can trigger the panic.

### Affected locations

| File | Function | Issue |
|---|---|---|
| `sdk/src/crypto/ocsp/mod.rs` | `from_der_checked` | Primary panic: `ocsp_certs[0]` when `certs = Some([])` |
| `sdk/src/crypto/cose/ocsp.rs` | `check_stapled_ocsp_response` | Defense-in-depth: `&ocsp_certs[0]` |
| `sdk/src/crypto/cose/ocsp.rs` | `fetch_and_check_ocsp_response` | Defense-in-depth: `&ocsp_certs[0]` |

## Fix

All three `[0]` index accesses replaced with `.first()` + `let-else` guards
that return `Ok(OcspResponse::default())` (unknown/ignored OCSP status) rather
than panicking:

```rust
// Fixed pattern — all three sites:
let Some(first_cert) = ocsp_certs.first() else {
    return Ok(output);  // or Ok(OcspResponse::default())
};
```

### `sdk/src/crypto/ocsp/mod.rs` — `from_der_checked` (primary fix)

```rust
// grab the signing key from the first cert; reject if certs is empty
let Some(first_cert) = ocsp_certs.first() else {
    return Ok(output);
};
let Ok(signing_key_der) =
    rasn::der::encode(&first_cert.tbs_certificate.subject_public_key_info)
else {
    return Ok(output);
};
```

### `sdk/src/crypto/cose/ocsp.rs` — two defense-in-depth sites

`check_stapled_ocsp_response`:
```rust
if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
    let Some(first_cert) = ocsp_certs.first() else {
        return Ok(OcspResponse::default());
    };
    // ... rest of validation unchanged
}
```

`fetch_and_check_ocsp_response`:
```rust
if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {
    let Some(first_cert) = ocsp_certs.first() else {
        return Ok(OcspResponse::default());
    };
    // ... rest of validation unchanged
}
```

## Tests Added

### `sdk/src/crypto/ocsp/mod.rs` — 1 regression test

| Test | Validates |
|---|---|
| `from_der_checked_empty_certs_returns_default_not_panic` | Crafted DER with `certs = Some([])` returns `Ok(OcspResponse::default())` instead of panicking |

The test uses `OCSP_EMPTY_CERTS_DER` — 95 hand-crafted bytes representing a
structurally valid `OcspResponse` with `responseStatus = successful`,
`id-pkix-ocsp-basic`, a dummy SHA-256 signature, and `certs = Some([])`.
Running this test against the unfixed code panics at `ocsp_certs[0]`.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
