### PR TITLE
fix: Harden additional JUMBF parser sites against integer underflow

### DIFF
--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -2138,7 +2138,10 @@ impl BoxReader {
             }
 
             if header.name == BoxType::SaltHash {
-                let data_len = header.size - HEADER_SIZE;
+                let data_len = header
+                    .size
+                    .checked_sub(HEADER_SIZE)
+                    .ok_or(JumbfParseError::InvalidBoxHeader)?;
                 let buf = reader
                     .read_to_vec(data_len)
                     .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -2304,7 +2307,9 @@ impl BoxReader {
         reader.read_exact(&mut uuid)?;
 
         // and finally the data itself...
-        let data_len = size - HEADER_SIZE - 16 /*UUID*/;
+        let data_len = size
+            .checked_sub(HEADER_SIZE + 16 /*UUID*/)
+            .ok_or(JumbfParseError::InvalidBoxHeader)?;
         let buf = reader
             .read_to_vec(data_len)
             .map_err(|_| JumbfParseError::InvalidBoxHeader)?;
@@ -3292,6 +3297,32 @@ pub mod tests {
         let mut reader = Cursor::new(bytes);
         assert!(matches!(
             BoxReader::read_super_box(&mut reader),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_uuid_box_rejects_undersized_box() {
+        let stream = vec![0x03u8; 64];
+        let mut reader = Cursor::new(&stream);
+        assert!(matches!(
+            BoxReader::read_uuid_box(&mut reader, 20),
+            Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_read_desc_box_salthash_rejects_undersized_box() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0u8; 16]);
+        data.push(0x13); // toggles: labeled + private
+        data.extend_from_slice(b"a\0");
+        data.extend_from_slice(&4u32.to_be_bytes());
+        data.extend_from_slice(b"c2sh");
+
+        let mut reader = Cursor::new(data);
+        assert!(matches!(
+            BoxReader::read_desc_box(&mut reader, 35),
             Err(JumbfParseError::InvalidBoxHeader)
         ));
     }


### PR DESCRIPTION
## Vulnerability

  Two additional sites in `sdk/src/jumbf/boxes.rs` compute `size - HEADER_SIZE` (or similar) on attacker-controlled `size` values without first validating the minimum size. Both follow the same underflow pattern addressed in #2200 but were not in the original report.

  ## Sites

  - `read_uuid_box` — `size - HEADER_SIZE - 16` (UUID box's payload subtraction)
  - `read_desc_box` SaltHash private-box branch — `header.size - HEADER_SIZE`

  ## Fix

  Same `checked_sub(...).ok_or(InvalidBoxHeader)?` pattern as #2200

  - `read_uuid_box`: `size.checked_sub(HEADER_SIZE + 16).ok_or(...)?`
  - `read_desc_box` SaltHash branch: `header.size.checked_sub(HEADER_SIZE).ok_or(...)?`

  ## Tests

  Added 2 regression tests covering both sites.

  ## Checklist
  - [x] This PR represents a single feature, fix, or change.
  - [x] All applicable changes have been documented.
  - [x] Any `TO DO` items have been entered as GitHub issues and the link has been included in a comment.
