### PR TITLE
fix: Harden against unchecked array index in JUMBF brotli box accessor

### DIFF
--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -356,11 +356,12 @@ impl JUMBFSuperBox {
     }
 
     pub fn data_box_as_brotli_box(&self, index: usize) -> Option<&JUMBFBrotliContentBox> {
-        let da_box = &self.data_boxes[index];
-        da_box
-            .as_ref()
-            .as_any()
-            .downcast_ref::<JUMBFBrotliContentBox>()
+        self.data_boxes.get(index).and_then(|da_box| {
+            da_box
+                .as_ref()
+                .as_any()
+                .downcast_ref::<JUMBFBrotliContentBox>()
+        })
     }
 }
 
@@ -3195,6 +3196,14 @@ pub mod tests {
             "expected BoxNestingTooDeep for {} nested boxes",
             BoxReader::MAX_JUMB_DEPTH + 1
         );
+    }
+
+    #[test]
+    fn test_data_box_as_brotli_box_empty_returns_none() {
+        // `data_box_as_brotli_box` on a superbox with no data boxes must return
+        // None, not panic on out-of-bounds indexing.
+        let sbox = JUMBFSuperBox::new("test.empty", None);
+        assert!(sbox.data_box_as_brotli_box(0).is_none());
     }
 }
 


### PR DESCRIPTION
## Vulnerability

  `JUMBFSuperBox::data_box_as_brotli_box` at `sdk/src/jumbf/boxes.rs:358` used direct array indexing (`&self.data_boxes[index]`)

  A 127-byte JPEG containing a `c2cm` (compressed manifest) superbox with a valid `jumd` description box but zero data boxes triggers a panic during JUMBF parsing, before any cryptographic verification:

```
  thread 'main' panicked at sdk/src/jumbf/boxes.rs:359:38:
  index out of bounds: the len is 0 but the index is 0
 ```

  The caller `CAIManifest::from()` at line 1528 expects `None` for the no-brotli-box case, but the method panicked instead.

  ## Fix

  Use bounds-checked `.get(index).and_then(...)` consistent with the other `data_box_as_*` methods. 

  ## Verification

  Verified against the HackerOne PoC (`poc72_empty_manifest.jpg`, 127 bytes):

  |  | Output | Exit code |
  | --- | --- | --- |
  | Before fix | \`thread 'main' panicked at sdk/src/jumbf/boxes.rs:359:38: index out of bounds: the len is 0 but the index is 0\` | 101 |
  | After fix | \`Error: claim superbox not found\` | 1 |

  ## Test added

  `test_data_box_as_brotli_box_empty_returns_none` — constructs an empty `JUMBFSuperBox` and asserts `data_box_as_brotli_box(0)` returns `None`.


  ## Checklist
  - [x] This PR represents a single feature, fix, or change.
  - [x] All applicable changes have been documented.
  - [x] Any \`TO DO\` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.