### PR TITLE
fix: Load ingredient manifest store esp. to load resources on search/load miss

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,9 @@ tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
 wasi = "0.14"
 wstd = "0.5"
 
+[package.metadata.cargo-udeps.ignore]
+development = ["mockall"]
+
 [dev-dependencies]
 mockall = "0.14.0"
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1748,10 +1748,8 @@ pub mod tests {
     /// that is lazily deferred in `source_store`.
     #[test]
     fn test_resource_to_stream_retrieve_deferred_manifest_data() -> Result<()> {
-        let reader = Reader::default().with_stream(
-            "image/jpeg",
-            Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST),
-        )?;
+        let reader = Reader::default()
+            .with_stream("image/jpeg", Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST))?;
 
         let active = reader.active_manifest().unwrap();
         let ingredient = active

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -882,7 +882,7 @@ impl Reader {
     pub fn resource_to_stream(
         &self,
         uri: &str,
-        stream: impl Write + Read + Seek + MaybeSend,
+        mut stream: impl Write + Read + Seek + MaybeSend,
     ) -> Result<usize> {
         // get the manifest referenced by the uri, or the active one if None
         // add logic to search for local or absolute uri identifiers
@@ -917,7 +917,30 @@ impl Reader {
                 Ok(resource) => resource.write_stream(&relative_uri, stream),
                 Err(_) => match find_resource(&absolute_uri) {
                     Ok(resource) => resource.write_stream(&absolute_uri, stream),
-                    Err(e) => Err(e),
+                    Err(_) => {
+                        // Fallback: ingredient manifest_data may be lazily loaded.
+                        // We must try to materialize it on cache miss/not loaded state...
+                        // This is to cover the case a resource was asked for, but the resource
+                        // may not have been loaded eagerly.
+                        // manifest_label_from_uri() extracts <claim-label>, which is
+                        // what set_deferred_manifest_data() stores in md_ref.identifier.
+                        for ingredient in manifest.ingredients() {
+                            if let Some(md_ref) = ingredient.manifest_data_ref() {
+                                if md_ref.identifier == label
+                                    || md_ref.identifier == relative_uri
+                                    || md_ref.identifier == absolute_uri
+                                {
+                                    if let Some(cow) = ingredient.manifest_data() {
+                                        let bytes = cow.into_owned();
+                                        let len = bytes.len();
+                                        stream.write_all(&bytes).map_err(Error::IoError)?;
+                                        return Ok(len as usize);
+                                    }
+                                }
+                            }
+                        }
+                        Err(Error::ResourceNotFound(relative_uri.to_owned()))
+                    }
                 },
             }
         } else {
@@ -1717,6 +1740,41 @@ pub mod tests {
         let mut out2 = Cursor::new(Vec::new());
         reader.resource_to_stream(&uri2, &mut out2)?;
         assert_eq!(out2.into_inner(), thumbnail2);
+
+        Ok(())
+    }
+
+    /// Verify that `resource_to_stream` can load ingredient `manifest_data`
+    /// that is lazily deferred in `source_store`.
+    #[test]
+    fn test_resource_to_stream_retrieve_deferred_manifest_data() -> Result<()> {
+        let reader = Reader::default().with_stream(
+            "image/jpeg",
+            &mut Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST),
+        )?;
+
+        let active = reader.active_manifest().unwrap();
+        let ingredient = active
+            .ingredients()
+            .first()
+            .expect("no ingredient in CACA.jpg");
+
+        let md_ref = ingredient
+            .manifest_data_ref()
+            .expect("ingredient has no manifest_data_ref");
+
+        // Confirm the bytes are not already in the in-memory resource store
+        // (lazy path executed, no eager load anymore here, so nothing to see... yet!)
+        assert!(
+            ingredient.resources().get(&md_ref.identifier).is_err(),
+            "expected deferred manifest_data — lazy load path not exercised"
+        );
+
+        // resource_to_stream must succeed no matter what, loading resources
+        let mut out = Cursor::new(Vec::new());
+        let n = reader.resource_to_stream(&md_ref.identifier, &mut out)?;
+        assert!(n > 0, "expected non-empty manifest_data bytes");
+        assert!(!out.into_inner().is_empty());
 
         Ok(())
     }

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -934,7 +934,7 @@ impl Reader {
                                         let bytes = cow.into_owned();
                                         let len = bytes.len();
                                         stream.write_all(&bytes).map_err(Error::IoError)?;
-                                        return Ok(len as usize);
+                                        return Ok(len);
                                     }
                                 }
                             }
@@ -1750,7 +1750,7 @@ pub mod tests {
     fn test_resource_to_stream_retrieve_deferred_manifest_data() -> Result<()> {
         let reader = Reader::default().with_stream(
             "image/jpeg",
-            &mut Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST),
+            Cursor::new(IMAGE_WITH_INGREDIENT_MANIFEST),
         )?;
 
         let active = reader.active_manifest().unwrap();


### PR DESCRIPTION
## Changes in this pull request
Since https://github.com/contentauth/c2pa-rs/pull/2103, ingredients manifest stores are lazy loaded. But if a caller is trying to get to resources of a lazy loaded ingredient, there may be misses as the resources may not have yet been loaded.

Especially, this breaks the legacy approach to extract ingredients from a Builder to reattach them to a new Builder.

This was detected by 3 c2pa-cpp failing when running with a build from c2pa-rs main (since those changes are currently unreleased), that exercise the legacy way of doing things (all fail with a resource not found error, due to resources not being loaded at time of checking them/wanting to use them):
[  FAILED  ] BuilderTest.ExtractIngredientsFromArchive
[  FAILED  ] BuilderTest.ExtractIngredientsFromArchiveToBuilder
[  FAILED  ] BuilderTest.ExtractIngredientsFromArchives

I *believe* we don't want to break that yet, to give time for users who may rely on the legacy approach to switch to the new API. This PR offers a fallback approach on this (now edge?) case when the resource is not found, to still try to load it. 
(I am not sure if this side-effect was intended from the perf PR, but here we are. We either need a fix of the perf PR, or the fallback that eager loads on miss).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
