### PR TITLE
chore: update make_test_images baseline JSON files.

### DIFF
--- a/make_test_images/json_manifests_v2/C.json
+++ b/make_test_images/json_manifests_v2/C.json
@@ -1,21 +1,20 @@
 {
-  "active_manifest": "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth",
+  "active_manifest": "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth",
   "manifests": {
-    "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth": {
+    "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "C.jpg",
-      "instance_id": "xmp:iid:f31e250d-3fdf-48f4-bb10-afc1def59d80",
+      "instance_id": "xmp:iid:ea77291f-cdf6-4532-bb45-8c7e25dca024",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
-      "ingredients": [],
       "assertions": [
         {
           "label": "c2pa.actions.v2",
@@ -23,73 +22,87 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth"
+      "label": "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     }
   },
   "validation_state": "Valid"

--- a/make_test_images/json_manifests_v2/CA.json
+++ b/make_test_images/json_manifests_v2/CA.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+  "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,83 +50,108 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
-    }
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Valid"
 }

--- a/make_test_images/json_manifests_v2/CACA.json
+++ b/make_test_images/json_manifests_v2/CACA.json
@@ -1,94 +1,115 @@
 {
-  "active_manifest": "urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth",
+  "active_manifest": "urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth",
   "manifests": {
-    "urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth": {
+    "urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CACA.jpg",
-      "instance_id": "xmp:iid:1de570bc-0372-4aeb-a0ec-ee12cd3f317e",
+      "instance_id": "xmp:iid:894a0b81-8fac-4b0c-9888-eae627c94cb7",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
           "title": "CA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:323feb8c-8b0e-4f0b-87bf-8b3ee191d6a0",
+          "instance_id": "xmp:iid:d76c0b9b-5582-4abe-a66b-3204c49fa157",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
           },
           "label": "c2pa.ingredient.v3"
         }
@@ -104,7 +125,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "yoa6J96OcLOdqTz4HT3UXpwgUsUoeay5T46zBG+1Q1c="
+                      "hash": "ozpopyieL7/+uHBKyNass68/6yTSAmQ05gzhF+VvIn4="
                     }
                   ]
                 }
@@ -115,32 +136,33 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:48+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth"
+      "label": "urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth",
+      "claim_version": 2
     },
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -149,7 +171,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -166,7 +188,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -177,86 +199,100 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:8cf21017-2951-4c4a-997f-045b46774aa1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:f2efe145-cf16-4185-af67-6ebba8dc5a8e:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CACAE-uri-CA.json
+++ b/make_test_images/json_manifests_v2/CACAE-uri-CA.json
@@ -1,322 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth",
+  "active_manifest": "urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth",
   "manifests": {
-    "urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CACAE-uri-CA.jpg",
-      "instance_id": "xmp:iid:49198dfd-c394-446b-8d4d-036bf0ee85af",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "CAE-uri-CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:3b5a84cf-9c2f-40d1-a83b-3465386d4908",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            },
-            "ingredientDeltas": [
-              {
-                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                "validationDeltas": {
-                  "success": [
-                    {
-                      "code": "ingredient.manifest.validated",
-                      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-                      "explanation": "ingredient hash matched"
-                    }
-                  ],
-                  "informational": [],
-                  "failure": []
-                }
-              }
-            ]
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "YpLtGdqah/vExwWB3m5Io8nchMufz5rCiiMS8Ro+7D4="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "YpLtGdqah/vExwWB3m5Io8nchMufz5rCiiMS8Ro+7D4="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:52+00:00"
-      },
-      "label": "urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth"
-    },
-    "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CAE-uri-CA.jpg",
-      "instance_id": "xmp:iid:49d6d5c9-f446-4cb6-b709-5f21699d88f4",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "E-uri-CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:cb30ecf5-aa36-470e-bb8d-e13d9c026a86",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": [
-                {
-                  "code": "assertion.hashedURI.mismatch",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                }
-              ]
-            }
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "0X+UvcoARMDaAH7k64cFjst+gsQv/iSmld2fe/KNeHg="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "0X+UvcoARMDaAH7k64cFjst+gsQv/iSmld2fe/KNeHg="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:51+00:00"
-      },
-      "label": "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth"
-    },
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -325,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -342,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -353,86 +50,408 @@
                   "name": "brightnessdeadbeef"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CAE-uri-CA.jpg",
+      "instance_id": "xmp:iid:ee990bea-b59a-4060-bc3c-34a736424387",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "E-uri-CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:da8677f7-38d4-4a60-9f01-ec1454392107",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                },
+                {
+                  "code": "assertion.hashedURI.mismatch",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "X6/Z4cXo5k8VYhYSEYQFci/L+T4uqTw2U3V00OFKAzA="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:19+00:00"
+      },
+      "label": "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CACAE-uri-CA.jpg",
+      "instance_id": "xmp:iid:56374787-e89d-41e0-b9a1-604f85fda015",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "CAE-uri-CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:43da6897-9cb8-4782-9cab-a7521c839294",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [
+                    {
+                      "code": "ingredient.manifest.validated",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+                      "explanation": "ingredient hash matched"
+                    }
+                  ],
+                  "informational": [],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "XgbnWvvSgvrHUyjQta2XUJ4n5VRBgI+EOKZPtDhCxr0="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:19+00:00"
+      },
+      "label": "urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3c7b60bf-7aba-4e93-b1bd-49cfe5bdbdb4:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:2a40056a-55a6-4102-b56f-2476fa25c054:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CACAICAICICA.json
+++ b/make_test_images/json_manifests_v2/CACAICAICICA.json
@@ -1,584 +1,115 @@
 {
-  "active_manifest": "urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth",
+  "active_manifest": "urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "A.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "parentOf",
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
-      },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
-    },
-    "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CAICA.jpg",
-      "instance_id": "xmp:iid:6c006ecb-bb4f-42d1-9196-67862526ed81",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "A.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "parentOf",
-          "label": "c2pa.ingredient.v3"
-        },
-        {
-          "title": "CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:5c21dd78-966a-4c55-bbc6-2d4d91cb71a2",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            }
-          },
-          "label": "c2pa.ingredient.v3__1"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "rkifcfPhHY8DcE9RVs+rPKMvVcJU1wcT5NMKJSnbyRg="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "rmeMnABlmPTO1wjE70yWVkPCQaLfLL176vzkK8+wJNc="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "rmeMnABlmPTO1wjE70yWVkPCQaLfLL176vzkK8+wJNc="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
-      },
-      "label": "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth"
-    },
-    "urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CACAICAICICA.jpg",
-      "instance_id": "xmp:iid:2f3a2449-7579-4a9e-998e-0f743991f0c8",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "CAICA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:c6c5ef22-8832-4a5a-b760-8954e7b329b5",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            },
-            "ingredientDeltas": [
-              {
-                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-                "validationDeltas": {
-                  "success": [
-                    {
-                      "code": "ingredient.manifest.validated",
-                      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-                      "explanation": "ingredient hash matched"
-                    }
-                  ],
-                  "informational": [],
-                  "failure": []
-                }
-              }
-            ]
-          },
-          "label": "c2pa.ingredient.v3"
-        },
-        {
-          "title": "CICA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:a78f66cf-0350-4d15-b4ab-a160a387e16d",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            },
-            "ingredientDeltas": [
-              {
-                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                "validationDeltas": {
-                  "success": [
-                    {
-                      "code": "ingredient.manifest.validated",
-                      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-                      "explanation": "ingredient hash matched"
-                    }
-                  ],
-                  "informational": [],
-                  "failure": []
-                }
-              }
-            ]
-          },
-          "label": "c2pa.ingredient.v3__1"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "3A3rXhtYp/LIHGm1gIqFCkf5tIlBRvAzy85uUDIzxck="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "qK0LJGFaZeNpzt7x9OWYKdH0dOqUlyJV7n58SrAQF6M="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "qK0LJGFaZeNpzt7x9OWYKdH0dOqUlyJV7n58SrAQF6M="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:50+00:00"
-      },
-      "label": "urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth"
-    },
-    "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CICA.jpg",
-      "instance_id": "xmp:iid:0411e4d8-4a9d-4389-976d-a27a395f28c6",
+      "instance_id": "xmp:iid:4dc81412-39b1-43ff-b286-27892885ad29",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
           "title": "CA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:57cd7057-4c8b-4fd5-8be0-bc6c79f355f4",
+          "instance_id": "xmp:iid:69f3e1b6-6674-4e1e-b02e-111e65eaf850",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
           },
           "label": "c2pa.ingredient.v3"
         }
@@ -590,7 +121,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -602,120 +133,639 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
+                      "hash": "bH16CZZncz+9Mz3o/klB10vDL1phGedcoMwrTM2aQAY="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:50+00:00"
+        "time": "2026-05-27T20:42:17+00:00"
       },
-      "label": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth"
+      "label": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CA.jpg",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "A.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:14+00:00"
+      },
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CACAICAICICA.jpg",
+      "instance_id": "xmp:iid:1e16291c-9b59-433c-8f37-68f9be6cf077",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "CAICA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:7148a07c-7ade-4cb7-a811-974fb71b7e8c",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              },
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                "validationDeltas": {
+                  "success": [
+                    {
+                      "code": "ingredient.manifest.validated",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+                      "explanation": "ingredient hash matched"
+                    }
+                  ],
+                  "informational": [],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        },
+        {
+          "title": "CICA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:cb85f5aa-c76b-47e1-a4a5-fbc5b9df5012",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [
+                    {
+                      "code": "ingredient.manifest.validated",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+                      "explanation": "ingredient hash matched"
+                    }
+                  ],
+                  "informational": [],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth"
+          },
+          "label": "c2pa.ingredient.v3__1"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "thuAy2mRv7MJp64ElE5V+YeYsNVHim//iJ4oubmD8j8="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                      "hash": "F918D+mNeEQ/WGyzMp+0LGMOCfOEpUozf74NAQEtJG4="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:18+00:00"
+      },
+      "label": "urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CAICA.jpg",
+      "instance_id": "xmp:iid:dad8f172-2c76-44ea-ab52-f80f632597c7",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "A.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "label": "c2pa.ingredient.v3"
+        },
+        {
+          "title": "CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:95a09aa5-27a3-436b-94c2-1fc0e258315b",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3__1"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "Hf2DJo8ROcuhrW72LjQL2HZD5gB6uWdZ2bYY4zDpoYc="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                      "hash": "8rClleqBN3R1HST+oMWg8IZtKlgHB4hWPh3l7wMoVdk="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:17+00:00"
+      },
+      "label": "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],
@@ -724,12 +774,12 @@
         }
       },
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3473630f-5cb7-496f-bfaf-e5059b73dc9b:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:be0c28c8-3b56-4086-a35e-8cb478f6bc76:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CAE-uri-CA.json
+++ b/make_test_images/json_manifests_v2/CAE-uri-CA.json
@@ -1,19 +1,173 @@
 {
-  "active_manifest": "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth",
+  "active_manifest": "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CAE-uri-CA.jpg",
+      "instance_id": "xmp:iid:ee990bea-b59a-4060-bc3c-34a736424387",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "E-uri-CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:da8677f7-38d4-4a60-9f01-ec1454392107",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                },
+                {
+                  "code": "assertion.hashedURI.mismatch",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "X6/Z4cXo5k8VYhYSEYQFci/L+T4uqTw2U3V00OFKAzA="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:19+00:00"
+      },
+      "label": "urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +176,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +193,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,235 +204,100 @@
                   "name": "brightnessdeadbeef"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
-    },
-    "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CAE-uri-CA.jpg",
-      "instance_id": "xmp:iid:49d6d5c9-f446-4cb6-b709-5f21699d88f4",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "E-uri-CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:cb30ecf5-aa36-470e-bb8d-e13d9c026a86",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": [
-                {
-                  "code": "assertion.hashedURI.mismatch",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                }
-              ]
-            }
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "0X+UvcoARMDaAH7k64cFjst+gsQv/iSmld2fe/KNeHg="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "0X+UvcoARMDaAH7k64cFjst+gsQv/iSmld2fe/KNeHg="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:51+00:00"
-      },
-      "label": "urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:a2ab51e7-45ce-4567-a2cf-b770440ef0b1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddfdb68c-354f-44d9-b170-0d56dc3b79ca:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CAI.json
+++ b/make_test_images/json_manifests_v2/CAI.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth",
+  "active_manifest": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
   "manifests": {
-    "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth": {
+    "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CAI.jpg",
-      "instance_id": "xmp:iid:4f583422-38d0-4688-9284-ba98624514d7",
+      "instance_id": "xmp:iid:e2ed16a4-87b0-4935-b1c8-9bb7ca3bd6af",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -33,7 +33,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3__1"
@@ -50,7 +50,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "7/sJ8lBGiWH0FOTgtWb6dUHjAcA1VOdOERoaDvHnCk8="
+                      "hash": "/wktJm0cLSuA7NZaiOx8957bx0k4AREKySafZ1Jw5Xw="
                     }
                   ]
                 }
@@ -67,117 +67,140 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
+                      "hash": "7xueQhPcTQ0BvrpyfjMQNJkC+RXfy6mSlFPa33DkWgg="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
+        "time": "2026-05-27T20:42:16+00:00"
       },
-      "label": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth"
+      "label": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
-    }
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      },
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+              "explanation": "I.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Valid"
 }

--- a/make_test_images/json_manifests_v2/CAIAIIICAICIICAIICICA.json
+++ b/make_test_images/json_manifests_v2/CAIAIIICAICIICAIICICA.json
@@ -1,260 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth",
+  "active_manifest": "urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth",
   "manifests": {
-    "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth": {
+    "urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CAI.jpg",
-      "instance_id": "xmp:iid:4f583422-38d0-4688-9284-ba98624514d7",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "A.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "parentOf",
-          "label": "c2pa.ingredient.v3"
-        },
-        {
-          "title": "I.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
-          },
-          "relationship": "componentOf",
-          "label": "c2pa.ingredient.v3__1"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "7/sJ8lBGiWH0FOTgtWb6dUHjAcA1VOdOERoaDvHnCk8="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
-      },
-      "label": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth"
-    },
-    "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CICA.jpg",
-      "instance_id": "xmp:iid:0411e4d8-4a9d-4389-976d-a27a395f28c6",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:57cd7057-4c8b-4fd5-8be0-bc6c79f355f4",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            }
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:50+00:00"
-      },
-      "label": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth"
-    },
-    "urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CAIAIIICAICIICAIICICA.jpg",
-      "instance_id": "xmp:iid:451dc5d3-33b9-4012-86fc-e7ac8e66906c",
+      "instance_id": "xmp:iid:4dc2e857-5a68-4ad2-abd0-c67766b47f49",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -263,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -271,61 +30,71 @@
         {
           "title": "C.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:14d89387-1837-4ec1-b0a8-cea15ff665e6",
+          "instance_id": "xmp:iid:88c592d9-7083-48c3-a1df-9fcbfdef83d8",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth",
+          "active_manifest": "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
             }
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth"
           },
           "label": "c2pa.ingredient.v3__1"
         },
@@ -335,7 +104,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__2"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3__2"
@@ -343,322 +112,400 @@
         {
           "title": "CA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:f313244a-a47a-494d-9ace-59d51caff1c9",
+          "instance_id": "xmp:iid:63239a22-35c7-45c6-aa2d-f064060ece3c",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__3"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
           },
           "label": "c2pa.ingredient.v3__3"
         },
         {
           "title": "CI.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:e7b58837-2743-4d15-95c7-16c40f35febf",
+          "instance_id": "xmp:iid:3dc78baf-7b0b-47dc-ae20-d1bbdcf016b7",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__4"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth",
+          "active_manifest": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "I.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "I.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth"
           },
           "label": "c2pa.ingredient.v3__4"
         },
         {
           "title": "CAI.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:43d3b9d1-c385-4438-9748-2322fd08e402",
+          "instance_id": "xmp:iid:88531c5c-4a08-4d26-872f-57df9912f3e2",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__5"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth",
+          "active_manifest": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-                  "explanation": "I.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              },
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                      "explanation": "I.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth"
           },
           "label": "c2pa.ingredient.v3__5"
         },
         {
           "title": "CICA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:b267369b-0632-41c3-8862-073dd1ef044c",
+          "instance_id": "xmp:iid:65104e9d-99e5-4165-8d87-9a105168818f",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__6"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth",
+          "active_manifest": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
             },
             "ingredientDeltas": [
               {
-                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                 "validationDeltas": {
                   "success": [
                     {
                       "code": "ingredient.manifest.validated",
-                      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
                       "explanation": "ingredient hash matched"
                     }
                   ],
@@ -667,6 +514,10 @@
                 }
               }
             ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth"
           },
           "label": "c2pa.ingredient.v3__6"
         }
@@ -682,7 +533,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "noRBlAtLbDGUJH1FQI+sojORZJ0qd7dBiwrHMge++zc="
+                      "hash": "9o3kWfD62UJFamkAcLfpNMgbyJMJ7agIm9VBFWpK98E="
                     }
                   ]
                 }
@@ -699,7 +550,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "EPDbwdCYpIQUFYeTIg8mDDHaurucFwLQy4wcwSJknNY="
+                      "hash": "KLGfXI9MItVX55Cf/m3ct16FLzJZEHdEXP3ethkma/0="
                     }
                   ]
                 }
@@ -710,7 +561,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "noRBlAtLbDGUJH1FQI+sojORZJ0qd7dBiwrHMge++zc="
+                      "hash": "9o3kWfD62UJFamkAcLfpNMgbyJMJ7agIm9VBFWpK98E="
                     }
                   ]
                 }
@@ -721,7 +572,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2",
-                      "hash": "ToW8tilMuxGeBN7BilyPJ+7LA5JJ9rMltYUwEJvFs70="
+                      "hash": "QOmCeRuWZJq1VIzf79iEGvXt4SZ50vKzY8rq6Ux/inM="
                     }
                   ]
                 }
@@ -732,7 +583,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__3",
-                      "hash": "pbb5UxRfP2XqLZEbOQU5woWTFmQgjZfCWbo/ZRI6BS4="
+                      "hash": "/JdtR++YkXwu+0Uiy/61tFyCUmNc39aMU2oHkdAq/Dc="
                     }
                   ]
                 }
@@ -743,7 +594,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__4",
-                      "hash": "NkXrKQpgVS1kVTE/Rf+rgmj3VRlF7hp34TsWOF2aGAY="
+                      "hash": "/t7WSPgasXNoAa4guC/wGl/ZDVA6ycVTk4DQaZhQidM="
                     }
                   ]
                 }
@@ -754,7 +605,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__5",
-                      "hash": "FSPub67/a2lwntje1HHmScCKdKn2DwSa8JiouhwPDEQ="
+                      "hash": "rDbwq5mf2seKrbXWnMDw0YQv4EZA1kx+OF4W8RQoGiI="
                     }
                   ]
                 }
@@ -765,108 +616,42 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__6",
-                      "hash": "S6t03V5xCecgK21YOcmDF0G5asnnRUcyoFs2sJadFP0="
+                      "hash": "tY79G4UwlbWBcUnK8LB601o8ot4sh/HOxiq8RewDzBo="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__4",
-                      "hash": "NkXrKQpgVS1kVTE/Rf+rgmj3VRlF7hp34TsWOF2aGAY="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__5",
-                      "hash": "FSPub67/a2lwntje1HHmScCKdKn2DwSa8JiouhwPDEQ="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__6",
-                      "hash": "S6t03V5xCecgK21YOcmDF0G5asnnRUcyoFs2sJadFP0="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2",
-                      "hash": "ToW8tilMuxGeBN7BilyPJ+7LA5JJ9rMltYUwEJvFs70="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "EPDbwdCYpIQUFYeTIg8mDDHaurucFwLQy4wcwSJknNY="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__3",
-                      "hash": "pbb5UxRfP2XqLZEbOQU5woWTFmQgjZfCWbo/ZRI6BS4="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:52+00:00"
+        "time": "2026-05-27T20:42:20+00:00"
       },
-      "label": "urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth"
+      "label": "urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth",
+      "claim_version": 2
     },
-    "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth": {
+    "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "C.jpg",
-      "instance_id": "xmp:iid:f31e250d-3fdf-48f4-bb10-afc1def59d80",
+      "instance_id": "xmp:iid:ea77291f-cdf6-4532-bb45-8c7e25dca024",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
-      "ingredients": [],
       "assertions": [
         {
           "label": "c2pa.actions.v2",
@@ -874,38 +659,39 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth"
+      "label": "urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth",
+      "claim_version": 2
     },
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -914,7 +700,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -931,7 +717,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -942,32 +728,33 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     },
-    "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth": {
+    "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CI.jpg",
-      "instance_id": "xmp:iid:ec137b66-38c0-478d-a6f1-4793a908f3fd",
+      "instance_id": "xmp:iid:57a816b2-ee5e-48d4-8073-f23f8aa76e57",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -976,7 +763,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3"
@@ -989,7 +776,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -1001,13 +788,241 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
+                      "hash": "zMkNHrPOM73VKPO6UW8Zo0iZpDzK0fwfSzUew1dlXLo="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:15+00:00"
+      },
+      "label": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CAI.jpg",
+      "instance_id": "xmp:iid:e2ed16a4-87b0-4935-b1c8-9bb7ca3bd6af",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "A.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "label": "c2pa.ingredient.v3"
+        },
+        {
+          "title": "I.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
+          },
+          "relationship": "componentOf",
+          "label": "c2pa.ingredient.v3__1"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "/wktJm0cLSuA7NZaiOx8957bx0k4AREKySafZ1Jw5Xw="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                      "hash": "7xueQhPcTQ0BvrpyfjMQNJkC+RXfy6mSlFPa33DkWgg="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:16+00:00"
+      },
+      "label": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CICA.jpg",
+      "instance_id": "xmp:iid:4dc81412-39b1-43ff-b286-27892885ad29",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:69f3e1b6-6674-4e1e-b02e-111e65eaf850",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
               },
               {
                 "action": "c2pa.placed",
@@ -1015,29 +1030,38 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
+                      "hash": "bH16CZZncz+9Mz3o/klB10vDL1phGedcoMwrTM2aQAY="
                     }
                   ]
                 }
+              },
+              {
+                "action": "c2pa.resized"
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:48+00:00"
+        "time": "2026-05-27T20:42:17+00:00"
       },
-      "label": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth"
+      "label": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
+      "claim_version": 2
     }
   },
   "validation_status": [
     {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    },
+    {
       "code": "assertion.action.ingredientMismatch",
-      "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.actions.v2",
+      "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.actions.v2",
       "explanation": "action must have valid ingredient with ComponentOf relationship"
     }
   ],
@@ -1046,143 +1070,152 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
-        },
-        {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__2",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__2"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__3",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__3"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__4",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__4",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__4"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__4",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__4"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__5",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__5",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__5"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__5",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__5"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__6",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__6",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__6"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__6",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__6"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__2",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
       "failure": [
         {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        },
+        {
           "code": "assertion.action.ingredientMismatch",
-          "url": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "action must have valid ingredient with ComponentOf relationship"
         }
       ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      },
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:e8cfb0d0-8bd3-41db-abb9-68a8e4aa1bbf:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:c62d4c75-4814-45a9-b412-067bb80c96de:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],
@@ -1191,12 +1224,26 @@
         }
       },
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__4",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__2",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__2",
+              "explanation": "I.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      },
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__4",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],
@@ -1205,12 +1252,12 @@
         }
       },
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__5",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__5",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],
@@ -1219,12 +1266,12 @@
         }
       },
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:ddf6dbba-42e3-4e13-8c39-29b9b68c07f8:contentauth/c2pa.assertions/c2pa.ingredient.v3__6",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:0c2a0c53-7a24-44f9-ad21-7392571cad07:contentauth/c2pa.assertions/c2pa.ingredient.v3__6",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CAICA.json
+++ b/make_test_images/json_manifests_v2/CAICA.json
@@ -1,81 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth",
+  "active_manifest": "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "A.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "parentOf",
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
-      },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
-    },
-    "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CAICA.jpg",
-      "instance_id": "xmp:iid:6c006ecb-bb4f-42d1-9196-67862526ed81",
+      "instance_id": "xmp:iid:dad8f172-2c76-44ea-ab52-f80f632597c7",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -84,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -92,76 +30,97 @@
         {
           "title": "CA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:5c21dd78-966a-4c55-bbc6-2d4d91cb71a2",
+          "instance_id": "xmp:iid:95a09aa5-27a3-436b-94c2-1fc0e258315b",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
           },
           "label": "c2pa.ingredient.v3__1"
         }
@@ -177,7 +136,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "rkifcfPhHY8DcE9RVs+rPKMvVcJU1wcT5NMKJSnbyRg="
+                      "hash": "Hf2DJo8ROcuhrW72LjQL2HZD5gB6uWdZ2bYY4zDpoYc="
                     }
                   ]
                 }
@@ -194,120 +153,195 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "rmeMnABlmPTO1wjE70yWVkPCQaLfLL176vzkK8+wJNc="
+                      "hash": "8rClleqBN3R1HST+oMWg8IZtKlgHB4hWPh3l7wMoVdk="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "rmeMnABlmPTO1wjE70yWVkPCQaLfLL176vzkK8+wJNc="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
+        "time": "2026-05-27T20:42:17+00:00"
       },
-      "label": "urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth"
+      "label": "urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CA.jpg",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "A.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:14+00:00"
+      },
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:4bfa271c-dfdb-4256-8fa0-c2f66540eac1:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      },
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:c7f92158-7204-4520-8328-d318f001fb43:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CAICAI.json
+++ b/make_test_images/json_manifests_v2/CAICAI.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth",
+  "active_manifest": "urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth",
   "manifests": {
-    "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth": {
+    "urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
-      "title": "CAI.jpg",
-      "instance_id": "xmp:iid:4f583422-38d0-4688-9284-ba98624514d7",
+      "title": "CAICAI.jpg",
+      "instance_id": "xmp:iid:080b4cdb-4d9d-4b69-bafa-61f5b734023f",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,205 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "parentOf",
+          "label": "c2pa.ingredient.v3"
+        },
+        {
+          "title": "CAI.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:949a8e1c-4841-4dfd-8df0-4cd2739ba2b8",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              },
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+                      "explanation": "I.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth"
+          },
+          "label": "c2pa.ingredient.v3__1"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "jwmTdY4x8OkT2biVwylG+uKExzEhpyn0rkwvmDPoLEs="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.color_adjustments",
+                "parameters": {
+                  "name": "brightnesscontrast"
+                }
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                      "hash": "MBegJpmoZZalv5Nx0nxQqdLcqxqGtHTWYZP4qogLTWM="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:17+00:00"
+      },
+      "label": "urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CAI.jpg",
+      "instance_id": "xmp:iid:e2ed16a4-87b0-4935-b1c8-9bb7ca3bd6af",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "A.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -33,7 +231,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3__1"
@@ -50,7 +248,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "7/sJ8lBGiWH0FOTgtWb6dUHjAcA1VOdOERoaDvHnCk8="
+                      "hash": "/wktJm0cLSuA7NZaiOx8957bx0k4AREKySafZ1Jw5Xw="
                     }
                   ]
                 }
@@ -67,303 +265,132 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
+                      "hash": "7xueQhPcTQ0BvrpyfjMQNJkC+RXfy6mSlFPa33DkWgg="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "6oKhrZ2GKYMBtiIBku5g0beNOY+rSa6MOdmWhansBho="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
+        "time": "2026-05-27T20:42:16+00:00"
       },
-      "label": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth"
-    },
-    "urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CAICAI.jpg",
-      "instance_id": "xmp:iid:a91b2d84-0a4b-4539-9ce0-820fd32861e8",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "A.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "parentOf",
-          "label": "c2pa.ingredient.v3"
-        },
-        {
-          "title": "CAI.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:701b0cdd-37b1-43c0-b2e1-d1bd888dbb47",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-                  "explanation": "I.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            }
-          },
-          "label": "c2pa.ingredient.v3__1"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "K811tTryjaZq5I82L6+daoPjKuj/uv7FlGWANfiTYoc="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.color_adjustments",
-                "parameters": {
-                  "name": "brightnesscontrast"
-                }
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "T5Le8LfzBb8qpImbJFLiCdqbvc1aGiBKoMPr+ExCS/g="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
-                      "hash": "T5Le8LfzBb8qpImbJFLiCdqbvc1aGiBKoMPr+ExCS/g="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:50+00:00"
-      },
-      "label": "urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth"
+      "label": "urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient__1",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient__1"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:51485e5e-651a-459c-8398-12e60640fc80:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      },
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3ab088cb-e1c9-4eb2-87fc-559f522728e5:contentauth/c2pa.assertions/c2pa.ingredient.v3__1",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:3d135cf6-8156-4206-929a-b72fb4a32686:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:92a3d8e4-4971-4112-bddc-0f3694e16158:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CI.json
+++ b/make_test_images/json_manifests_v2/CI.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth",
+  "active_manifest": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
   "manifests": {
-    "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth": {
+    "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CI.jpg",
-      "instance_id": "xmp:iid:ec137b66-38c0-478d-a6f1-4793a908f3fd",
+      "instance_id": "xmp:iid:57a816b2-ee5e-48d4-8073-f23f8aa76e57",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3"
@@ -35,7 +35,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -47,102 +47,116 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
+                      "hash": "zMkNHrPOM73VKPO6UW8Zo0iZpDzK0fwfSzUew1dlXLo="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:48+00:00"
+        "time": "2026-05-27T20:42:15+00:00"
       },
-      "label": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth"
+      "label": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
-    }
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "I.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Valid"
 }

--- a/make_test_images/json_manifests_v2/CICA.json
+++ b/make_test_images/json_manifests_v2/CICA.json
@@ -1,162 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth",
+  "active_manifest": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
   "manifests": {
-    "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CICA.jpg",
-      "instance_id": "xmp:iid:0411e4d8-4a9d-4389-976d-a27a395f28c6",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:57cd7057-4c8b-4fd5-8be0-bc6c79f355f4",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": []
-            }
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "vTzFIcvoobupu645c5gRYEHfs58EP2zTCLeWEFy7wVU="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:50+00:00"
-      },
-      "label": "urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth"
-    },
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -165,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -182,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -193,86 +50,254 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CICA.jpg",
+      "instance_id": "xmp:iid:4dc81412-39b1-43ff-b286-27892885ad29",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:69f3e1b6-6674-4e1e-b02e-111e65eaf850",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "bH16CZZncz+9Mz3o/klB10vDL1phGedcoMwrTM2aQAY="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:17+00:00"
+      },
+      "label": "urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d67c2ffe-e8ab-4792-85cf-8fdf281fa847:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:3be5bfa0-f6f2-4654-862e-0d50d2b77102:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CICACACA.json
+++ b/make_test_images/json_manifests_v2/CICACACA.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth",
+  "active_manifest": "urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,107 +50,129 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     },
-    "urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth": {
+    "urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CICACACA.jpg",
-      "instance_id": "xmp:iid:85315938-4834-4e95-a67a-c830bd2b0dfd",
+      "instance_id": "xmp:iid:632575a0-b258-4685-af75-7f40058205cf",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
           "title": "CA.jpg",
           "format": "image/jpeg",
-          "instance_id": "xmp:iid:390094f5-bda0-4373-bb86-c4dd6d4d070d",
+          "instance_id": "xmp:iid:d71dcae9-4e16-44e2-8e04-da98bab03780",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
           "validation_results": {
             "activeManifest": {
               "success": [
                 {
                   "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 },
                 {
                   "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "claim signature valid"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
                 },
                 {
                   "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
                   "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
                 },
                 {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
                   "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
                   "explanation": "data hash valid"
                 }
               ],
               "informational": [
                 {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
                   "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
                   "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
                 }
               ],
-              "failure": []
-            }
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
           },
           "label": "c2pa.ingredient.v3"
         }
@@ -162,7 +184,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -174,7 +196,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "ysoz0Vhe6lFlNKxQIKW25wjcDvmADCTTVMX2JdbMca4="
+                      "hash": "cQyLyFzpAZTp4AQ7ERsBC1MyVhf1TqEbQrt1+bkKqBo="
                     }
                   ]
                 }
@@ -185,7 +207,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "ysoz0Vhe6lFlNKxQIKW25wjcDvmADCTTVMX2JdbMca4="
+                      "hash": "cQyLyFzpAZTp4AQ7ERsBC1MyVhf1TqEbQrt1+bkKqBo="
                     }
                   ]
                 }
@@ -196,105 +218,108 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "ysoz0Vhe6lFlNKxQIKW25wjcDvmADCTTVMX2JdbMca4="
+                      "hash": "cQyLyFzpAZTp4AQ7ERsBC1MyVhf1TqEbQrt1+bkKqBo="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "ysoz0Vhe6lFlNKxQIKW25wjcDvmADCTTVMX2JdbMca4="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:51+00:00"
+        "time": "2026-05-27T20:42:18+00:00"
       },
-      "label": "urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth"
+      "label": "urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:f4aa4b46-ad72-430f-b371-b8792266bc7a:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:855bd853-bb73-440e-9d59-9ac31da28666:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CIE-sig-CA.json
+++ b/make_test_images/json_manifests_v2/CIE-sig-CA.json
@@ -1,158 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth",
+  "active_manifest": "urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth",
   "manifests": {
-    "urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth": {
-      "claim_generator_info": [
-        {
-          "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
-        }
-      ],
-      "title": "CIE-sig-CA.jpg",
-      "instance_id": "xmp:iid:b3ee26aa-52ae-4ef5-937c-803f56ce8106",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "title": "E-sig-CA.jpg",
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:c63a8a8f-76bc-47dc-948f-a45047ecf47e",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [
-                {
-                  "code": "ingredient.unknownProvenance",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-                  "explanation": "A.jpg: ingredient does not have provenance"
-                },
-                {
-                  "code": "timeStamp.untrusted",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
-                }
-              ],
-              "failure": [
-                {
-                  "code": "claimSignature.mismatch",
-                  "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
-                  "explanation": "claim signature is not valid"
-                }
-              ]
-            }
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
-                "parameters": {
-                  "name": "gradient"
-                },
-                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Ev5mjQzeFvdk7jnK20F3b9HBUHXYHCFE8vev5z0TIsE="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Ev5mjQzeFvdk7jnK20F3b9HBUHXYHCFE8vev5z0TIsE="
-                    }
-                  ]
-                }
-              }
-            ],
-            "allActionsIncluded": true
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:51+00:00"
-      },
-      "label": "urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth"
-    },
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_xxxxxx",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -161,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -178,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -189,91 +50,249 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
+    },
+    "urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth": {
+      "claim_generator_info": [
+        {
+          "name": "make_test_images",
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
+        }
+      ],
+      "title": "CIE-sig-CA.jpg",
+      "instance_id": "xmp:iid:e61cd019-7afd-4ff5-9b82-e820101e2a24",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "title": "E-sig-CA.jpg",
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:c2df16c1-5e09-4a5b-bf8a-053fdfab388a",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
+          },
+          "relationship": "componentOf",
+          "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "timeStamp.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
+                }
+              ],
+              "failure": [
+                {
+                  "code": "signingCredential.untrusted",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "signing certificate untrusted"
+                },
+                {
+                  "code": "claimSignature.mismatch",
+                  "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+                  "explanation": "claim signature is not valid"
+                }
+              ]
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ]
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.created",
+                "softwareAgent": "Make Test Images 0.85.0",
+                "parameters": {
+                  "name": "gradient"
+                },
+                "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia"
+              },
+              {
+                "action": "c2pa.placed",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "ST0sr4UmjTLenOezumprw5FoLXvsJU3qdCqutYDTtJI="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.resized"
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-05-27T20:42:19+00:00"
+      },
+      "label": "urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:bd081a24-8c60-469c-b88a-f00691bf9045:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:930aa903-b4c7-44be-a98e-45ffe8840ad3:contentauth/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
               "code": "ingredient.manifest.validated",
-              "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
               "explanation": "ingredient hash matched"
             }
           ],

--- a/make_test_images/json_manifests_v2/CII.json
+++ b/make_test_images/json_manifests_v2/CII.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth",
+  "active_manifest": "urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth",
   "manifests": {
-    "urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth": {
+    "urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CII.jpg",
-      "instance_id": "xmp:iid:cf52ccbb-fa9f-4345-a0ff-0a6c3cb303f5",
+      "instance_id": "xmp:iid:b0c8a9df-f667-4250-99b1-cca67c06e585",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3"
@@ -35,7 +35,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -47,7 +47,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "E2HVoAy/8oCX+wKn0likGjyDVJ/FhqYb8zpmn6+01oE="
+                      "hash": "nWOCv9fhu7rlXFEjqh3EaaberlzrmsZTlG+nk7YWEjQ="
                     }
                   ]
                 }
@@ -58,102 +58,116 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "E2HVoAy/8oCX+wKn0likGjyDVJ/FhqYb8zpmn6+01oE="
+                      "hash": "nWOCv9fhu7rlXFEjqh3EaaberlzrmsZTlG+nk7YWEjQ="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "E2HVoAy/8oCX+wKn0likGjyDVJ/FhqYb8zpmn6+01oE="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:49+00:00"
+        "time": "2026-05-27T20:42:16+00:00"
       },
-      "label": "urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth"
+      "label": "urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth",
+      "claim_version": 2
     }
   },
+  "validation_status": [
+    {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    }
+  ],
   "validation_results": {
     "activeManifest": {
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:22609d00-6303-4ff7-9851-38a3425f8e21:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
-      "failure": []
-    }
+      "failure": [
+        {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        }
+      ]
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:1077faa4-cdab-4c01-8514-c7d7a46de520:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "I.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Valid"
 }

--- a/make_test_images/json_manifests_v2/E-sig-CA.json
+++ b/make_test_images/json_manifests_v2/E-sig-CA.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+  "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_xxxxxx",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,24 +50,30 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
   "validation_status": [
     {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    },
+    {
       "code": "claimSignature.mismatch",
-      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
       "explanation": "claim signature is not valid"
     }
   ],
@@ -76,60 +82,76 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
       "failure": [
         {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        },
+        {
           "code": "claimSignature.mismatch",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature is not valid"
         }
       ]
-    }
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Invalid"
 }

--- a/make_test_images/json_manifests_v2/E-uri-CA.json
+++ b/make_test_images/json_manifests_v2/E-uri-CA.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+  "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,24 +50,30 @@
                   "name": "brightnessdeadbeef"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
   "validation_status": [
     {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    },
+    {
       "code": "assertion.hashedURI.mismatch",
-      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
       "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
     }
   ],
@@ -76,65 +82,81 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-        },
-        {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
       "failure": [
         {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        },
+        {
           "code": "assertion.hashedURI.mismatch",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hash does not match assertion data: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         }
       ]
-    }
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Invalid"
 }

--- a/make_test_images/json_manifests_v2/XCA.json
+++ b/make_test_images/json_manifests_v2/XCA.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth",
+  "active_manifest": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
   "manifests": {
-    "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth": {
+    "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CA.jpg",
-      "instance_id": "xmp:iid:d5032a83-ac47-40c4-a3f9-77b0d3d4b11b",
+      "instance_id": "xmp:iid:f57ba003-97de-45f9-ac22-3455b0eb2a4e",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:813ee422-9736-4cdc-9be6-4e35ed8e41cb",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "parentOf",
           "label": "c2pa.ingredient.v3"
@@ -39,7 +39,7 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "Q5NDuiDFY1u6xbFURXm9lCvn18CK8C5AuxFyGQ1Mw7U="
+                      "hash": "ALaQeUNZ6RjwtmF3ocTbPuYjGvvfAFoLloO4jnGvSrA="
                     }
                   ]
                 }
@@ -50,24 +50,30 @@
                   "name": "brightnesscontrast"
                 }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:47+00:00"
+        "time": "2026-05-27T20:42:14+00:00"
       },
-      "label": "urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth"
+      "label": "urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth",
+      "claim_version": 2
     }
   },
   "validation_status": [
     {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    },
+    {
       "code": "assertion.dataHash.mismatch",
-      "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+      "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
       "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"
     }
   ],
@@ -76,65 +82,81 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-        },
-        {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "A.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
       "failure": [
         {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        },
+        {
           "code": "assertion.dataHash.mismatch",
-          "url": "self#jumbf=/c2pa/urn:c2pa:bb0da609-a5cb-4923-9e74-35540472478d:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"
         }
       ]
-    }
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:40a3ede9-5915-47e1-8675-82329fdf0d30:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "A.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Invalid"
 }

--- a/make_test_images/json_manifests_v2/XCI.json
+++ b/make_test_images/json_manifests_v2/XCI.json
@@ -1,19 +1,19 @@
 {
-  "active_manifest": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth",
+  "active_manifest": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
   "manifests": {
-    "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth": {
+    "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth": {
       "claim_generator_info": [
         {
           "name": "make_test_images",
-          "version": "0.58.0",
-          "org.contentauth.c2pa_rs": "0.58.0"
+          "version": "0.85.0",
+          "org.contentauth.c2pa_rs": "0.85.0"
         }
       ],
       "title": "CI.jpg",
-      "instance_id": "xmp:iid:ec137b66-38c0-478d-a6f1-4793a908f3fd",
+      "instance_id": "xmp:iid:57a816b2-ee5e-48d4-8073-f23f8aa76e57",
       "thumbnail": {
         "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim"
       },
       "ingredients": [
         {
@@ -22,7 +22,7 @@
           "instance_id": "xmp.iid:8a00de7a-e694-43b2-a7e6-ed950421a21a",
           "thumbnail": {
             "format": "image/jpeg",
-            "identifier": "self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
+            "identifier": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient"
           },
           "relationship": "componentOf",
           "label": "c2pa.ingredient.v3"
@@ -35,7 +35,7 @@
             "actions": [
               {
                 "action": "c2pa.created",
-                "softwareAgent": "Make Test Images 0.58.0",
+                "softwareAgent": "Make Test Images 0.85.0",
                 "parameters": {
                   "name": "gradient"
                 },
@@ -47,43 +47,38 @@
                   "ingredients": [
                     {
                       "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
+                      "hash": "zMkNHrPOM73VKPO6UW8Zo0iZpDzK0fwfSzUew1dlXLo="
                     }
                   ]
                 }
               },
               {
                 "action": "c2pa.resized"
-              },
-              {
-                "action": "c2pa.placed",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "tEqsFb3uICKJX1rn6EsqftmSnq7r3i8e+uvTR5VrZgo="
-                    }
-                  ]
-                }
               }
-            ],
-            "allActionsIncluded": true
+            ]
           }
         }
       ],
       "signature_info": {
         "alg": "Ps256",
         "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
         "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2025-07-28T05:55:48+00:00"
+        "time": "2026-05-27T20:42:15+00:00"
       },
-      "label": "urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth"
+      "label": "urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth",
+      "claim_version": 2
     }
   },
   "validation_status": [
     {
+      "code": "signingCredential.untrusted",
+      "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
+      "explanation": "signing certificate untrusted"
+    },
+    {
       "code": "assertion.dataHash.mismatch",
-      "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
+      "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
       "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"
     }
   ],
@@ -92,65 +87,81 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
+          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+        },
+        {
+          "code": "assertion.hashedURI.match",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.thumbnail.ingredient",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
-        },
-        {
-          "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
-          "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
         }
       ],
       "informational": [
         {
-          "code": "ingredient.unknownProvenance",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.ingredient.v3",
-          "explanation": "I.jpg: ingredient does not have provenance"
-        },
-        {
           "code": "timeStamp.untrusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
           "explanation": "timestamp cert untrusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         }
       ],
       "failure": [
         {
+          "code": "signingCredential.untrusted",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.signature",
+          "explanation": "signing certificate untrusted"
+        },
+        {
           "code": "assertion.dataHash.mismatch",
-          "url": "self#jumbf=/c2pa/urn:c2pa:0aec1ba5-0770-4e13-9c9e-278ca7bb1339:contentauth/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.hash.data",
           "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"
         }
       ]
-    }
+    },
+    "ingredientDeltas": [
+      {
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+        "validationDeltas": {
+          "success": [],
+          "informational": [
+            {
+              "code": "ingredient.unknownProvenance",
+              "url": "self#jumbf=/c2pa/urn:c2pa:d9dc8b6a-fac7-4e29-a86e-cf88bb9a5136:contentauth/c2pa.assertions/c2pa.ingredient.v3",
+              "explanation": "I.jpg: ingredient does not have provenance"
+            }
+          ],
+          "failure": []
+        }
+      }
+    ]
   },
   "validation_state": "Invalid"
 }


### PR DESCRIPTION
These certify the current changes so that make_test_images will only show deltas from here.