### PR TITLE
fix: TSA resolver client reuse

### DIFF
--- a/sdk/src/crypto/time_stamp/provider.rs
+++ b/sdk/src/crypto/time_stamp/provider.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::sync::LazyLock;
+
 use async_trait::async_trait;
 use bcder::{encode::Values, OctetString};
 use rand::{thread_rng, Rng};
@@ -25,6 +27,10 @@ use crate::{
     http::SyncGenericResolver,
     maybe_send_sync::MaybeSync,
 };
+
+// Shared reusable TSA resolver
+static DEFAULT_TS_RESOLVER: LazyLock<SyncGenericResolver> =
+    LazyLock::new(|| SyncGenericResolver::with_redirects().unwrap_or_default());
 
 /// A `TimeStampProvider` implementation can contact a [RFC 3161] time stamp
 /// service and generate a corresponding time stamp for a specific piece of
@@ -68,7 +74,7 @@ pub trait TimeStampProvider {
                     headers,
                     &body,
                     message,
-                    &SyncGenericResolver::with_redirects().unwrap_or_default(),
+                    &*DEFAULT_TS_RESOLVER,
                 ));
             }
         }

--- a/sdk/src/signer.rs
+++ b/sdk/src/signer.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::sync::LazyLock;
+
 use async_trait::async_trait;
 
 use crate::{
@@ -23,6 +25,10 @@ use crate::{
     maybe_send_sync::{MaybeSend, MaybeSync},
     Result,
 };
+
+// Shared reusable TSA resolver
+static DEFAULT_TS_RESOLVER: LazyLock<SyncGenericResolver> =
+    LazyLock::new(|| SyncGenericResolver::with_redirects().unwrap_or_default());
 
 // Type aliases for boxed trait objects with conditional Send + Sync bounds
 // These are the canonical definitions used throughout the codebase
@@ -97,7 +103,7 @@ pub trait Signer {
                         headers,
                         &body,
                         message,
-                        &SyncGenericResolver::with_redirects().unwrap_or_default(),
+                        &*DEFAULT_TS_RESOLVER,
                     )
                     .map_err(|e| e.into()),
                 );


### PR DESCRIPTION
## Changes in this pull request
Reuse TSA resolved across calls. 

The default `Signer::send_timestamp_request` and `TimeStampProvider::send_time_stamp_request` impl each construct(ed) a fresh `SyncGenericResolver` per call, which in the `http_reqwest_blocking` path means a fresh `reqwest::blocking::Client` per call.

That client spawns a dedicated `reqwest-internal-sync-runtime` thread. When done (drop), that closes properly but  pages stay in the allocator, so memory use grew across repeated signs.

By reusing the resolver, memory growth due to that should be kept in check. 

(FOund and verified using ad-hoc Python benchmarks).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
