### PR TITLE
fix: Harden against unbounded HTTP response body read in DID web server

### DIFF
--- a/sdk/src/http/mod.rs
+++ b/sdk/src/http/mod.rs
@@ -40,7 +40,7 @@
 //! [`SignerSettings::Remote`]: crate::settings::signer::SignerSettings::Remote
 
 use std::{
-    io::{self, Read},
+    io::{self, Cursor, Read},
     sync::Arc,
 };
 
@@ -199,6 +199,7 @@ impl SyncHttpResolver for SyncGenericResolver {
 /// [`RestrictedResolver`]: restricted::RestrictedResolver
 pub struct AsyncGenericResolver {
     inner: async_resolver::Impl,
+    max_response_body_size: Option<u64>,
 }
 
 impl AsyncGenericResolver {
@@ -211,6 +212,7 @@ impl AsyncGenericResolver {
     pub fn new() -> Self {
         Self {
             inner: async_resolver::new(),
+            max_response_body_size: None,
         }
     }
 
@@ -219,7 +221,24 @@ impl AsyncGenericResolver {
     ///
     /// For more information, see [`AsyncGenericResolver::new`].
     pub fn with_redirects() -> Option<Self> {
-        async_resolver::with_redirects().map(|inner| Self { inner })
+        async_resolver::with_redirects().map(|inner| Self {
+            inner,
+            max_response_body_size: None,
+        })
+    }
+
+    /// Set the maximum number of bytes accepted from an HTTP response body.
+    ///
+    /// When set, [`http_resolve_async`] checks the `Content-Length` response header before
+    /// returning the response. If the advertised size exceeds `limit`, it returns
+    /// [`HttpResolverError::ResponseTooLarge`] immediately, without reading the body.
+    ///
+    /// This is an opt-in guard; the default is no limit (`None`).
+    ///
+    /// [`http_resolve_async`]: AsyncHttpResolver::http_resolve_async
+    pub fn with_max_response_body_size(mut self, limit: u64) -> Self {
+        self.max_response_body_size = Some(limit);
+        self
     }
 }
 
@@ -236,7 +255,36 @@ impl AsyncHttpResolver for AsyncGenericResolver {
         &self,
         request: Request<Vec<u8>>,
     ) -> Result<Response<Box<dyn Read>>, HttpResolverError> {
-        self.inner.http_resolve_async(request).await
+        let response = self.inner.http_resolve_async(request).await?;
+
+        if let Some(limit) = self.max_response_body_size {
+            // Fast-fail if Content-Length exceeds the limit before reading body bytes.
+            let reported_len = response
+                .headers()
+                .get(http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            if let Some(len) = reported_len {
+                if len > limit {
+                    return Err(HttpResolverError::ResponseTooLarge);
+                }
+            }
+
+            // Read the body with a hard cap so servers that omit or lie about
+            // Content-Length are also bounded.
+            let (parts, body) = response.into_parts();
+            let mut buf = Vec::new();
+            body.take(limit + 1).read_to_end(&mut buf)?;
+            if buf.len() as u64 > limit {
+                return Err(HttpResolverError::ResponseTooLarge);
+            }
+            return Ok(http::Response::from_parts(
+                parts,
+                Box::new(Cursor::new(buf)) as Box<dyn Read>,
+            ));
+        }
+
+        Ok(response)
     }
 }
 
@@ -273,6 +321,11 @@ pub enum HttpResolverError {
     /// [`Core::allowed_network_hosts`]: crate::settings::Core::allowed_network_hosts
     #[error("remote URI \"{uri}\" is not permitted by the allowed list")]
     UriDisallowed { uri: String },
+
+    /// The `Content-Length` response header exceeded the limit set via
+    /// [`AsyncGenericResolver::with_max_response_body_size`].
+    #[error("response body exceeded maximum allowed size")]
+    ResponseTooLarge,
 
     /// An error occured from the underlying HTTP resolver.
     #[error("an error occurred from the underlying http resolver")]

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -18,8 +18,13 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::io::Read;
+
 use super::{did::Did, did_doc::DidDocument};
 use crate::http::{AsyncGenericResolver, AsyncHttpResolver, HttpResolverError};
+
+/// Maximum number of bytes accepted from a DID Web server response body.
+pub(crate) const MAX_DID_DOC_SIZE: u64 = 1024 * 1024; // 1 MiB
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
@@ -55,6 +60,9 @@ pub enum DidWebError {
 
     #[error("invalid web DID: {0}")]
     InvalidWebDid(String),
+
+    #[error("response body exceeded size limit of {MAX_DID_DOC_SIZE} bytes")]
+    ResponseTooLarge,
 }
 
 pub(crate) async fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
@@ -96,8 +104,13 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
     };
 
     let mut document = Vec::new();
-    body.read_to_end(&mut document)
+    body.take(MAX_DID_DOC_SIZE + 1)
+        .read_to_end(&mut document)
         .map_err(|e| DidWebError::Response(e.into()))?;
+
+    if document.len() as u64 > MAX_DID_DOC_SIZE {
+        return Err(DidWebError::ResponseTooLarge);
+    }
 
     Ok(document)
 }
@@ -190,7 +203,7 @@ mod tests {
         use super::did;
         use crate::identity::claim_aggregation::w3c_vc::{
             did_doc::DidDocument,
-            did_web::{self, PROXY},
+            did_web::{self, DidWebError, MAX_DID_DOC_SIZE, PROXY},
         };
 
         #[tokio::test]
@@ -234,6 +247,36 @@ mod tests {
             });
 
             did_doc_mock.assert();
+        }
+
+        #[tokio::test]
+        async fn oversized_response_returns_error() {
+            let server = MockServer::start();
+
+            PROXY.with(|proxy| {
+                let server_url = server.url("/").replace("127.0.0.1", "localhost");
+                proxy.replace(Some(server_url));
+            });
+
+            // Serve a body one byte larger than the allowed limit.
+            let oversized_body = vec![b'X'; (MAX_DID_DOC_SIZE + 1) as usize];
+            let _mock = server.mock(|when, then| {
+                when.method(GET).path("/.well-known/did.json");
+                then.status(200)
+                    .header("content-type", "application/did+json")
+                    .body(oversized_body);
+            });
+
+            let result = did_web::resolve(&did("did:web:localhost")).await;
+
+            PROXY.with(|proxy| {
+                proxy.replace(None);
+            });
+
+            assert!(
+                matches!(result, Err(did_web::DidWebError::ResponseTooLarge)),
+                "expected ResponseTooLarge, got {result:?}"
+            );
         }
 
         /*

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -92,9 +92,13 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
         .map_err(|e| DidWebError::Request(url.to_owned(), e.into()))?;
     let response = AsyncGenericResolver::with_redirects()
         .unwrap_or_default()
+        .with_max_response_body_size(MAX_DID_DOC_SIZE)
         .http_resolve_async(request)
         .await
-        .map_err(|e| DidWebError::Request(url.to_owned(), e))?;
+        .map_err(|e| match e {
+            HttpResolverError::ResponseTooLarge => DidWebError::ResponseTooLarge,
+            e => DidWebError::Request(url.to_owned(), e),
+        })?;
 
     let (parts, mut body) = response.into_parts();
     match parts.status {
@@ -104,13 +108,8 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
     };
 
     let mut document = Vec::new();
-    body.take(MAX_DID_DOC_SIZE + 1)
-        .read_to_end(&mut document)
+    body.read_to_end(&mut document)
         .map_err(|e| DidWebError::Response(e.into()))?;
-
-    if document.len() as u64 > MAX_DID_DOC_SIZE {
-        return Err(DidWebError::ResponseTooLarge);
-    }
 
     Ok(document)
 }
@@ -247,6 +246,39 @@ mod tests {
             });
 
             did_doc_mock.assert();
+        }
+
+        #[tokio::test]
+        async fn content_length_above_limit_rejected() {
+            let server = MockServer::start();
+
+            PROXY.with(|proxy| {
+                let server_url = server.url("/").replace("127.0.0.1", "localhost");
+                proxy.replace(Some(server_url));
+            });
+
+            // Server explicitly advertises Content-Length above the limit.
+            // The Content-Length pre-check in AsyncGenericResolver rejects the
+            // response immediately, before passing any body bytes to the caller.
+            let oversized_body = vec![b'X'; (MAX_DID_DOC_SIZE + 1) as usize];
+            let _mock = server.mock(|when, then| {
+                when.method(GET).path("/.well-known/did.json");
+                then.status(200)
+                    .header("content-type", "application/did+json")
+                    .header("content-length", (MAX_DID_DOC_SIZE + 1).to_string())
+                    .body(oversized_body);
+            });
+
+            let result = did_web::resolve(&did("did:web:localhost")).await;
+
+            PROXY.with(|proxy| {
+                proxy.replace(None);
+            });
+
+            assert!(
+                matches!(result, Err(did_web::DidWebError::ResponseTooLarge)),
+                "expected ResponseTooLarge, got {result:?}"
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: did:web Unbounded Response Body Read (OOM DoS)

## Vulnerability

The `did:web` resolver in `sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs`
reads HTTP response bodies without any size limit. A malicious DID Web server
can crash any application using c2pa-rs by returning an infinitely large
response body, causing out-of-memory process termination.

### Root cause

`get_did_doc` calls `read_to_end` directly on the response body with no cap:

```rust
// Vulnerable code — reads unlimited bytes into memory
let mut document = Vec::new();
body.read_to_end(&mut document)
    .map_err(|e| DidWebError::Response(e.into()))?;
```

`Vec::read_to_end` will keep allocating until either the server closes the
connection or the process is killed by OOM.

### Attack surface

Any DID identity validation that resolves a `did:web` DID causes an outbound
HTTP request. An attacker controls the server at the domain encoded in the DID.
If they return a streaming/infinite body, the validator's memory grows without
bound until the OS kills the process.

### Affected location

| File | Function | Issue |
|---|---|---|
| `sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs` | `get_did_doc` | `body.read_to_end(&mut document)` — no size limit |

## Fix

The body size limit is enforced inside `AsyncGenericResolver::http_resolve_async`
in `sdk/src/http/mod.rs` via an opt-in config. No existing callers are affected.

### New config on `AsyncGenericResolver`

```rust
pub fn with_max_response_body_size(mut self, limit: u64) -> Self {
    self.max_response_body_size = Some(limit);
    self
}
```

When set, `AsyncGenericResolver::http_resolve_async` applies two guards before
returning the response to the caller:

**Layer 1 — Content-Length fast-fail** (before reading body bytes):

```rust
let reported_len = response
    .headers()
    .get(http::header::CONTENT_LENGTH)
    .and_then(|v| v.to_str().ok())
    .and_then(|s| s.parse::<u64>().ok());
if let Some(len) = reported_len {
    if len > limit {
        return Err(HttpResolverError::ResponseTooLarge);
    }
}
```

**Layer 2 — hard body cap** (defense-in-depth for servers that omit or lie about
`Content-Length`):

```rust
let (parts, mut body) = response.into_parts();
let mut buf = Vec::new();
body.take(limit + 1).read_to_end(&mut buf)?;
if buf.len() as u64 > limit {
    return Err(HttpResolverError::ResponseTooLarge);
}
return Ok(http::Response::from_parts(
    parts,
    Box::new(Cursor::new(buf)) as Box<dyn Read>,
));
```

The response returned to the caller always has a body bounded by `limit` bytes.
A new `HttpResolverError::ResponseTooLarge` variant is added.

### `get_did_doc` opts in and maps the error

```rust
let response = AsyncGenericResolver::with_redirects()
    .unwrap_or_default()
    .with_max_response_body_size(MAX_DID_DOC_SIZE)
    .http_resolve_async(request)
    .await
    .map_err(|e| match e {
        HttpResolverError::ResponseTooLarge => DidWebError::ResponseTooLarge,
        e => DidWebError::Request(url.to_owned(), e),
    })?;
```

The body read in `get_did_doc` is now a plain `read_to_end` — the resolver has
already bounded the bytes:

```rust
let mut document = Vec::new();
body.read_to_end(&mut document)
    .map_err(|e| DidWebError::Response(e.into()))?;
```

`MAX_DID_DOC_SIZE = 1 MiB` remains in `did_web.rs`.

### Why two layers?

`Content-Length` is advisory: a malicious server can omit it or advertise less
than it actually sends. Layer 1 fast-fails for honest large responses; Layer 2
catches dishonest ones. Together they bound allocation in all cases.

## Tests Added

### `did_web::tests::resolve` — 2 async unit tests

| Test | Layer | Validates |
|---|---|---|
| `content_length_above_limit_rejected` | Layer 1 | Mock server sends explicit `Content-Length: MAX_DID_DOC_SIZE + 1` with matching body; `resolve()` returns `Err(DidWebError::ResponseTooLarge)` before body bytes reach the caller |
| `oversized_response_returns_error` | Layer 1 + 2 | Mock server returns `MAX_DID_DOC_SIZE + 1` bytes (httpmock auto-adds Content-Length); `resolve()` returns `Err(DidWebError::ResponseTooLarge)` |
## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
