### PR TITLE
fix: Prevent duplicate timestamp assertion

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1985,7 +1985,6 @@ impl Builder {
                 let cose_sign1 = claim.cose_sign1()?;
                 if cose::get_cose_tst_info(&cose_sign1).is_some() {
                     claim_uris.remove(&claim.uri());
-                    continue;
                 }
 
                 // Then check timestamp assertions.


### PR DESCRIPTION
## Changes in this pull request
When the `auto_timestamp_assertion` builder setting is used with `skip_existing` the SDK populates a list of claim URIs based on the `fetch_scope` setting. Then it loops through the ingredients removing any claim URIs that have a COSE timestamp. It also needs to remove any claim URIs present in a `c2pa.time-stamp assertion` on the ingredient. The timestamp assertion check gets skipped by the `continue;` statement when the ingredient has a COSE timestamp.

This PR removes the continue so both checks always run.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
