### PR TITLE
fix: Exact ingredient redaction URI matching

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1821,10 +1821,13 @@ impl Claim {
 
         // delete assertion or databox
         if assertion_uri.contains(ASSERTION_STORE) {
+            // Extract the last path segment from the URI to match exactly,
+            // avoids substring false-positives.
+            let uri_label = assertion_uri.rsplit('/').next().unwrap_or(assertion_uri);
             if let Some(index) = self
                 .assertion_store
                 .iter()
-                .position(|x| assertion_uri.contains(&x.label()))
+                .position(|x| x.label() == uri_label)
             {
                 self.assertion_store.remove(index);
                 return Ok(());
@@ -4236,5 +4239,65 @@ pub mod tests {
         }
 
         Ok(())
+    }
+
+    /// When a claim has two assertions whose labels share a prefix
+    /// (e.g. `c2pa.thumbnail.ingredient` and `c2pa.thumbnail.ingredient__1`),
+    /// redacting the `__1` URI must remove only the `__1` instance and leave
+    /// the base instance intact, not vice-versa.
+    #[test]
+    fn test_redact_assertion_exact_label_match_with_shared_prefix() {
+        use crate::{assertions::{labels, EmbeddedData}, jumbf::labels::to_assertion_uri};
+
+        let mut claim = Claim::new("unit test", Some("test"), 2);
+
+        // Add two ingredient thumbnails — the second gets the `__1` suffix.
+        let thumb0 = EmbeddedData::new(labels::INGREDIENT_THUMBNAIL, "image/jpeg", vec![0u8; 4]);
+        let thumb1 = EmbeddedData::new(labels::INGREDIENT_THUMBNAIL, "image/jpeg", vec![1u8; 4]);
+        claim.add_assertion(&thumb0).expect("add thumb0");
+        claim.add_assertion(&thumb1).expect("add thumb1");
+
+        // Both labels must be here
+        assert!(
+            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_some(),
+            "instance 0 should exist"
+        );
+        assert!(
+            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 1).is_some(),
+            "instance 1 should exist"
+        );
+
+        let manifest_label = claim.label();
+        let uri_base = to_assertion_uri(manifest_label, labels::INGREDIENT_THUMBNAIL);
+        let uri_instance1 = to_assertion_uri(
+            manifest_label,
+            &format!("{}__1", labels::INGREDIENT_THUMBNAIL),
+        );
+
+        // Order is important here, first redact the __1 URI
+        claim
+            .redact_assertion(&uri_instance1)
+            .expect("redact instance 1 should succeed");
+
+        // The URI without the __1 (base) should still be here
+        assert!(
+            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_some(),
+            "instance 0 must still exist after redacting instance 1"
+        );
+
+        // Now redact the base
+        claim
+            .redact_assertion(&uri_base)
+            .expect("redact base instance should succeed");
+
+        // Both URIs must be gone now
+        assert!(
+            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_none(),
+            "instance 0 should be gone"
+        );
+        assert!(
+            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 1).is_none(),
+            "instance 1 should be gone"
+        );
     }
 }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1821,14 +1821,9 @@ impl Claim {
 
         // delete assertion or databox
         if assertion_uri.contains(ASSERTION_STORE) {
-            if let Some(index) = self
-                .assertion_store
-                .iter()
-                .position(|x| {
-                    assertion_uri
-                        .ends_with(&Claim::label_with_instance(&x.label_raw(), x.instance()))
-                })
-            {
+            if let Some(index) = self.assertion_store.iter().position(|x| {
+                assertion_uri.ends_with(&Claim::label_with_instance(&x.label_raw(), x.instance()))
+            }) {
                 self.assertion_store.remove(index);
                 return Ok(());
             }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -4247,7 +4247,10 @@ pub mod tests {
     /// the base instance intact, not vice-versa.
     #[test]
     fn test_redact_assertion_exact_label_match_with_shared_prefix() {
-        use crate::{assertions::{labels, EmbeddedData}, jumbf::labels::to_assertion_uri};
+        use crate::{
+            assertions::{labels, EmbeddedData},
+            jumbf::labels::to_assertion_uri,
+        };
 
         let mut claim = Claim::new("unit test", Some("test"), 2);
 
@@ -4259,11 +4262,15 @@ pub mod tests {
 
         // Both labels must be here
         assert!(
-            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_some(),
+            claim
+                .get_assertion(labels::INGREDIENT_THUMBNAIL, 0)
+                .is_some(),
             "instance 0 should exist"
         );
         assert!(
-            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 1).is_some(),
+            claim
+                .get_assertion(labels::INGREDIENT_THUMBNAIL, 1)
+                .is_some(),
             "instance 1 should exist"
         );
 
@@ -4281,7 +4288,9 @@ pub mod tests {
 
         // The URI without the __1 (base) should still be here
         assert!(
-            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_some(),
+            claim
+                .get_assertion(labels::INGREDIENT_THUMBNAIL, 0)
+                .is_some(),
             "instance 0 must still exist after redacting instance 1"
         );
 
@@ -4292,11 +4301,15 @@ pub mod tests {
 
         // Both URIs must be gone now
         assert!(
-            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 0).is_none(),
+            claim
+                .get_assertion(labels::INGREDIENT_THUMBNAIL, 0)
+                .is_none(),
             "instance 0 should be gone"
         );
         assert!(
-            claim.get_assertion(labels::INGREDIENT_THUMBNAIL, 1).is_none(),
+            claim
+                .get_assertion(labels::INGREDIENT_THUMBNAIL, 1)
+                .is_none(),
             "instance 1 should be gone"
         );
     }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1821,13 +1821,13 @@ impl Claim {
 
         // delete assertion or databox
         if assertion_uri.contains(ASSERTION_STORE) {
-            // Extract the last path segment from the URI to match exactly,
-            // avoids substring false-positives.
-            let uri_label = assertion_uri.rsplit('/').next().unwrap_or(assertion_uri);
             if let Some(index) = self
                 .assertion_store
                 .iter()
-                .position(|x| x.label() == uri_label)
+                .position(|x| {
+                    assertion_uri
+                        .ends_with(&Claim::label_with_instance(&x.label_raw(), x.instance()))
+                })
             {
                 self.assertion_store.remove(index);
                 return Ok(());


### PR DESCRIPTION
## Changes in this pull request
Follow-up of https://github.com/contentauth/c2pa-rs/pull/2199. 
Exact ingredient redaction URI matching when looking for redactions.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
