### PR TITLE
perf: avoid buffering stream when computing placeholder PNG C2PA chunk

### DIFF
--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -355,13 +355,24 @@ impl CAIWriter for PngIO {
             let file_end = input_stream.seek(SeekFrom::End(0))? as usize;
             (ps, file_end)
         } else {
-            let mut output_stream = Cursor::new(Vec::new());
-            self.write_cai(input_stream, &mut output_stream, &[])?;
+            let ihdr_index = ps
+                .iter()
+                .position(|c| c.name == IMG_HDR)
+                .ok_or(Error::EmbeddingError)?;
 
-            output_stream.rewind()?;
-            let ps = get_png_chunk_positions(&mut output_stream)?;
-            let file_end = output_stream.seek(SeekFrom::End(0))? as usize;
-            (ps, file_end)
+            let mut ps = ps;
+            ps.insert(
+                ihdr_index + 1,
+                PngChunkPos {
+                    start: ps[ihdr_index].end(),
+                    length: 0,
+                    name: CAI_CHUNK,
+                    name_str: String::from_utf8_lossy(&CAI_CHUNK).into_owned(),
+                },
+            );
+
+            let file_end = input_stream.seek(SeekFrom::End(0))? as usize;
+            (ps, file_end + PNG_HDR_LEN as usize)
         };
 
         let pcp = ps

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -349,7 +349,7 @@ impl CAIWriter for PngIO {
         let mut positions: Vec<HashObjectPositions> = Vec::new();
 
         input_stream.rewind()?;
-        let ps = get_png_chunk_positions(input_stream)?;
+        let mut ps = get_png_chunk_positions(input_stream)?;
 
         let (ps, file_end) = if ps.iter().any(|chunk| chunk.name == CAI_CHUNK) {
             let file_end = input_stream.seek(SeekFrom::End(0))? as usize;
@@ -360,7 +360,6 @@ impl CAIWriter for PngIO {
                 .position(|c| c.name == IMG_HDR)
                 .ok_or(Error::EmbeddingError)?;
 
-            let mut ps = ps;
             ps.insert(
                 ihdr_index + 1,
                 PngChunkPos {


### PR DESCRIPTION
Reduces memory usage when reading/signing a PNG that doesn't contain a C2PA manifest by optimizing `get_object_locations_from_stream` to quickly find where the C2PA chunk goes rather than computing it via `write_cai`. When signing a 100MB PNG, the total memory usage decreases by 29.4%.

Before:
<img width="289" height="51" alt="Screenshot 2026-05-18 at 5 25 14 PM" src="https://github.com/user-attachments/assets/2341f5ba-8e96-4351-9fc1-f0293f4b0d5b" />
After:
<img width="277" height="50" alt="Screenshot 2026-05-18 at 5 25 30 PM" src="https://github.com/user-attachments/assets/8576fd8c-d4bb-4eda-8519-470582ad4109" />