### PR TITLE
fix: use XMP instance_id from source asset in sign and save_to_stream

### DIFF
--- a/docs/instanceid_behavior.md
+++ b/docs/instanceid_behavior.md
@@ -1,0 +1,52 @@
+# C2PA SDK: `instanceID` Behavior
+
+The C2PA claim's `instanceID` field is intended to bind the claim to a specific incarnation of an asset. When the asset contains XMP, `xmpMM:InstanceID` is the canonical source of this value and must agree with the claim.
+
+The correct behavior depends on two factors: whether the source asset already has an InstanceID, and whether the SDK is responsible for writing the output asset.
+
+---
+
+## SDK owns the write (embed)
+
+The SDK is modifying the file, so it owns the output incarnation identity.
+
+The caller can configure behavior via `InstanceIDBehavior`:
+
+| Source has InstanceID | `Preserve` | `Bump` (default) |
+|---|---|---|
+| Yes | Use source InstanceID in claim; write it to output XMP | Generate new UUID; write to output XMP; use in claim |
+| No | Generate new UUID; write to output XMP; use in claim | Generate new UUID; write to output XMP; use in claim |
+
+When the source has no InstanceID, `Preserve` and `Bump` are identical — a new UUID must be generated, and since the SDK is writing the file it writes the UUID to XMP.
+
+**`Bump` is the default.** It is the only behavior that is unambiguously correct about what the SDK is doing to the file. Use `Preserve` when the caller has already finalized the asset's InstanceID (e.g., streamed an asset to the SDK that already has the intended InstanceID set) and wants that value preserved in both the claim and the output.
+
+---
+
+## Caller owns the write (SDK receives a finished asset)
+
+The asset is already finalized before the SDK is invoked. The SDK reads but does not write.
+
+| Source has InstanceID | Behavior |
+|---|---|
+| Yes | Use source InstanceID in claim. No XMP written. |
+| No | Generate UUID for claim only. Cannot write to asset. Binding is weak. |
+
+No mode knob applies here. The caller is responsible for ensuring the asset's InstanceID is correct before invoking the SDK.
+
+---
+
+## Sidecar
+
+The SDK does not modify the asset.
+
+| Source has InstanceID | Behavior |
+|---|---|
+| Yes | Use source InstanceID in claim. Asset untouched. |
+| No | Generate UUID for claim only. Asset untouched. Binding is weak. |
+
+---
+
+## Weak binding
+
+In cases where the source has no InstanceID and the SDK cannot write to the asset (caller-owns-write or sidecar), the claim will contain a generated UUID that nothing in the asset corroborates. The binding between claim and asset exists only by convention. Callers should be aware of this limitation and ideally ensure the asset has an InstanceID before signing.

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -52,7 +52,7 @@ use crate::{
     store::Store,
     utils::{
         hash_utils::hash_to_b64, merkle::MerkleAccumulator, mime::format_to_mime,
-        path_utils::sanitize_archive_path,
+        path_utils::sanitize_archive_path, xmp_inmemory_utils::XmpInfo,
     },
     AsyncSigner, ClaimGeneratorInfo, EphemeralSigner, HashRange, HashedUri, Ingredient,
     ManifestAssertionKind, Reader, Relationship, Signer,
@@ -2853,8 +2853,10 @@ impl Builder {
     {
         let format = format_to_mime(format);
         self.definition.format.clone_from(&format);
-        // todo:: read instance_id from xmp from stream ?
-        self.definition.instance_id = format!("xmp:iid:{}", Uuid::new_v4());
+        if let Some(instance_id) = XmpInfo::from_source(source, &format).instance_id {
+            self.definition.instance_id = instance_id;
+        }
+        source.rewind()?;
 
         #[cfg(feature = "file_io")]
         #[allow(deprecated)]
@@ -2953,8 +2955,10 @@ impl Builder {
     {
         let format = format_to_mime(format);
         self.definition.format.clone_from(&format);
-        // todo:: read instance_id from xmp from stream ?
-        self.definition.instance_id = format!("xmp:iid:{}", Uuid::new_v4());
+        if let Some(instance_id) = XmpInfo::from_source(source, &format).instance_id {
+            self.definition.instance_id = instance_id;
+        }
+        source.rewind()?;
 
         #[cfg(feature = "file_io")]
         #[allow(deprecated)]


### PR DESCRIPTION
This was a regression, older sdks did this correctily

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
