### PR TITLE
perf: avoid buffering PNG into memory when writing

### DIFF
--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -13,7 +13,7 @@
 
 use std::{
     fs::File,
-    io::{Cursor, Read, Seek, SeekFrom},
+    io::{self, Cursor, Read, Seek, SeekFrom},
     path::Path,
 };
 
@@ -273,31 +273,33 @@ impl CAIWriter for PngIO {
         output_stream: &mut dyn CAIReadWrite,
         store_bytes: &[u8],
     ) -> Result<()> {
-        let mut cai_data = Vec::new();
-        let mut cai_encoder = png_pong::Encoder::new(&mut cai_data).into_chunk_enc();
+        let mut c2pa_data = Vec::new();
+        let mut c2pa_encoder = png_pong::Encoder::new(&mut c2pa_data).into_chunk_enc();
 
-        let mut png_buf = Vec::new();
-        input_stream.rewind()?;
-        input_stream
-            .read_to_end(&mut png_buf)
-            .map_err(Error::IoError)?;
-
-        let mut cursor = Cursor::new(png_buf);
-        let mut ps = get_png_chunk_positions(&mut cursor)?;
-
-        // get back buffer
-        png_buf = cursor.into_inner();
-
-        // create CAI store chunk
-        let cai_unknown = png_pong::chunk::Unknown {
+        let mut c2pa_chunk = png_pong::chunk::Chunk::Unknown(png_pong::chunk::Unknown {
             name: CAI_CHUNK,
             data: store_bytes.to_vec(),
-        };
-
-        let mut cai_chunk = png_pong::chunk::Chunk::Unknown(cai_unknown);
-        cai_encoder
-            .encode(&mut cai_chunk)
+        });
+        c2pa_encoder
+            .encode(&mut c2pa_chunk)
             .map_err(|_| Error::EmbeddingError)?;
+
+        input_stream.rewind()?;
+        let ps = get_png_chunk_positions(input_stream)?;
+
+        let ihdr_end = ps
+            .iter()
+            .find(|pcp| pcp.name == IMG_HDR)
+            .ok_or(Error::EmbeddingError)?
+            .end();
+
+        let existing_c2pa_position = ps
+            .iter()
+            .find(|pcp| pcp.name == CAI_CHUNK)
+            .map(|pcp| (pcp.start, pcp.end()));
+
+        input_stream.rewind()?;
+        output_stream.rewind()?;
 
         /*  splice in new chunk.  Each PNG chunk has the following format:
                 chunk data length (4 bytes big endian)
@@ -306,38 +308,30 @@ impl CAIWriter for PngIO {
                 chunk crc (4 bytes in crc in format defined in PNG spec)
         */
 
-        // erase existing cai data
-        let empty_buf = Vec::new();
-        let mut iter = ps.into_iter();
-        if let Some(existing_cai_data) = iter.find(|png_cp| png_cp.name == CAI_CHUNK) {
-            // replace existing CAI data
-            let cai_start = usize::try_from(existing_cai_data.start)
-                .map_err(|_err| Error::InvalidAsset("value out of range".to_owned()))?; // get beginning of chunk which starts 4 bytes before label
-
-            let cai_end = usize::try_from(existing_cai_data.end())
-                .map_err(|_err| Error::InvalidAsset("value out of range".to_owned()))?;
-
-            png_buf.splice(cai_start..cai_end, empty_buf.iter().cloned());
-        };
-
-        // update positions and reset png_buf
-        cursor = Cursor::new(png_buf);
-        ps = get_png_chunk_positions(&mut cursor)?;
-        iter = ps.into_iter();
-        png_buf = cursor.into_inner();
-
-        // add new cai data after the image header chunk
-        if let Some(img_hdr) = iter.find(|png_cp| png_cp.name == IMG_HDR) {
-            let img_hdr_end = usize::try_from(img_hdr.end())
-                .map_err(|_err| Error::InvalidAsset("value out of range".to_owned()))?;
-
-            png_buf.splice(img_hdr_end..img_hdr_end, cai_data.iter().cloned());
-        } else {
-            return Err(Error::EmbeddingError);
+        match existing_c2pa_position {
+            // existing caBX is before IHDR, remove it and insert after IHDR
+            Some((c2pa_start, c2pa_end)) if c2pa_end <= ihdr_end => {
+                io::copy(&mut input_stream.take(c2pa_start), output_stream)?;
+                input_stream.seek(SeekFrom::Start(c2pa_end))?;
+                io::copy(&mut input_stream.take(ihdr_end - c2pa_end), output_stream)?;
+                output_stream.write_all(&c2pa_data)?;
+                io::copy(input_stream, output_stream)?;
+            }
+            // existing caBX is after IHDR, insert new caBX after IHDR and skip the old
+            Some((c2pa_start, c2pa_end)) => {
+                io::copy(&mut input_stream.take(ihdr_end), output_stream)?;
+                output_stream.write_all(&c2pa_data)?;
+                io::copy(&mut input_stream.take(c2pa_start - ihdr_end), output_stream)?;
+                input_stream.seek(SeekFrom::Start(c2pa_end))?;
+                io::copy(input_stream, output_stream)?;
+            }
+            // no existing caBX, insert after IHDR
+            None => {
+                io::copy(&mut input_stream.take(ihdr_end), output_stream)?;
+                output_stream.write_all(&c2pa_data)?;
+                io::copy(input_stream, output_stream)?;
+            }
         }
-
-        output_stream.rewind()?;
-        output_stream.write_all(&png_buf)?;
 
         Ok(())
     }


### PR DESCRIPTION
Avoids buffering the PNG into memory by using streaming operations in `write_cai`. Reduces total memory usage for writing C2PA in a 100MB PNG by 34.82% and peak memory usage by 23.17%.

Before:
<img width="272" height="50" alt="Screenshot 2026-05-21 at 12 10 56 PM" src="https://github.com/user-attachments/assets/0a3b95f9-cfe7-4c69-be39-a01f32ccc918" />

After:
<img width="268" height="52" alt="Screenshot 2026-05-21 at 12 11 08 PM" src="https://github.com/user-attachments/assets/1d811df6-604d-41bc-a5bc-ab284614f65c" />