### PR TITLE
fix: preserve validation status log kind after deserialization

### DIFF
--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -148,19 +148,23 @@ impl ValidationResults {
             let get_statuses = |i: Ingredient| {
                 // Get a flat list of validation statuses from the ingredient.
                 // If validation_results are present, use them, otherwise use the ingredient's validation_status.
-                let validation_status = match i.validation_results {
-                    Some(v) => Some(v.validation_status()),
-                    None => i.validation_status.map(|s| {
-                        s.iter()
+                //
+                // the `kind` field is `#[serde(skip)]` so it doesn't survive serialization
+                // of the ingredient. we also need to fix up `kind` since the older validation
+                // statuses don't have it set.
+                let validation_status: Option<Vec<ValidationStatus>> = i
+                    .validation_results
+                    .map(|v| v.validation_status())
+                    .or(i.validation_status)
+                    .map(|statuses| {
+                        statuses
+                            .into_iter()
                             .map(|s| {
-                                let status = s.to_owned();
-                                // We need to fix up kind since the older validation statuses don't have it set.
-                                let kind = log_kind(status.code());
-                                status.set_kind(kind)
+                                let kind = log_kind(s.code());
+                                s.set_kind(kind)
                             })
                             .collect()
-                    }),
-                };
+                    });
 
                 // Convert any relative manifest urls found in ingredient validation statuses to absolute.
                 validation_status.map(|mut statuses| {

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -1224,6 +1224,11 @@ pub mod tests {
         let ingredient = Ingredient {
             relationship: Relationship::ComponentOf,
             version: 3,
+            active_manifest: Some(HashedUri::new(
+                inner_manifest_uri.clone(),
+                Some("sha256".into()),
+                &[0u8; 32],
+            )),
             validation_results: Some(attested),
             ..Default::default()
         };

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -977,10 +977,20 @@ pub mod validation_codes {
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
-    use crate::validation_status::{
-        ASSERTION_DATAHASH_MISMATCH, CLAIM_MALFORMED, CLAIM_SIGNATURE_INSIDE_VALIDITY,
-        CLAIM_SIGNATURE_VALIDATED, SIGNING_CREDENTIAL_TRUSTED, SIGNING_CREDENTIAL_UNTRUSTED,
+    use crate::{
+        assertions,
+        claim::Claim,
+        jumbf::labels,
+        log_item,
+        validation_status::{
+            ASSERTION_DATAHASH_MISMATCH, ASSERTION_HASHEDURI_MISMATCH, CLAIM_MALFORMED,
+            CLAIM_SIGNATURE_INSIDE_VALIDITY, CLAIM_SIGNATURE_VALIDATED, SIGNING_CREDENTIAL_TRUSTED,
+            SIGNING_CREDENTIAL_UNTRUSTED,
+        },
+        HashedUri, Relationship,
     };
 
     #[test]
@@ -1198,5 +1208,61 @@ pub mod tests {
             validation_results.validation_state(),
             ValidationState::Invalid
         );
+    }
+
+    #[test]
+    fn from_store_attested_ingredient_failure_after_serde_roundtrip() {
+        let inner_label = "urn:uuid:inner-test";
+        let inner_manifest_uri = labels::to_manifest_uri(inner_label);
+        let assertion_url = format!("{inner_manifest_uri}/c2pa.assertions/org.test.data");
+
+        let mut attested = ValidationResults::default();
+        attested.add_status(
+            ValidationStatus::new_failure(ASSERTION_HASHEDURI_MISMATCH).set_url(&assertion_url),
+        );
+
+        let ingredient = Ingredient {
+            relationship: Relationship::ComponentOf,
+            version: 3,
+            validation_results: Some(attested),
+            ..Default::default()
+        };
+
+        let mut outer_claim = Claim::new("test-generator", None, 2);
+        outer_claim.add_assertion(&ingredient).unwrap();
+        let outer_label = outer_claim.label().to_string();
+
+        let mut store = Store::new();
+        store.insert_restored_claim(outer_label.clone(), outer_claim);
+
+        let mut tracker = StatusTracker::default();
+        tracker.push_ingredient_uri(labels::to_assertion_uri(
+            &outer_label,
+            assertions::labels::INGREDIENT,
+        ));
+        let _ = log_item!(
+            assertion_url.clone(),
+            "hash does not match assertion data",
+            "verify_internal"
+        )
+        .validation_status(ASSERTION_HASHEDURI_MISMATCH)
+        .failure(&mut tracker, "hash mismatch");
+        tracker.pop_ingredient_uri();
+
+        let results = ValidationResults::from_store(&store, &tracker);
+
+        let delta_failures: Vec<_> = results
+            .ingredient_deltas
+            .as_ref()
+            .map(|deltas| {
+                deltas
+                    .iter()
+                    .flat_map(|deltas| deltas.validation_deltas().failure().iter())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // check that there are no failures since they were attested to
+        assert!(delta_failures.is_empty());
     }
 }


### PR DESCRIPTION
`ValidationStatus::kind` is marked as `#[serde(skip)]` since it's internal, not in the C2PA spec. The problem is that it defaults to `LogKind::Success`, so when an ingredient with this struct is serialized then deserialized it always defaults to success. This change recomputes the field for when we deserialize from an ingredient.
https://github.com/contentauth/c2pa-rs/blob/d466080b08e4e62a42d24f5ddf1b35d0248e0cd0/sdk/src/validation_status.rs#L51-L53

Here is the code later in the `ValidationResults::from_store` logic where we get the results from a serialized ingredient:
https://github.com/contentauth/c2pa-rs/blob/d466080b08e4e62a42d24f5ddf1b35d0248e0cd0/sdk/src/validation_results.rs#L187-L194