### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.80.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.80.2...c2pa-v0.80.3)
+_29 April 2026_
+
+### Added
+
+* Support DNG big data ([#2092](https://github.com/contentauth/c2pa-rs/pull/2092))
+* Add `init trust`, trust sidecars, and atomic sidecar writes, plus fixes ([#2093](https://github.com/contentauth/c2pa-rs/pull/2093))
+
+### Updated dependencies
+
+* Bump openssl from 0.10.77 to 0.10.78 ([#2082](https://github.com/contentauth/c2pa-rs/pull/2082))
+
 ## [0.80.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.80.1...c2pa-v0.80.2)
 _28 April 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.52"
+version = "0.26.53"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2487,7 +2487,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.80.2"
+version = "0.80.3"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.80.2"
+version = "0.80.3"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.80.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.80.2...c2pa-c-ffi-v0.80.3)
+_29 April 2026_
+
 ## [0.80.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.80.1...c2pa-c-ffi-v0.80.2)
 _28 April 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.80.2", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.80.3", default-features = false, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.53](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.52...c2patool-v0.26.53)
+_29 April 2026_
+
+### Added
+
+* Add `init trust`, trust sidecars, and atomic sidecar writes, plus fixes ([#2093](https://github.com/contentauth/c2pa-rs/pull/2093))
+
 ## [0.26.52](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.51...c2patool-v0.26.52)
 _28 April 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.52"
+version = "0.26.53"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -28,7 +28,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-c2pa = { path = "../sdk", version = "0.80.2", features = [
+c2pa = { path = "../sdk", version = "0.80.3", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
 
 [dependencies]
 anyhow = "1.0.40"
-c2pa = { path = "../sdk", version = "0.80.2", features = [
+c2pa = { path = "../sdk", version = "0.80.3", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.80.2 -> 0.80.3 (✓ API compatible changes)
* `c2patool`: 0.26.52 -> 0.26.53
* `c2pa-c-ffi`: 0.80.2 -> 0.80.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.80.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.80.2...c2pa-v0.80.3)

_29 April 2026_

### Added

* Support DNG big data ([#2092](https://github.com/contentauth/c2pa-rs/pull/2092))
* Add `init trust`, trust sidecars, and atomic sidecar writes, plus fixes ([#2093](https://github.com/contentauth/c2pa-rs/pull/2093))

### Updated dependencies

* Bump openssl from 0.10.77 to 0.10.78 ([#2082](https://github.com/contentauth/c2pa-rs/pull/2082))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.53](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.52...c2patool-v0.26.53)

_29 April 2026_

### Added

* Add `init trust`, trust sidecars, and atomic sidecar writes, plus fixes ([#2093](https://github.com/contentauth/c2pa-rs/pull/2093))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.80.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.80.2...c2pa-c-ffi-v0.80.3)

_29 April 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).