### PR TITLE
ci: release-plz release commit match on `!` after commit type

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -37,7 +37,7 @@ dependencies_update = true
 features_always_increment_minor = false
 pr_labels = ["release"]
 release_always = false
-release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[(:]"
+release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
 
 [[package]]
 name = "c2pa"


### PR DESCRIPTION
As in the title. For instance:
`refactor!: remove config crate and use serde_json directly`
failed to trigger a release dude to the `!`. Now it does.