### PR TITLE
chore: cargo upgrade crates (brings many crates up to date)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2600,9 +2600,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4143,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4214,9 +4214,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4775,9 +4775,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -4902,9 +4902,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5607,18 +5607,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -36,16 +36,16 @@ c2pa = { path = "../sdk", version = "0.85.0", default-features = false, features
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.36", features = ["rt-multi-thread", "rt"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1.36", features = ["rt", "macros", "io-util", "time"] }
+tokio = { version = "1.52", features = ["rt", "macros", "io-util", "time"] }
 
 [dev-dependencies]
-tempfile = "3.7.0"
+tempfile = "3.27.0"
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,22 +30,22 @@ c2pa = { path = "../sdk", version = "0.85.0", features = [
     "add_thumbnails",
     "pdf",
 ] }
-clap = { version = "4.5.50", features = ["derive", "env", "string"] }
-env_logger = "0.11.8"
-glob = "0.3.1"
+clap = { version = "4.6.1", features = ["derive", "env", "string"] }
+env_logger = "0.11.10"
+glob = "0.3.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "1.0.2"
-tempfile = "3.3"
+toml = "1.1.2"
+tempfile = "3.27"
 treeline = "0.1.0"
 pem = "3.0.6"
-url = "2.5.0"
+url = "2.5.8"
 etcetera = "0.11.0"
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-reqwest = { version = "0.12.4", features = ["blocking"] }
-tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
+reqwest = { version = "0.12.28", features = ["blocking"] }
+tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread"] }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.14"
@@ -58,6 +58,6 @@ development = ["mockall"]
 mockall = "0.14.0"
 
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
-assert_cmd = "2.0.14"
-httpmock = "0.8.2"
+assert_cmd = "2.2.2"
+httpmock = "0.8.3"
 predicates = "3.1"

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,6 @@ yanked = "deny"
 ignore = [
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
   "RUSTSEC-2024-0370", # proc-macro-error
-  "RUSTSEC-2026-0097", # rand unsound with custom logger (https://github.com/contentauth/c2pa-rs/issues/2045)
 ]
 
 [bans]

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 rust-version = "1.88.0"
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0.102"
 c2pa = { path = "../sdk", features = ["json_schema"], default-features = false }
-schemars = "1.0.4"
-serde_json = "1.0.117"
+schemars = "1.2.1"
+serde_json = "1.0.150"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,5 +10,5 @@ rust-version = "1.88.0"
 proc-macro = true
 
 [dependencies]
-quote = "1.0.40"
-syn = { version = "2.0.82" }
+quote = "1.0.45"
+syn = { version = "2.0.117" }

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0.102"
 c2pa = { path = "../sdk", version = "0.85.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
@@ -16,15 +16,15 @@ c2pa = { path = "../sdk", version = "0.85.0", features = [
     "default_http"
 ]}
 env_logger = "0.11"
-lazy_static = "1.4.0"
-image = { version = "0.25.2", default-features = false, features = [
+lazy_static = "1.5.0"
+image = { version = "0.25.10", default-features = false, features = [
 	"jpeg",
 	"png",
 ] }
-memchr = "2.7.6"
+memchr = "2.8.1"
 nom = "7.1.3"
-regex = "1.5.6"
-serde = "1.0.197"
-serde_json = { version = "1.0.117", features = ["preserve_order"] }
-tempfile = "3.15.0"
-toml = "1.0.2"
+regex = "1.12.3"
+serde = "1.0.228"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+tempfile = "3.27.0"
+toml = "1.1.2"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -93,27 +93,27 @@ name = "redaction"
 crate-type = ["lib"]
 
 [dependencies]
-asn1-rs = "0.7.1"
+asn1-rs = "0.7.2"
 async-generic = "1.1"
-async-trait = "0.1.78"
+async-trait = "0.1.89"
 atree = "0.5.4"
 base64 = "0.22.1"
-bcder = "0.7.3"
+bcder = "0.7.6"
 bytes = "1.11.1"
 brotli = "7.0.0"
-byteorder = { version = "1.4.3", default-features = false }
+byteorder = { version = "1.5.0", default-features = false }
 byteordered = "0.6.0"
-chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.44", default-features = false, features = ["serde"] }
 c2pa_cbor = "0.77.2"
-const-hex = "1.14"
+const-hex = "1.19"
 const-oid = { version = "0.9.6", optional = true }
-coset = "0.4.0"
-der = { version = "0.7.9", features = ["alloc"] }
+coset = "0.4.2"
+der = { version = "0.7.10", features = ["alloc"] }
 extfmt = "0.2.0"
 getrandom = { version = "0.3.4", default-features = false, features = ["std"] }
-glob = "0.3.1"
+glob = "0.3.3"
 ecdsa = { version = "0.16.9", features = ["digest", "sha2"], optional = true }
-ed25519-dalek = { version = "2.1.1", features = [
+ed25519-dalek = { version = "2.2.0", features = [
     "alloc",
     "digest",
     "pem",
@@ -121,22 +121,22 @@ ed25519-dalek = { version = "2.1.1", features = [
     "rand_core",
 ] }
 hex = "0.4.3"
-http = "1.3.1"
-id3 = "1.16.3"
+http = "1.4.1"
+id3 = "1.17.0"
 img-parts = "0.4.0"
 iref = { version = "3.2.2", features = ["serde"] }
 jfifdump = "0.6.0"
-log = "0.4.8"
+log = "0.4.30"
 lopdf = { version = "0.39.0", optional = true }
-lazy_static = "1.4.0"
-memchr = "2.7.6"
+lazy_static = "1.5.0"
+memchr = "2.8.1"
 mp4 = "0.14.0"
 nom = "7.1.3"
 non-empty-string = { version = "0.2.6", features = ["serde"] }
-nonempty-collections = { version = "1.2.1", features = ["serde"] }
-num-bigint-dig = { version = "0.8.4", optional = true }
+nonempty-collections = { version = "1.3.0", features = ["serde"] }
+num-bigint-dig = { version = "0.8.6", optional = true }
 p256 = { version = "0.13.2", optional = true }
-p384 = { version = "0.13.0", optional = true }
+p384 = { version = "0.13.1", optional = true }
 p521 = { version = "0.13.3", features = [
     "pkcs8",
     "digest",
@@ -146,36 +146,36 @@ pem = "3.0.6"
 pkcs1 = { version = "0.7.5", optional = true }
 pkcs8 = "0.10.2"
 png_pong = "0.10.0"
-quick-xml = "0.39.0"
-rand = "0.8.5"
+quick-xml = "0.39.4"
+rand = "0.8.6"
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 range-set = "0.1.0"
-rasn = "0.28.2"
-rasn-cms = "0.28.2"
-rasn-ocsp = "0.28.2"
-rasn-pkix = "0.28.2"
-regex = "1.11"
+rasn = "0.28.13"
+rasn-cms = "0.28.13"
+rasn-ocsp = "0.28.13"
+rasn-pkix = "0.28.13"
+regex = "1.12"
 riff = "2.0.0"
 rsa = { version = "0.9.10", features = ["pem", "sha2", "std"], optional = true }
-schemars = { version = "1.0.4", optional = true }
-serde = { version = "1.0.225", features = ["derive"] }
-serde_bytes = "0.11.14"
-serde_derive = "1.0.197"
-serde_json = { version = "1.0.117", features = ["preserve_order"] }
-serde_with = "3.15.1"
+schemars = { version = "1.2.1", optional = true }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_bytes = "0.11.19"
+serde_derive = "1.0.228"
+serde_json = { version = "1.0.150", features = ["preserve_order"] }
+serde_with = "3.20.0"
 serde-transcode = "1.1.1"
 sha1 = "0.10.6"
 spki = { version = "0.7.3", optional = true }
 static-iref = "3.0"
-tempfile = "3.23.0"
-thiserror = "2.0.17"
-toml = "1.0.2"
-url = "2.5.3"
-uuid = { version = "1.18.0", features = ["serde", "v4"] }
+tempfile = "3.27.0"
+thiserror = "2.0.18"
+toml = "1.1.2"
+url = "2.5.8"
+uuid = { version = "1.23.2", features = ["serde", "v4"] }
 web-time = "1.1"
-x509-parser = "0.18.0"
+x509-parser = "0.18.1"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
-zip = { version = "8.1.0", default-features = false }
+zip = { version = "8.6.0", default-features = false }
 
 # Use the asm feature of sha2 on aarch64 macOS for better performance. This nearly
 # halves hashing time for large assets (> 50gb mp4, for example).
@@ -191,7 +191,7 @@ sha2 = "0.10.6"
 sha2 = { version = "0.10.6", features = ["asm"] }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-reqwest = { version = "0.12.23", default-features = false, features = [
+reqwest = { version = "0.12.28", default-features = false, features = [
     # These are some of the defaults in `reqwest`.
     "http2",
     "system-proxy",
@@ -199,26 +199,26 @@ reqwest = { version = "0.12.23", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-openssl = { version = "0.10.78", features = ["vendored"], optional = true }
-ureq = { version = "3.1.0", default-features = false, features = [
+openssl = { version = "0.10.80", features = ["vendored"], optional = true }
+ureq = { version = "3.3.0", default-features = false, features = [
     "rustls"
 ], optional = true }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = { version = "0.14.3", optional = true }
-wstd = { version = "0.5.4", optional = true }
+wasi = { version = "0.14.7", optional = true }
+wstd = { version = "0.5.6", optional = true }
 
 # `wstd` is required for testing, but optional as a normal dependency.
 [target.'cfg(target_os = "wasi")'.dev-dependencies]
-wstd = "0.5.4"
+wstd = "0.5.6"
 
 # This list matches the `rust_native_crypto` feature since they are not optional on WASM.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 const-oid = "0.9.6"
 ecdsa = { version = "0.16.9", features = ["digest", "sha2"] }
-num-bigint-dig = "0.8.4"
+num-bigint-dig = "0.8.6"
 p256 = "0.13.2"
-p384 = "0.13.0"
+p384 = "0.13.1"
 p521 = { version = "0.13.3", features = [
     "pkcs8",
     "digest",
@@ -229,7 +229,7 @@ rsa = { version = "0.9.10", features = ["sha2"] }
 spki = "0.7.3"
 
 [target.'cfg(any(target_os = "wasi", not(target_arch = "wasm32")))'.dependencies]
-image = { version = "0.25.6", default-features = false, features = [
+image = { version = "0.25.10", default-features = false, features = [
     # TODO: eventually define feature flags for the asset handlers and match them
     #       up here.
     "png",
@@ -245,12 +245,12 @@ image = { version = "0.25.6", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies.chrono]
-version = "0.4.39"
+version = "0.4.44"
 default-features = false
 features = ["now"]
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "emscripten"))'.dependencies.chrono]
-version = "0.4.39"
+version = "0.4.44"
 default-features = false
 features = ["clock", "serde"]
 
@@ -259,21 +259,21 @@ getrandom = { version = "0.3.4", features = ["wasm_js"] }
 # Also enable getrandom 0.2 with js feature for other dependencies (rand, tempfile, config)
 # This is needed until all dependencies migrate to getrandom 0.3
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
-uuid = { version = "1.18.0", features = ["serde", "v4", "js"] }
+uuid = { version = "1.23.2", features = ["serde", "v4", "js"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-chrono = { version = "0.4.39", default-features = false, features = [
+chrono = { version = "0.4.44", default-features = false, features = [
     "clock",
     "serde",
     "wasmbind",
 ] }
 console_log = { version = "1.0.0", features = ["color"] }
 # Enable getrandom with wasm_js feature for WASM support
-js-sys = "0.3.89"
+js-sys = "0.3.99"
 serde-wasm-bindgen = "0.6.5"
-wasm-bindgen = "0.2.112"
-wasm-bindgen-futures = "0.4.31"
-web-sys = { version = "0.3.58", features = [
+wasm-bindgen = "0.2.122"
+wasm-bindgen-futures = "0.4.72"
+web-sys = { version = "0.3.99", features = [
     "console",
     "Crypto",
     "SubtleCrypto",
@@ -283,28 +283,28 @@ web-sys = { version = "0.3.58", features = [
 ] }
 
 [dev-dependencies]
-anyhow = "1.0.97"
-env_logger = "0.11.8"
-glob = "0.3.1"
-hex-literal = "1.0.0"
+anyhow = "1.0.102"
+env_logger = "0.11.10"
+glob = "0.3.3"
+hex-literal = "1.1.0"
 jumbf = "0.7.0"
 c2pa_macros = { path = "../macros" }
 mockall = "0.14.0"
-jsonschema = { version = "0.45.0", default-features = false }
+jsonschema = { version = "0.45.1", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
-wasm-bindgen-test = "0.3.55"
+wasm-bindgen-test = "0.3.72"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-httpmock = "0.8.2"
-tokio = { version = "1.44.2", features = ["full"] }
-criterion = { package = "codspeed-criterion-compat", version = "4.2.1" }
+httpmock = "0.8.3"
+tokio = { version = "1.52.3", features = ["full"] }
+criterion = { package = "codspeed-criterion-compat", version = "4.7.0" }
 dhat = "0.3.3"
 
 # WASM/WASI doesn't support default criterion features.
 # https://github.com/bheisler/criterion.rs/blob/4c19e913b84e6a7e4a8470cb0f766796886ed891/book/src/user_guide/wasi.md
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-criterion = { package = "codspeed-criterion-compat", version = "4.2.1", default-features = false }
+criterion = { package = "codspeed-criterion-compat", version = "4.7.0", default-features = false }
 
 [[bench]]
 name = "sign"


### PR DESCRIPTION
## Dependency Updates

### sdk
| Crate | From | To |
|---|---|---|
| asn1-rs | 0.7.1 | 0.7.2 |
| async-trait | 0.1.78 | 0.1.89 |
| bcder | 0.7.3 | 0.7.6 |
| byteorder | 1.4.3 | 1.5.0 |
| chrono | 0.4.42 | 0.4.44 |
| const-hex | 1.14 | 1.19 |
| coset | 0.4.0 | 0.4.2 |
| der | 0.7.9 | 0.7.10 |
| ed25519-dalek | 2.1.1 | 2.2.0 |
| glob | 0.3.1 | 0.3.3 |
| http | 1.3.1 | 1.4.1 |
| id3 | 1.16.3 | 1.17.0 |
| lazy_static | 1.4.0 | 1.5.0 |
| log | 0.4.8 | 0.4.30 |
| memchr | 2.7.6 | 2.8.1 |
| nonempty-collections | 1.2.1 | 1.3.0 |
| num-bigint-dig | 0.8.4 | 0.8.6 |
| p384 | 0.13.0 | 0.13.1 |
| quick-xml | 0.39.0 | 0.39.4 |
| rand | 0.8.5 | 0.8.6 |
| rasn / rasn-cms / rasn-ocsp / rasn-pkix | 0.28.2 | 0.28.13 | | regex | 1.11 | 1.12 |
| reqwest | 0.12.23 | 0.12.28 |
| schemars | 1.0.4 | 1.2.1 |
| serde / serde_derive | 1.0.225 | 1.0.228 |
| serde_bytes | 0.11.14 | 0.11.19 |
| serde_json | 1.0.117 | 1.0.150 |
| serde_with | 3.15.1 | 3.20.0 |
| tempfile | 3.23.0 | 3.27.0 |
| thiserror | 2.0.17 | 2.0.18 |
| toml | 1.0.2 | 1.1.2 |
| url | 2.5.3 | 2.5.8 |
| uuid | 1.18.0 | 1.23.2 |
| x509-parser | 0.18.0 | 0.18.1 |
| zip | 8.1.0 | 8.6.0 |

### c2pa-c-ffi
| Crate | From | To |
|---|---|---|
| tempfile | 3.7.0 | 3.27.0 |
| thiserror | 2.0.17 | 2.0.18 |
| tokio | 1.36 | 1.52 |

### macros
| Crate | From | To |
|---|---|---|
| quote | 1.0.40 | 1.0.45 |
| syn | 2.0.82 | 2.0.117 |

### c2patool
| Crate | From | To | Note |
|---|---|---|---|
| assert_cmd | 2.0.14 | 2.2.2 | |
| clap | 4.5.50 | 4.6.1 | |
| env_logger | 0.11.8 | 0.11.10 | |
| glob | 0.3.1 | 0.3.3 | |
| httpmock | 0.8.2 | 0.8.3 | |
| reqwest | 0.12.4 | 0.12.28 | latest 0.13.4 is incompatible, deferred | | tempfile | 3.3 | 3.27 | |
| tokio | 1.44.2 | 1.52.3 | |
| toml | 1.0.2 | 1.1.2 | |
| url | 2.5.0 | 2.5.8 | |

### export_schema
| Crate | From | To |
|---|---|---|
| anyhow | 1.0.40 | 1.0.102 |
| schemars | 1.0.4 | 1.2.1 |
| serde_json | 1.0.117 | 1.0.150 |

### make_test_images
| Crate | From | To |
|---|---|---|
| anyhow | 1.0.40 | 1.0.102 |
| image | 0.25.2 | 0.25.10 |
| lazy_static | 1.4.0 | 1.5.0 |
| memchr | 2.7.6 | 2.8.1 |
| regex | 1.5.6 | 1.12.3 |
| serde | 1.0.197 | 1.0.228 |
| serde_json | 1.0.117 | 1.0.150 |
| tempfile | 3.15.0 | 3.27.0 |
| toml | 1.0.2 | 1.1.2 |

### deny.toml
Removed ignored advisory RUSTSEC-2026-0097 (rand unsoundness) — resolved by rand 0.8.6 upgrade.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
