### PR TITLE
fix: populate common_name in CertificateInfo for CAWG identity assertions

### DIFF
--- a/sdk/src/crypto/cose/verifier.rs
+++ b/sdk/src/crypto/cose/verifier.rs
@@ -165,11 +165,19 @@ impl Verifier<'_> {
             .map(|attr| attr.to_string())
             .map_err(|_| CoseError::MissingSigningCertificateChain)?;
 
+        let common_name = sign_cert
+            .subject()
+            .iter_common_name()
+            .filter_map(|attr| attr.as_str().ok())
+            .next()
+            .map(|s| s.to_string());
+
         Ok(CertificateInfo {
             alg: Some(alg),
             date: tst_info.map(|t| t.gen_time.clone().into()),
             cert_serial_number: Some(sign_cert.serial.clone()),
             issuer_org: Some(subject),
+            common_name,
             validated: true,
             cert_chain: dump_cert_chain(&certs)?,
             revocation_status: Some(true),


### PR DESCRIPTION
## Problem

`cawg.identity.signature_info.common_name` is always absent when verifying
a CAWG identity assertion, even when the signing certificate has a valid CN.
The top-level manifest `signature.common_name` (standard C2PA) works correctly
because it uses a different code path.

## Root Cause

Two divergent code paths exist in `c2pa`:

- `src/cose_validator.rs` → `get_signing_info()` (standard C2PA manifest signatures)
  calls `extract_common_name_from_cert()` and sets `common_name` in `CertificateInfo`. ✅

- `src/crypto/cose/verifier.rs` → `verify_signature()` (CAWG identity assertions)
  builds `CertificateInfo` with `..Default::default()`, leaving `common_name: None`. ❌

The `CertificateInfo` struct (`certificate_info.rs:38`) has `pub common_name: Option<String>`
defined, and `cose_validator.rs` correctly populates it. But when `verifier.rs` was
introduced in #801 (Dec 2024) to handle the CAWG identity verification path,
`common_name` was never ported over.

## Fix

Extract `common_name` from the end-entity cert's subject in `verifier.rs`,
using the same `x509_parser` approach already used for `issuer_org` just above.

## Testing

Verified by:
1. Signing a JPEG with a CAWG identity assertion (cert CN = "rajat customer")
2. Before fix: `c2patool file.jpeg -d` shows `cawg.identity.signature_info`
   with `alg`, `issuer`, `cert_serial_number` but no `common_name`
3. After fix: `common_name: "rajat customer"` appears correctly