### PR TITLE
refactor: consolidate async verify functions

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1869,91 +1869,7 @@ impl Claim {
     /// Verify claim signature, assertion store and asset hashes
     /// claim - claim to be verified
     /// asset_bytes - reference to bytes of the asset
-    pub(crate) async fn verify_claim_async(
-        claim: &Claim,
-        asset_data: &mut ClaimAssetData<'_>,
-        svi: &StoreValidationInfo<'_>,
-        cert_check: bool,
-        ctp: &CertificateTrustPolicy,
-        validation_log: &mut StatusTracker,
-        context: &Context,
-    ) -> Result<()> {
-        let settings = context.settings();
-        // Parse COSE signed data (signature) and validate it.
-        let sig = claim.signature_val().clone();
-        let additional_bytes: Vec<u8> = Vec::new();
-        let data = claim.data()?;
-
-        // use the signature uri as the current uri while validating the signature info
-        validation_log.push_current_uri(to_signature_uri(claim.label()));
-
-        // make sure signature manifest if present points to this manifest
-        let sig_box_err = match jumbf::labels::manifest_label_from_uri(&claim.signature) {
-            Some(signature_url) if signature_url != claim.label() => true,
-            _ => {
-                jumbf::labels::box_name_from_uri(&claim.signature).unwrap_or_default()
-                    != jumbf::labels::SIGNATURE
-            } // relative signature box
-        };
-
-        if sig_box_err {
-            log_item!(
-                to_signature_uri(claim.label()),
-                "signature missing",
-                "verify_claim_async"
-            )
-            .validation_status(validation_status::CLAIM_SIGNATURE_MISSING)
-            .failure(validation_log, Error::ClaimMissingSignatureBox)?;
-        }
-
-        // for V2 and greater claims the label must conform
-        if claim.version() > 1 && manifest_label_to_parts(claim.label()).is_none() {
-            log_item!(
-                to_manifest_uri(claim.label()),
-                "claim box label invalid",
-                "verify_claim_async"
-            )
-            .validation_status(validation_status::CLAIM_MALFORMED)
-            .failure(validation_log, Error::ClaimInvalidContent)?;
-        }
-
-        let sign1 = parse_cose_sign1(&sig, &data, validation_log)?;
-        let certificate_serial_num = get_signing_cert_serial_num(&sign1)?.to_string();
-
-        // check certificate revocation
-        check_ocsp_status_async(
-            &sign1,
-            &data,
-            ctp,
-            svi.certificate_statuses.get(&certificate_serial_num),
-            svi.timestamps.get(claim.label()),
-            validation_log,
-            context,
-        )
-        .await?;
-
-        let verified = verify_cose_async(
-            &sig,
-            &data,
-            &additional_bytes,
-            cert_check,
-            ctp,
-            svi.timestamps.get(claim.label()),
-            validation_log,
-            settings,
-        )
-        .await;
-
-        let result =
-            Claim::verify_internal(claim, asset_data, svi, verified, validation_log, context);
-        validation_log.pop_current_uri();
-        result
-    }
-
-    /// Verify claim signature, assertion store and asset hashes
-    /// claim - claim to be verified
-    /// asset_bytes - reference to bytes of the asset
-    #[allow(clippy::too_many_arguments)]
+    #[async_generic]
     pub(crate) fn verify_claim(
         claim: &Claim,
         asset_data: &mut ClaimAssetData<'_>,
@@ -2021,27 +1937,54 @@ impl Claim {
 
         let certificate_serial_num = get_signing_cert_serial_num(&sign1)?.to_string();
         // check certificate revocation
-        check_ocsp_status(
-            &sign1,
-            data,
-            ctp,
-            svi.certificate_statuses.get(&certificate_serial_num),
-            svi.timestamps.get(claim.label()),
-            validation_log,
-            context,
-        )?;
+        if _sync {
+            check_ocsp_status(
+                &sign1,
+                data,
+                ctp,
+                svi.certificate_statuses.get(&certificate_serial_num),
+                svi.timestamps.get(claim.label()),
+                validation_log,
+                context,
+            )?;
+        } else {
+            check_ocsp_status_async(
+                &sign1,
+                data,
+                ctp,
+                svi.certificate_statuses.get(&certificate_serial_num),
+                svi.timestamps.get(claim.label()),
+                validation_log,
+                context,
+            )
+            .await?;
+        }
 
         context.check_progress(ProgressPhase::VerifyingSignature, 1, 1)?;
-        let verified = verify_cose(
-            sig,
-            data,
-            &additional_bytes,
-            cert_check,
-            ctp,
-            svi.timestamps.get(claim.label()),
-            validation_log,
-            &adjusted_settings,
-        );
+        let verified = if _sync {
+            verify_cose(
+                sig,
+                data,
+                &additional_bytes,
+                cert_check,
+                ctp,
+                svi.timestamps.get(claim.label()),
+                validation_log,
+                &adjusted_settings,
+            )
+        } else {
+            verify_cose_async(
+                sig,
+                data,
+                &additional_bytes,
+                cert_check,
+                ctp,
+                svi.timestamps.get(claim.label()),
+                validation_log,
+                &adjusted_settings,
+            )
+            .await
+        };
 
         let result =
             Claim::verify_internal(claim, asset_data, svi, verified, validation_log, context);

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1530,10 +1530,11 @@ impl Store {
     }
 
     // recursively walk the ingredients and validate
+    #[async_generic]
     fn ingredient_checks(
         store: &Store,
         claim: &Claim,
-        svi: &StoreValidationInfo,
+        svi: &StoreValidationInfo<'_>,
         asset_data: &mut ClaimAssetData<'_>,
         validation_log: &mut StatusTracker,
         depth: usize,
@@ -1720,267 +1721,52 @@ impl Store {
                         }
                     }
 
-                    Claim::verify_claim(
-                        ingredient,
-                        asset_data,
-                        svi,
-                        check_ingredient_trust,
-                        &store.ctp,
-                        validation_log,
-                        context,
-                    )?;
-
-                    // recurse nested ingredients
-                    Store::ingredient_checks(
-                        store,
-                        ingredient,
-                        svi,
-                        asset_data,
-                        validation_log,
-                        depth.saturating_add(1),
-                        context,
-                    )?;
-                } else {
-                    log_item!(label.clone(), "ingredient not found", "ingredient_checks")
-                        .validation_status(validation_status::INGREDIENT_MANIFEST_MISSING)
-                        .failure(
+                    if _sync {
+                        Claim::verify_claim(
+                            ingredient,
+                            asset_data,
+                            svi,
+                            check_ingredient_trust,
+                            &store.ctp,
                             validation_log,
-                            Error::ClaimVerification(format!("ingredient: {label} is missing")),
+                            context,
                         )?;
-                }
-            } else {
-                let title = ingredient_assertion.title.unwrap_or("no title".into());
-                let description = format!("{title}: ingredient does not have provenance");
-                log_item!(
-                    jumbf::labels::to_assertion_uri(claim.label(), &i.label()),
-                    description,
-                    "ingredient_checks"
-                )
-                .validation_status(validation_status::INGREDIENT_PROVENANCE_UNKNOWN)
-                .informational(validation_log);
-            }
-            validation_log.pop_ingredient_uri();
-        }
-
-        Ok(())
-    }
-
-    // recursively walk the ingredients and validate
-    async fn ingredient_checks_async(
-        store: &Store,
-        claim: &Claim,
-        svi: &StoreValidationInfo<'_>,
-        asset_data: &mut ClaimAssetData<'_>,
-        validation_log: &mut StatusTracker,
-        depth: usize,
-        context: &Context,
-    ) -> Result<()> {
-        if depth >= MAX_INGREDIENT_DEPTH {
-            return Err(Error::InvalidAsset(format!(
-                "ingredient chain depth ({depth}) exceeds maximum ({MAX_INGREDIENT_DEPTH})"
-            )));
-        }
-
-        let settings = context.settings();
-
-        let total_ingredients = claim
-            .ingredient_assertions()
-            .iter()
-            .filter(|i| !is_zero(i.assertion().data()))
-            .count() as u32;
-        let mut ingredient_step = 0u32;
-
-        // walk the ingredients
-        for i in claim.ingredient_assertions() {
-            // allow for zero out ingredient assertions
-            if is_zero(i.assertion().data()) {
-                continue;
-            }
-
-            let ingredient_assertion = Ingredient::from_assertion(i.assertion()).map_err(|e| {
-                log_item!(
-                    i.label().clone(),
-                    "ingredient assertion could not be parsed",
-                    "ingredient_checks"
-                )
-                .validation_status(validation_status::ASSERTION_INGREDIENT_MALFORMED)
-                .failure_as_err(validation_log, e)
-            })?;
-
-            // we don't care about InputTo ingredients
-            if ingredient_assertion.relationship == Relationship::InputTo {
-                continue;
-            }
-
-            ingredient_step += 1;
-            context.check_progress(
-                ProgressPhase::VerifyingIngredient,
-                ingredient_step,
-                total_ingredients,
-            )?;
-
-            validation_log
-                .push_ingredient_uri(jumbf::labels::to_assertion_uri(claim.label(), &i.label()));
-
-            // is this an ingredient
-            if let Some(c2pa_manifest) = ingredient_assertion.c2pa_manifest() {
-                // if this is a v3 ingredient then it must have validation report indicating it was validated
-                if let Some(ingredient_version) = ingredient_assertion.version() {
-                    if ingredient_version >= 3 && ingredient_assertion.validation_results.is_none()
-                    {
-                        log_item!(
-                            jumbf::labels::to_assertion_uri(claim.label(), &i.label()),
-                            "ingredient V3 must have validation results",
-                            "ingredient_checks"
-                        )
-                        .validation_status(validation_status::ASSERTION_INGREDIENT_MALFORMED)
-                        .failure(
-                            validation_log,
-                            Error::HashMismatch(
-                                "ingredient V3 missing validation status".to_string(),
-                            ),
-                        )?;
-                    }
-                }
-
-                let label = Store::manifest_label_from_path(&c2pa_manifest.url());
-
-                if let Some(ingredient) = store.get_claim(&label) {
-                    let alg = match c2pa_manifest.alg() {
-                        Some(a) => a,
-                        None => ingredient.alg().to_owned(),
-                    };
-
-                    // are we evaluating a 2.x manifest, then use those rule
-                    let ingredient_version = ingredient.version();
-                    let has_redactions = svi.redactions.iter().any(|r| r.contains(&label));
-
-                    // allow the extra ingredient trust checks
-                    // these checks are to prevent the trust spoofing
-                    let check_ingredient_trust = settings.verify.verify_trust;
-
-                    // get the 1.1-1.2 box hash
-                    let ingredient_hashes = store.get_manifest_box_hashes(ingredient);
-
-                    // since no redactions we can try manifest match method
-                    let mut pre_v1_3_hash = false;
-                    let manifests_match = if !has_redactions {
-                        // test for 1.1 hash then 1.0 version
-                        if !vec_compare(&c2pa_manifest.hash(), &ingredient_hashes.manifest_box_hash)
-                        {
-                            // try legacy hash
-                            pre_v1_3_hash = true;
-                            verify_by_alg(&alg, &c2pa_manifest.hash(), &ingredient.data()?, None)
-                        } else {
-                            true
-                        }
                     } else {
-                        false
-                    };
-
-                    // since the manifest hashes are equal we can short circuit the rest of the validation
-                    // we can only do this for post 1.3 Claims since manfiest box hashing was not available
-                    if manifests_match && !pre_v1_3_hash {
-                        log_item!(
-                            c2pa_manifest.url(),
-                            "ingredient hash matched",
-                            "ingredient_checks"
-                        )
-                        .validation_status(validation_status::INGREDIENT_MANIFEST_VALIDATED)
-                        .success(validation_log);
-                    }
-
-                    // if mismatch is not because of a redaction this is a hard error
-                    if !manifests_match && !has_redactions {
-                        log_item!(
-                            c2pa_manifest.url(),
-                            "ingredient hash incorrect",
-                            "ingredient_checks"
-                        )
-                        .validation_status(validation_status::INGREDIENT_MANIFEST_MISMATCH)
-                        .failure(
+                        Claim::verify_claim_async(
+                            ingredient,
+                            asset_data,
+                            svi,
+                            check_ingredient_trust,
+                            &store.ctp,
                             validation_log,
-                            Error::HashMismatch(
-                                "ingredient hash does not match found ingredient".to_string(),
-                            ),
-                        )?;
+                            context,
+                        )
+                        .await?;
                     }
-
-                    // if manifest hash did not match and this is a V2 or greater claim then we
-                    // must try the signature validation method before proceeding
-                    if !manifests_match && has_redactions && ingredient_version > 1 {
-                        let claim_signature =
-                            ingredient_assertion.signature().ok_or_else(|| {
-                                log_item!(
-                                    c2pa_manifest.url(),
-                                    "ingredient claimSignature missing",
-                                    "ingredient_checks"
-                                )
-                                .validation_status(
-                                    validation_status::INGREDIENT_CLAIM_SIGNATURE_MISSING,
-                                )
-                                .failure_as_err(
-                                    validation_log,
-                                    Error::HashMismatch(
-                                        "ingredient claimSignature missing".to_string(),
-                                    ),
-                                )
-                            })?;
-
-                        // compare the signature box hashes
-                        if vec_compare(
-                            &claim_signature.hash(),
-                            &ingredient_hashes.signature_box_hash,
-                        ) {
-                            log_item!(
-                                c2pa_manifest.url(),
-                                "ingredient claimSignature validated",
-                                "ingredient_checks"
-                            )
-                            .validation_status(
-                                validation_status::INGREDIENT_CLAIM_SIGNATURE_VALIDATED,
-                            )
-                            .informational(validation_log);
-                        } else {
-                            log_item!(
-                                c2pa_manifest.url(),
-                                "ingredient claimSignature mismatch",
-                                "ingredient_checks"
-                            )
-                            .validation_status(
-                                validation_status::INGREDIENT_CLAIM_SIGNATURE_MISMATCH,
-                            )
-                            .failure(
-                                validation_log,
-                                Error::HashMismatch(
-                                    "ingredient claimSignature mismatch".to_string(),
-                                ),
-                            )?;
-                        }
-                    }
-
-                    Claim::verify_claim_async(
-                        ingredient,
-                        asset_data,
-                        svi,
-                        check_ingredient_trust,
-                        &store.ctp,
-                        validation_log,
-                        context,
-                    )
-                    .await?;
 
                     // recurse nested ingredients
-                    Box::pin(Store::ingredient_checks_async(
-                        store,
-                        ingredient,
-                        svi,
-                        asset_data,
-                        validation_log,
-                        depth.saturating_add(1),
-                        context,
-                    ))
-                    .await?;
+                    if _sync {
+                        Store::ingredient_checks(
+                            store,
+                            ingredient,
+                            svi,
+                            asset_data,
+                            validation_log,
+                            depth.saturating_add(1),
+                            context,
+                        )?;
+                    } else {
+                        Box::pin(Store::ingredient_checks_async(
+                            store,
+                            ingredient,
+                            svi,
+                            asset_data,
+                            validation_log,
+                            depth.saturating_add(1),
+                            context,
+                        ))
+                        .await?;
+                    }
                 } else {
                     log_item!(label.clone(), "ingredient not found", "ingredient_checks")
                         .validation_status(validation_status::INGREDIENT_MANIFEST_MISSING)


### PR DESCRIPTION
Removes duplicate async functions for validation. There were slight differences between them as well.