### PR TITLE
ci: don't run benchmark workflow on forks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,12 +22,13 @@ jobs:
     name: Build benchmarks
     if: |
       github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release') ||
-      contains(github.event.pull_request.labels.*.name, 'benchmark')
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.pull_request.author_association == 'COLLABORATOR' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+        contains(github.event.pull_request.labels.*.name, 'check-release') ||
+        contains(github.event.pull_request.labels.*.name, 'benchmark')))
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Forks don't have access to the secrets to download from AWS, needs caution to properly setup. For now disable the benchmarking workflow on forks.