### PR TITLE
fix: Harden against integer overflow attack in png chunk hashing for 32 bit WASM architecture

### DIFF
--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -402,21 +402,27 @@ impl CAIWriter for PngIO {
             .find(|pcp| pcp.name == CAI_CHUNK)
             .ok_or(Error::JumbfNotFound)?;
 
+        let cai_offset = usize::try_from(pcp.start)
+            .map_err(|_| Error::InvalidAsset("PNG CAI chunk offset overflows usize".to_string()))?;
+        let cai_length = usize::try_from(pcp.length as u64 + PNG_HDR_LEN)
+            .map_err(|_| Error::InvalidAsset("PNG CAI chunk length overflows usize".to_string()))?;
+        let end = usize::try_from(pcp.end())
+            .map_err(|_| Error::InvalidAsset("PNG CAI chunk end overflows usize".to_string()))?;
+
         positions.push(HashObjectPositions {
-            offset: pcp.start as usize,
-            length: pcp.length as usize + PNG_HDR_LEN as usize,
+            offset: cai_offset,
+            length: cai_length,
             htype: HashBlockObjectType::Cai,
         });
 
         // add hash of chunks before cai
         positions.push(HashObjectPositions {
             offset: 0,
-            length: pcp.start as usize,
+            length: cai_offset,
             htype: HashBlockObjectType::Other,
         });
 
         // add position from cai to end
-        let end = pcp.end() as usize;
         let file_end = png_buf.len();
         positions.push(HashObjectPositions {
             offset: end, // len of cai
@@ -604,7 +610,7 @@ fn get_xmp_insertion_point(asset_reader: &mut dyn CAIRead) -> Option<(u64, u32)>
 
     if let Some(xmp) = xmp_box {
         // overwrite existing box
-        Some((xmp.start, xmp.length + PNG_HDR_LEN as u32))
+        Some((xmp.start, xmp.length.checked_add(PNG_HDR_LEN as u32)?))
     } else {
         // insert after IHDR
         ps.iter()
@@ -1050,6 +1056,32 @@ pub mod tests {
             Err(Error::JumbfNotFound) => (),
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn test_cai_chunk_length_near_u32_max_returns_error() {
+        // A CAI chunk claiming length = u32::MAX - 11 is the minimum value whose
+        // `length as usize + PNG_HDR_LEN(12)` overflows usize on 32-bit/WASM targets.
+        // Without actual chunk data the parser hits EOF at CRC-read time, so the
+        // call must return Err — not panic — on any target width.
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(&PNG_ID);
+        // Minimal IHDR: width=1, height=1, 8-bit RGB, no interlace
+        let ihdr_payload: [u8; 13] = [0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0];
+        data.extend_from_slice(&(ihdr_payload.len() as u32).to_be_bytes());
+        data.extend_from_slice(b"IHDR");
+        data.extend_from_slice(&ihdr_payload);
+        data.extend_from_slice(&[0x90, 0x77, 0x53, 0xde]); // valid IHDR CRC
+                                                           // CAI chunk: claimed length = u32::MAX - 11 (overflows usize + 12 on 32-bit).
+                                                           // No payload follows — the parser hits EOF before recording this chunk position.
+        data.extend_from_slice(&(u32::MAX - 11).to_be_bytes());
+        data.extend_from_slice(b"caBX");
+
+        let png_io = PngIO {};
+        let mut stream = Cursor::new(data);
+        assert!(png_io
+            .get_object_locations_from_stream(&mut stream)
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: PNG Chunk Length Integer Overflow on 32-bit/WASM Targets

## Vulnerability

`get_object_locations_from_stream` in `sdk/src/asset_handlers/png_io.rs` uses
unsafe integer casts when computing `HashObjectPositions` from a parsed PNG
chunk. On 32-bit targets (notably WebAssembly), these casts can overflow,
producing wrong hash region boundaries and potentially enabling signature bypass.

### Root cause

The PNG chunk length field (`pcp.length`) is a `u32` — directly attacker-
controlled via the PNG binary. `PNG_HDR_LEN` is 12. The additions and casts:

```rust
// Vulnerable — unsafe casts
offset: pcp.start as usize,                              // u64→usize: truncates on 32-bit
length: pcp.length as usize + PNG_HDR_LEN as usize,      // overflow when length > usize::MAX - 12
...
length: pcp.start as usize,                              // u64→usize: truncates on 32-bit
let end = pcp.end() as usize;                            // u64→usize: truncates on 32-bit
```

On 32-bit WASM (`usize` = 32 bits, max `4,294,967,295`):
- `pcp.length as usize + 12` overflows when `pcp.length > 4,294,967,283`.
- Debug builds: panic with `"attempt to add with overflow"`.
- Release builds: result silently wraps to a small value.

A wrapped `length` in `HashObjectPositions` causes the hash to be computed over
far fewer bytes than the actual chunk spans, allowing an attacker to modify
chunk content without invalidating the C2PA signature.

A second independent overflow exists in `get_xmp_insertion_point`:

```rust
// Vulnerable — u32 + u32 with no overflow check
Some((xmp.start, xmp.length + PNG_HDR_LEN as u32))
```

Debug: panic. Release: wraps, producing a wrong XMP replacement offset.

### Affected locations

| File | Line | Expression | Issue |
|---|---|---|---|
| `sdk/src/asset_handlers/png_io.rs` | 406 | `pcp.start as usize` | u64→usize truncation |
| `sdk/src/asset_handlers/png_io.rs` | 407 | `pcp.length as usize + PNG_HDR_LEN as usize` | **primary** — overflow on 32-bit |
| `sdk/src/asset_handlers/png_io.rs` | 414 | `pcp.start as usize` | u64→usize truncation |
| `sdk/src/asset_handlers/png_io.rs` | 419 | `pcp.end() as usize` | u64→usize truncation |
| `sdk/src/asset_handlers/png_io.rs` | 607 | `xmp.length + PNG_HDR_LEN as u32` | u32 overflow |

## Fix

Replace all unsafe casts with checked conversions that propagate errors:

```rust
// get_object_locations_from_stream
let cai_offset = usize::try_from(pcp.start)
    .map_err(|_| Error::InvalidAsset("PNG CAI chunk offset overflows usize".to_string()))?;
let cai_length = usize::try_from(pcp.length as u64 + PNG_HDR_LEN)
    .map_err(|_| Error::InvalidAsset("PNG CAI chunk length overflows usize".to_string()))?;
let end = usize::try_from(pcp.end())
    .map_err(|_| Error::InvalidAsset("PNG CAI chunk end overflows usize".to_string()))?;
```

```rust
// get_xmp_insertion_point
Some((xmp.start, xmp.length.checked_add(PNG_HDR_LEN as u32)?))
```

Returns `None` on overflow rather than panicking or wrapping.

## Test Added

`test_cai_chunk_length_near_u32_max_returns_error` in `asset_handlers::png_io::tests`:

Crafts a minimal PNG with a CAI chunk whose claimed length is `u32::MAX - 11`
(the minimum value whose `length + 12` would overflow a 32-bit usize). The
parser hits EOF when seeking past the absent chunk data, so the call returns
`Err` rather than panicking — on any target width.


## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
