### PR TITLE
test: ignore `test_multiple_identities_valid` due to intermittent networking failures

### DIFF
--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -99,6 +99,8 @@ mod tests {
         );
     }
 
+    // TODO: https://github.com/contentauth/c2pa-rs/issues/2182
+    #[ignore]
     #[c2pa_test_async]
     async fn test_multiple_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();


### PR DESCRIPTION
The `test_multiple_identities_valid` intermittently fails due to networking issues. This is presumably due to the new changes that allow network requests to be called for CAWG in sync contexts. See #2172 and #2120.

Ideally we mock the networking, but for the time being let's ignore it so CI isn't failing.

See #2182 for more information.