### PR TITLE
fix: Sync resolver for CAWG web DID

### DIFF
--- a/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
+++ b/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
@@ -459,17 +459,9 @@ impl IcaSignatureVerifier {
 
             "web" => {
                 let did_doc = if _sync {
-                    did_web::resolve_sync(&primary_did).map_err(|e| {
-                        ValidationError::SignatureError(IcaValidationError::InvalidDidDocument(
-                            e.to_string(),
-                        ))
-                    })?
+                    did_web::resolve_sync(&primary_did)?
                 } else {
-                    did_web::resolve(&primary_did).await.map_err(|e| {
-                        ValidationError::SignatureError(IcaValidationError::InvalidDidDocument(
-                            e.to_string(),
-                        ))
-                    })?
+                    did_web::resolve(&primary_did).await?
                 };
 
                 let Some(vm1) = did_doc.verification_relationships.assertion_method.first() else {

--- a/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
+++ b/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
@@ -459,9 +459,9 @@ impl IcaSignatureVerifier {
 
             "web" => {
                 let did_doc = if _sync {
-                    did_web::resolve_sync(&primary_did)?
+                    did_web::resolve(&primary_did)?
                 } else {
-                    did_web::resolve(&primary_did).await?
+                    did_web::resolve_async(&primary_did).await?
                 };
 
                 let Some(vm1) = did_doc.verification_relationships.assertion_method.first() else {

--- a/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
+++ b/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
@@ -458,56 +458,59 @@ impl IcaSignatureVerifier {
             }
 
             "web" => {
-                if _sync {
+                let did_doc = if _sync {
+                    did_web::resolve_sync(&primary_did).map_err(|e| {
+                        ValidationError::SignatureError(IcaValidationError::InvalidDidDocument(
+                            e.to_string(),
+                        ))
+                    })?
+                } else {
+                    did_web::resolve(&primary_did).await.map_err(|e| {
+                        ValidationError::SignatureError(IcaValidationError::InvalidDidDocument(
+                            e.to_string(),
+                        ))
+                    })?
+                };
+
+                let Some(vm1) = did_doc.verification_relationships.assertion_method.first() else {
                     return Err(ValidationError::SignatureError(
-                        IcaValidationError::UnsupportedIssuerDid(
-                            "did:web requires async resolution".to_string(),
+                        IcaValidationError::InvalidDidDocument(
+                            "DID document doesn't contain an assertionMethod entry".to_string(),
                         ),
                     ));
-                } else {
-                    let did_doc = did_web::resolve(&primary_did).await?;
+                };
 
-                    let Some(vm1) = did_doc.verification_relationships.assertion_method.first()
-                    else {
-                        return Err(ValidationError::SignatureError(
-                            IcaValidationError::InvalidDidDocument(
-                                "DID document doesn't contain an assertionMethod entry".to_string(),
-                            ),
-                        ));
-                    };
+                let super::w3c_vc::did_doc::ValueOrReference::Value(vm1) = vm1 else {
+                    return Err(ValidationError::SignatureError(
+                        IcaValidationError::InvalidDidDocument(
+                            "DID document's assertionMethod is not a value".to_string(),
+                        ),
+                    ));
+                };
 
-                    let super::w3c_vc::did_doc::ValueOrReference::Value(vm1) = vm1 else {
-                        return Err(ValidationError::SignatureError(
-                            IcaValidationError::InvalidDidDocument(
-                                "DID document's assertionMethod is not a value".to_string(),
-                            ),
-                        ));
-                    };
+                let Some(jwk_prop) = vm1.properties.get("publicKeyJwk") else {
+                    return Err(ValidationError::SignatureError(
+                        IcaValidationError::InvalidDidDocument(
+                            "DID document's assertionMethod doesn't contain a publicKeyJwk entry"
+                                .to_string(),
+                        ),
+                    ));
+                };
 
-                    let Some(jwk_prop) = vm1.properties.get("publicKeyJwk") else {
-                        return Err(ValidationError::SignatureError(
-                            IcaValidationError::InvalidDidDocument(
-                                "DID document's assertionMethod doesn't contain a publicKeyJwk entry"
-                                    .to_string(),
-                            ),
-                        ));
-                    };
+                // OMG SO HACKY!
+                let Ok(jwk_json) = serde_json::to_string_pretty(jwk_prop) else {
+                    return Err(ValidationError::InternalError(
+                        "couldn't re-serialize JWK".to_string(),
+                    ));
+                };
 
-                    // OMG SO HACKY!
-                    let Ok(jwk_json) = serde_json::to_string_pretty(jwk_prop) else {
-                        return Err(ValidationError::InternalError(
-                            "couldn't re-serialize JWK".to_string(),
-                        ));
-                    };
+                let Ok(jwk) = serde_json::from_str(&jwk_json) else {
+                    return Err(ValidationError::InternalError(
+                        "couldn't re-serialize JWK".to_string(),
+                    ));
+                };
 
-                    let Ok(jwk) = serde_json::from_str(&jwk_json) else {
-                        return Err(ValidationError::InternalError(
-                            "couldn't re-serialize JWK".to_string(),
-                        ));
-                    };
-
-                    jwk
-                }
+                jwk
             }
 
             x => {

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -276,7 +276,9 @@ mod tests {
                     .body(DID_JSON);
             });
 
-            let doc = did_web::resolve_async(&did("did:web:localhost")).await.unwrap();
+            let doc = did_web::resolve_async(&did("did:web:localhost"))
+                .await
+                .unwrap();
             let doc_expected = DidDocument::from_json(DID_JSON).unwrap();
             assert_eq!(doc, doc_expected);
 

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -68,23 +68,25 @@ pub enum DidWebError {
     ResponseTooLarge,
 }
 
-pub(crate) async fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
+fn prepare_url(did: &Did<'_>) -> Result<String, DidWebError> {
     let method = did.method_name();
     #[allow(clippy::panic)] // TEMPORARY while refactoring
     if method != "web" {
         panic!("Unexpected DID method {method}");
     }
+    to_url(did.method_specific_id())
+}
 
-    let method_specific_id = did.method_specific_id();
+fn parse_did_doc(bytes: Vec<u8>, url: &str) -> Result<DidDocument, DidWebError> {
+    let json = String::from_utf8(bytes).map_err(|_| DidWebError::InvalidData(url.to_owned()))?;
+    DidDocument::from_json(&json).map_err(|_| DidWebError::InvalidData(url.to_owned()))
+}
 
-    let url = to_url(method_specific_id)?;
+pub(crate) async fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
+    let url = prepare_url(did)?;
     // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
-
-    let did_doc = get_did_doc(&url).await?;
-
-    let json = String::from_utf8(did_doc).map_err(|_| DidWebError::InvalidData(url.clone()))?;
-
-    DidDocument::from_json(&json).map_err(|_| DidWebError::InvalidData(url))
+    let bytes = get_did_doc(&url).await?;
+    parse_did_doc(bytes, &url)
 }
 
 async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
@@ -118,22 +120,10 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
 }
 
 pub(crate) fn resolve_sync(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
-    let method = did.method_name();
-    #[allow(clippy::panic)] // TEMPORARY while refactoring
-    if method != "web" {
-        panic!("Unexpected DID method {method}");
-    }
-
-    let method_specific_id = did.method_specific_id();
-
-    let url = to_url(method_specific_id)?;
+    let url = prepare_url(did)?;
     // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
-
-    let did_doc = get_did_doc_sync(&url)?;
-
-    let json = String::from_utf8(did_doc).map_err(|_| DidWebError::InvalidData(url.clone()))?;
-
-    DidDocument::from_json(&json).map_err(|_| DidWebError::InvalidData(url))
+    let bytes = get_did_doc_sync(&url)?;
+    parse_did_doc(bytes, &url)
 }
 
 fn get_did_doc_sync(url: &str) -> Result<Vec<u8>, DidWebError> {

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -89,12 +89,35 @@ pub(crate) async fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
     parse_did_doc(bytes, &url)
 }
 
-async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
-    let request = http::Request::get(url)
+fn build_request(url: &str) -> Result<http::Request<Vec<u8>>, DidWebError> {
+    http::Request::get(url)
         .header(header::USER_AGENT, USER_AGENT)
         .header(header::ACCEPT, "application/did+json")
         .body(Vec::new())
-        .map_err(|e| DidWebError::Request(url.to_owned(), e.into()))?;
+        .map_err(|e| DidWebError::Request(url.to_owned(), e.into()))
+}
+
+fn check_response_status(status: http::StatusCode, url: &str) -> Result<(), DidWebError> {
+    match status {
+        http::StatusCode::OK => Ok(()),
+        http::StatusCode::NOT_FOUND => Err(DidWebError::NotFound(url.to_string())),
+        _ => Err(DidWebError::Server(status.to_string())),
+    }
+}
+
+fn read_body_with_limit(body: Box<dyn Read>, url: &str) -> Result<Vec<u8>, DidWebError> {
+    let mut document = Vec::new();
+    body.take(MAX_DID_DOC_SIZE + 1)
+        .read_to_end(&mut document)
+        .map_err(|e| DidWebError::Response(e.into()))?;
+    if document.len() as u64 > MAX_DID_DOC_SIZE {
+        return Err(DidWebError::ResponseTooLarge);
+    }
+    Ok(document)
+}
+
+async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
+    let request = build_request(url)?;
     let response = AsyncGenericResolver::with_redirects()
         .unwrap_or_default()
         .with_max_response_body_size(MAX_DID_DOC_SIZE)
@@ -104,19 +127,9 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
             HttpResolverError::ResponseTooLarge => DidWebError::ResponseTooLarge,
             e => DidWebError::Request(url.to_owned(), e),
         })?;
-
-    let (parts, mut body) = response.into_parts();
-    match parts.status {
-        http::StatusCode::OK => (),
-        http::StatusCode::NOT_FOUND => return Err(DidWebError::NotFound(url.to_string())),
-        _ => return Err(DidWebError::Server(parts.status.to_string())),
-    };
-
-    let mut document = Vec::new();
-    body.read_to_end(&mut document)
-        .map_err(|e| DidWebError::Response(e.into()))?;
-
-    Ok(document)
+    let (parts, body) = response.into_parts();
+    check_response_status(parts.status, url)?;
+    read_body_with_limit(body, url)
 }
 
 pub(crate) fn resolve_sync(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
@@ -127,12 +140,7 @@ pub(crate) fn resolve_sync(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
 }
 
 fn get_did_doc_sync(url: &str) -> Result<Vec<u8>, DidWebError> {
-    let request = http::Request::get(url)
-        .header(header::USER_AGENT, USER_AGENT)
-        .header(header::ACCEPT, "application/did+json")
-        .body(Vec::new())
-        .map_err(|e| DidWebError::Request(url.to_owned(), e.into()))?;
-
+    let request = build_request(url)?;
     let response = SyncGenericResolver::with_redirects()
         .unwrap_or_default()
         .http_resolve(request)
@@ -140,24 +148,9 @@ fn get_did_doc_sync(url: &str) -> Result<Vec<u8>, DidWebError> {
             HttpResolverError::ResponseTooLarge => DidWebError::ResponseTooLarge,
             e => DidWebError::Request(url.to_owned(), e),
         })?;
-
-    let (parts, mut body) = response.into_parts();
-    match parts.status {
-        http::StatusCode::OK => (),
-        http::StatusCode::NOT_FOUND => return Err(DidWebError::NotFound(url.to_string())),
-        _ => return Err(DidWebError::Server(parts.status.to_string())),
-    };
-
-    let mut document = Vec::new();
-    // Read one byte past the limit so we can detect an oversized response.
-    body.take(MAX_DID_DOC_SIZE + 1)
-        .read_to_end(&mut document)
-        .map_err(|e| DidWebError::Response(e.into()))?;
-    if document.len() as u64 > MAX_DID_DOC_SIZE {
-        return Err(DidWebError::ResponseTooLarge);
-    }
-
-    Ok(document)
+    let (parts, body) = response.into_parts();
+    check_response_status(parts.status, url)?;
+    read_body_with_limit(body, url)
 }
 
 pub(crate) fn to_url(did: &str) -> Result<String, DidWebError> {

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -82,7 +82,7 @@ fn parse_did_doc(bytes: Vec<u8>, url: &str) -> Result<DidDocument, DidWebError> 
     DidDocument::from_json(&json).map_err(|_| DidWebError::InvalidData(url.to_owned()))
 }
 
-pub(crate) async fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
+pub(crate) async fn resolve_async(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
     let url = prepare_url(did)?;
     // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
     let bytes = get_did_doc(&url).await?;
@@ -132,7 +132,7 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
     read_body_with_limit(body, url)
 }
 
-pub(crate) fn resolve_sync(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
+pub(crate) fn resolve(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
     let url = prepare_url(did)?;
     // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
     let bytes = get_did_doc_sync(&url)?;
@@ -276,7 +276,7 @@ mod tests {
                     .body(DID_JSON);
             });
 
-            let doc = did_web::resolve(&did("did:web:localhost")).await.unwrap();
+            let doc = did_web::resolve_async(&did("did:web:localhost")).await.unwrap();
             let doc_expected = DidDocument::from_json(DID_JSON).unwrap();
             assert_eq!(doc, doc_expected);
 
@@ -308,7 +308,7 @@ mod tests {
                     .body(oversized_body);
             });
 
-            let result = did_web::resolve(&did("did:web:localhost")).await;
+            let result = did_web::resolve_async(&did("did:web:localhost")).await;
 
             PROXY.with(|proxy| {
                 proxy.replace(None);
@@ -338,7 +338,7 @@ mod tests {
                     .body(oversized_body);
             });
 
-            let result = did_web::resolve(&did("did:web:localhost")).await;
+            let result = did_web::resolve_async(&did("did:web:localhost")).await;
 
             PROXY.with(|proxy| {
                 proxy.replace(None);

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -21,7 +21,10 @@
 use std::io::Read;
 
 use super::{did::Did, did_doc::DidDocument};
-use crate::http::{AsyncGenericResolver, AsyncHttpResolver, HttpResolverError};
+use crate::http::{
+    AsyncGenericResolver, AsyncHttpResolver, HttpResolverError, SyncGenericResolver,
+    SyncHttpResolver,
+};
 
 /// Maximum number of bytes accepted from a DID Web server response body.
 pub(crate) const MAX_DID_DOC_SIZE: u64 = 1024 * 1024; // 1 MiB
@@ -110,6 +113,59 @@ async fn get_did_doc(url: &str) -> Result<Vec<u8>, DidWebError> {
     let mut document = Vec::new();
     body.read_to_end(&mut document)
         .map_err(|e| DidWebError::Response(e.into()))?;
+
+    Ok(document)
+}
+
+pub(crate) fn resolve_sync(did: &Did<'_>) -> Result<DidDocument, DidWebError> {
+    let method = did.method_name();
+    #[allow(clippy::panic)] // TEMPORARY while refactoring
+    if method != "web" {
+        panic!("Unexpected DID method {method}");
+    }
+
+    let method_specific_id = did.method_specific_id();
+
+    let url = to_url(method_specific_id)?;
+    // TODO: https://w3c-ccg.github.io/did-method-web/#in-transit-security
+
+    let did_doc = get_did_doc_sync(&url)?;
+
+    let json = String::from_utf8(did_doc).map_err(|_| DidWebError::InvalidData(url.clone()))?;
+
+    DidDocument::from_json(&json).map_err(|_| DidWebError::InvalidData(url))
+}
+
+fn get_did_doc_sync(url: &str) -> Result<Vec<u8>, DidWebError> {
+    let request = http::Request::get(url)
+        .header(header::USER_AGENT, USER_AGENT)
+        .header(header::ACCEPT, "application/did+json")
+        .body(Vec::new())
+        .map_err(|e| DidWebError::Request(url.to_owned(), e.into()))?;
+
+    let response = SyncGenericResolver::with_redirects()
+        .unwrap_or_default()
+        .http_resolve(request)
+        .map_err(|e| match e {
+            HttpResolverError::ResponseTooLarge => DidWebError::ResponseTooLarge,
+            e => DidWebError::Request(url.to_owned(), e),
+        })?;
+
+    let (parts, mut body) = response.into_parts();
+    match parts.status {
+        http::StatusCode::OK => (),
+        http::StatusCode::NOT_FOUND => return Err(DidWebError::NotFound(url.to_string())),
+        _ => return Err(DidWebError::Server(parts.status.to_string())),
+    };
+
+    let mut document = Vec::new();
+    // Read one byte past the limit so we can detect an oversized response.
+    body.take(MAX_DID_DOC_SIZE + 1)
+        .read_to_end(&mut document)
+        .map_err(|e| DidWebError::Response(e.into()))?;
+    if document.len() as u64 > MAX_DID_DOC_SIZE {
+        return Err(DidWebError::ResponseTooLarge);
+    }
 
     Ok(document)
 }


### PR DESCRIPTION
## Changes in this pull request
There are code paths which are purely sync, and which still need to be able to resolve web did.
Example: Reader from files (especially if called through the C FFI in C++).
This PR implements a sync resolver, with the obvious tradeoff that... the resolver is sync. I tried to share as much code as possible between sync and async implementations, hence some small refactors (new functions that get reused).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment. _(Existing TODOs were left in place, not sure they were linked to issues already...)._
