### PR TITLE
feat: add Intent support to c2patool

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.26.59](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.58...c2patool-v0.26.59)
+### Added
+
+* `--create <source-type>` flag to sign an asset as a new original creation with the specified [C2PA digital source type](https://cv.iptc.org/newscodes/digitalsourcetype/) (e.g. `digitalCapture`, `trainedAlgorithmicMedia`). Automatically injects a `c2pa.created` action. Mutually exclusive with `--update` and `--parent`.
+* `--update` flag to generate an [update manifest](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_update_manifests) for non-editorial changes applied to an already-signed asset. Automatically injects a `c2pa.opened` action and sets the source asset as the parent ingredient. The source asset must already contain a C2PA manifest. Mutually exclusive with `--create`.
+
+### Changed
+
+* Default signing behavior now applies **Edit** intent: the source asset is automatically added as a parent ingredient and a `c2pa.opened` action is injected. Previously no intent or parent was set automatically.
+* Signature validation after signing is now enabled by default in all builds (previously only in test builds). Use `--no_signing_verify` to skip it.(https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.58...c2patool-v0.26.59)
 _12 May 2026_
 
 ## [0.26.58](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.57...c2patool-v0.26.58)

--- a/cli/docs/usage.md
+++ b/cli/docs/usage.md
@@ -28,6 +28,7 @@ The following options are available with any (or no) subcommand.  Additional opt
 |-----|----|----|----|
 | `--certs` | | N/A | Extract a certificate chain to standard output (stdout). See [Extracting a certificate chain](#extracting-a-certificate-chain). |
 | `--config` | `-c` | `<config>` | Specify a [manifest definition](manifest.md) as a JSON string. See [Providing a manifest definition on the command line](#providing-a-manifest-definition-on-the-command-line). |
+| `--create` | | `<source_type>` | Create a new manifest with the specified [C2PA digital source type](https://cv.iptc.org/newscodes/digitalsourcetype/) (e.g. `digitalCapture`, `trainedAlgorithmicMedia`). Mutually exclusive with `--update` and `--parent`. See [Specifying manifest intent](#specifying-manifest-intent). |
 | `--detailed` | `-d` | N/A | Display detailed C2PA-formatted manifest data. See [Displaying a detailed manifest report](#detailed-manifest-report). |
 | `--external-manifest` | N/A | `<c2pa_file>` | Path to the binary `.c2pa` (sidecar) manifest to use for validation against the input asset. See [Using an external manifest](#using-an-external-manifest). |
 | `--force` | `-f` | N/A | Force overwriting output file. See [Forced overwrite](#forced-overwrite). |
@@ -45,6 +46,7 @@ The following options are available with any (or no) subcommand.  Additional opt
 | `--sidecar` | `-s` | N/A | Put manifest in external "sidecar" file with `.c2pa` extension. See [Generating an external manifest](#generating-an-external-manifest). |
 | `--signer-path` | N/A | `<command>` | Command for signing the C2PA claim. See [Signing assets](signing.md). |
 | `--tree` | | N/A | Create a tree diagram of the manifest store. See [Displaying a tree diagram](#displaying-a-tree-diagram). |
+| `--update` | | N/A | Create an [update manifest](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#_update_manifests) (non-editorial changes to an already-signed parent asset). Mutually exclusive with `--create`. See [Specifying manifest intent](#specifying-manifest-intent). |
 | `--version` | `-V` | N/A | Display version information. |
 
 ## Displaying manifest data
@@ -168,6 +170,63 @@ c2patool sample/C.jpg --ingredient --output ./ingredient
 
 c2patool sample/image.jpg -m sample/test.json -p ./ingredient -o signed_image.jpg
 ```
+
+### Specifying manifest intent
+
+Every C2PA manifest records an _intent_ that describes how the content was produced. C2PA Tool supports three intents, controlled by the `--create` and `--update` flags:
+
+| Intent | Flag | When to use |
+|--------|------|-------------|
+| **Create** | `--create <source-type>` | The output is a new original creation with no prior editing history. |
+| **Edit** | _(default — no flag needed)_ | The output is derived from one or more source assets through an editorial process. |
+| **Update** | `--update` | Non-editorial technical changes were applied to an already-signed asset (e.g., re-encoding or format conversion). |
+
+#### Create intent (`--create`)
+
+Use `--create <source-type>` to declare that the output is a new creation. Provide one of the [IPTC digital source type](https://cv.iptc.org/newscodes/digitalsourcetype/) values:
+
+```shell
+c2patool new_image.jpg \
+  -c '{"assertions":[]}' \
+  --create digitalCapture \
+  -o signed_image.jpg
+```
+
+The tool automatically adds a `c2pa.created` action. `--create` is mutually exclusive with `--update` and `--parent`.
+
+Some common source-type values:
+
+| Value | Meaning |
+|-------|---------|
+| `digitalCapture` | Original capture from a camera or microphone |
+| `algorithmicMedia` | Produced entirely by an algorithm |
+| `trainedAlgorithmicMedia` | Produced by a trained AI model |
+| `compositeWithTrainedAlgorithmicMedia` | Composite that includes AI-generated elements |
+
+See the [IPTC digital source type vocabulary](https://cv.iptc.org/newscodes/digitalsourcetype/) for the full list.
+
+#### Edit intent (default)
+
+When neither `--create` nor `--update` is given, the tool applies **Edit** intent. The source asset is automatically added as a parent ingredient and a `c2pa.opened` action is injected into the manifest:
+
+```shell
+c2patool source_image.jpg -m sample/test.json -o signed_image.jpg
+```
+
+Use `--parent` / `-p` when the parent asset is a different file from the source (see [Specifying a parent file](#specifying-a-parent-file)).
+
+#### Update intent (`--update`)
+
+Use `--update` to declare that non-editorial changes were applied to an already-signed asset. The source asset **must already contain a C2PA manifest**.
+
+```shell
+c2patool source_with_manifest.jpg \
+  -c '{"assertions":[]}' \
+  --update \
+  -o updated_image.jpg
+```
+
+The tool automatically adds a `c2pa.opened` action and sets the source asset as the parent ingredient. `--update` is mutually exclusive with `--create`.
 
 ### Generating an external manifest
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,15 +29,16 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use c2pa::{
-    create_signer, format_from_path, settings::Settings, BoxedSigner, Builder, CallbackSigner,
-    ClaimGeneratorInfo, Context as C2paContext, Error, Ingredient, ManifestDefinition, Reader,
-    Signer, SigningAlg,
+    create_signer, format_from_path, settings::Settings, BoxedSigner, Builder, BuilderIntent,
+    CallbackSigner, ClaimGeneratorInfo, Context as C2paContext, DigitalSourceType, Error,
+    Ingredient, ManifestDefinition, Reader, Signer, SigningAlg,
 };
 use clap::{Parser, Subcommand};
 use env_logger::Env;
 use etcetera::BaseStrategy;
 use log::debug;
 use serde::Deserialize;
+use serde_json::json;
 use signer::SignConfig;
 use tempfile::NamedTempFile;
 use url::Url;
@@ -85,6 +86,19 @@ struct CliArgs {
     /// Path to a parent file.
     #[clap(short, long)]
     parent: Option<PathBuf>,
+
+    /// Digital source type for a new creation (e.g. `digitalCapture`, `empty`).
+    ///
+    /// Passing this flag sets the builder intent to `Create`.
+    /// Mutually exclusive with `--update` and `--parent`.
+    #[clap(long, conflicts_with = "update", conflicts_with = "parent")]
+    create: Option<String>,
+
+    /// Treat this as an update manifest (non-editorial changes to a parent asset).
+    ///
+    /// Mutually exclusive with `--create`.
+    #[clap(long, conflicts_with = "create")]
+    update: bool,
 
     /// Manifest definition passed as a JSON string.
     #[clap(short, long, conflicts_with = "manifest")]
@@ -467,8 +481,8 @@ fn ext_normal(path: &Path) -> String {
     }
 }
 
-// loads an ingredient, allowing for a folder or json ingredient
-fn load_ingredient(path: &Path) -> Result<Ingredient> {
+// adds an ingredient, from a file, folder or json definition
+fn add_ingredient(builder: &mut Builder, path: &Path, is_parent: bool) -> Result<()> {
     // if the path is a folder, look for ingredient.json
     let mut path_buf = PathBuf::from(path);
     let path = if path.is_dir() {
@@ -478,16 +492,27 @@ fn load_ingredient(path: &Path) -> Result<Ingredient> {
         path
     };
     if path.extension() == Some(std::ffi::OsStr::new("json")) {
+        // ingredient is a json file, load it directly and set the base path for any resources
         let json = std::fs::read_to_string(path)?;
         let mut ingredient: Ingredient = serde_json::from_slice(json.as_bytes())?;
         if let Some(base) = path.parent() {
             ingredient.resources_mut().set_base_path(base);
         }
-        Ok(ingredient)
+        if is_parent {
+            ingredient.set_relationship(c2pa::Relationship::ParentOf);
+        }
+        builder.add_ingredient(ingredient.clone());
+        Ok(())
     } else {
-        #[allow(deprecated)]
-        let result = Ingredient::from_file(path)?;
-        Ok(result)
+        // ingredient is a file, load it as an ingredient with a relationship
+        let mut file = File::open(path)?;
+        let format = format_from_path(path)
+            .ok_or_else(|| anyhow!("Could not determine format from path: {:?}", path))?;
+        let json = json!({
+            "relationship": if is_parent { c2pa::Relationship::ParentOf } else { c2pa::Relationship::ComponentOf },
+        }).to_string();
+        builder.add_ingredient_from_stream(json, &format, &mut file)?;
+        Ok(())
     }
 }
 
@@ -1008,11 +1033,6 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let is_fragment = matches!(
-        &args.command,
-        Some(Commands::Fragment { fragments_glob: _ })
-    );
-
     // configure the SDK
     let mut settings = configure_sdk(&args).context("Could not configure c2pa-rs")?;
     let context = Arc::new(C2paContext::new().with_settings(&settings)?);
@@ -1084,28 +1104,27 @@ fn main() -> Result<()> {
                         path = base.join(&path)
                     }
                 }
-                let ingredient = load_ingredient(&path)?;
-                builder.add_ingredient(ingredient);
+                add_ingredient(&mut builder, &path, false)?;
             }
         }
 
         if let Some(parent_path) = args.parent {
-            let mut ingredient = load_ingredient(&parent_path)?;
-            ingredient.set_is_parent();
-            builder.add_ingredient(ingredient);
+            add_ingredient(&mut builder, &parent_path, true)?
         }
 
-        // If the source file has a manifest store, and no parent is specified treat the source as a parent.
-        // note: This could be treated as an update manifest eventually since the image is the same
-        let has_parent = builder.definition.ingredients.iter().any(|i| i.is_parent());
-        if !has_parent && !is_fragment {
-            #[allow(deprecated)]
-            let mut source_ingredient = Ingredient::from_file(path)?;
-            if source_ingredient.manifest_data().is_some() {
-                source_ingredient.set_is_parent();
-                builder.add_ingredient(source_ingredient);
-            }
-        }
+        let intent = if let Some(source_type_str) = &args.create {
+            let source_type: DigitalSourceType =
+                serde_json::from_value(serde_json::Value::String(source_type_str.clone()))
+                    .with_context(|| {
+                        format!("Invalid --create source type: '{source_type_str}'")
+                    })?;
+            BuilderIntent::Create(source_type)
+        } else if args.update {
+            BuilderIntent::Update
+        } else {
+            BuilderIntent::Edit
+        };
+        builder.set_intent(intent);
 
         if let Some(remote) = args.remote {
             if args.sidecar {

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -43,6 +43,7 @@ fn temp_path(name: &str) -> PathBuf {
     create_dir_all(&path).ok();
     path.join(name)
 }
+
 #[test]
 fn tool_not_found() -> Result<(), Box<dyn Error>> {
     let mut cmd = Command::new(cargo::cargo_bin!("c2patool"));
@@ -100,6 +101,7 @@ fn tool_embed_jpeg_report() -> Result<(), Box<dyn Error>> {
         .stdout(str::contains("My Title"));
     Ok(())
 }
+
 #[test]
 fn tool_fs_output_report() -> Result<(), Box<dyn Error>> {
     let path = temp_path("output_dir");
@@ -692,5 +694,88 @@ fn tool_read_image_crjson() -> Result<(), Box<dyn Error>> {
         .success()
         .stdout(str::contains("\"jsonGenerator\""))
         .stdout(str::contains("https://c2pa.org/crjson"));
+    Ok(())
+}
+
+// Minimal manifest definition with no actions; lets the SDK auto-inject the
+// correct c2pa.created / c2pa.opened action based on intent.
+const MINIMAL_MANIFEST: &str = r#"{"assertions": []}"#;
+
+#[test]
+// c2patool earth_apollo17.jpg --create digitalCapture -c '{"assertions":[]}' -o out.jpg -f
+// Create intent: auto-injects c2pa.created with digitalCapture, no parent ingredient.
+fn intent_create_adds_created_action() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE))
+        .arg("--create")
+        .arg("digitalCapture")
+        .arg("-c")
+        .arg(MINIMAL_MANIFEST)
+        .arg("-o")
+        .arg(temp_path("intent_create_out.jpg"))
+        .arg("-f")
+        .assert()
+        .success()
+        .stdout(str::contains("c2pa.created"))
+        .stdout(str::contains("digitalCapture"))
+        .stdout(str::contains("parentOf").not());
+    Ok(())
+}
+
+#[test]
+// --create and --parent are mutually exclusive at the CLI level.
+fn intent_create_rejects_parent_flag() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE))
+        .arg("--create")
+        .arg("digitalCapture")
+        .arg("--parent")
+        .arg(fixture_path(TEST_IMAGE))
+        .arg("-c")
+        .arg(MINIMAL_MANIFEST)
+        .arg("-o")
+        .arg(temp_path("intent_create_parent_out.jpg"))
+        .arg("-f")
+        .assert()
+        .failure()
+        .stderr(str::contains("cannot be used with"));
+    Ok(())
+}
+
+#[test]
+// Default (no --create / --update flag) = Edit intent.
+// SDK auto-adds source as parent ingredient and injects c2pa.opened tied to it.
+fn intent_edit_default_adds_parent_and_opened_action() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE))
+        .arg("-c")
+        .arg(MINIMAL_MANIFEST)
+        .arg("-o")
+        .arg(temp_path("intent_edit_out.jpg"))
+        .arg("-f")
+        .assert()
+        .success()
+        .stdout(str::contains("c2pa.opened"))
+        .stdout(str::contains("parentOf"));
+    Ok(())
+}
+
+#[test]
+// --update = Update manifest intent.
+// The source must already have a manifest (update manifests require provenance on the parent).
+// SDK auto-adds source as parent ingredient and injects c2pa.opened tied to it.
+fn intent_update_adds_parent_and_opened_action() -> Result<(), Box<dyn Error>> {
+    Command::new(cargo::cargo_bin!("c2patool"))
+        .arg(fixture_path(TEST_IMAGE_WITH_MANIFEST)) // C.jpg already has a manifest
+        .arg("--update")
+        .arg("-c")
+        .arg(MINIMAL_MANIFEST)
+        .arg("-o")
+        .arg(temp_path("intent_update_out.jpg"))
+        .arg("-f")
+        .assert()
+        .success()
+        .stdout(str::contains("c2pa.opened"))
+        .stdout(str::contains("parentOf"));
     Ok(())
 }


### PR DESCRIPTION
now defaults to the edit intent
--create with a digital source type allows creation 
--update will trigger an update manifests

Note: c2patool would always try to add a parent ingredient from the source if no parent was specified. But it would only do this if the parent had a manifest. That left a kind of backdoor for doing a created manifest before we had that concept.
This will now always use the source as a parent if it has a manifest or not. So that's a potential compatibiliy issue.
But anyone doing that should now be using --created so that the proper action is set up.
