### PR TITLE
feat: Add Mac Catalyst builds

### DIFF
--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -34,6 +34,10 @@ jobs:
             target: x86_64-apple-ios
           - os: macos-latest
             target: aarch64-apple-ios-sim
+          - os: macos-latest
+            target: aarch64-apple-ios-macabi
+          - os: macos-latest
+            target: x86_64-apple-ios-macabi
           - os: ubuntu-latest
             target: aarch64-linux-android
           - os: ubuntu-latest

--- a/c2pa_c_ffi/Makefile
+++ b/c2pa_c_ffi/Makefile
@@ -160,6 +160,22 @@ release-ios-arm64-sim:
 	cargo build --target=aarch64-apple-ios-sim $(CARGO_BUILD_FLAGS)
 	@$(call make_zip,$(TARGET_DIR)/aarch64-apple-ios-sim/release,aarch64-apple-ios-sim)
 
+# Mac Catalyst on Apple Silicon
+release-ios-arm64-macabi:
+	rustup target add aarch64-apple-ios-macabi
+	SDKROOT=$$(xcrun -sdk macosx --show-sdk-path) \
+	IPHONEOS_DEPLOYMENT_TARGET=$(IPHONEOS_DEPLOYMENT_TARGET) \
+	cargo build --target=aarch64-apple-ios-macabi $(CARGO_BUILD_FLAGS)
+	@$(call make_zip,$(TARGET_DIR)/aarch64-apple-ios-macabi/release,aarch64-apple-ios-macabi)
+
+# Mac Catalyst on Intel Macs
+release-ios-x86_64-macabi:
+	rustup target add x86_64-apple-ios-macabi
+	SDKROOT=$$(xcrun -sdk macosx --show-sdk-path) \
+	IPHONEOS_DEPLOYMENT_TARGET=$(IPHONEOS_DEPLOYMENT_TARGET) \
+	cargo build --target=x86_64-apple-ios-macabi $(CARGO_BUILD_FLAGS)
+	@$(call make_zip,$(TARGET_DIR)/x86_64-apple-ios-macabi/release,x86_64-apple-ios-macabi)
+
 # 64-bit Android devices
 release-android-arm64:
 	$(CROSS_INSTALL_RUSTFLAGS) cargo install cross --git https://github.com/cross-rs/cross
@@ -218,6 +234,10 @@ else ifeq ($(TARGET),x86_64-apple-ios)
 release: release-ios-x86_64
 else ifeq ($(TARGET),aarch64-apple-ios-sim)
 release: release-ios-arm64-sim
+else ifeq ($(TARGET),aarch64-apple-ios-macabi)
+release: release-ios-arm64-macabi
+else ifeq ($(TARGET),x86_64-apple-ios-macabi)
+release: release-ios-x86_64-macabi
 else ifeq ($(TARGET),aarch64-linux-android)
 release: release-android-arm64
 else ifeq ($(TARGET),armv7-linux-androideabi)


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._
Adds Mac Catalyst build targets to provide support for the new multiplatform framework in c2pa-swift (formerly c2pa-ios)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
