### PR TITLE
fix: Harden against integer underflow in JUMBF box parsers

### DIFF
--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2177,7 +2177,9 @@ impl BoxReader {
             unread_bytes(reader, HEADER_SIZE)?;
         }
 
-        let json_len = size - HEADER_SIZE;
+        let json_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(json_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2199,7 +2201,9 @@ impl BoxReader {
             unread_bytes(reader, HEADER_SIZE)?;
         }
 
-        let cbor_len = size - HEADER_SIZE;
+        let cbor_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(cbor_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2221,7 +2225,9 @@ impl BoxReader {
             unread_bytes(reader, HEADER_SIZE)?;
         }
 
-        let padding_len = size - HEADER_SIZE;
+        let padding_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(padding_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2244,7 +2250,9 @@ impl BoxReader {
         }
 
         // read the data itself...
-        let data_len = size - HEADER_SIZE;
+        let data_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(data_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2267,7 +2275,9 @@ impl BoxReader {
         }
 
         // read the data itself...
-        let data_len = size - HEADER_SIZE;
+        let data_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(data_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2384,7 +2394,9 @@ impl BoxReader {
         }
 
         // read data itself...
-        let data_len = size - HEADER_SIZE;
+        let data_len = size
+            .checked_sub(HEADER_SIZE)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(data_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2496,7 +2508,10 @@ impl BoxReader {
                         }
 
                         // read data itself...
-                        let data_len = box_header.size - HEADER_SIZE;
+                        let data_len = box_header
+                            .size
+                            .checked_sub(HEADER_SIZE)
+                            .ok_or(JumbfParseError::InvalidBoxHeader)?;
                         reader
                             .read_to_vec(data_len)
                             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -3204,6 +3219,81 @@ pub mod tests {
         // None, not panic on out-of-bounds indexing.
         let sbox = JUMBFSuperBox::new("test.empty", None);
         assert!(sbox.data_box_as_brotli_box(0).is_none());
+    }
+
+    #[test]
+    fn test_read_json_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_json_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_cbor_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_cbor_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_padding_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_padding_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_jp2c_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_jp2c_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_brotli_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_brotli_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_embedded_content_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_embedded_content_box(&mut reader, 4),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_super_box_rejects_undersized_unknown_box() {
+        let sbox = JUMBFSuperBox::new("a", None);
+        let mut bytes = Vec::new();
+        sbox.write_box(&mut bytes).expect("write failed");
+        bytes.extend_from_slice(&4u32.to_be_bytes());
+        bytes.extend_from_slice(b"xxxx");
+
+        let mut reader = Cursor::new(bytes);
+        assert!(matches!(
+            BoxReader::read_super_box(&mut reader),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
     }
 }
 


### PR DESCRIPTION
## Vulnerability

 7 functions in `sdk/src/jumbf/boxes.rs` compute `size - HEADER_SIZE` on attacker-controlled `size` values without first validating `size >= HEADER_SIZE`. A 207-byte malformed JPEG with a JUMBF box declaring
  `size = 4` triggers `attempt to subtract with overflow` during JUMBF structural parsing.

  ## Fix

  Replace `size - HEADER_SIZE` with `size.checked_sub(HEADER_SIZE).ok_or(InvalidBoxHeader)?` at each of the 7 reported sites:

  - `read_json_box`
  - `read_cbor_box`
  - `read_padding_box`
  - `read_jp2c_box`
  - `read_brotli_box`
  - `read_embedded_content_box`
  - `read_super_box_impl` unknown box handler

  ## Tests

  Added 7 regression tests covering all 7 fix paths.

  ## Checklist
  - [x] This PR represents a single feature, fix, or change.
  - [x] All applicable changes have been documented.
  - [x] Any `TO DO` items have been entered as GitHub issues and the link has been included in a comment.
