### PR TITLE
fix: case-insensitive enums in settings to preserve backwards compatibility with `config` crate

### DIFF
--- a/sdk/src/crypto/raw_signature/signing_alg.rs
+++ b/sdk/src/crypto/raw_signature/signing_alg.rs
@@ -68,8 +68,7 @@ impl FromStr for SigningAlg {
     }
 }
 
-// Manual implementation so that it works with case-insensitive strings. This is done for
-// backwards compatibility with behavior in the `config` crate.
+// Case-insensitive for backwards compatibility with the `config` crate.
 impl<'de> Deserialize<'de> for SigningAlg {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -25,7 +25,7 @@ use crate::{
     builder::BuilderIntent,
     cbor_types::DateT,
     resource_store::UriOrResource,
-    settings::SettingsValidate,
+    settings::{deserialize_case_insensitive, deserialize_case_insensitive_opt, SettingsValidate},
     ClaimGeneratorInfo, Error, ResourceRef, Result,
 };
 
@@ -93,7 +93,11 @@ pub struct ThumbnailSettings {
     /// input format.
     ///
     /// The default value is None.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_case_insensitive_opt"
+    )]
     pub format: Option<ThumbnailFormat>,
     /// Whether or not to prefer a smaller sized media format for the thumbnail.
     ///
@@ -112,6 +116,7 @@ pub struct ThumbnailSettings {
     /// algorithms for various formats.
     ///
     /// The default value is [`ThumbnailQuality::Medium`].
+    #[serde(deserialize_with = "deserialize_case_insensitive")]
     pub quality: ThumbnailQuality,
 }
 
@@ -491,6 +496,7 @@ pub struct TimeStampSettings {
     /// Which manifests to fetch timestamps for.
     ///
     /// The default value is [`TimeStampFetchScope::All`].
+    #[serde(deserialize_with = "deserialize_case_insensitive")]
     pub fetch_scope: TimeStampFetchScope,
 }
 
@@ -534,6 +540,7 @@ pub struct BuilderSettings {
     /// For more information, see [Certificate status assertion - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#certificate_status_assertion).
     ///
     /// [`CertificateStatus`]: crate::assertions::CertificateStatus
+    #[serde(default, deserialize_with = "deserialize_case_insensitive_opt")]
     pub(crate) certificate_status_fetch: Option<OcspFetchScope>,
     // TODO: this setting affects fetching and generation of the assertion; needs clarification
     /// Whether to only use [`CertificateStatus`] assertions to check certificate revocation status. If there
@@ -551,6 +558,7 @@ pub struct BuilderSettings {
     ///
     /// [`BuilderIntent`]: crate::BuilderIntent
     /// [`Builder`]: crate::Builder
+    #[serde(default, deserialize_with = "deserialize_case_insensitive_opt")]
     pub intent: Option<BuilderIntent>,
     /// Assertions with a base label included in this list will be automatically marked as a created assertion.
     /// Assertions not in this list will be automatically marked as gathered.
@@ -801,5 +809,32 @@ pub mod tests {
             Some(SoftwareAgent::ClaimGeneratorInfo(_))
         ));
         assert_eq!(action.reason, Some("Privacy concerns".to_string()));
+    }
+
+    // For backwards compatibility with the `config` crate.
+    #[test]
+    fn test_case_insensitive_enum_deserialization() {
+        use crate::settings::Settings;
+
+        let settings = Settings::new()
+            .with_json(r#"{"builder": {"thumbnail": {"format": "PNG", "quality": "HIGH"}, "intent": "EDIT"}}"#)
+            .unwrap();
+        assert_eq!(
+            settings.builder.thumbnail.format,
+            Some(ThumbnailFormat::Png)
+        );
+        assert_eq!(settings.builder.thumbnail.quality, ThumbnailQuality::High);
+        assert_eq!(settings.builder.intent, Some(BuilderIntent::Edit));
+
+        let settings = Settings::new()
+            .with_json(r#"{"builder": {"intent": {"create": "empty"}}}"#)
+            .unwrap();
+        assert_eq!(
+            settings.builder.intent,
+            Some(BuilderIntent::Create(DigitalSourceType::Empty))
+        );
+
+        let result = Settings::new().with_json(r#"{"builder": {"intent": {"Create": "empty"}}}"#);
+        assert!(result.is_err());
     }
 }

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -23,7 +23,7 @@ use std::{
     io::{BufRead, BufReader, Cursor},
 };
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use signer::SignerSettings;
 
@@ -1010,6 +1010,37 @@ fn get_settings_value<T: serde::de::DeserializeOwned>(value_path: &str) -> Resul
 // #[deprecated = "use `Settings::reset` instead"]
 pub fn reset_default_settings() -> Result<()> {
     Settings::reset()
+}
+
+// Used for backwards compatibility with the `config` crate.
+pub(crate) fn deserialize_case_insensitive<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    let value = Value::deserialize(deserializer)?;
+    serde_json::from_value(normalize_enum_value(value)).map_err(serde::de::Error::custom)
+}
+
+// Used for backwards compatibility with the `config` crate.
+pub(crate) fn deserialize_case_insensitive_opt<'de, D, T>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    Option::<Value>::deserialize(deserializer)?
+        .map(|v| serde_json::from_value(normalize_enum_value(v)).map_err(serde::de::Error::custom))
+        .transpose()
+}
+
+// Used for backwards compatibility with the `config` crate.
+fn normalize_enum_value(value: Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(s.to_lowercase()),
+        other => other,
+    }
 }
 
 #[cfg(test)]

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -72,19 +72,6 @@ impl From<ThumbnailFormat> for ImageFormat {
     }
 }
 
-impl From<ThumbnailFormat> for serde_json::Value {
-    fn from(value: ThumbnailFormat) -> Self {
-        let variant = match value {
-            ThumbnailFormat::Png => "png",
-            ThumbnailFormat::Jpeg => "jpeg",
-            ThumbnailFormat::Gif => "gif",
-            ThumbnailFormat::WebP => "webp",
-            ThumbnailFormat::Tiff => "tiff",
-        };
-        serde_json::Value::String(variant.to_owned())
-    }
-}
-
 impl fmt::Display for ThumbnailFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", ImageFormat::from(*self).to_mime_type())


### PR DESCRIPTION
Allows for case-insensitive enums to preserve backwards compatibility with the `config` crate.