### PR TITLE
chore: probe — force system ld on ubuntu-latest+stable tier-1b job

### DIFF
--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -55,13 +55,16 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
         rust_version: [stable, 1.88.0]
         # PROBE (do not merge): on ubuntu-latest + stable (Rust 1.96.0) the
-        # doctest link crashes with SIGBUS inside rust-lld. Force the system
-        # `ld` on that matrix entry only, to confirm rust-lld is the cause.
+        # doctest link crashes with SIGBUS inside rust-lld. Disable rust-lld
+        # on that matrix entry only, to confirm rust-lld is the cause. The
+        # rustc-level `-C linker-features=-lld` is required: a `-C link-arg`
+        # override is rejected because rustc still prepends its `gcc-ld`
+        # search dir, which only contains the lld stub.
         # See PR investigation in #2184 CI run 26646459500.
         include:
           - os: ubuntu-latest
             rust_version: stable
-            extra_rustflags: "-C link-arg=-fuse-ld=ld"
+            extra_rustflags: "-C linker-features=-lld"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -54,6 +54,14 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         rust_version: [stable, 1.88.0]
+        # PROBE (do not merge): on ubuntu-latest + stable (Rust 1.96.0) the
+        # doctest link crashes with SIGBUS inside rust-lld. Force the system
+        # `ld` on that matrix entry only, to confirm rust-lld is the cause.
+        # See PR investigation in #2184 CI run 26646459500.
+        include:
+          - os: ubuntu-latest
+            rust_version: stable
+            extra_rustflags: "-C link-arg=-fuse-ld=ld"
 
     steps:
       - name: Checkout repository
@@ -71,6 +79,8 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
+          RUSTFLAGS: ${{ matrix.extra_rustflags }}
+          RUSTDOCFLAGS: ${{ matrix.extra_rustflags }}
         run: |
           cargo test --features "$FEATURES"
 


### PR DESCRIPTION
PROBE BRANCH (do not merge). Targets only the matrix entry that crashes in rust-lld with SIGBUS on Rust 1.96.0 stable (ubuntu-latest, OpenSSL features). Sets RUSTFLAGS/RUSTDOCFLAGS="-C link-arg=-fuse-ld=ld" via matrix include so other entries are untouched.

If this run passes where the no-op repro PR fails, rust-lld is confirmed as the cause and the file-a-bug path opens.

Related: PR #2184 CI run 26646459500.