### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.86.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.2...c2pa-v0.86.0)
+_04 June 2026_
+
+### Fixed
+
+* [**breaking**] Remove unused `Error` variant types ([#2195](https://github.com/contentauth/c2pa-rs/pull/2195))
+* Harden additional JUMBF parser sites against integer underflow ([#2201](https://github.com/contentauth/c2pa-rs/pull/2201))
+
 ## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.1...c2pa-v0.85.2)
 _03 June 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.85.2"
+version = "0.86.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.85.2"
+version = "0.86.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.85.2"
+version = "0.86.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.62"
+version = "0.26.63"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.85.2"
+version = "0.86.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2518,7 +2518,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.85.2"
+version = "0.86.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -5584,9 +5584,9 @@ checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.85.2"
+version = "0.86.0"
 
 [workspace.dependencies]
 c2pa = { path = "sdk", default-features = false }

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.86.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.2...c2pa-c-ffi-v0.86.0)
+_04 June 2026_
+
+### Fixed
+
+* [**breaking**] Remove unused `Error` variant types ([#2195](https://github.com/contentauth/c2pa-rs/pull/2195))
+
 ## [0.85.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.1...c2pa-c-ffi-v0.85.2)
 _03 June 2026_
 

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.85.2", default-features = false, features = [
+c2pa = { path = "../sdk", version = "0.86.0", default-features = false, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.63](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.62...c2patool-v0.26.63)
+_04 June 2026_
+
 ## [0.26.62](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.61...c2patool-v0.26.62)
 _03 June 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.62"
+version = "0.26.63"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",
@@ -24,7 +24,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-c2pa = { path = "../sdk", version = "0.85.2", features = [
+c2pa = { path = "../sdk", version = "0.86.0", features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { path = "../sdk", version = "0.85.2", features = [
+c2pa = { path = "../sdk", version = "0.86.0", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.85.2 -> 0.86.0 (⚠ API breaking changes)
* `c2pa-c-ffi`: 0.85.2 -> 0.86.0
* `c2patool`: 0.26.62 -> 0.26.63

### ⚠ `c2pa` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::AssertionUnsupportedVersion, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:42
  variant Error::MissingFeature, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:72
  variant Error::ClaimAlreadySigned, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:89
  variant Error::ClaimMissingIdentity, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:98
  variant Error::UnreferencedManifest, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:128
  variant Error::InvalidCoseSignature, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:132
  variant Error::CoseMissingKey, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:143
  variant Error::CoseCertExpiration, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:159
  variant Error::CoseCertRevoked, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:162
  variant Error::CoseCertUntrusted, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:165
  variant Error::CoseInvalidTimeStamp, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:169
  variant Error::CoseTimeStampValidity, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:172
  variant Error::CoseTimeStampMismatch, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:176
  variant Error::CoseTimeStampAuthority, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:183
  variant Error::WasmVerifier, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:192
  variant Error::WasmRsaKeyImport, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:195
  variant Error::WasmRsaVerification, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:198
  variant Error::WasmKey, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:201
  variant Error::WasmInvalidContext, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:204
  variant Error::WasmNoCrypto, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:207
  variant Error::WasmNoRemoteSigner, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:210
  variant Error::WasmFeatureUnsupported, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:213
  variant Error::FailedToFetchSettings, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:235
  variant Error::LogStop, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:241
  variant Error::OutOfRange, previously in file /tmp/.tmp8w8ki6/c2pa/src/error.rs:365
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.86.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.85.2...c2pa-v0.86.0)

_04 June 2026_

### Fixed

* [**breaking**] Remove unused `Error` variant types ([#2195](https://github.com/contentauth/c2pa-rs/pull/2195))
* Harden additional JUMBF parser sites against integer underflow ([#2201](https://github.com/contentauth/c2pa-rs/pull/2201))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.86.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.85.2...c2pa-c-ffi-v0.86.0)

_04 June 2026_

### Fixed

* [**breaking**] Remove unused `Error` variant types ([#2195](https://github.com/contentauth/c2pa-rs/pull/2195))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.63](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.62...c2patool-v0.26.63)

_04 June 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).