### PR TITLE
chore: Replace live HTTP GET with a local mock server for Connected Identities service

### DIFF
--- a/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did_web.rs
@@ -32,11 +32,32 @@ pub(crate) const MAX_DID_DOC_SIZE: u64 = 1024 * 1024; // 1 MiB
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 #[cfg(test)]
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::HashMap};
 
 #[cfg(test)]
 thread_local! {
-    pub(crate) static PROXY: RefCell<Option<String>> = const { RefCell::new(None) };
+    /// Maps a `did:web` domain name to a URL prefix (ending in `/`) that should
+    /// be used in place of the real `https://{domain}/` origin. Tests register
+    /// entries here to redirect DID document resolution to a local mock server,
+    /// keeping the suite hermetic.
+    pub(crate) static PROXIES: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+}
+
+/// Redirect `did:web` resolution for `domain` to `url_prefix` (a base URL
+/// ending in `/`, such as a mock server origin) for the current thread.
+#[cfg(test)]
+pub(crate) fn set_proxy(domain: &str, url_prefix: &str) {
+    PROXIES.with(|proxies| {
+        proxies
+            .borrow_mut()
+            .insert(domain.to_string(), url_prefix.to_string());
+    });
+}
+
+/// Remove all `did:web` resolution redirects for the current thread.
+#[cfg(test)]
+pub(crate) fn clear_proxies() {
+    PROXIES.with(|proxies| proxies.borrow_mut().clear());
 }
 
 use http::header;
@@ -183,12 +204,9 @@ pub(crate) fn to_url(did: &str) -> Result<String, DidWebError> {
     );
 
     #[cfg(test)]
-    PROXY.with(|proxy| {
-        if let Some(ref proxy) = *proxy.borrow() {
-            if domain_name == "localhost" {
-                url = format!("{proxy}{path}/did.json");
-                dbg!(&url);
-            }
+    PROXIES.with(|proxies| {
+        if let Some(prefix) = proxies.borrow().get(domain_name) {
+            url = format!("{prefix}{path}/did.json");
         }
     });
 
@@ -241,7 +259,7 @@ mod tests {
         use super::did;
         use crate::identity::claim_aggregation::w3c_vc::{
             did_doc::DidDocument,
-            did_web::{self, DidWebError, MAX_DID_DOC_SIZE, PROXY},
+            did_web::{self, DidWebError, MAX_DID_DOC_SIZE},
         };
 
         #[tokio::test]
@@ -263,11 +281,8 @@ mod tests {
 
             let server = MockServer::start();
 
-            PROXY.with(|proxy| {
-                let server_url = server.url("/").replace("127.0.0.1", "localhost");
-                dbg!(&server_url);
-                proxy.replace(Some(server_url));
-            });
+            let server_url = server.url("/").replace("127.0.0.1", "localhost");
+            did_web::set_proxy("localhost", &server_url);
 
             let did_doc_mock = server.mock(|when, then| {
                 when.method(GET).path("/.well-known/did.json");
@@ -282,9 +297,7 @@ mod tests {
             let doc_expected = DidDocument::from_json(DID_JSON).unwrap();
             assert_eq!(doc, doc_expected);
 
-            PROXY.with(|proxy| {
-                proxy.replace(None);
-            });
+            did_web::clear_proxies();
 
             did_doc_mock.assert();
         }
@@ -293,10 +306,8 @@ mod tests {
         async fn content_length_above_limit_rejected() {
             let server = MockServer::start();
 
-            PROXY.with(|proxy| {
-                let server_url = server.url("/").replace("127.0.0.1", "localhost");
-                proxy.replace(Some(server_url));
-            });
+            let server_url = server.url("/").replace("127.0.0.1", "localhost");
+            did_web::set_proxy("localhost", &server_url);
 
             // Server explicitly advertises Content-Length above the limit.
             // The Content-Length pre-check in AsyncGenericResolver rejects the
@@ -312,9 +323,7 @@ mod tests {
 
             let result = did_web::resolve_async(&did("did:web:localhost")).await;
 
-            PROXY.with(|proxy| {
-                proxy.replace(None);
-            });
+            did_web::clear_proxies();
 
             assert!(
                 matches!(result, Err(did_web::DidWebError::ResponseTooLarge)),
@@ -326,10 +335,8 @@ mod tests {
         async fn oversized_response_returns_error() {
             let server = MockServer::start();
 
-            PROXY.with(|proxy| {
-                let server_url = server.url("/").replace("127.0.0.1", "localhost");
-                proxy.replace(Some(server_url));
-            });
+            let server_url = server.url("/").replace("127.0.0.1", "localhost");
+            did_web::set_proxy("localhost", &server_url);
 
             // Serve a body one byte larger than the allowed limit.
             let oversized_body = vec![b'X'; (MAX_DID_DOC_SIZE + 1) as usize];
@@ -342,9 +349,7 @@ mod tests {
 
             let result = did_web::resolve_async(&did("did:web:localhost")).await;
 
-            PROXY.with(|proxy| {
-                proxy.replace(None);
-            });
+            did_web::clear_proxies();
 
             assert!(
                 matches!(result, Err(did_web::DidWebError::ResponseTooLarge)),

--- a/sdk/src/identity/tests/fixtures/claim_aggregation/connected_identities_did.json
+++ b/sdk/src/identity/tests/fixtures/claim_aggregation/connected_identities_did.json
@@ -1,0 +1,19 @@
+{
+    "@context": "https://www.w3.org/ns/did/v1",
+    "id": "did:web:connected-identities.identity-stage.adobe.com",
+    "assertionMethod": [
+        {
+            "id": "did:web:connected-identities.identity-stage.adobe.com#key-0",
+            "controller": "did:web:connected-identities.identity-stage.adobe.com",
+            "publicKeyJwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": "gPfQ48DeVQtfDMh9in27XZfCBlblW7FdgcyqsHPBmis",
+                "kid": "did:web:connected-identities.identity-stage.adobe.com#key-0",
+                "alg": "EdDSA"
+            },
+            "type": "JsonWebKey"
+        }
+    ],
+    "services": []
+}

--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -72,9 +72,42 @@ mod tests {
     const MULTIPLE_IDENTITIES_VALID: &[u8] =
         include_bytes!("tests/fixtures/claim_aggregation/ims_multiple_manifests.jpg");
 
+    // DID document for the `did:web` issuer that both Adobe-signed fixtures above
+    // were signed against. Served by a local mock so validation does not depend on
+    // reaching the Adobe stage server over the network.
+    #[cfg(not(target_arch = "wasm32"))]
+    const CONNECTED_IDENTITIES_DID: &str =
+        include_str!("tests/fixtures/claim_aggregation/connected_identities_did.json");
+
+    /// Start a local mock server that serves the issuer DID document and redirect
+    /// `did:web` resolution for the Adobe stage domain to it. The returned
+    /// `MockServer` must be kept alive for the duration of the test.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn mock_connected_identities_did() -> httpmock::MockServer {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/.well-known/did.json");
+            then.status(200)
+                .header("content-type", "application/did+json")
+                .body(CONNECTED_IDENTITIES_DID);
+        });
+
+        crate::identity::claim_aggregation::w3c_vc::did_web::set_proxy(
+            "connected-identities.identity-stage.adobe.com",
+            &server.url("/"),
+        );
+
+        server
+    }
+
     #[c2pa_test_async]
     async fn test_connected_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _did_server = mock_connected_identities_did();
 
         let mut stream = Cursor::new(CONNECTED_IDENTITIES_VALID);
 
@@ -102,6 +135,9 @@ mod tests {
     #[c2pa_test_async]
     async fn test_multiple_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _did_server = mock_connected_identities_did();
 
         let mut stream = Cursor::new(MULTIPLE_IDENTITIES_VALID);
 


### PR DESCRIPTION
## Root cause (confirmed)

`test_multiple_identities_valid` (and `test_connected_identities_valid`) validate JPEGs whose CAWG identity assertions are issued by `did:web:connected-identities.identity-stage.adobe.com`. Validation resolved that DID by making a **live HTTPS GET** to `https://connected-identities.identity-stage.adobe.com/.well-known/did.json`. Any network/server hiccup on that Adobe stage host produced an intermittent failure.

## The fix

Generalized the test PROXY hook in `did_web.rs`: replaced the single-value `PROXY: Option<String>` (which only rewrote `localhost`) with a `PROXIES: HashMap<domain → url-prefix>`, plus `set_proxy()` / `clear_proxies()` helpers. `to_url()` now redirects resolution for any registered domain. Updated the three existing `did_web` resolve tests to the new API.

Captured the issuer DID document as a fixture: `connected_identities_did.json`.

Made both validator tests hermetic in `validator.rs`: a `mock_connected_identities_did()` helper starts an `httpmock` server serving the fixture and registers a proxy entry for the Adobe stage domain. The mock setup is gated `#[cfg(not(target_arch = "wasm32"))]`, matching the existing `did_web` network tests (`httpmock` is a native-only dev-dep); Wasm behavior is unchanged.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
