### PR TITLE
fix: Harden JUMBF and JPEG XL parsers against Brotli decompression bombs

### DIFF
--- a/docs/context-settings.md
+++ b/docs/context-settings.md
@@ -230,7 +230,8 @@ Here's the Settings JSON with all default values:
     "merkle_tree_max_proofs": 5,
     "backing_store_memory_threshold_in_mb": 512,
     "decode_identity_assertions": true,
-    "allowed_network_hosts": null
+    "allowed_network_hosts": null,
+    "max_decompressed_manifest_size_in_mb": 32
   },
   "signer": null,
   "trust": {

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -224,7 +224,7 @@ fn parse_all_boxes(reader: &mut dyn CAIRead) -> Result<Vec<JxlBoxInfo>> {
 /// If a `brob` box wraps content of the given target type, decompress and return it.
 /// The reader should be positioned at the start of the brob box's data area.
 fn decompress_brob(reader: &mut dyn CAIRead, data_size: u64) -> Result<([u8; 4], Vec<u8>)> {
-    const MAX_DECOMPRESSED_BROB_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+    const MAX_DECOMPRESSED_BROB_SIZE: usize = 1024 * 1024; // 1 MiB
 
     let mut original_type = [0u8; 4];
     reader
@@ -1518,7 +1518,7 @@ pub mod tests {
 
     #[test]
     fn test_brob_decompression_rejects_bomb() {
-        let payload = vec![0u8; 11 * 1024 * 1024];
+        let payload = vec![0u8; 1024 * 1024 + 1];
         let mut compressed = Vec::new();
         let params = brotli::enc::BrotliEncoderParams::default();
         brotli::BrotliCompress(

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -234,7 +234,7 @@ fn decompress_brob(reader: &mut dyn CAIRead, data_size: u64) -> Result<([u8; 4],
     let compressed_size = data_size.saturating_sub(4);
     let mut constrained_reader = reader.take(compressed_size);
 
-    let mut bounded_writer = BoundedVecWriter::new(MAX_DECOMPRESSED_BROB_SIZE);
+    let mut bounded_writer = BoundedVecWriter::new(MAX_DECOMPRESSED_BROB_SIZE)?;
     brotli::BrotliDecompress(&mut constrained_reader, &mut bounded_writer)
         .map_err(|_| Error::InvalidAsset("Failed to decompress brob box".to_string()))?;
 

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -51,7 +51,7 @@ use crate::{
     },
     error::{Error, Result},
     utils::{
-        io_utils::{patch_stream, safe_vec, stream_len, tempfile_builder},
+        io_utils::{patch_stream, safe_vec, stream_len, tempfile_builder, BoundedVecWriter},
         xmp_inmemory_utils::{add_provenance, MIN_XMP},
     },
 };
@@ -234,8 +234,7 @@ fn decompress_brob(reader: &mut dyn CAIRead, data_size: u64) -> Result<([u8; 4],
     let compressed_size = data_size.saturating_sub(4);
     let mut constrained_reader = reader.take(compressed_size);
 
-    let mut bounded_writer =
-        crate::utils::io_utils::BoundedVecWriter::new(MAX_DECOMPRESSED_BROB_SIZE);
+    let mut bounded_writer = BoundedVecWriter::new(MAX_DECOMPRESSED_BROB_SIZE);
     brotli::BrotliDecompress(&mut constrained_reader, &mut bounded_writer)
         .map_err(|_| Error::InvalidAsset("Failed to decompress brob box".to_string()))?;
 

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -224,6 +224,8 @@ fn parse_all_boxes(reader: &mut dyn CAIRead) -> Result<Vec<JxlBoxInfo>> {
 /// If a `brob` box wraps content of the given target type, decompress and return it.
 /// The reader should be positioned at the start of the brob box's data area.
 fn decompress_brob(reader: &mut dyn CAIRead, data_size: u64) -> Result<([u8; 4], Vec<u8>)> {
+    const MAX_DECOMPRESSED_BROB_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+
     let mut original_type = [0u8; 4];
     reader
         .read_exact(&mut original_type)
@@ -232,11 +234,12 @@ fn decompress_brob(reader: &mut dyn CAIRead, data_size: u64) -> Result<([u8; 4],
     let compressed_size = data_size.saturating_sub(4);
     let mut constrained_reader = reader.take(compressed_size);
 
-    let mut decompressed = Vec::new();
-    brotli::BrotliDecompress(&mut constrained_reader, &mut decompressed)
+    let mut bounded_writer =
+        crate::utils::io_utils::BoundedVecWriter::new(MAX_DECOMPRESSED_BROB_SIZE);
+    brotli::BrotliDecompress(&mut constrained_reader, &mut bounded_writer)
         .map_err(|_| Error::InvalidAsset("Failed to decompress brob box".to_string()))?;
 
-    Ok((original_type, decompressed))
+    Ok((original_type, bounded_writer.into_inner()))
 }
 
 /// Returns `true` if the given `jumb` box payload contains a JUMBF description box (`jumd`)
@@ -1512,6 +1515,29 @@ pub mod tests {
 
         assert_eq!(orig_type, BOX_XML);
         assert_eq!(decompressed, original_data);
+    }
+
+    #[test]
+    fn test_brob_decompression_rejects_bomb() {
+        let payload = vec![0u8; 11 * 1024 * 1024];
+        let mut compressed = Vec::new();
+        let params = brotli::enc::BrotliEncoderParams::default();
+        brotli::BrotliCompress(
+            &mut Cursor::new(payload.as_slice()),
+            &mut compressed,
+            &params,
+        )
+        .unwrap();
+
+        let mut brob_payload = Vec::new();
+        brob_payload.extend_from_slice(&BOX_XML);
+        brob_payload.extend_from_slice(&compressed);
+
+        let mut cursor = Cursor::new(&brob_payload);
+        assert!(matches!(
+            decompress_brob(&mut cursor, brob_payload.len() as u64),
+            Err(Error::InvalidAsset(_))
+        ));
     }
 
     #[test]

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -1523,17 +1523,18 @@ impl CAIManifest {
     }
 
     pub fn from(sbox: &JUMBFSuperBox) -> JumbfParseResult<Self> {
+        const MAX_DECOMPRESSED_MANIFEST_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+
         let mut compressed_store = false;
 
         // decompress brotli box if available
         let store_box = if let Some(compressed_manifest) = sbox.data_box_as_brotli_box(0) {
-            let decompressed_manifest = Vec::new();
-
-            let mut decompressed_stream = Cursor::new(decompressed_manifest);
+            let mut bounded_writer =
+                crate::utils::io_utils::BoundedVecWriter::new(MAX_DECOMPRESSED_MANIFEST_SIZE);
             let mut compressed_stream = Cursor::new(compressed_manifest.data());
-            brotli::BrotliDecompress(&mut compressed_stream, &mut decompressed_stream)?;
+            brotli::BrotliDecompress(&mut compressed_stream, &mut bounded_writer)?;
 
-            decompressed_stream.rewind()?;
+            let mut decompressed_stream = Cursor::new(bounded_writer.into_inner());
 
             compressed_store = true;
             BoxReader::read_super_box(&mut decompressed_stream)?
@@ -3324,6 +3325,26 @@ pub mod tests {
         assert!(matches!(
             BoxReader::read_desc_box(&mut reader, 35),
             Err(JumbfParseError::InvalidBoxHeader)
+        ));
+    }
+
+    #[test]
+    fn test_caimanifest_from_rejects_decompression_bomb() {
+        use brotli::enc::BrotliEncoderParams;
+
+        let payload = vec![0u8; 11 * 1024 * 1024];
+        let mut compressed = Vec::new();
+        let mut input = Cursor::new(payload.as_slice());
+        brotli::BrotliCompress(&mut input, &mut compressed, &BrotliEncoderParams::default())
+            .expect("brotli compress");
+
+        let brotli_box = JUMBFBrotliContentBox::new(compressed);
+        let mut sbox = JUMBFSuperBox::new("test", None);
+        sbox.add_data_box(Box::new(brotli_box));
+
+        assert!(matches!(
+            CAIManifest::from(&sbox),
+            Err(JumbfParseError::IoError(_))
         ));
     }
 }

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -26,7 +26,7 @@ use std::{
     any::Any,
     ffi::CString,
     fmt,
-    io::{Cursor, Read, Result as IoResult, Seek, SeekFrom, Write},
+    io::{Cursor, Error as IoError, Read, Result as IoResult, Seek, SeekFrom, Write},
 };
 
 use byteorder::{BigEndian, ReadBytesExt};
@@ -36,7 +36,6 @@ use thiserror::Error;
 
 use crate::{
     jumbf::{boxio, labels},
-    settings::Settings,
     utils::io_utils::{BoundedVecWriter, ReaderUtils},
 };
 
@@ -1523,17 +1522,13 @@ impl CAIManifest {
         }
     }
 
-    pub fn from(sbox: &JUMBFSuperBox, settings: &Settings) -> JumbfParseResult<Self> {
-        let max_size = settings
-            .core
-            .max_decompressed_manifest_size_in_mb
-            .saturating_mul(1024 * 1024);
-
+    pub fn from(sbox: &JUMBFSuperBox, max_manifest_size: usize) -> JumbfParseResult<Self> {
         let mut compressed_store = false;
 
         // decompress brotli box if available
         let store_box = if let Some(compressed_manifest) = sbox.data_box_as_brotli_box(0) {
-            let mut bounded_writer = BoundedVecWriter::new(max_size);
+            let mut bounded_writer = BoundedVecWriter::new(max_manifest_size)
+                .map_err(|e| JumbfParseError::IoError(IoError::other(e.to_string())))?;
             let mut compressed_stream = Cursor::new(compressed_manifest.data());
             brotli::BrotliDecompress(&mut compressed_stream, &mut bounded_writer)?;
 
@@ -3332,12 +3327,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_caimanifest_from_rejects_bomb_at_default_cap() {
+    fn test_caimanifest_from_rejects_bomb_above_cap() {
         use brotli::enc::BrotliEncoderParams;
 
-        use crate::settings::Settings;
-
-        let payload = vec![0u8; 32 * 1024 * 1024 + 1];
+        let cap = 1024 * 1024; // 1 MiB
+        let payload = vec![0u8; cap + 1];
         let mut compressed = Vec::new();
         brotli::BrotliCompress(
             &mut Cursor::new(payload.as_slice()),
@@ -3351,36 +3345,7 @@ pub mod tests {
         sbox.add_data_box(Box::new(brotli_box));
 
         assert!(matches!(
-            CAIManifest::from(&sbox, &Settings::default()),
-            Err(JumbfParseError::IoError(_))
-        ));
-    }
-
-    #[test]
-    fn test_caimanifest_from_rejects_bomb_above_lowered_cap() {
-        use brotli::enc::BrotliEncoderParams;
-
-        use crate::settings::Settings;
-
-        let settings = Settings::default()
-            .with_value("core.max_decompressed_manifest_size_in_mb", 16usize)
-            .unwrap();
-
-        let payload = vec![0u8; 16 * 1024 * 1024 + 1];
-        let mut compressed = Vec::new();
-        brotli::BrotliCompress(
-            &mut Cursor::new(payload.as_slice()),
-            &mut compressed,
-            &BrotliEncoderParams::default(),
-        )
-        .expect("brotli compress");
-
-        let brotli_box = JUMBFBrotliContentBox::new(compressed);
-        let mut sbox = JUMBFSuperBox::new("test", None);
-        sbox.add_data_box(Box::new(brotli_box));
-
-        assert!(matches!(
-            CAIManifest::from(&sbox, &settings),
+            CAIManifest::from(&sbox, cap),
             Err(JumbfParseError::IoError(_))
         ));
     }

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -36,6 +36,7 @@ use thiserror::Error;
 
 use crate::{
     jumbf::{boxio, labels},
+    settings::Settings,
     utils::io_utils::{BoundedVecWriter, ReaderUtils},
 };
 
@@ -1522,14 +1523,17 @@ impl CAIManifest {
         }
     }
 
-    pub fn from(sbox: &JUMBFSuperBox) -> JumbfParseResult<Self> {
-        const MAX_DECOMPRESSED_MANIFEST_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+    pub fn from(sbox: &JUMBFSuperBox, settings: &Settings) -> JumbfParseResult<Self> {
+        let max_size = settings
+            .core
+            .max_decompressed_manifest_size_in_mb
+            .saturating_mul(1024 * 1024);
 
         let mut compressed_store = false;
 
         // decompress brotli box if available
         let store_box = if let Some(compressed_manifest) = sbox.data_box_as_brotli_box(0) {
-            let mut bounded_writer = BoundedVecWriter::new(MAX_DECOMPRESSED_MANIFEST_SIZE);
+            let mut bounded_writer = BoundedVecWriter::new(max_size);
             let mut compressed_stream = Cursor::new(compressed_manifest.data());
             brotli::BrotliDecompress(&mut compressed_stream, &mut bounded_writer)?;
 
@@ -3328,21 +3332,55 @@ pub mod tests {
     }
 
     #[test]
-    fn test_caimanifest_from_rejects_decompression_bomb() {
+    fn test_caimanifest_from_rejects_bomb_at_default_cap() {
         use brotli::enc::BrotliEncoderParams;
 
-        let payload = vec![0u8; 11 * 1024 * 1024];
+        use crate::settings::Settings;
+
+        let payload = vec![0u8; 32 * 1024 * 1024 + 1];
         let mut compressed = Vec::new();
-        let mut input = Cursor::new(payload.as_slice());
-        brotli::BrotliCompress(&mut input, &mut compressed, &BrotliEncoderParams::default())
-            .expect("brotli compress");
+        brotli::BrotliCompress(
+            &mut Cursor::new(payload.as_slice()),
+            &mut compressed,
+            &BrotliEncoderParams::default(),
+        )
+        .expect("brotli compress");
 
         let brotli_box = JUMBFBrotliContentBox::new(compressed);
         let mut sbox = JUMBFSuperBox::new("test", None);
         sbox.add_data_box(Box::new(brotli_box));
 
         assert!(matches!(
-            CAIManifest::from(&sbox),
+            CAIManifest::from(&sbox, &Settings::default()),
+            Err(JumbfParseError::IoError(_))
+        ));
+    }
+
+    #[test]
+    fn test_caimanifest_from_rejects_bomb_above_lowered_cap() {
+        use brotli::enc::BrotliEncoderParams;
+
+        use crate::settings::Settings;
+
+        let settings = Settings::default()
+            .with_value("core.max_decompressed_manifest_size_in_mb", 16usize)
+            .unwrap();
+
+        let payload = vec![0u8; 16 * 1024 * 1024 + 1];
+        let mut compressed = Vec::new();
+        brotli::BrotliCompress(
+            &mut Cursor::new(payload.as_slice()),
+            &mut compressed,
+            &BrotliEncoderParams::default(),
+        )
+        .expect("brotli compress");
+
+        let brotli_box = JUMBFBrotliContentBox::new(compressed);
+        let mut sbox = JUMBFSuperBox::new("test", None);
+        sbox.add_data_box(Box::new(brotli_box));
+
+        assert!(matches!(
+            CAIManifest::from(&sbox, &settings),
             Err(JumbfParseError::IoError(_))
         ));
     }

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 
 use crate::{
     jumbf::{boxio, labels},
-    utils::io_utils::ReaderUtils,
+    utils::io_utils::{BoundedVecWriter, ReaderUtils},
 };
 
 /// `JumbfParseError` enumerates errors detected while parsing JUMBF data structures.
@@ -1529,8 +1529,7 @@ impl CAIManifest {
 
         // decompress brotli box if available
         let store_box = if let Some(compressed_manifest) = sbox.data_box_as_brotli_box(0) {
-            let mut bounded_writer =
-                crate::utils::io_utils::BoundedVecWriter::new(MAX_DECOMPRESSED_MANIFEST_SIZE);
+            let mut bounded_writer = BoundedVecWriter::new(MAX_DECOMPRESSED_MANIFEST_SIZE);
             let mut compressed_stream = Cursor::new(compressed_manifest.data());
             brotli::BrotliDecompress(&mut compressed_stream, &mut bounded_writer)?;
 

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -295,6 +295,11 @@ pub struct Core {
     /// See more information in the spec here:
     /// [Compressed manifests - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_compressed_boxes)
     pub prefer_compress_manifests: bool,
+    /// Maximum size in megabytes of a Brotli-decompressed JUMBF manifest.
+    /// Limits memory consumption from decompression bomb attacks.
+    ///
+    /// The default is 32 MB.
+    pub max_decompressed_manifest_size_in_mb: usize,
 }
 
 impl Default for Core {
@@ -306,6 +311,7 @@ impl Default for Core {
             decode_identity_assertions: true,
             allowed_network_hosts: None,
             prefer_compress_manifests: false,
+            max_decompressed_manifest_size_in_mb: 32,
         }
     }
 }
@@ -1125,6 +1131,7 @@ pub mod tests {
             merkle_tree_chunk_size_in_kb = true
             merkle_tree_max_proofs = "sha1000000"
             backing_store_memory_threshold_in_mb = -123456
+            max_decompressed_manifest_size_in_mb = -123456
         }
         .to_string();
 

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -318,6 +318,12 @@ impl Default for Core {
 
 impl SettingsValidate for Core {
     fn validate(&self) -> Result<()> {
+        const MAX_MANIFEST_SIZE_MB: usize = 1024; // 1 GiB
+        if self.max_decompressed_manifest_size_in_mb > MAX_MANIFEST_SIZE_MB {
+            return Err(Error::BadParam(format!(
+                "max_decompressed_manifest_size_in_mb must not exceed {MAX_MANIFEST_SIZE_MB} MB"
+            )));
+        }
         Ok(())
     }
 }
@@ -1136,6 +1142,13 @@ pub mod tests {
         .to_string();
 
         assert!(Settings::new().with_toml(&modified_core).is_err());
+    }
+
+    #[test]
+    fn test_core_validate_rejects_oversized_manifest_cap() {
+        let result =
+            Settings::default().with_value("core.max_decompressed_manifest_size_in_mb", 1025usize);
+        assert!(result.is_err());
     }
 
     /// Legacy test: verifies arbitrary (hidden) keys can be stored and retrieved via the

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1195,12 +1195,12 @@ impl Store {
 
     #[inline]
     pub fn from_jumbf(buffer: &[u8], validation_log: &mut StatusTracker) -> Result<Store> {
-        Self::from_jumbf_impl(
-            Store::new(),
-            buffer,
-            validation_log,
-            &get_thread_local_settings(),
-        )
+        // Legacy path: no Context available; read thread-local settings for backward compatibility.
+        let max_manifest_size = get_thread_local_settings()
+            .core
+            .max_decompressed_manifest_size_in_mb
+            .saturating_mul(1024 * 1024);
+        Self::from_jumbf_impl(Store::new(), buffer, validation_log, max_manifest_size)
     }
 
     #[inline]
@@ -1209,11 +1209,16 @@ impl Store {
         validation_log: &mut StatusTracker,
         context: &Context,
     ) -> Result<Store> {
+        let max_manifest_size = context
+            .settings()
+            .core
+            .max_decompressed_manifest_size_in_mb
+            .saturating_mul(1024 * 1024);
         Self::from_jumbf_impl(
             Store::from_context(context),
             buffer,
             validation_log,
-            context.settings(),
+            max_manifest_size,
         )
     }
 
@@ -1221,7 +1226,7 @@ impl Store {
         mut store: Store,
         buffer: &[u8],
         validation_log: &mut StatusTracker,
-        settings: &Settings,
+        max_manifest_size: usize,
     ) -> Result<Store> {
         if buffer.is_empty() {
             return Err(Error::JumbfNotFound);
@@ -1253,7 +1258,7 @@ impl Store {
                 cai_block
                     .data_box_as_superbox(idx)
                     .ok_or(Error::JumbfBoxNotFound)?,
-                settings,
+                max_manifest_size,
             )?;
             let cai_store_box = store_box.super_box();
             let cai_store_desc_box = cai_store_box.desc_box();

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -71,7 +71,7 @@ use crate::{
     log_item,
     manifest_store_report::ManifestStoreReport,
     maybe_send_sync::MaybeSend,
-    settings::{builder::OcspFetchScope, Settings, MAX_ASSERTIONS},
+    settings::{builder::OcspFetchScope, get_thread_local_settings, Settings, MAX_ASSERTIONS},
     status_tracker::{ErrorBehavior, StatusTracker},
     utils::{
         hash_utils::HashRange,
@@ -1195,7 +1195,12 @@ impl Store {
 
     #[inline]
     pub fn from_jumbf(buffer: &[u8], validation_log: &mut StatusTracker) -> Result<Store> {
-        Self::from_jumbf_impl(Store::new(), buffer, validation_log)
+        Self::from_jumbf_impl(
+            Store::new(),
+            buffer,
+            validation_log,
+            &get_thread_local_settings(),
+        )
     }
 
     #[inline]
@@ -1204,13 +1209,19 @@ impl Store {
         validation_log: &mut StatusTracker,
         context: &Context,
     ) -> Result<Store> {
-        Self::from_jumbf_impl(Store::from_context(context), buffer, validation_log)
+        Self::from_jumbf_impl(
+            Store::from_context(context),
+            buffer,
+            validation_log,
+            context.settings(),
+        )
     }
 
     fn from_jumbf_impl(
         mut store: Store,
         buffer: &[u8],
         validation_log: &mut StatusTracker,
+        settings: &Settings,
     ) -> Result<Store> {
         if buffer.is_empty() {
             return Err(Error::JumbfNotFound);
@@ -1242,6 +1253,7 @@ impl Store {
                 cai_block
                     .data_box_as_superbox(idx)
                     .ok_or(Error::JumbfBoxNotFound)?,
+                settings,
             )?;
             let cai_store_box = store_box.super_box();
             let cai_store_desc_box = cai_store_box.desc_box();
@@ -5677,6 +5689,67 @@ pub mod tests {
         assert!(!report.logged_items().is_empty());
 
         assert!(report.has_error(Error::UnsupportedType));
+    }
+
+    fn make_brotli_bomb_jumbf(decompressed_size: usize) -> Vec<u8> {
+        use brotli::enc::BrotliEncoderParams;
+
+        use crate::{
+            jumbf::boxes::{Cai, JUMBFBrotliContentBox, JUMBFSuperBox, CAI_MANIFEST_UUID},
+            store::BMFFBox,
+        };
+
+        let payload = vec![0u8; decompressed_size];
+        let mut compressed = Vec::new();
+        brotli::BrotliCompress(
+            &mut Cursor::new(payload.as_slice()),
+            &mut compressed,
+            &BrotliEncoderParams::default(),
+        )
+        .expect("brotli compress");
+
+        let brotli_box = JUMBFBrotliContentBox::new(compressed);
+        let mut manifest_sbox = JUMBFSuperBox::new("test.manifest", Some(CAI_MANIFEST_UUID));
+        manifest_sbox.add_data_box(Box::new(brotli_box));
+
+        let mut cai = Cai::new();
+        cai.add_box(Box::new(manifest_sbox));
+
+        let mut bytes = Vec::new();
+        cai.super_box()
+            .write_box(&mut bytes)
+            .expect("serialize cai block");
+        bytes
+    }
+
+    #[test]
+    fn test_from_jumbf_rejects_brotli_bomb_via_thread_local() {
+        crate::settings::set_settings_value("core.max_decompressed_manifest_size_in_mb", 1usize)
+            .unwrap();
+
+        let result = Store::from_jumbf(
+            &make_brotli_bomb_jumbf(2 * 1024 * 1024),
+            &mut StatusTracker::default(),
+        );
+
+        crate::settings::reset_default_settings().unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_jumbf_with_context_rejects_brotli_bomb() {
+        let settings = Settings::default()
+            .with_value("core.max_decompressed_manifest_size_in_mb", 1usize)
+            .unwrap();
+        let context = Context::new().with_settings(settings).unwrap();
+
+        let result = Store::from_jumbf_with_context(
+            &make_brotli_bomb_jumbf(2 * 1024 * 1024),
+            &mut StatusTracker::default(),
+            &context,
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -156,6 +156,40 @@ pub(crate) fn stream_with_fs_fallback(
     Ok(spooled)
 }
 
+// Write adapter that caps output at `max_len` bytes, preventing decompression
+// bombs and similar unbounded-output attacks.
+pub(crate) struct BoundedVecWriter {
+    inner: Vec<u8>,
+    max_len: usize,
+}
+
+impl BoundedVecWriter {
+    pub(crate) fn new(max_len: usize) -> Self {
+        Self {
+            inner: Vec::new(),
+            max_len,
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
+impl Write for BoundedVecWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.inner.len().saturating_add(buf.len()) > self.max_len {
+            return Err(std::io::Error::other("output exceeds maximum size"));
+        }
+        self.inner.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 // Returns a new Vec first making sure it can hold the desired capacity.  Fill
 // with default value if provided
 pub(crate) fn safe_vec<T: Clone>(item_cnt: u64, init_with: Option<T>) -> Result<Vec<T>> {

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -164,11 +164,11 @@ pub(crate) struct BoundedVecWriter {
 }
 
 impl BoundedVecWriter {
-    pub(crate) fn new(max_len: usize) -> Self {
-        Self {
-            inner: Vec::new(),
+    pub(crate) fn new(max_len: usize) -> Result<Self> {
+        Ok(Self {
+            inner: safe_vec(max_len as u64, None)?,
             max_len,
-        }
+        })
     }
 
     pub(crate) fn into_inner(self) -> Vec<u8> {


### PR DESCRIPTION
## Vulnerability

Two sites decompress attacker-controlled Brotli data into an unbounded `Vec<u8>`. A few KB crafted payload can expand to gigabytes and exhaust memory. 

 ## Sites
 - `CAIManifest::from` in `sdk/src/jumbf/boxes.rs` (JUMBF Brotli box)
 - `decompress_brob` in `sdk/src/asset_handlers/jpegxl_io.rs` (JPEG XL `brob` box)

 ## Fix

Added `BoundedVecWriter` in `sdk/src/utils/io_utils.rs` — a `Write` that fails once the bytes written exceed a cap. Both sites use `BoundedVecWriter` with a maximum limit of **10 MiB**.  We should discuss adjusting the cap based on expected manifest / XMP sizes

 ## Tests

 Two regression tests — each compresses an 11 MiB zero buffer and asserts the decode returns `Err`.

  ## Checklist
  - [x] This PR represents a single feature, fix, or change.
  - [x] All applicable changes have been documented.
  - [x] Any `TO DO` items have been entered as GitHub issues and the link has been included in a comment.
