### PR TITLE
fix: Harden against integer underflow attack in GIF XMP validation

### DIFF
--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -53,6 +53,13 @@ impl CAIReader for GifIO {
             .ok()?
             .map(|marker| marker.block.data_sub_blocks.to_decoded_bytes())?;
 
+        // The XMP magic trailer is exactly 257 bytes. A block shorter than that
+        // cannot carry a valid trailer; reject it rather than underflowing the
+        // usize subtraction below (panic in debug, wrap-to-MAX in release).
+        if bytes.len() < 257 {
+            return None;
+        }
+
         // TODO: this should be validated on construction
         // Validate the 258-byte XMP magic trailer (excluding terminator).
         if let Some(byte) = bytes.get(bytes.len() - 257) {
@@ -1487,6 +1494,39 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_xmp_short_trailer_does_not_panic() {
+        // An XMP Application Extension whose decoded payload is shorter than 257 bytes
+        // must return None, not panic with "attempt to subtract with overflow".
+        // Craft the minimum valid GIF structure with a short XMP block.
+        let gif_io = GifIO {};
+
+        // Build a minimal GIF89a with a single short XMP Application Extension.
+        // Header(6) + LogicalScreenDescriptor(7, no GCT) + AppExt + Trailer(1)
+        let mut data: Vec<u8> = Vec::new();
+
+        // GIF89a header
+        data.extend_from_slice(b"GIF89a");
+        // Logical Screen Descriptor: width=1, height=1, packed=0x00 (no GCT), bg=0, aspect=0
+        data.extend_from_slice(&[0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+        // Application Extension introducer + label
+        data.push(0x21); // Extension introducer
+        data.push(0xff); // Application Extension label
+        data.push(0x0b); // Block size = 11
+        data.extend_from_slice(b"XMP Data"); // identifier (8 bytes)
+        data.extend_from_slice(&[0x58, 0x4d, 0x50]); // auth code "XMP"
+                                                     // One short sub-block: 10 bytes of payload (well under 257)
+        data.push(0x0a); // sub-block size
+        data.extend_from_slice(&[0u8; 10]); // payload
+        data.push(0x00); // sub-block terminator
+                         // Trailer
+        data.push(0x3b);
+
+        let mut stream = Cursor::new(data);
+        // Must return None, must not panic.
+        assert_eq!(gif_io.read_xmp(&mut stream), None);
     }
 
     #[test]

--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -38,6 +38,9 @@ use crate::{
 };
 
 // https://www.w3.org/Graphics/GIF/spec-gif89a.txt
+
+const XMP_MAGIC_TRAILER_LEN: usize = 257;
+
 pub struct GifIO {}
 
 impl CAIReader for GifIO {
@@ -56,24 +59,28 @@ impl CAIReader for GifIO {
         // The XMP magic trailer is exactly 257 bytes. A block shorter than that
         // cannot carry a valid trailer; reject it rather than underflowing the
         // usize subtraction below (panic in debug, wrap-to-MAX in release).
-        if bytes.len() < 257 {
+        if bytes.len() < XMP_MAGIC_TRAILER_LEN {
             return None;
         }
 
         // TODO: this should be validated on construction
-        // Validate the 258-byte XMP magic trailer (excluding terminator).
-        if let Some(byte) = bytes.get(bytes.len() - 257) {
+        if let Some(byte) = bytes.get(bytes.len() - XMP_MAGIC_TRAILER_LEN) {
             if *byte != 1 {
                 return None;
             }
         }
-        for (i, byte) in bytes.iter().rev().take(256).enumerate() {
+        for (i, byte) in bytes
+            .iter()
+            .rev()
+            .take(XMP_MAGIC_TRAILER_LEN - 1)
+            .enumerate()
+        {
             if *byte != i as u8 {
                 return None;
             }
         }
 
-        bytes.truncate(bytes.len() - 257);
+        bytes.truncate(bytes.len() - XMP_MAGIC_TRAILER_LEN);
         String::from_utf8(bytes).ok()
     }
 }
@@ -910,7 +917,7 @@ impl ApplicationExtension {
 
     fn new_xmp(mut bytes: Vec<u8>) -> Result<ApplicationExtension> {
         // Add XMP magic trailer.
-        bytes.reserve(257);
+        bytes.reserve(XMP_MAGIC_TRAILER_LEN);
         bytes.push(1);
         for byte in (0..=255).rev() {
             bytes.push(byte);


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: GIF XMP Magic Trailer usize Underflow (Panic / Incorrect Output)

## Vulnerability

`CAIReader::read_xmp` in `sdk/src/asset_handlers/gif_io.rs` subtracts the
constant `257` from `bytes.len()` (a `usize`) without first confirming that the
decoded payload is at least 257 bytes long. When an attacker supplies a GIF with
a short XMP Application Extension the subtraction underflows:

- **Debug builds** — Rust panics with `"attempt to subtract with overflow"`,
  crashing the host process.
- **Release builds** — `usize` wraps to `usize::MAX - N`; the bounds check at
  `bytes.get(usize::MAX - N)` returns `None` (first validation is silently
  skipped), and `bytes.truncate(usize::MAX - N)` is a no-op; the function
  returns a garbage XMP string instead of `None`.

### Root cause

```rust
// Vulnerable — no minimum-length guard before subtraction
if let Some(byte) = bytes.get(bytes.len() - 257) { // panics when len < 257
    ...
}
...
bytes.truncate(bytes.len() - 257); // panics when len < 257
```

### Attack surface

Any caller of `Reader::from_stream("image/gif", ...)` on an attacker-supplied
GIF. A ~30-byte crafted GIF with a short `XMP Data` application extension is
sufficient. The panic is unconditional in debug builds; in release it silently
produces incorrect XMP data.

### Affected location

| File | Function | Issue |
|---|---|---|
| `sdk/src/asset_handlers/gif_io.rs` | `CAIReader::read_xmp` | `bytes.len() - 257` underflows when `bytes.len() < 257` (lines 58 and 69) |

## Fix

Add a minimum-length guard before the first subtraction. If the decoded payload
is shorter than 257 bytes it cannot carry a valid XMP magic trailer; `read_xmp`
returns `None` immediately:

```rust
// The XMP magic trailer is exactly 257 bytes. A block shorter than that
// cannot carry a valid trailer; reject it rather than underflowing the
// usize subtraction below (panic in debug, wrap-to-MAX in release).
if bytes.len() < 257 {
    return None;
}
```

The single guard protects both subtraction sites. No other changes were needed.

## Test Added

`test_xmp_short_trailer_does_not_panic` in `asset_handlers::gif_io::tests`:

Constructs a minimal valid GIF89a (header + logical screen descriptor + XMP
Application Extension with a 10-byte payload + trailer) and calls `read_xmp`.
Asserts the return value is `None` — not a panic, not garbage XMP.


## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
