### PR TITLE
fix!: use absolute URIs for ingredient thumbnails

### DIFF
--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1153,6 +1153,8 @@ impl Ingredient {
                 Some(label) => label,           // use the manifest from the thumbnail uri
                 None => claim_label.to_owned(), /* relative so use the whole url from the thumbnail assertion */
             };
+            let absolute_uri =
+                jumbf::labels::to_absolute_uri(&target_claim_label, &hashed_uri.url());
             let maybe_resource_ref = match hashed_uri.url() {
                 uri if uri.contains(jumbf::labels::ASSERTIONS) => {
                     // Get the bits of the thumbnail and convert it to a resource
@@ -1161,16 +1163,14 @@ impl Ingredient {
                         .get_assertion_from_uri_and_claim(&hashed_uri.url(), &target_claim_label)
                         .map(|assertion| {
                             let (format, image) = Self::thumbnail_from_assertion(assertion);
-                            ingredient
-                                .resources
-                                .add_uri(&hashed_uri.url(), format, image)
+                            ingredient.resources.add_uri(&absolute_uri, format, image)
                         })
                 }
                 uri if uri.contains(jumbf::labels::DATABOXES) => store
                     .get_data_box_from_uri_and_claim(hashed_uri, &target_claim_label)
                     .map(|data_box| {
                         ingredient.resources.add_uri(
-                            &hashed_uri.url(),
+                            &absolute_uri,
                             &data_box.format,
                             data_box.data.clone(),
                         )
@@ -1746,6 +1746,7 @@ mod tests {
     use wasm_bindgen_test::*;
 
     use super::*;
+    use crate::{utils::test_signer::test_signer, Builder, Reader, SigningAlg};
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -1976,6 +1977,37 @@ mod tests {
         assert_eq!(ingredient.validation_status(), None);
         assert!(ingredient.manifest_data().is_some());
         assert!(ingredient.provenance().is_some());
+    }
+
+    #[test]
+    fn test_ingredient_thumbnail_uri_is_absolute() {
+        let mut ingredient = Ingredient::new_v2("Test Ingredient", "image/jpeg");
+        ingredient
+            .set_thumbnail("image/jpeg", b"a super real thumbnail".to_vec())
+            .unwrap();
+
+        let mut builder = Builder::default()
+            .with_definition(r#"{"title": "Test Image"}"#)
+            .unwrap();
+        builder.add_ingredient(ingredient);
+
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut source = Cursor::new(include_bytes!("../tests/fixtures/C.jpg").as_slice());
+        let mut output = Cursor::new(Vec::new());
+        builder
+            .sign(&signer, "image/jpeg", &mut source, &mut output)
+            .unwrap();
+
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .unwrap();
+        let manifest = reader.active_manifest().unwrap();
+        let manifest_label = manifest.label().unwrap();
+        let ingredient = manifest.ingredients().first().unwrap();
+        let thumb_ref = ingredient.thumbnail_ref().unwrap();
+
+        let expected_prefix = format!("self#jumbf=/c2pa/{manifest_label}/");
+        assert!(thumb_ref.identifier.starts_with(&expected_prefix),);
     }
 }
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1356,7 +1356,10 @@ pub mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use crate::utils::test::test_context;
+    use crate::{
+        utils::{test::test_context, test_signer::test_signer},
+        Builder, SigningAlg,
+    };
 
     const IMAGE_COMPLEX_MANIFEST: &[u8] = include_bytes!("../tests/fixtures/CACAE-uri-CA.jpg");
     const IMAGE_WITH_MANIFEST: &[u8] = include_bytes!("../tests/fixtures/CA.jpg");
@@ -1684,5 +1687,51 @@ pub mod tests {
             assert_send::<Reader>();
             assert_sync::<Reader>();
         }
+    }
+
+    #[test]
+    fn test_two_ingredient_thumbnails_via_resource_to_stream() -> Result<()> {
+        let thumbnail1 = b"the first super real thumbnail";
+        let thumbnail2 = b"the second super real thumbnail";
+
+        let mut ingredient1 = Ingredient::new_v2("Ingredient One", "image/jpeg");
+        ingredient1
+            .set_thumbnail("image/jpeg", thumbnail1.to_vec())
+            .unwrap();
+
+        let mut ingredient2 = Ingredient::new_v2("Ingredient Two", "image/jpeg");
+        ingredient2
+            .set_thumbnail("image/jpeg", thumbnail2.to_vec())
+            .unwrap();
+
+        let mut builder = Builder::default()
+            .with_definition(r#"{"title": "Test Image"}"#)
+            .unwrap();
+        builder.add_ingredient(ingredient1);
+        builder.add_ingredient(ingredient2);
+
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut source = Cursor::new(include_bytes!("../tests/fixtures/C.jpg").as_slice());
+        let mut output = Cursor::new(Vec::new());
+        builder.sign(&signer, "image/jpeg", &mut source, &mut output)?;
+
+        let reader = Reader::default().with_stream("image/jpeg", &mut output)?;
+        let manifest = reader.active_manifest().unwrap();
+        let ingredients = manifest.ingredients();
+        assert_eq!(ingredients.len(), 2);
+
+        let uri1 = ingredients[0].thumbnail_ref().unwrap().identifier.clone();
+        let uri2 = ingredients[1].thumbnail_ref().unwrap().identifier.clone();
+        assert_ne!(uri1, uri2);
+
+        let mut out1 = Cursor::new(Vec::new());
+        reader.resource_to_stream(&uri1, &mut out1)?;
+        assert_eq!(out1.into_inner(), thumbnail1);
+
+        let mut out2 = Cursor::new(Vec::new());
+        reader.resource_to_stream(&uri2, &mut out2)?;
+        assert_eq!(out2.into_inner(), thumbnail2);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Use absolute URI for the ingredient thumbnail.

Before this change, all ingredient thumbnails used relative JUMBF URIs which were equivalent. Thus, when the reader collected thumbnails into its resource store, ingredient thumbnails would overwrite each other with the same key. This change uses the absolute URI so that they are all unique.