### PR TITLE
fix: Borrow instead of cloning for redactions

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1459,7 +1459,7 @@ impl Builder {
             // add it to the claim
             let uri = ingredient.add_to_claim(
                 &mut claim,
-                definition.redactions.clone(),
+                definition.redactions.as_deref(),
                 Some(&self.resources),
                 &self.context,
             )?;

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1248,7 +1248,7 @@ impl Ingredient {
     pub(crate) fn add_to_claim(
         &self,
         claim: &mut Claim,
-        redactions: Option<Vec<String>>,
+        redactions: Option<&[String]>,
         resources: Option<&ResourceStore>, // use alternate resource store (for Builder model)
         context: &Context,
     ) -> Result<HashedUri> {

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1264,7 +1264,6 @@ impl Ingredient {
 
         // Collect the redacted thumbnail URIs, use them for comparison.
         let redacted_thumbnail_uris: std::collections::HashSet<String> = redactions
-            .as_deref()
             .unwrap_or_default()
             .iter()
             .filter(|r| {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -4110,7 +4110,7 @@ impl Store {
     pub fn load_ingredient_to_claim(
         claim: &mut Claim,
         data: &[u8],
-        redactions: Option<Vec<String>>,
+        redactions: Option<&[String]>,
         context: &Context,
     ) -> Result<Store> {
         // constants for ingredient conflict reasons
@@ -4178,7 +4178,8 @@ impl Store {
 
             if !potential_conflicts.is_empty() {
                 // get info about conflicting Claim from current claim
-                let mut claim_redactions: Vec<String> = redactions.clone().unwrap_or_default();
+                let mut claim_redactions: Vec<String> =
+                    redactions.unwrap_or_default().to_vec();
                 for c in claim.claim_ingredients() {
                     if let Some(r) = c.redactions() {
                         claim_redactions.append(&mut r.clone().into_iter().collect::<Vec<_>>());

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -4178,8 +4178,7 @@ impl Store {
 
             if !potential_conflicts.is_empty() {
                 // get info about conflicting Claim from current claim
-                let mut claim_redactions: Vec<String> =
-                    redactions.unwrap_or_default().to_vec();
+                let mut claim_redactions: Vec<String> = redactions.unwrap_or_default().to_vec();
                 for c in claim.claim_ingredients() {
                     if let Some(r) = c.redactions() {
                         claim_redactions.append(&mut r.clone().into_iter().collect::<Vec<_>>());

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -4271,8 +4271,8 @@ impl Store {
         // make necessary changes to the incoming store
         let mut i_store_mut = Store::from_jumbf_with_context(data, &mut report, context)?;
         let mut final_redactions = Vec::new();
-        if let Some(mut redactions) = redactions {
-            final_redactions.append(&mut redactions);
+        if let Some(redactions) = redactions {
+            final_redactions.extend_from_slice(redactions);
         }
 
         // remove the claims from the incoming store as to not overwrite the current claim


### PR DESCRIPTION
## Changes in this pull request
Changes the redactions parameter on `Ingredient::add_to_claim` and `Store::load_ingredient_to_claim` from `Option<Vec<String>>` to `Option<&[String]>`, favoring borrowing. Side-effect: eliminates one clone.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
