### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.0...c2pa-v0.85.1)
+_01 June 2026_
+
+### Fixed
+
+* Preserve validation status log kind after deserialization ([#2162](https://github.com/contentauth/c2pa-rs/pull/2162))
+* Declare c2pa XML namespace on SVG root, not manifest tag ([#2113](https://github.com/contentauth/c2pa-rs/pull/2113))
+
+### Other
+
+* Avoid buffering intermediate streams if stream len is greater than threshold ([#2178](https://github.com/contentauth/c2pa-rs/pull/2178))
+* Avoid buffering PNG when writing XMP and removing manifest ([#2177](https://github.com/contentauth/c2pa-rs/pull/2177))
+
 ## [0.85.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.84.1...c2pa-v0.85.0)
 _27 May 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.60"
+version = "0.26.61"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.2"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
 dependencies = [
  "clap",
  "heck",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2337,9 +2337,9 @@ checksum = "68cf72bc7b75b6615ffd06bfe6840f3c57e7e4ea615558a2a452f458ebf5551e"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2518,7 +2518,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.85.0"
+version = "0.85.1"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.85.0"
+version = "0.85.1"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.0...c2pa-c-ffi-v0.85.1)
+_01 June 2026_
+
+### Added
+
+* Add Mac Catalyst builds ([#2160](https://github.com/contentauth/c2pa-rs/pull/2160))
+
 ## [0.85.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.84.1...c2pa-c-ffi-v0.85.0)
 _27 May 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.85.0", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.85.1", default-features = false, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.61](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.60...c2patool-v0.26.61)
+_01 June 2026_
+
 ## [0.26.60](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.59...c2patool-v0.26.60)
 _27 May 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.60"
+version = "0.26.61"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -24,7 +24,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-c2pa = { path = "../sdk", version = "0.85.0", features = [
+c2pa = { path = "../sdk", version = "0.85.1", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { path = "../sdk", version = "0.85.0", features = [
+c2pa = { path = "../sdk", version = "0.85.1", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.85.0 -> 0.85.1 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.85.0 -> 0.85.1
* `c2patool`: 0.26.60 -> 0.26.61

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.0...c2pa-v0.85.1)

_01 June 2026_

### Fixed

* Preserve validation status log kind after deserialization ([#2162](https://github.com/contentauth/c2pa-rs/pull/2162))
* Declare c2pa XML namespace on SVG root, not manifest tag ([#2113](https://github.com/contentauth/c2pa-rs/pull/2113))

### Other

* Avoid buffering intermediate streams if stream len is greater than threshold ([#2178](https://github.com/contentauth/c2pa-rs/pull/2178))
* Avoid buffering PNG when writing XMP and removing manifest ([#2177](https://github.com/contentauth/c2pa-rs/pull/2177))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.0...c2pa-c-ffi-v0.85.1)

_01 June 2026_

### Added

* Add Mac Catalyst builds ([#2160](https://github.com/contentauth/c2pa-rs/pull/2160))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.61](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.60...c2patool-v0.26.61)

_01 June 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).