### PR TITLE
fix: Warn instead of error when redaction cannot be applied

### DIFF
--- a/c2pa_c_ffi/src/error.rs
+++ b/c2pa_c_ffi/src/error.rs
@@ -87,9 +87,7 @@ impl C2paError {
         let err_str = err.to_string();
         match err {
             c2pa::Error::AssertionMissing { url } => Self::AssertionNotFound("".to_string()),
-            AssertionInvalidRedaction
-            | AssertionRedactionNotFound
-            | AssertionUnsupportedVersion => Self::Assertion(err_str),
+            AssertionInvalidRedaction | AssertionUnsupportedVersion => Self::Assertion(err_str),
             ClaimAlreadySigned
             | ClaimUnsigned
             | ClaimMissingSignatureBox

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -24,7 +24,6 @@ The C2PA specification imposes restrictions on what can be redacted:
 | **No self-redaction** | A manifest cannot redact its own assertions. |
 | **Cannot redact `c2pa.actions`** | Action assertions are protected. |
 | **Cannot redact `c2pa.hash.*`** | Hash binding assertions are protected. |
-| **URI must match** | Every URI in the redactions list must resolve to an assertion in an ingredient, or signing fails with `AssertionRedactionNotFound`. |
 
 ## JUMBF URI format
 

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1488,7 +1488,9 @@ impl Builder {
             let applied = claim.redactions().map(|r| r.as_slice()).unwrap_or_default();
             for redaction in redactions {
                 if !applied.contains(redaction) {
-                    return Err(Error::AssertionRedactionNotFound);
+                    log::warn!(
+                        "Redaction URI was not applied (assertion not found in any ingredient): {redaction}"
+                    );
                 }
             }
         }
@@ -3427,6 +3429,7 @@ mod tests {
         validation_results::ValidationState,
         Reader,
     };
+    use std::sync::{Arc, Mutex};
 
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -7722,7 +7725,9 @@ mod tests {
     }
 
     #[test]
-    fn test_redact_nonexistent_assertion_returns_not_found() {
+    fn test_redact_nonexistent_assertion_succeeds_with_warning() {
+        // A redaction URI that references a non-existent assertion label should
+        // not fail signing, and instead log a warning but otherwise succeed.
         let mut input = Cursor::new(TEST_IMAGE);
 
         let parent = Reader::default()
@@ -7743,7 +7748,7 @@ mod tests {
         let signer = test_signer(SigningAlg::Ps256);
         let mut output = Cursor::new(Vec::new());
         let result = builder.sign(signer.as_ref(), "image/jpeg", &mut input, &mut output);
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[test]
@@ -7912,7 +7917,9 @@ mod tests {
     }
 
     #[test]
-    fn test_redact_empty_uri_returns_not_found() {
+    fn test_redact_empty_uri_succeeds_with_warning() {
+        // An empty redaction URI cannot match any assertion. Signing should
+        // succeed and emit a warning rather than failing.
         let mut input = Cursor::new(TEST_IMAGE);
 
         let mut builder = Builder::default();
@@ -7922,11 +7929,13 @@ mod tests {
         let signer = test_signer(SigningAlg::Ps256);
         let mut output = Cursor::new(Vec::new());
         let result = builder.sign(signer.as_ref(), "image/jpeg", &mut input, &mut output);
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[test]
-    fn test_redact_malformed_uri_returns_not_found() {
+    fn test_redact_malformed_uri_succeeds_with_warning() {
+        // A malformed URI cannot match any assertion.
+        // Signing should succeed and emit a warning rather than failing.
         let mut input = Cursor::new(TEST_IMAGE);
 
         let mut builder = Builder::default();
@@ -7936,11 +7945,13 @@ mod tests {
         let signer = test_signer(SigningAlg::Ps256);
         let mut output = Cursor::new(Vec::new());
         let result = builder.sign(signer.as_ref(), "image/jpeg", &mut input, &mut output);
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[test]
-    fn test_redact_wrong_manifest_label_returns_not_found() {
+    fn test_redact_wrong_manifest_label_succeeds_with_warning() {
+        // A URI with a fabricated manifest label won't match any ingredient.
+        // Signing should succeed and emit a warning rather than failing.
         let mut input = Cursor::new(TEST_IMAGE);
 
         let _parent = Reader::default()
@@ -7960,7 +7971,7 @@ mod tests {
         let signer = test_signer(SigningAlg::Ps256);
         let mut output = Cursor::new(Vec::new());
         let result = builder.sign(signer.as_ref(), "image/jpeg", &mut input, &mut output);
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[test]
@@ -8039,21 +8050,22 @@ mod tests {
             .unwrap();
         final_builder.add_ingredient(parent);
 
+        // The URI belongs to an ingredient that wasn't included, so it cannot
+        // be applied — signing still succeeds, emitting a warning.
         let result = final_builder.sign(
             signer.as_ref(),
             "image/jpeg",
             &mut final_input,
             &mut final_output,
         );
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[test]
     fn test_redact_duplicate_uri_in_redactions() {
-        // Documents behavior when same URI appears twice in `redactions`.
-        // First pass redacts the assertion, second pass cannot find it but the
-        // post-sign check only verifies each requested redaction is present
-        // in `claim.redactions()`, which dedupes naturally, so succeeds.
+        // Duplicate URIs dedupe in claim.redactions(), so the post-sign check
+        // should always pass. Signing succeeds even if the assertion was only
+        // removed on the first pass.
         let mut input = Cursor::new(TEST_IMAGE);
 
         let parent = Reader::default()
@@ -8077,22 +8089,15 @@ mod tests {
 
         let signer = test_signer(SigningAlg::Ps256);
         let mut output = Cursor::new(Vec::new());
-        let result = builder.sign(signer.as_ref(), "image/jpeg", &mut input, &mut output);
-        // Either succeeds (dedupe-tolerant) or returns AssertionRedactionNotFound
-        // for the second pass.
-        match result {
-            Ok(_) => {
-                output.set_position(0);
-                let reader = Reader::default()
-                    .with_stream("image/jpeg", &mut output)
-                    .expect("from_bytes");
-                assert_eq!(reader.validation_state(), ValidationState::Trusted);
-            }
-            Err(Error::AssertionRedactionNotFound) => {
-                // Acceptable, second iteration could not re-redact.
-            }
-            Err(e) => unreachable!("unexpected error: {e:?}"),
-        }
+        builder
+            .sign(signer.as_ref(), "image/jpeg", &mut input, &mut output)
+            .expect("sign");
+
+        output.set_position(0);
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut output)
+            .expect("from_bytes");
+        assert_eq!(reader.validation_state(), ValidationState::Trusted);
     }
 
     #[test]
@@ -8381,6 +8386,8 @@ mod tests {
             .expect("sign a");
 
         // Step 2: try to redact the same URI again with B taking A as ingredient.
+        // The assertion was already removed in step 1, so signing succeeds and
+        // emits a warning rather than failing.
         output_a.set_position(0);
         let mut builder_b = Builder::default();
         builder_b.set_intent(BuilderIntent::Edit);
@@ -8392,7 +8399,7 @@ mod tests {
         builder_b.add_action(redacted_action_b).unwrap();
         let mut output_b = Cursor::new(Vec::new());
         let result = builder_b.sign(signer.as_ref(), "image/jpeg", &mut output_a, &mut output_b);
-        assert!(matches!(result, Err(Error::AssertionRedactionNotFound)));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
     #[cfg(feature = "add_thumbnails")]

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1810,8 +1810,9 @@ impl Claim {
     }
 
     /// Redact an assertion from a prior claim.
-    /// This will remove the assertion from the JUMBF
-    fn redact_assertion(&mut self, assertion_uri: &str) -> Result<()> {
+    /// This will remove the assertion from the JUMBF.
+    /// Returns `true` if the assertion was found and removed, `false` if not found.
+    fn redact_assertion(&mut self, assertion_uri: &str) -> Result<bool> {
         // cannot redact action assertions per the spec
         // cannot redact hash bindings
         let (label, _instance) = Claim::assertion_label_from_link(assertion_uri);
@@ -1827,7 +1828,7 @@ impl Claim {
                 .position(|x| assertion_uri.contains(&x.label()))
             {
                 self.assertion_store.remove(index);
-                return Ok(());
+                return Ok(true);
             }
         } else if assertion_uri.contains(DATABOX_STORE) {
             if let Some(index) = self
@@ -1836,11 +1837,11 @@ impl Claim {
                 .position(|(x, _d)| assertion_uri.contains(&x.url()))
             {
                 self.data_boxes.remove(index);
-                return Ok(());
+                return Ok(true);
             }
         }
 
-        Err(Error::AssertionRedactionNotFound)
+        Ok(false)
     }
 
     /// Return a hash of this claim.
@@ -3457,10 +3458,8 @@ impl Claim {
                     .iter_mut()
                     .find(|x| redaction.contains(x.label()))
                 {
-                    match claim.redact_assertion(redaction) {
-                        Ok(()) => applied_redactions.push(redaction.clone()),
-                        Err(Error::AssertionRedactionNotFound) => {}
-                        Err(e) => return Err(e),
+                    if claim.redact_assertion(redaction)? {
+                        applied_redactions.push(redaction.clone());
                     }
                 }
             }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -3457,8 +3457,11 @@ impl Claim {
                     .iter_mut()
                     .find(|x| redaction.contains(x.label()))
                 {
-                    claim.redact_assertion(redaction)?;
-                    applied_redactions.push(redaction.clone());
+                    match claim.redact_assertion(redaction) {
+                        Ok(()) => applied_redactions.push(redaction.clone()),
+                        Err(Error::AssertionRedactionNotFound) => {}
+                        Err(e) => return Err(e),
+                    }
                 }
             }
         }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -54,8 +54,6 @@ pub enum Error {
     #[error("assertion could not be redacted")]
     AssertionInvalidRedaction,
 
-    #[error("could not find the assertion to redact")]
-    AssertionRedactionNotFound,
 
     #[error("assertion-specific error: {0}")]
     AssertionSpecificError(String),


### PR DESCRIPTION
## Changes in this pull request
- Update logic in `builder.rs` and `claim.rs` to only emit a warning when a redaction cannot be applied, rather than throwing an `AssertionRedactionNotFound` error.
- Remove `AssertionRedactionNotFound` entirely; use a boolean to communicate whether applying a redaction was successful or not
- Update `redaction.md` to remove the requirement that URIs in the redactions list must match an assertion

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
