### PR TITLE
ci: run `miri` on `c2pa-c-ffi`

### DIFF
--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -200,3 +200,40 @@ jobs:
 
       - name: Run cargo-udeps
         run: cargo udeps --all-targets --all-features
+
+  miri:
+    name: Miri on c2pa-c-ffi
+    if: contains(github.event.pull_request.labels.*.name, 'miri')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cargo-nextest
+        run: cargo binstall --no-confirm cargo-nextest
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Miri
+        run: cargo +nightly miri setup
+
+      - name: Run Miri on c2pa-c-ffi
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"
+        run: |
+          cargo +nightly miri nextest run \
+            --config 'profile.default.slow-timeout={ period = "120s", terminate-after = 5 }' \
+            -p c2pa-c-ffi \
+            --no-default-features \
+            --features rust_native_crypto,file_io \
+            --no-fail-fast

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -232,7 +232,6 @@ jobs:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"
         run: |
           cargo +nightly miri nextest run \
-            --config 'profile.default.slow-timeout={ period = "120s", terminate-after = 5 }' \
             -p c2pa-c-ffi \
             --no-default-features \
             --features rust_native_crypto,file_io \


### PR DESCRIPTION
Builds off #2089 to run `miri` in CI on `c2pa-c-ffi` tests.