### PR TITLE
feat: add `init trust`, trust sidecars, and atomic sidecar writes, plus fixes

### DIFF
--- a/cli/docs/manifest.md
+++ b/cli/docs/manifest.md
@@ -41,6 +41,10 @@ c2patool image_to_sign.jpg -m manifest.json -o signed_with_icon.jpg
 > [!NOTE]
 > [ACA Inspect](https://inspect.cr/) will only display an icon for a signing certificate if the certificate can be traced back to a root certificate on the [C2PA trust list](https://opensource.contentauthenticity.org/docs/conformance/trust-lists#c2pa-trust-list).
 
+## `claim_generator_info` (optional)
+
+If you omit this property, or set it to an empty array `[]`, the SDK fills in a default when the claim is built: it uses `builder.claim_generator_info` from your [Context settings](../../docs/context-settings.md#with-builder) if you configured one, otherwise a built-in default for the `c2pa` library.
+
 ## Special properties used by C2PA Tool
 
 The following manifest properties are specific to C2PA Tool and used for signing manifests:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -611,6 +611,14 @@ fn print_reader(reader: &Reader, detailed: bool, crjson: bool) -> Result<()> {
     }
 }
 
+/// True when `--output` is suitable for folder-style use (e.g. `--ingredient` to a report dir,
+/// or manifest report to a directory). A missing path is allowed (`create_dir_all` will make it);
+/// an existing path must be a directory (names like `v1.0` are not inferred from a dot in the
+/// last component).
+pub(crate) fn folder_mode_output_path_ok(path: &Path) -> bool {
+    !path.exists() || path.is_dir()
+}
+
 fn main() -> Result<()> {
     let args = CliArgs::parse();
 
@@ -864,7 +872,7 @@ fn main() -> Result<()> {
     } else if args.parent.is_some() || args.sidecar || args.remote.is_some() {
         bail!("Manifest definition required with these options or flags")
     } else if let Some(output) = args.output {
-        if output.is_file() || output.extension().is_some() {
+        if !folder_mode_output_path_ok(&output) {
             bail!("Output must be a folder for this option.")
         }
         if output.exists() {
@@ -930,6 +938,7 @@ pub mod tests {
     #![allow(clippy::unwrap_used)]
 
     use c2pa::{BuilderIntent, DigitalSourceType};
+    use std::fs::{create_dir, write};
     use tempfile::TempDir;
 
     use super::*;
@@ -953,6 +962,29 @@ pub mod tests {
 
         #[cfg(not(target_os = "wasi"))]
         return tempfile::tempdir().map_err(Into::into);
+    }
+
+    #[test]
+    fn folder_mode_output_path_accepts_dir_with_dot_in_name() {
+        let tmp = tempdirectory().unwrap();
+        let p = tmp.path().join("release.v1.0");
+        create_dir(&p).unwrap();
+        assert!(folder_mode_output_path_ok(&p));
+    }
+
+    #[test]
+    fn folder_mode_output_path_accepts_nonexistent_path() {
+        let tmp = tempdirectory().unwrap();
+        let p = tmp.path().join("not_created_yet");
+        assert!(folder_mode_output_path_ok(&p));
+    }
+
+    #[test]
+    fn folder_mode_output_path_rejects_existing_file() {
+        let tmp = tempdirectory().unwrap();
+        let f = tmp.path().join("report.json");
+        write(&f, b"{}").unwrap();
+        assert!(!folder_mode_output_path_ok(&f));
     }
 
     #[allow(deprecated)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,6 +34,7 @@ use c2pa::{
     Signer,
 };
 use clap::{Parser, Subcommand};
+use env_logger::Env;
 use etcetera::BaseStrategy;
 use log::debug;
 use serde::Deserialize;
@@ -622,11 +623,8 @@ pub(crate) fn folder_mode_output_path_ok(path: &Path) -> bool {
 fn main() -> Result<()> {
     let args = CliArgs::parse();
 
-    // set RUST_LOG=debug to get detailed debug logging
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "error");
-    }
-    env_logger::init();
+    // default to error logging, RUST_LOG=debug to get detailed debug logging
+    env_logger::Builder::from_env(Env::default().default_filter_or("error")).init();
 
     let path = &args.path;
 
@@ -937,8 +935,9 @@ fn main() -> Result<()> {
 pub mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use c2pa::{BuilderIntent, DigitalSourceType};
     use std::fs::{create_dir, write};
+
+    use c2pa::{BuilderIntent, DigitalSourceType};
     use tempfile::TempDir;
 
     use super::*;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -230,8 +230,9 @@ enum Commands {
 #[derive(Debug, Default, Deserialize)]
 // Add fields that are not part of the standard Manifest
 struct ManifestDef {
+    // Flattened into the JSON root; the field is not read directly after deserialize.
     #[serde(flatten)]
-    manifest: ManifestDefinition,
+    _manifest: ManifestDefinition,
     // allows adding ingredients with file paths
     ingredient_paths: Option<Vec<PathBuf>>,
 }
@@ -702,18 +703,16 @@ fn main() -> Result<()> {
         // read the manifest information
         let manifest_def: ManifestDef = serde_json::from_slice(json.as_bytes())?;
         let mut builder = Builder::from_shared_context(&context).with_definition(&json)?;
-        let mut manifest = manifest_def.manifest;
 
         // add claim_tool generator so we know this was created using this tool
         let mut tool_generator = ClaimGeneratorInfo::new(env!("CARGO_PKG_NAME"));
         tool_generator.set_version(env!("CARGO_PKG_VERSION"));
-        if !manifest.claim_generator_info.is_empty()
-            || manifest.claim_generator_info[0].name == "c2pa-rs"
+        if builder.definition.claim_generator_info.is_empty()
+            || builder.definition.claim_generator_info[0].name == "c2pa-rs"
         {
-            manifest.claim_generator_info = vec![tool_generator];
-        } else {
-            manifest.claim_generator_info.insert(1, tool_generator);
+            builder.definition.claim_generator_info = vec![tool_generator];
         }
+        // else: user supplied a custom `claim_generator_info` (v2 allows only one); keep it
 
         // set manifest base path before ingredients so ingredients can override it
         if let Some(base) = base_path.as_ref() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,8 +14,8 @@
 
 /// Tool to display and create C2PA manifests.
 ///
-/// A file path to an asset must be provided. If only the path
-/// is given, this will generate a summary report of any claims
+/// A file path to an asset is required for normal commands (not for `init`).
+/// If only the path is given, this will generate a summary report of any claims
 /// in that file. If a manifest definition JSON file is specified,
 /// the claim will be added to any existing claims.
 use std::{
@@ -57,9 +57,30 @@ mod tree;
 mod callback_signer;
 mod signer;
 
+/// Official C2PA conformance trust list (PEM bundle).
+const TRUST_LIST_OFFICIAL_URL: &str =
+    "https://raw.githubusercontent.com/c2pa-org/conformance-public/refs/heads/main/trust-list/C2PA-TRUST-LIST.pem";
+/// Legacy interim trust anchors (PEM), fetched only with `init trust --legacy`.
+const TRUST_LIST_LEGACY_ANCHORS_URL: &str = "https://contentcredentials.org/trust/anchors.pem";
+const TRUST_LEGACY_STORE_CFG_URL: &str = "https://contentcredentials.org/trust/store.cfg";
+const TRUST_LEGACY_ALLOWED_URL: &str = "https://contentcredentials.org/trust/allowed.sha256.txt";
+
+/// Sidecar trust files stored next to the settings file (`--settings` parent directory).
+const SIDECAR_TRUST_LIST_PEM: &str = "c2pa-trust-list.pem";
+const SIDECAR_TRUST_LIST_LEGACY_PEM: &str = "c2pa-trust-list-legacy.pem";
+const SIDECAR_TRUST_STORE_CFG: &str = "c2pa-trust-store.cfg";
+const SIDECAR_TRUST_ALLOWED: &str = "c2pa-trust-allowed.sha256.txt";
+
 /// Tool for displaying and creating C2PA manifests.
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None, arg_required_else_help(true))]
+#[command(
+    author,
+    version,
+    about,
+    long_about = None,
+    arg_required_else_help(true),
+    subcommand_negates_reqs = true
+)]
 struct CliArgs {
     /// Path to manifest definition JSON file.
     #[clap(short, long, requires = "output")]
@@ -89,8 +110,8 @@ struct CliArgs {
     #[clap(short, long)]
     force: bool,
 
-    /// The path to an asset to examine or embed a manifest into.
-    path: PathBuf,
+    /// Path to an asset (omit for `init` only).
+    path: Option<PathBuf>,
 
     /// Embed remote URL manifest reference.
     #[clap(short, long)]
@@ -133,25 +154,7 @@ struct CliArgs {
     #[clap(long)]
     signer_path: Option<PathBuf>,
 
-    /// To be used with the [callback_signer] argument. This value should at least: size of CoseSign1 CBOR +
-    /// the size of certificate chain provided in the manifest definition's `sign_cert` field + the size of the
-    /// signature of the Time Stamp Authority response. A typical size of CoseSign1 CBOR is in the 1-2K range. If
-    /// the reserve size is too small an error will be returned during signing.
-    /// For example:
-    ///
-    /// The reserve-size can be calculated like this if you aren't including a `tsa_url` key in
-    /// your manifest description:
-    ///
-    ///     1024 + sign_cert.len()
-    ///
-    /// Or, if you are including a `tsa_url` in your manifest definition, you will calculate the
-    /// reserve size like this:
-    ///
-    ///     1024 + sign_cert.len() + tsa_signature_response.len()
-    ///
-    /// Note:
-    /// We'll default the `reserve-size` to a value of 20_000, if no value is provided. This
-    /// will probably leave extra `0`s of unused space. Please specify a reserve-size if possible.
+    /// Reserved buffer size for `--signer-path` signing only.
     #[clap(long, default_value("20000"))]
     reserve_size: usize,
 
@@ -191,10 +194,25 @@ fn parse_resource_string(s: &str) -> Result<TrustResource> {
     }
 }
 
+#[derive(Debug, Subcommand)]
+enum InitCmd {
+    /// Fetch trust PEM/config sidecars next to `--settings` (no PATH required).
+    Trust {
+        /// Also fetch legacy interim anchors, store config, and allowed list (separate files).
+        #[arg(long)]
+        legacy: bool,
+    },
+}
+
 // We only construct one per invocation, not worth shrinking this.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Bootstrap files beside `--settings` (trust lists, …).
+    Init {
+        #[command(subcommand)]
+        cmd: InitCmd,
+    },
     /// Sub-command to configure trust store options, "trust --help for more details"
     Trust {
         /// URL or path to file containing list of trust anchors in PEM format
@@ -401,6 +419,150 @@ fn blocking_get(url: &str) -> Result<String> {
     }
 }
 
+/// Write `contents` to `dest` atomically: temp file in the same directory, fsync, then rename.
+/// If `dest` already exists it is replaced without truncating in place (best-effort crash safety).
+fn atomic_write_file(dest: &Path, contents: &[u8]) -> Result<()> {
+    let parent = dest
+        .parent()
+        .context("destination path has no parent directory")?;
+    fs::create_dir_all(parent)?;
+    let stem = dest
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("c2pa-trust");
+    let tmp = parent.join(format!(".{stem}.{}.tmp", std::process::id()));
+    {
+        let mut f = File::create(&tmp)?;
+        f.write_all(contents)?;
+        f.sync_all()?;
+    }
+    if cfg!(windows) && dest.exists() {
+        fs::remove_file(dest)?;
+    }
+    fs::rename(&tmp, dest)
+        .with_context(|| format!("atomic rename {} -> {}", tmp.display(), dest.display()))?;
+    Ok(())
+}
+
+/// Load trust PEM/config sidecars from the same directory as `--settings`, if present.
+/// Returns whether any trust material was applied (for enabling `verify_trust`).
+fn apply_trust_sidecars(settings: &mut Settings, settings_path: &Path) -> Result<bool> {
+    let Some(dir) = settings_path.parent() else {
+        return Ok(false);
+    };
+    let mut applied = false;
+
+    let official = dir.join(SIDECAR_TRUST_LIST_PEM);
+    if official.exists() {
+        let data = fs::read_to_string(&official)
+            .with_context(|| format!("read trust sidecar {}", official.display()))?;
+        settings.update_from_str(
+            &toml::toml! {
+                [trust]
+                trust_anchors = data
+            }
+            .to_string(),
+            "toml",
+        )?;
+        applied = true;
+    }
+
+    let legacy_pem = dir.join(SIDECAR_TRUST_LIST_LEGACY_PEM);
+    if legacy_pem.exists() {
+        let data = fs::read_to_string(&legacy_pem)
+            .with_context(|| format!("read legacy trust sidecar {}", legacy_pem.display()))?;
+        settings.update_from_str(
+            &toml::toml! {
+                [trust]
+                user_anchors = data
+            }
+            .to_string(),
+            "toml",
+        )?;
+        applied = true;
+    }
+
+    let store_cfg = dir.join(SIDECAR_TRUST_STORE_CFG);
+    if store_cfg.exists() {
+        let data = fs::read_to_string(&store_cfg)
+            .with_context(|| format!("read trust sidecar {}", store_cfg.display()))?;
+        settings.update_from_str(
+            &toml::toml! {
+                [trust]
+                trust_config = data
+            }
+            .to_string(),
+            "toml",
+        )?;
+        applied = true;
+    }
+
+    let allowed = dir.join(SIDECAR_TRUST_ALLOWED);
+    if allowed.exists() {
+        let data = fs::read_to_string(&allowed)
+            .with_context(|| format!("read trust sidecar {}", allowed.display()))?;
+        settings.update_from_str(
+            &toml::toml! {
+                [trust]
+                allowed_list = data
+            }
+            .to_string(),
+            "toml",
+        )?;
+        applied = true;
+    }
+
+    Ok(applied)
+}
+
+fn run_trust_init(legacy: bool, settings_path: &Path) -> Result<()> {
+    #[cfg(target_os = "wasi")]
+    {
+        bail!("`init trust` is not supported on this target (network fetch unavailable)");
+    }
+    #[cfg(not(target_os = "wasi"))]
+    {
+        let dir = settings_path
+            .parent()
+            .context("settings path has no parent directory")?;
+        fs::create_dir_all(dir)?;
+
+        println!("Fetching official C2PA trust list...");
+        let official = load_trust_resource(&TrustResource::Url(
+            Url::parse(TRUST_LIST_OFFICIAL_URL).expect("constant URL"),
+        ))?;
+        let dest = dir.join(SIDECAR_TRUST_LIST_PEM);
+        atomic_write_file(&dest, official.as_bytes())?;
+        println!("Wrote {}", dest.display());
+
+        if legacy {
+            println!("Fetching legacy interim trust material...");
+            let leg = load_trust_resource(&TrustResource::Url(
+                Url::parse(TRUST_LIST_LEGACY_ANCHORS_URL).expect("constant URL"),
+            ))?;
+            atomic_write_file(&dir.join(SIDECAR_TRUST_LIST_LEGACY_PEM), leg.as_bytes())?;
+
+            let cfg = load_trust_resource(&TrustResource::Url(
+                Url::parse(TRUST_LEGACY_STORE_CFG_URL).expect("constant URL"),
+            ))?;
+            atomic_write_file(&dir.join(SIDECAR_TRUST_STORE_CFG), cfg.as_bytes())?;
+
+            let allowed = load_trust_resource(&TrustResource::Url(
+                Url::parse(TRUST_LEGACY_ALLOWED_URL).expect("constant URL"),
+            ))?;
+            atomic_write_file(&dir.join(SIDECAR_TRUST_ALLOWED), allowed.as_bytes())?;
+
+            println!("Wrote legacy sidecars under {}", dir.display());
+        }
+
+        println!(
+            "Trust sidecars are loaded automatically on the next run (same directory as {}).",
+            settings_path.display()
+        );
+        Ok(())
+    }
+}
+
 fn configure_sdk(args: &CliArgs) -> Result<Settings> {
     let mut settings = if args.settings.exists() {
         Settings::new().with_file(&args.settings)?
@@ -408,7 +570,9 @@ fn configure_sdk(args: &CliArgs) -> Result<Settings> {
         Settings::default()
     };
 
-    let mut enable_trust_checks = false;
+    let sidecar_trust = apply_trust_sidecars(&mut settings, &args.settings)?;
+
+    let mut enable_trust_checks = sidecar_trust;
 
     if let Some(Commands::Trust {
         trust_anchors,
@@ -465,8 +629,7 @@ fn configure_sdk(args: &CliArgs) -> Result<Settings> {
         }
     }
 
-    // if any trust setting is provided enable the trust checks
-    // there is no disabling of default setting only the ability to enable if they were internally disabled
+    // If trust material came from CLI or sidecars, enable trust checks (cannot disable defaults).
     if enable_trust_checks {
         settings.update_from_str(
             &toml::toml! {
@@ -574,21 +737,25 @@ fn validate_cawg(reader: &mut Reader) -> Result<()> {
     }
 }
 
-fn reader_from_args(args: &CliArgs, context: &Arc<C2paContext>) -> Result<Reader> {
+fn reader_from_args(
+    asset_path: &Path,
+    args: &CliArgs,
+    context: &Arc<C2paContext>,
+) -> Result<Reader> {
     if let Some(external_manifest) = &args.external_manifest {
         let c2pa_data = fs::read(external_manifest)?;
-        let format = match c2pa::format_from_path(&args.path) {
+        let format = match c2pa::format_from_path(asset_path) {
             Some(format) => format,
             None => {
-                bail!("Format for {:?} is unrecognized", args.path);
+                bail!("Format for {:?} is unrecognized", asset_path);
             }
         };
         Ok(Reader::from_shared_context(context)
-            .with_manifest_data_and_stream(&c2pa_data, &format, File::open(&args.path)?)
+            .with_manifest_data_and_stream(&c2pa_data, &format, File::open(asset_path)?)
             .map_err(special_errs)?)
     } else {
         Ok(Reader::from_shared_context(context)
-            .with_file(&args.path)
+            .with_file(asset_path)
             .map_err(special_errs)?)
     }
 }
@@ -627,7 +794,16 @@ fn main() -> Result<()> {
     // default to error logging, RUST_LOG=debug to get detailed debug logging
     env_logger::Builder::from_env(Env::default().default_filter_or("error")).init();
 
-    let path = &args.path;
+    if let Some(Commands::Init { cmd }) = &args.command {
+        return match cmd {
+            InitCmd::Trust { legacy } => run_trust_init(*legacy, &args.settings),
+        };
+    }
+
+    let path = args
+        .path
+        .as_ref()
+        .context("PATH to an asset is required (omit only for `init`)")?;
 
     if args.info {
         return info(path);
@@ -745,7 +921,7 @@ fn main() -> Result<()> {
         let has_parent = builder.definition.ingredients.iter().any(|i| i.is_parent());
         if !has_parent && !is_fragment {
             #[allow(deprecated)]
-            let mut source_ingredient = Ingredient::from_file(&args.path)?;
+            let mut source_ingredient = Ingredient::from_file(path)?;
             if source_ingredient.manifest_data().is_some() {
                 source_ingredient.set_is_parent();
                 builder.add_ingredient(source_ingredient);
@@ -792,16 +968,16 @@ fn main() -> Result<()> {
                 }
 
                 if let Some(fg) = &fragments_glob {
-                    return sign_fragmented(&mut builder, signer.as_ref(), &args.path, fg, &output);
+                    return sign_fragmented(&mut builder, signer.as_ref(), path, fg, &output);
                 } else {
                     bail!("fragments_glob must be set");
                 }
             } else {
-                if ext_normal(&output) != ext_normal(&args.path) {
+                if ext_normal(&output) != ext_normal(path) {
                     bail!("Output type must match source type");
                 }
                 if output.exists() {
-                    if args.force && output != args.path {
+                    if args.force && output != *path {
                         remove_file(&output)?;
                     } else if !args.force {
                         bail!("Output already exists; use -f/force to force write");
@@ -814,16 +990,16 @@ fn main() -> Result<()> {
                     bail!("Missing extension output");
                 }
 
-                let manifest_data = if args.path != output {
+                let manifest_data = if *path != output {
                     builder
-                        .sign_file(signer.as_ref(), &args.path, &output)
+                        .sign_file(signer.as_ref(), path, &output)
                         .context("embedding manifest")?
                 } else {
                     let mut file = NamedTempFile::new()?;
-                    let format = format_from_path(&args.path)
+                    let format = format_from_path(path)
                         .ok_or(c2pa::Error::UnsupportedType)
                         .context("unsupported file type")?;
-                    let mut source = File::open(&args.path)?;
+                    let mut source = File::open(path)?;
                     if builder.definition.title.is_none() {
                         if let Some(title) = output.file_name() {
                             builder.definition.title = Some(title.to_string_lossy().to_string());
@@ -882,14 +1058,14 @@ fn main() -> Result<()> {
         create_dir_all(&output)?;
         if args.ingredient {
             #[allow(deprecated)]
-            let report = Ingredient::from_file_with_folder(&args.path, &output)
+            let report = Ingredient::from_file_with_folder(path, &output)
                 .map_err(special_errs)?
                 .to_string();
             File::create(output.join("ingredient.json"))?.write_all(&report.into_bytes())?;
             println!("Ingredient report written to the directory {:?}", &output);
         } else {
             let mut reader = Reader::from_shared_context(&context)
-                .with_file(&args.path)
+                .with_file(path)
                 .map_err(special_errs)?;
             validate_cawg(&mut reader)?;
             reader.to_folder(&output)?;
@@ -905,13 +1081,13 @@ fn main() -> Result<()> {
         }
     } else if args.ingredient {
         #[allow(deprecated)]
-        let ingredient = Ingredient::from_file(&args.path).map_err(special_errs)?;
+        let ingredient = Ingredient::from_file(path).map_err(special_errs)?;
         println!("{}", ingredient)
     } else if let Some(Commands::Fragment {
         fragments_glob: Some(fg),
     }) = &args.command
     {
-        let mut stores = verify_fragmented(&args.path, fg, &context)?;
+        let mut stores = verify_fragmented(path, fg, &context)?;
         if stores.len() == 1 {
             validate_cawg(&mut stores[0])?;
             println!("{}", stores[0]);
@@ -922,7 +1098,7 @@ fn main() -> Result<()> {
             println!("{} Init manifests validated", stores.len());
         }
     } else {
-        let mut reader = reader_from_args(&args, &context)?;
+        let mut reader = reader_from_args(path, &args, &context)?;
         validate_cawg(&mut reader)?;
         print_reader(&reader, args.detailed, args.crjson)?;
     }
@@ -936,7 +1112,7 @@ pub mod tests {
 
     use std::fs::{create_dir, write};
 
-    use c2pa::{BuilderIntent, DigitalSourceType};
+    use c2pa::{BuilderIntent, DigitalSourceType, Settings};
     use tempfile::TempDir;
 
     use super::*;
@@ -1010,5 +1186,35 @@ pub mod tests {
         println!("{ms}");
         //let ms = report_from_path(&OUTPUT_PATH, false).expect("report_from_path");
         assert!(ms.contains("my_key"));
+    }
+
+    #[test]
+    fn atomic_write_file_writes_and_replaces() {
+        let tmp = tempdirectory().unwrap();
+        let dest = tmp.path().join("out.pem");
+        atomic_write_file(&dest, b"first").unwrap();
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "first");
+        atomic_write_file(&dest, b"second").unwrap();
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "second");
+    }
+
+    #[test]
+    fn apply_trust_sidecars_reads_official_pem() {
+        const SAMPLE_ANCHOR_PEM: &str = include_str!("../../cli/tests/fixtures/trust/anchors.pem");
+        let tmp = tempdirectory().unwrap();
+        let settings_path = tmp.path().join("c2pa.toml");
+        write(
+            tmp.path().join(SIDECAR_TRUST_LIST_PEM),
+            SAMPLE_ANCHOR_PEM.as_bytes(),
+        )
+        .unwrap();
+        let mut settings = Settings::default();
+        assert!(apply_trust_sidecars(&mut settings, &settings_path).unwrap());
+        let ta = settings
+            .trust
+            .trust_anchors
+            .as_deref()
+            .expect("trust_anchors");
+        assert!(ta.contains("BEGIN CERTIFICATE"));
     }
 }

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -429,6 +429,40 @@ fn tool_sign_to_same_file_no_force() -> Result<(), Box<dyn Error>> {
 // }
 
 #[test]
+// With RUST_LOG unset, default level is `error` (see main) — debug! lines in configure_sdk must not appear.
+fn rust_log_unset_suppresses_trust_debug_messages() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE_WITH_MANIFEST))
+        .arg("trust")
+        .arg("--trust_anchors")
+        .arg(fixture_path("trust/anchors.pem"))
+        .arg("--trust_config")
+        .arg(fixture_path("trust/store.cfg"))
+        .env_remove("RUST_LOG")
+        .assert()
+        .success()
+        .stderr(str::contains("Using trust anchors").not());
+    Ok(())
+}
+
+#[test]
+// With RUST_LOG=debug, trust setup emits debug! lines; proves the test above is exercising log level.
+fn rust_log_debug_shows_trust_debug_messages() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE_WITH_MANIFEST))
+        .arg("trust")
+        .arg("--trust_anchors")
+        .arg(fixture_path("trust/anchors.pem"))
+        .arg("--trust_config")
+        .arg(fixture_path("trust/store.cfg"))
+        .env("RUST_LOG", "debug")
+        .assert()
+        .success()
+        .stderr(str::contains("Using trust"));
+    Ok(())
+}
+
+#[test]
 // c2patool tests/fixtures/C.jpg trust --trust_anchors=tests/fixtures/trust/anchors.pem --trust_config=tests/fixtures/trust/store.cfg
 fn tool_load_trust_settings_from_file_trusted() -> Result<(), Box<dyn Error>> {
     Command::new(cargo::cargo_bin!("c2patool"))

--- a/docs/context-settings.md
+++ b/docs/context-settings.md
@@ -140,6 +140,8 @@ fn main() -> Result<()> {
 }
 ```
 
+When the manifest JSON omits `claim_generator_info` (or uses `[]`), `Builder` resolves it at claim time: first from `builder.claim_generator_info` in the settings you passed to `Context` (as in the `json!` above, if you set that field), otherwise the library default.
+
 ## Settings definition
 
 The Settings definition has the following top-level structure:

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -162,8 +162,13 @@ pub struct ManifestDefinition {
     /// This is typically a reverse domain name.
     pub vendor: Option<String>,
 
-    /// Claim Generator Info is always required with an entry
-    #[serde(default = "default_claim_generator_info")]
+    /// Software that generated the claim, as a list of [`ClaimGeneratorInfo`].
+    ///
+    /// In JSON, when this key is **omitted** (or the array is empty), the value is
+    /// resolved at claim-building time: settings.builder.claim_generator_info if set, otherwise
+    /// on the active [`Context`] is used if set, otherwise [`ClaimGeneratorInfo::default`].
+    /// A non-empty list in the definition is used as given.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub claim_generator_info: Vec<ClaimGeneratorInfo>,
 
     /// Optional manifest metadata. This will be deprecated in the future; not recommended to use.
@@ -216,10 +221,6 @@ pub struct ManifestDefinition {
 
 fn default_instance_id() -> String {
     format!("xmp:iid:{}", Uuid::new_v4())
-}
-
-fn default_claim_generator_info() -> Vec<ClaimGeneratorInfo> {
-    [ClaimGeneratorInfo::default()].to_vec()
 }
 
 fn default_format() -> String {
@@ -1381,19 +1382,20 @@ impl Builder {
 
         let definition = &self.definition;
         let mut claim_generator_info = definition.claim_generator_info.clone();
-
-        // add the default claim generator info for this library
         if claim_generator_info.is_empty() {
-            let claim_generator_info_settings =
-                &self.context.settings().builder.claim_generator_info;
-            match claim_generator_info_settings {
-                Some(claim_generator_info_settings) => {
-                    claim_generator_info.push(claim_generator_info_settings.clone().try_into()?);
-                }
-                _ => {
-                    claim_generator_info.push(ClaimGeneratorInfo::default());
-                }
-            }
+            //Manifest omitted `claim_generator_info` (or `[]`): one entry from settings, else
+            // [`ClaimGeneratorInfo::default`].
+            let info: ClaimGeneratorInfo = match self
+                .context
+                .settings()
+                .builder
+                .claim_generator_info
+                .as_ref()
+            {
+                Some(settings) => settings.clone().try_into()?,
+                None => ClaimGeneratorInfo::default(),
+            };
+            claim_generator_info.push(info);
         }
 
         claim_generator_info[0].insert("org.contentauth.c2pa_rs", env!("CARGO_PKG_VERSION"));
@@ -3620,6 +3622,79 @@ mod tests {
         // convert back to json and compare to original
         let builder_json = serde_json::to_string(&builder.definition).unwrap();
         assert_eq!(builder_json, stripped_json);
+    }
+
+    #[test]
+    fn test_omitted_claim_generator_info_is_empty_vec() {
+        let json = json!({
+            "title": "Test_Manifest",
+            "format": "image/jpeg",
+        })
+        .to_string();
+        let def: ManifestDefinition = serde_json::from_str(&json).expect("parse");
+        assert!(def.claim_generator_info.is_empty());
+    }
+
+    #[test]
+    fn test_claim_generator_info_uses_settings_when_omitted_from_json() {
+        use std::sync::Arc;
+
+        let settings = Settings::new()
+            .with_toml(
+                r#"
+                [builder.claim_generator_info]
+                name = "from_settings"
+                version = "9.9.9"
+                "#,
+            )
+            .expect("with_toml");
+        let context = Arc::new(
+            Context::new()
+                .with_settings(settings)
+                .expect("with_settings"),
+        );
+
+        let json = json!({
+            "title": "t",
+            "format": "image/jpeg",
+            "assertions": [
+                {
+                    "label": "c2pa.actions",
+                    "data": {
+                        "actions": [
+                            {
+                                "action": "c2pa.created",
+                                "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty",
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+        let mut builder = Builder::from_shared_context(&context)
+            .with_definition(json.to_string())
+            .expect("with_definition");
+
+        const TEST_IMAGE: &[u8] = include_bytes!("../tests/fixtures/no_manifest.jpg");
+        let format = "image/jpeg";
+        let mut source = Cursor::new(TEST_IMAGE);
+        let mut dest = Cursor::new(Vec::new());
+        let signer = test_signer(SigningAlg::Ps256);
+        builder
+            .sign(signer.as_ref(), format, &mut source, &mut dest)
+            .expect("sign");
+
+        dest.set_position(0);
+        let reader = Reader::from_shared_context(&context)
+            .with_stream(format, &mut dest)
+            .expect("reader");
+        let m = reader.active_manifest().expect("active manifest");
+        let cgi = m
+            .claim_generator_info
+            .as_ref()
+            .expect("claim_generator_info in manifest");
+        assert_eq!(cgi[0].name, "from_settings");
+        assert_eq!(cgi[0].version.as_deref(), Some("9.9.9"));
     }
 
     #[test]

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -512,10 +512,10 @@ pub struct BuilderSettings {
     /// The name of the vendor creating the content credential.
     pub vendor: Option<String>,
 
-    /// Claim generator info that is automatically added to the builder.
-    ///
-    /// Note that this information will prepend any claim generator info
-    /// provided explicitly to the builder.
+    /// When set, used as [`ClaimGeneratorInfo`] when
+    /// [`ManifestDefinition::claim_generator_info`](crate::builder::ManifestDefinition) is empty
+    /// (e.g. key omitted in JSON or an empty array). If `None` or when the definition lists at
+    /// least one generator, that path does not use this value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub claim_generator_info: Option<ClaimGeneratorInfoSettings>,
     /// Various settings for configuring automatic thumbnail generation.


### PR DESCRIPTION
**PR Description:**

Adds c2patool init trust to bootstrap C2PA trust-list files locally, and auto-loads those files as sidecars on subsequent runs — eliminating the need to pass --trust_anchors etc. manually. Also fixes claim_generator_info resolution and hardens logging initialization.

**init trust subcommand**

init trust fetches the official C2PA trust list PEM and writes it atomically next to --settings
init trust --legacy additionally fetches interim Content Credentials anchors, store config, and allowed-SHA list
Sidecar files are auto-loaded on every run; finding any sidecar enables trust checks automatically
Writes use a temp-file + fsync + rename pattern to avoid partial writes on crash

**SDK fix: claim_generator_info resolution** 
[CAI-10486](https://jira.corp.adobe.com/browse/CAI-10486)
the claim_generator_info from settings was never getting used in practice. This fixes things to work in the correct order:
manifest defintion -> settings -> default.
ManifestDefinition::claim_generator_info now deserializes to an empty Vec when absent or [], resolved at claim-build time via settings → library default
Fixes a logic inversion that could suppress or duplicate the tool's own generator entry
c2patool will now report itself as the generator if no other claim_generator specified (was using c2pa-rs library)

**allow periods in pathnames**
[CAI-11758](https://jira.corp.adobe.com/browse/CAI-11758)

**Logging hardening**
[CAI-10487](https://jira.corp.adobe.com/browse/CAI-10487)
Replaces unsound set_var + env_logger::init() with env_logger::Builder::from_env
Tests: integration tests for log-level behavior; unit tests for claim_generator_info deserialization and settings-based resolution