### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.1...c2pa-v0.85.2)
+_03 June 2026_
+
+### Fixed
+
+* Exact ingredient redaction URI matching ([#2203](https://github.com/contentauth/c2pa-rs/pull/2203))
+* Harden against integer underflow in JUMBF box parsers ([#2200](https://github.com/contentauth/c2pa-rs/pull/2200))
+* Dup redaction ([#2199](https://github.com/contentauth/c2pa-rs/pull/2199))
+* Harden against unchecked array index in JUMBF brotli box accessor ([#2192](https://github.com/contentauth/c2pa-rs/pull/2192))
+* Make GIF box map C2PA placeholder len 0 rather than 1 ([#2156](https://github.com/contentauth/c2pa-rs/pull/2156))
+* Error with validation results on invalid manifest after verify after sign ([#2147](https://github.com/contentauth/c2pa-rs/pull/2147))
+
 ## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.0...c2pa-v0.85.1)
 _01 June 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bitvec"
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.61"
+version = "0.26.62"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lopdf"
@@ -2518,7 +2518,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.85.1"
+version = "0.85.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -4048,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.85.1"
+version = "0.85.2"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.1...c2pa-c-ffi-v0.85.2)
+_03 June 2026_
+
+### Fixed
+
+* Error with validation results on invalid manifest after verify after sign ([#2147](https://github.com/contentauth/c2pa-rs/pull/2147))
+
 ## [0.85.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.0...c2pa-c-ffi-v0.85.1)
 _01 June 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.85.1", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.85.2", default-features = false, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.62](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.61...c2patool-v0.26.62)
+_03 June 2026_
+
 ## [0.26.61](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.60...c2patool-v0.26.61)
 _01 June 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.61"
+version = "0.26.62"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -24,7 +24,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-c2pa = { path = "../sdk", version = "0.85.1", features = [
+c2pa = { path = "../sdk", version = "0.85.2", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { path = "../sdk", version = "0.85.1", features = [
+c2pa = { path = "../sdk", version = "0.85.2", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.85.1 -> 0.85.2 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.85.1 -> 0.85.2
* `c2patool`: 0.26.61 -> 0.26.62

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.1...c2pa-v0.85.2)

_03 June 2026_

### Fixed

* Exact ingredient redaction URI matching ([#2203](https://github.com/contentauth/c2pa-rs/pull/2203))
* Harden against integer underflow in JUMBF box parsers ([#2200](https://github.com/contentauth/c2pa-rs/pull/2200))
* Dup redaction ([#2199](https://github.com/contentauth/c2pa-rs/pull/2199))
* Harden against unchecked array index in JUMBF brotli box accessor ([#2192](https://github.com/contentauth/c2pa-rs/pull/2192))
* Make GIF box map C2PA placeholder len 0 rather than 1 ([#2156](https://github.com/contentauth/c2pa-rs/pull/2156))
* Error with validation results on invalid manifest after verify after sign ([#2147](https://github.com/contentauth/c2pa-rs/pull/2147))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.1...c2pa-c-ffi-v0.85.2)

_03 June 2026_

### Fixed

* Error with validation results on invalid manifest after verify after sign ([#2147](https://github.com/contentauth/c2pa-rs/pull/2147))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.62](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.61...c2patool-v0.26.62)

_03 June 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).