### PR TITLE
ci: run benchmarks on main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,9 @@ name: Benchmarks
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Runs benchmarks when commits are made to main. This was accidentally omitted and is needed for codspeed to track history.