### PR TITLE
perf: avoid buffering intermediate streams if stream len is greater than threshold

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2876,7 +2876,8 @@ impl Store {
 
         let threshold = settings.core.backing_store_memory_threshold_in_mb;
 
-        let mut intermediate_stream = io_utils::stream_with_fs_fallback(threshold);
+        let input_len = io_utils::stream_len(input_stream)?;
+        let mut intermediate_stream = io_utils::stream_with_fs_fallback(threshold, input_len)?;
 
         #[allow(unused_mut)] // Not mutable in the non-async case.
         self.start_save_stream(
@@ -2973,7 +2974,8 @@ impl Store {
         let settings = context.settings();
         let threshold = settings.core.backing_store_memory_threshold_in_mb;
 
-        let mut intermediate_stream = io_utils::stream_with_fs_fallback(threshold);
+        let input_len = io_utils::stream_len(input_stream)?;
+        let mut intermediate_stream = io_utils::stream_with_fs_fallback(threshold, input_len)?;
 
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
 
@@ -3007,7 +3009,7 @@ impl Store {
                         .get_writer(format)
                         .ok_or(Error::UnsupportedType)?;
 
-                    let mut tmp_stream = io_utils::stream_with_fs_fallback(threshold);
+                    let mut tmp_stream = io_utils::stream_with_fs_fallback(threshold, input_len)?;
                     manifest_writer.remove_cai_store_from_stream(input_stream, &mut tmp_stream)?;
 
                     // add external ref if possible
@@ -3138,7 +3140,7 @@ impl Store {
 
                 // insert Merkle UUID boxes at the correct location if required
                 if let Some(merkle_uuid_boxes) = &bmff_hash.merkle_uuid_boxes {
-                    let mut temp_stream = io_utils::stream_with_fs_fallback(threshold);
+                    let mut temp_stream = io_utils::stream_with_fs_fallback(threshold, input_len)?;
 
                     if !source_is_intermediate {
                         // Merkle insertion requires a writable source; populate intermediate

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -121,8 +121,8 @@ pub(crate) fn stream_len<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<u64>
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn stream_with_fs_fallback(
-    _threshold: usize,
-    _expected_size: u64,
+    _threshold_mb: usize,
+    _expected_size_bytes: u64,
 ) -> Result<impl Read + Write + Seek> {
     Ok(std::io::Cursor::new(Vec::new()))
 }
@@ -134,6 +134,8 @@ pub(crate) fn stream_with_fs_fallback(
 /// - `threshold`: Size (in MB) of stream beyond which an on-disk stream will be used.
 ///   This threshold should be the one specified in settings under
 ///   `core.backing_store_memory_threshold_in_mb`.
+/// - `expected_size_bytes`: Size (in bytes) of the stream. If this exceeds the threshold
+///   it will return a file-backed stream directly.
 ///
 /// # Errors
 /// - Returns an error if the threshold value from settings is not valid.
@@ -143,12 +145,12 @@ pub(crate) fn stream_with_fs_fallback(
 /// support file I/O.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn stream_with_fs_fallback(
-    threshold: usize,
-    expected_size: u64,
+    threshold_mb: usize,
+    expected_size_bytes: u64,
 ) -> Result<impl Read + Write + Seek> {
-    let threshold_bytes = threshold.saturating_mul(1024 * 1024);
+    let threshold_bytes = threshold_mb.saturating_mul(1024 * 1024);
     let mut spooled = SpooledTempFile::new(threshold_bytes);
-    if expected_size > threshold_bytes as u64 {
+    if expected_size_bytes > threshold_bytes as u64 {
         spooled.roll()?;
     }
     Ok(spooled)

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -119,13 +119,21 @@ pub(crate) fn stream_len<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<u64>
     Ok(len)
 }
 
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn stream_with_fs_fallback(
+    _threshold: usize,
+    _expected_size: u64,
+) -> Result<impl Read + Write + Seek> {
+    Ok(std::io::Cursor::new(Vec::new()))
+}
+
 /// Will create a [`Read`]-, [`Write`]-, and [`Seek`]-capable stream that will
 /// stay in memory unless a threshold size is exceeded.
 ///
 /// # Parameters
 /// - `threshold`: Size (in MB) of stream beyond which an on-disk stream will be used.
-///    This threshold should be the one specified in settings under
-///    `core.backing_store_memory_threshold_in_mb`.
+///   This threshold should be the one specified in settings under
+///   `core.backing_store_memory_threshold_in_mb`.
 ///
 /// # Errors
 /// - Returns an error if the threshold value from settings is not valid.
@@ -133,15 +141,17 @@ pub(crate) fn stream_len<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<u64>
 /// # Note
 /// This will always return an in-memory stream when the compilation target doesn't
 /// support file I/O.
-#[cfg(target_arch = "wasm32")]
-pub(crate) fn stream_with_fs_fallback(_threshold: usize) -> impl Read + Write + Seek {
-    std::io::Cursor::new(Vec::new())
-}
-
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn stream_with_fs_fallback(threshold: usize) -> impl Read + Write + Seek {
-    SpooledTempFile::new(threshold * 1024 * 1024)
-    // IMPORTANT: SpooledTempFile API is in bytes; this function's API is in MB.
+pub(crate) fn stream_with_fs_fallback(
+    threshold: usize,
+    expected_size: u64,
+) -> Result<impl Read + Write + Seek> {
+    let threshold_bytes = threshold.saturating_mul(1024 * 1024);
+    let mut spooled = SpooledTempFile::new(threshold_bytes);
+    if expected_size > threshold_bytes as u64 {
+        spooled.roll()?;
+    }
+    Ok(spooled)
 }
 
 // Returns a new Vec first making sure it can hold the desired capacity.  Fill


### PR DESCRIPTION
Avoids buffering assets into memory when the input stream len exceeds the threshold defined in settings. When signing a simple 100MB PNG with the threshold set 50MB, total memory usage decreases by 79.7%.

Before:
<img width="292" height="53" alt="Screenshot 2026-05-28 at 2 46 09 PM" src="https://github.com/user-attachments/assets/6a31458e-ccff-4d9d-b3a4-63c0ab50e68c" />


After:
<img width="283" height="54" alt="Screenshot 2026-05-28 at 2 47 20 PM" src="https://github.com/user-attachments/assets/bcd6e34b-8e7a-4cc3-bfe3-e8598828a422" />

These benchmarks are given the `backing_store_memory_threshold_in_mb` is set to 50 on a 100MB PNG. I also included the changes in #2177 to these benchmarks.