### PR TITLE
fix: Harden against Builder::base_path injection attack on archive deserialisation

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -407,6 +407,7 @@ pub struct Builder {
     /// Base path to search for resources.
     #[cfg(feature = "file_io")]
     #[deprecated(note = "Use set_base_path() instead")]
+    #[serde(skip)]
     pub base_path: Option<PathBuf>,
 
     /// A builder should construct a created, opened or updated manifest.
@@ -3360,7 +3361,7 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     #![allow(deprecated)]
     use std::{
-        io::{self, Cursor},
+        io::{self, Cursor, Write},
         vec,
     };
 
@@ -9414,6 +9415,62 @@ mod tests {
                 max: MAX_ASSERTIONS
             }
         ));
+    }
+
+    // Verify that `base_path` in manifest.json is ignored during archive deserialization.
+    // An attacker embedding "base_path": "/" must not be able to redirect resource
+    // resolution to an arbitrary filesystem root (file exfiltration via archive).
+    //
+    // Uses the legacy zip archive path (generate_c2pa_archive = false) so we can
+    // manipulate the manifest.json inside the zip before loading it back.
+    #[test]
+    #[cfg(feature = "file_io")]
+    fn test_base_path_not_deserialized_from_archive() {
+        // Force the old zip format so we can manipulate manifest.json directly.
+        let settings = Settings::new()
+            .with_value("builder.generate_c2pa_archive", false)
+            .unwrap();
+        let builder = Builder::from_context(Context::new().with_settings(settings).unwrap());
+
+        let mut archive = Cursor::new(Vec::new());
+        builder.to_archive(&mut archive).unwrap();
+        archive.rewind().unwrap();
+
+        // Inject "base_path": "/" into manifest.json inside the zip.
+        let mut modified = Cursor::new(Vec::new());
+        {
+            let mut zip_in = ZipArchive::new(&mut archive).unwrap();
+            let mut zip_out = ZipWriter::new(&mut modified);
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+            for i in 0..zip_in.len() {
+                let mut entry = zip_in.by_index(i).unwrap();
+                let name = entry.name().to_string();
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf).unwrap();
+
+                zip_out.start_file(&name, options).unwrap();
+                if name == "manifest.json" {
+                    let mut value: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+                    value["base_path"] = serde_json::Value::String("/".to_string());
+                    zip_out
+                        .write_all(&serde_json::to_vec(&value).unwrap())
+                        .unwrap();
+                } else {
+                    zip_out.write_all(&buf).unwrap();
+                }
+            }
+            zip_out.finish().unwrap();
+        }
+        modified.rewind().unwrap();
+
+        let loaded = Builder::from_archive(modified).unwrap();
+
+        assert!(
+            loaded.base_path.is_none(),
+            "base_path must not be populated from archive JSON"
+        );
     }
 
     // Ensures that the future returned by `Builder::sign_async` implements `Send`, thus making it


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: Builder `base_path` Deserialized from Archive Enables File Exfiltration

## Vulnerability

`Builder` in `sdk/src/builder.rs` exposes a `base_path` field that controls
where the SDK reads resource files (thumbnails, etc.) from disk during signing.
This field was **not** marked `#[serde(skip)]`, unlike all other runtime-only
fields (`resources`, `context`, `placeholder_jumbf_len`, `bmff_hasher`).

When a victim calls `Builder::from_archive()` on an attacker-supplied `.c2pa`
ZIP, the archive's `manifest.json` is deserialized directly into a `Builder`
struct. An attacker who crafts `"base_path": "/"` in that JSON causes the SDK
to root all resource resolution at the filesystem root.

### Root cause

```rust
// Vulnerable — base_path deserialized from untrusted archive JSON
#[cfg(feature = "file_io")]
#[deprecated(note = "Use set_base_path() instead")]
pub base_path: Option<PathBuf>,   // ← no #[serde(skip)]
```

### Attack path

1. Attacker crafts a `.c2pa` ZIP whose `manifest.json` contains:
   ```json
   {
     "base_path": "/",
     "thumbnail": { "format": "image/jpeg", "identifier": "etc/passwd" }
   }
   ```
2. Victim loads it with `Builder::from_archive(attacker_archive)`.
3. `serde_json::from_slice` populates `builder.base_path = Some("/")`.
4. Victim calls `builder.sign(...)`.
5. `sign()` calls `self.resources.set_base_path("/")`.
6. Resource resolution reads `/etc/passwd` from disk and embeds its contents
   as the manifest thumbnail in the signed output file.
7. Attacker retrieves the exfiltrated data from the signed file.

### Affected location

| File | Line | Field | Issue |
|---|---|---|---|
| `sdk/src/builder.rs` | 410 | `Builder::base_path` | Not `#[serde(skip)]` — deserialized from untrusted archive JSON |

## Fix

Add `#[serde(skip)]` to the `base_path` field. Serde then ignores any
`"base_path"` key in the archive's `manifest.json`; the field always
initialises to `None` (its `Default`) regardless of archive content.
`base_path` can still be set at runtime via `Builder::set_base_path()`.

```rust
// Fixed
#[cfg(feature = "file_io")]
#[deprecated(note = "Use set_base_path() instead")]
#[serde(skip)]
pub base_path: Option<PathBuf>,
```

Note: All other runtime-only fields were already correctly protected with
`#[serde(skip)]`. The scan confirmed `base_path` was the only unprotected
field in this struct.

## Test Added

`test_base_path_not_deserialized_from_archive` in `builder::tests`:

1. Creates a valid archive with `Builder::to_archive` (zip format via
   `generate_c2pa_archive = false`).
2. Opens the zip and injects `"base_path": "/"` into `manifest.json`.
3. Repacks the modified zip and calls `Builder::from_archive`.
4. Asserts `builder.base_path.is_none()` — the injected value must be ignored.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
