### PR TITLE
style: fix lints in newer Rust versions.

### DIFF
--- a/sdk/src/crypto/raw_signature/rust_native/validators/rsa_legacy_validator.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/validators/rsa_legacy_validator.rs
@@ -85,6 +85,8 @@ impl RawSignatureValidator for RsaLegacyValidator {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use crate::crypto::raw_signature::RawSignatureValidator;
 

--- a/sdk/src/crypto/raw_signature/rust_native/validators/rsa_validator.rs
+++ b/sdk/src/crypto/raw_signature/rust_native/validators/rsa_validator.rs
@@ -95,6 +95,8 @@ pub(super) fn biguint_val(ber_object: &BerObject) -> BigUint {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use crate::crypto::raw_signature::RawSignatureValidator;
 


### PR DESCRIPTION
Fixes lints likely caused by newer version of rustc.