### PR TITLE
fix: Allow boxes with incomplete content to succeed.

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1296,12 +1296,12 @@ pub(crate) fn build_bmff_tree<R: Read + Seek + ?Sized>(
         let header = match BoxHeaderLite::read(reader) {
             Ok(h) => h,
             Err(_) => {
-                // if we can't read a header, just return what we have so far since some files have trailing data after the last box 
+                // if we can't read a header, just return what we have so far since some files have trailing data after the last box
                 skip_bytes_to(reader, end)?;
-                break;    
+                break;
             }
         };
-            
+
         // Break if size zero BoxHeader
         let mut s = header.size;
         if s == 0 {

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1293,9 +1293,15 @@ pub(crate) fn build_bmff_tree<R: Read + Seek + ?Sized>(
     let mut current = start;
     while current < end {
         // Get box header.
-        let header = BoxHeaderLite::read(reader)
-            .map_err(|err| Error::InvalidAsset(format!("Bad BMFF {err}")))?;
-
+        let header = match BoxHeaderLite::read(reader) {
+            Ok(h) => h,
+            Err(_) => {
+                // if we can't read a header, just return what we have so far since some files have trailing data after the last box 
+                skip_bytes_to(reader, end)?;
+                break;    
+            }
+        };
+            
         // Break if size zero BoxHeader
         let mut s = header.size;
         if s == 0 {


### PR DESCRIPTION
## Changes in this pull request
Allow boxes that are incomplete to pass through.  This is allowed and expected by the BMFF spec.  This handles cases where a parent box has additional data that is not accounted for by the sub boxes.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
