### PR TITLE
fix: Harden error code mapping for hash mismatch in validator

### DIFF
--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -142,7 +142,7 @@ impl ValidationStatus {
             "ClaimMissing" => CLAIM_MISSING,
             e if e.starts_with("AssertionMissing") => ASSERTION_MISSING,
             e if e.starts_with("AssertionDecoding") => ASSERTION_REQUIRED_MISSING,
-            e if e.starts_with("HashMismatch") => ASSERTION_DATAHASH_MATCH,
+            e if e.starts_with("HashMismatch") => ASSERTION_DATAHASH_MISMATCH,
             e if e.starts_with("RemoteManifestFetch") => MANIFEST_INACCESSIBLE,
             e if e.starts_with("PrereleaseError") => STATUS_PRERELEASE,
             _ => GENERAL_ERROR,
@@ -155,7 +155,7 @@ impl ValidationStatus {
             Error::ClaimMissing { .. } => CLAIM_MISSING,
             Error::AssertionMissing { .. } => ASSERTION_MISSING,
             Error::AssertionDecoding(_code) => ASSERTION_REQUIRED_MISSING, /* todo detect json/cbor errors */
-            Error::HashMismatch(_) => ASSERTION_DATAHASH_MATCH,
+            Error::HashMismatch(_) => ASSERTION_DATAHASH_MISMATCH,
             Error::RemoteManifestFetch(_) => MANIFEST_INACCESSIBLE,
             Error::PrereleaseError => STATUS_PRERELEASE,
             _ => GENERAL_ERROR,
@@ -215,3 +215,37 @@ impl PartialEq for ValidationStatus {
 // -- unofficial status code --
 
 pub(crate) const STATUS_PRERELEASE: &str = "com.adobe.prerelease";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_mismatch_error_maps_to_mismatch_code() {
+        // Error::HashMismatch must produce the failure code, not the success code.
+        assert_eq!(
+            ValidationStatus::code_from_error(&Error::HashMismatch("digest differs".to_string())),
+            ASSERTION_DATAHASH_MISMATCH,
+        );
+    }
+
+    #[test]
+    fn hash_mismatch_error_str_maps_to_mismatch_code() {
+        // The string-based path (used when mapping log items without a typed error) must
+        // also produce the failure code.
+        assert_eq!(
+            ValidationStatus::code_from_error_str("HashMismatch(digest differs)"),
+            ASSERTION_DATAHASH_MISMATCH,
+        );
+    }
+
+    #[test]
+    fn hash_mismatch_from_error_is_failure_status() {
+        let status = ValidationStatus::from_error(&Error::HashMismatch("bad hash".to_string()));
+        assert_eq!(status.code(), ASSERTION_DATAHASH_MISMATCH);
+        assert!(
+            !status.passed(),
+            "hash mismatch must not be a passing status"
+        );
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: HashMismatch Mapped to Success Code Instead of Failure Code

## Vulnerability

`code_from_error` and `code_from_error_str` in `sdk/src/validation_status.rs`
both mapped `Error::HashMismatch` to `ASSERTION_DATAHASH_MATCH`
(`"assertion.dataHash.match"`) — a **success** code — instead of
`ASSERTION_DATAHASH_MISMATCH` (`"assertion.dataHash.mismatch"`) — the correct
**failure** code.

### Impact

Any caller that parses the validation status array and checks the `code` field
against known failure codes (e.g. `"assertion.dataHash.mismatch"`) would
silently miss a hash-mismatch failure. The asset would appear valid to code
that checks status codes rather than array position:

```json
{
  "validationResults": {
    "failure": [
      { "code": "assertion.dataHash.match", ... }   // ← success code in failure array
    ]
  }
}
```

This is a logic / semantic vulnerability: no memory safety issue, but consumers
performing code-based validation checks receive a misleading signal.

### Root cause

Copy-paste error — both match arms used `ASSERTION_DATAHASH_MATCH` instead of
`ASSERTION_DATAHASH_MISMATCH`:

```rust
// Vulnerable
e if e.starts_with("HashMismatch") => ASSERTION_DATAHASH_MATCH,  // wrong
Error::HashMismatch(_) => ASSERTION_DATAHASH_MATCH,              // wrong
```

### Affected locations

| File | Function | Line | Issue |
|---|---|---|---|
| `sdk/src/validation_status.rs` | `code_from_error_str` | 145 | `ASSERTION_DATAHASH_MATCH` should be `ASSERTION_DATAHASH_MISMATCH` |
| `sdk/src/validation_status.rs` | `code_from_error` | 158 | `ASSERTION_DATAHASH_MATCH` should be `ASSERTION_DATAHASH_MISMATCH` |

## Fix

Two one-word changes:

```rust
// Fixed
e if e.starts_with("HashMismatch") => ASSERTION_DATAHASH_MISMATCH,
Error::HashMismatch(_) => ASSERTION_DATAHASH_MISMATCH,
```

## Tests Added

Three unit tests in `validation_status::tests`:

| Test | Validates |
|---|---|
| `hash_mismatch_error_maps_to_mismatch_code` | `code_from_error(Error::HashMismatch(...))` returns `ASSERTION_DATAHASH_MISMATCH` |
| `hash_mismatch_error_str_maps_to_mismatch_code` | `code_from_error_str("HashMismatch(...)")` returns `ASSERTION_DATAHASH_MISMATCH` |
| `hash_mismatch_from_error_is_failure_status` | `from_error(Error::HashMismatch(...))` produces a status with the mismatch code and `passed() == false` |

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
