### PR TITLE
fix: Harden against integer overflow attacks in hash_stream_by_alg_with_progress range validation

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -257,7 +257,10 @@ where
 
             // verify structure of blocks
             let num_blocks = hr.len();
-            let range_end = hr[num_blocks - 1].start() + hr[num_blocks - 1].length();
+            let range_end = hr[num_blocks - 1]
+                .start()
+                .checked_add(hr[num_blocks - 1].length())
+                .ok_or(Error::BadParam("hash range overflow".to_string()))?;
             let data_end = data_len - 1;
 
             // range extends past end of file so fail
@@ -355,7 +358,11 @@ where
                         continue;
                     }
 
-                    let end = inclusion.start() + inclusion.length() - 1;
+                    let end = inclusion
+                        .start()
+                        .checked_add(inclusion.length())
+                        .ok_or(Error::BadParam("inclusion range overflow".to_string()))?
+                        - 1;
                     let inclusion_start = inclusion.start();
 
                     // add new BMFF V2 offset as a new range to be included so that we can
@@ -603,6 +610,32 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+
+    // Attacker-controlled HashRange with start+length > u64::MAX must return Err,
+    // not panic, in both the exclusion and inclusion paths.
+    #[test]
+    fn test_exclusion_range_overflow_returns_error() {
+        let data = vec![0u8; 64];
+        let mut reader = Cursor::new(&data);
+        let hr = vec![HashRange::new(u64::MAX - 10, 20)]; // start + length overflows u64
+        let result = hash_stream_by_alg("sha256", &mut reader, Some(hr), true);
+        assert!(
+            result.is_err(),
+            "exclusion range overflow must return Err, not panic"
+        );
+    }
+
+    #[test]
+    fn test_inclusion_range_overflow_returns_error() {
+        let data = vec![0u8; 64];
+        let mut reader = Cursor::new(&data);
+        let hr = vec![HashRange::new(u64::MAX, 1)]; // start + length overflows u64
+        let result = hash_stream_by_alg("sha256", &mut reader, Some(hr), false);
+        assert!(
+            result.is_err(),
+            "inclusion range overflow must return Err, not panic"
+        );
+    }
 
     #[test]
     fn progress_callback_is_called() {


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: HashRange u64 Addition Overflow → Panic (DoS)

## Vulnerability

`hash_stream_by_alg_with_progress` in `sdk/src/utils/hash_utils.rs` performs two
unchecked `u64` additions on `HashRange` fields (`start`, `length`) that are
deserialized directly from attacker-controlled CBOR in a C2PA manifest. When
`start + length` exceeds `u64::MAX` the process panics with
`"attempt to add with overflow"` and terminates (exit code 101).

This crashes **any** application that verifies a C2PA manifest. No valid
signature is required because manifest verification continues past COSE
signature failure.

### Affected asset types

- **DataHash** exclusion path — any file type (JPEG, PNG, GIF, TIFF, …)
- **BmffHash** inclusion path — BMFF-based assets (MP4, MOV, HEIC, AVIF)

### Root cause

```rust
// Line 260 — exclusion path: summary range_end check
let range_end = hr[num_blocks - 1].start() + hr[num_blocks - 1].length();
//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//             Panics in debug; wraps silently in release (bypass bounds check)

// Line 358 — inclusion path: per-range end calculation
let end = inclusion.start() + inclusion.length() - 1;
//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//        Panics when start + length > u64::MAX
```

Note: the per-range exclusion calculation (lines 286–291) was **already** using
`checked_add`/`checked_sub`. Only the two sites above were unguarded.

### Affected locations

| File | Line | Expression | Issue |
|---|---|---|---|
| `sdk/src/utils/hash_utils.rs` | 260 | `hr[last].start() + hr[last].length()` | Unchecked u64 addition — exclusion and inclusion paths |
| `sdk/src/utils/hash_utils.rs` | 358 | `inclusion.start() + inclusion.length() - 1` | Unchecked u64 addition — inclusion path only |

## Fix

Replace both bare `+` operations with `checked_add`, propagating an
`Error::BadParam` on overflow:

## Tests Added

Two regression tests in `utils::hash_utils::tests`:

| Test | Path exercised | HashRange used |
|---|---|---|
| `test_exclusion_range_overflow_returns_error` | Exclusion (`is_exclusion = true`) | `start = u64::MAX - 10, length = 20` |
| `test_inclusion_range_overflow_returns_error` | Inclusion (`is_exclusion = false`) | `start = u64::MAX, length = 1` |

Both assert `result.is_err()` — the function must return `Err`, not panic.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
