### PR TITLE
fix: parse PEM cert chain to DER in RemoteSigner construction

### DIFF
--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -118,13 +118,21 @@ impl SignerSettings {
                 tsa_url,
                 referenced_assertions: _,
                 roles: _,
-            } => Ok(Box::new(RemoteSigner {
-                url,
-                alg,
-                reserve_size: 10000 + sign_cert.len(),
-                certs: vec![sign_cert.into_bytes()],
-                tsa_url,
-            })),
+            } => {
+                let certs = pem::parse_many(&sign_cert)
+                    .map_err(|e| Error::OtherError(Box::new(e)))?
+                    .into_iter()
+                    .map(|p| p.into_contents())
+                    .collect::<Vec<Vec<u8>>>();
+                let reserve_size = 10000 + certs.iter().map(|c| c.len()).sum::<usize>();
+                Ok(Box::new(RemoteSigner {
+                    url,
+                    alg,
+                    reserve_size,
+                    certs,
+                    tsa_url,
+                }))
+            }
         }
     }
 


### PR DESCRIPTION
The Remote variant of SignerSettings::c2pa_signer() was passing the raw PEM string bytes as a single cert blob, rather than parsing individual PEM certificates into DER. This caused two issues:

1. certs contained raw PEM text instead of DER-encoded certificates
2. reserve_size was based on PEM text length rather than DER cert sizes

Parse the PEM cert chain with pem::parse_many() to extract individual DER-encoded certificates, matching the behavior of the Local variant which uses create_signer::from_keys() for proper PEM handling.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
