### PR TITLE
perf: avoid buffering PNG when writing XMP and removing manifest

### DIFF
--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -403,7 +403,7 @@ impl CAIWriter for PngIO {
         output_stream: &mut dyn CAIReadWrite,
     ) -> Result<()> {
         let ps = get_png_chunk_positions(input_stream)?;
-        let existing_cai = ps.iter().find(|pcp| pcp.name == CAI_CHUNK);
+        let existing_c2pa = ps.iter().find(|pcp| pcp.name == CAI_CHUNK);
 
         input_stream.rewind()?;
 
@@ -414,11 +414,11 @@ impl CAIWriter for PngIO {
                 chunk crc (4 bytes in crc in format defined in PNG spec)
         */
 
-        match existing_cai {
-            Some(cai) => {
-                io::copy(&mut input_stream.take(cai.start), output_stream)?;
+        match existing_c2pa {
+            Some(c2pa) => {
+                io::copy(&mut input_stream.take(c2pa.start), output_stream)?;
 
-                input_stream.seek(SeekFrom::Start(cai.end()))?;
+                input_stream.seek(SeekFrom::Start(c2pa.end()))?;
                 io::copy(input_stream, output_stream)?;
             }
             None => {

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -125,18 +125,12 @@ fn get_png_chunk_positions<R: Read + Seek + ?Sized>(f: &mut R) -> Result<Vec<Png
 fn get_cai_data<R: Read + Seek + ?Sized>(mut f: &mut R) -> Result<Vec<u8>> {
     let ps = get_png_chunk_positions(f)?;
 
-    if ps
-        .clone()
-        .into_iter()
-        .filter(|pcp| pcp.name == CAI_CHUNK)
-        .count()
-        > 1
-    {
+    if ps.iter().filter(|pcp| pcp.name == CAI_CHUNK).count() > 1 {
         return Err(Error::TooManyManifestStores);
     }
 
     let pcp = ps
-        .into_iter()
+        .iter()
         .find(|pcp| pcp.name == CAI_CHUNK)
         .ok_or(Error::JumbfNotFound)?;
 
@@ -182,7 +176,7 @@ impl CAIReader for PngIO {
         let ps = get_png_chunk_positions(asset_reader).ok()?;
         let mut xmp_str: Option<String> = None;
 
-        ps.into_iter().find(|pcp| {
+        ps.iter().find(|pcp| {
             if pcp.name == ITXT_CHUNK {
                 // seek to start of chunk
                 if asset_reader.seek(SeekFrom::Start(pcp.start + 8)).is_err() {
@@ -655,10 +649,7 @@ impl RemoteRefEmbed for PngIO {
                     // write everything before XMP
                     output_stream.rewind()?;
                     source_stream.rewind()?;
-                    io::copy(
-                        &mut source_stream.take(xmp_start),
-                        output_stream,
-                    )?;
+                    io::copy(&mut source_stream.take(xmp_start), output_stream)?;
 
                     // write new XMP
                     output_stream.write_all(&xmp_data)?;

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -402,13 +402,10 @@ impl CAIWriter for PngIO {
         input_stream: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
     ) -> Result<()> {
-        // get png byte
         let ps = get_png_chunk_positions(input_stream)?;
+        let existing_cai = ps.iter().find(|pcp| pcp.name == CAI_CHUNK);
 
-        // get image bytes
         input_stream.rewind()?;
-        let mut png_buf: Vec<u8> = Vec::new();
-        input_stream.read_to_end(&mut png_buf)?;
 
         /*  splice in new chunk.  Each PNG chunk has the following format:
                 chunk data length (4 bytes big endian)
@@ -417,22 +414,18 @@ impl CAIWriter for PngIO {
                 chunk crc (4 bytes in crc in format defined in PNG spec)
         */
 
-        // erase existing
-        let empty_buf = Vec::new();
-        let mut iter = ps.into_iter();
-        if let Some(existing_cai) = iter.find(|pcp| pcp.name == CAI_CHUNK) {
-            // replace existing CAI
-            let start = usize::try_from(existing_cai.start)
-                .map_err(|_err| Error::InvalidAsset("value out of range".to_string()))?; // get beginning of chunk which starts 4 bytes before label
+        match existing_cai {
+            Some(cai) => {
+                // copy before manifest
+                io::copy(&mut input_stream.take(cai.start), output_stream)?;
 
-            let end = usize::try_from(existing_cai.end())
-                .map_err(|_err| Error::InvalidAsset("value out of range".to_string()))?;
-
-            png_buf.splice(start..end, empty_buf.iter().cloned());
+                input_stream.seek(SeekFrom::Start(cai.end()))?;
+                io::copy(input_stream, output_stream)?;
+            }
+            None => {
+                io::copy(input_stream, output_stream)?;
+            }
         }
-
-        // save png data
-        output_stream.write_all(&png_buf)?;
 
         Ok(())
     }
@@ -583,7 +576,6 @@ fn get_xmp_insertion_point(asset_reader: &mut dyn CAIRead) -> Option<(u64, u32)>
     }
 }
 impl RemoteRefEmbed for PngIO {
-    #[allow(unused_variables)]
     fn embed_reference(&self, asset_path: &Path, embed_ref: RemoteRefEmbedType) -> Result<()> {
         match embed_ref {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -416,7 +416,6 @@ impl CAIWriter for PngIO {
 
         match existing_cai {
             Some(cai) => {
-                // copy before manifest
                 io::copy(&mut input_stream.take(cai.start), output_stream)?;
 
                 input_stream.seek(SeekFrom::Start(cai.end()))?;

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -649,31 +649,23 @@ impl RemoteRefEmbed for PngIO {
                     .encode(&mut xmp_chunk)
                     .map_err(|_| Error::EmbeddingError)?;
 
-                // patch output stream
-                let mut png_buf = Vec::new();
-                source_stream.rewind()?;
-                source_stream
-                    .read_to_end(&mut png_buf)
-                    .map_err(Error::IoError)?;
+                if let Some((xmp_start, xmp_len)) = get_xmp_insertion_point(source_stream) {
+                    let xmp_end = xmp_start + xmp_len as u64;
 
-                if let Some((start, xmp_len)) = get_xmp_insertion_point(source_stream) {
-                    let mut png_buf = Vec::new();
-                    source_stream.rewind()?;
-                    source_stream
-                        .read_to_end(&mut png_buf)
-                        .map_err(Error::IoError)?;
-
-                    // replace existing XMP
-                    let xmp_start = usize::try_from(start)
-                        .map_err(|_err| Error::InvalidAsset("value out of range".to_owned()))?; // get beginning of chunk which starts 4 bytes before label
-
-                    let xmp_end = usize::try_from(start + xmp_len as u64)
-                        .map_err(|_err| Error::InvalidAsset("value out of range".to_owned()))?;
-
-                    png_buf.splice(xmp_start..xmp_end, xmp_data.iter().cloned());
-
+                    // write everything before XMP
                     output_stream.rewind()?;
-                    output_stream.write_all(&png_buf)?;
+                    source_stream.rewind()?;
+                    io::copy(
+                        &mut source_stream.take(xmp_start),
+                        output_stream,
+                    )?;
+
+                    // write new XMP
+                    output_stream.write_all(&xmp_data)?;
+
+                    // write everything after XMP
+                    source_stream.seek(SeekFrom::Start(xmp_end))?;
+                    io::copy(source_stream, output_stream)?;
 
                     Ok(())
                 } else {

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     error::{Error, Result},
     utils::{
-        io_utils::{tempfile_builder, ReaderUtils},
+        io_utils::{patch_stream, tempfile_builder, ReaderUtils},
         xmp_inmemory_utils::{add_provenance, MIN_XMP},
     },
 };
@@ -416,10 +416,13 @@ impl CAIWriter for PngIO {
 
         match existing_c2pa {
             Some(c2pa) => {
-                io::copy(&mut input_stream.take(c2pa.start), output_stream)?;
-
-                input_stream.seek(SeekFrom::Start(c2pa.end()))?;
-                io::copy(input_stream, output_stream)?;
+                patch_stream(
+                    input_stream,
+                    output_stream,
+                    c2pa.start,
+                    c2pa.end() - c2pa.start,
+                    &[],
+                )?;
             }
             None => {
                 io::copy(input_stream, output_stream)?;
@@ -635,19 +638,14 @@ impl RemoteRefEmbed for PngIO {
                     .map_err(|_| Error::EmbeddingError)?;
 
                 if let Some((xmp_start, xmp_len)) = get_xmp_insertion_point(source_stream) {
-                    let xmp_end = xmp_start + xmp_len as u64;
-
-                    // write everything before XMP
                     output_stream.rewind()?;
-                    source_stream.rewind()?;
-                    io::copy(&mut source_stream.take(xmp_start), output_stream)?;
-
-                    // write new XMP
-                    output_stream.write_all(&xmp_data)?;
-
-                    // write everything after XMP
-                    source_stream.seek(SeekFrom::Start(xmp_end))?;
-                    io::copy(source_stream, output_stream)?;
+                    patch_stream(
+                        source_stream,
+                        output_stream,
+                        xmp_start,
+                        xmp_len as u64,
+                        &xmp_data,
+                    )?;
 
                     Ok(())
                 } else {


### PR DESCRIPTION
Avoids buffering the PNG into memory when writing XMP and removing manifests. Reduces total memory usage for writing XMP w/o embedded manifest in a 100MB PNG by 16% and peak memory usage by 26.7%.

Before:
<img width="290" height="53" alt="Screenshot 2026-05-28 at 1 50 23 PM" src="https://github.com/user-attachments/assets/58b8cf9b-ad8b-4563-956a-72200f996d6d" />


After:
<img width="283" height="52" alt="Screenshot 2026-05-28 at 1 50 13 PM" src="https://github.com/user-attachments/assets/c6af352c-b9c3-4f90-a572-62976a22c61d" />
