### PR TITLE
ci: Use latest `release-plz` and add a dry run job on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,43 +33,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}
-        run: |
-          echo "-- Running release-plz release-pr --"
-          release_pr_output=$(release-plz release-pr \
-            --git-token "${GITHUB_TOKEN}" \
-            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
-            -o json)
-          echo "release_pr_output: $release_pr_output"
-          prs=$(echo "$release_pr_output" | jq -c .prs)
-          echo "prs=$prs" >> "$GITHUB_OUTPUT"
-          prs_length=$(echo "$prs" | jq 'length')
-          if [ "$prs_length" != "0" ]; then
-            prs_created=true
-            first_pr=$(echo "$prs" | jq -c '.[0]')
-          else
-            prs_created=false
-            first_pr="{}"
-          fi
-          echo "pr=$first_pr" >> "$GITHUB_OUTPUT"
-          echo "prs_created=$prs_created" >> "$GITHUB_OUTPUT"
-
-          echo "-- Running release-plz release --"
-          release_output=$(release-plz release \
-            --git-token "${GITHUB_TOKEN}" \
-            -o json)
-          echo "release_output: $release_output"
-          releases=$(echo "$release_output" | jq -c .releases)
-          echo "releases=$releases" >> "$GITHUB_OUTPUT"
-          releases_length=$(echo "$releases" | jq 'length')
-          if [ "$releases_length" != "0" ]; then
-            releases_created=true
-          else
-            releases_created=false
-          fi
-          echo "releases_created=$releases_created" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch newly created tags
-        run: git fetch --tags
 
       - name: Debug release-plz outputs
         env:
@@ -90,12 +53,12 @@ jobs:
 
       - name: Identify c2patool release
         id: sniff-c2patool-release-tag
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
-          echo "All tags on HEAD:"
-          git tag --contains HEAD
-          echo "Filtered c2patool tags:"
-          git tag --contains HEAD | grep '^c2patool-' || echo "No c2patool tags found"
-          echo tag=`git tag --contains HEAD | grep '^c2patool-'` >> "$GITHUB_OUTPUT" || true
+          tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "c2patool") | .tag // empty')
+          echo "c2patool tag: ${tag:-<none>}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
   publish-c2patool-binaries:
     name: Publish c2patool binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,39 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
+  dry-run-release-plz:
+    name: Release-plz dry run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Dry-run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5.129
+        with:
+          command: release
+          dry_run: true
+          verbose: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}
+
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     outputs:
       c2patool-release-tag: ${{ steps.sniff-c2patool-release-tag.outputs.tag }}
@@ -30,6 +58,8 @@ jobs:
       - name: Run release-plz
         id: release-plz
         uses: MarcoIeni/release-plz-action@v0.5.129
+        with:
+          verbose: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ jobs:
     name: Release-plz
     runs-on: ubuntu-latest
 
-    env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
     outputs:
       c2patool-release-tag: ${{ steps.sniff-c2patool-release-tag.outputs.tag }}
 
@@ -31,32 +27,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # Hopefully temporary step while we sort out build issues.
-      - name: Work around crates.io git index issues
-        run: |
-          rm -rf ~/.cargo/registry/index/github.com-1ecc6299db9ec823/ || true
-
-      - name: Install release-plz from fork
-        run: |
-          curl -sL -o release-plz.tar.gz \
-            https://github.com/scouten-adobe/release-plz/releases/download/patched-2026-02-12/release-plz-linux-x86_64.tar.gz
-          tar -xzf release-plz.tar.gz
-          REPLZ=$(find . -maxdepth 2 -name 'release-plz' -type f | head -1)
-          chmod +x "$REPLZ" && sudo mv "$REPLZ" /usr/local/bin/release-plz
-          rm -f release-plz.tar.gz
-
-      - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@90b40388b8931b1c39e248959515e295e02e9066
-        with:
-          tool: cargo-semver-checks@0.46
-
-      - name: Configure git user from GitHub token
-        uses: release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-
       - name: Run release-plz
         id: release-plz
+        uses: MarcoIeni/release-plz-action@v0.5.129
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,56 +106,6 @@ jobs:
           echo "RP output: $PR"
           echo "========================="
 
-      - name: Force update of c2pa_c_ffi if only c2pa-rs is updated
-        if: ${{ contains(steps.release-plz.outputs.pr, '"c2pa"') && !contains(steps.release-plz.outputs.pr, 'c2pa-c-ffi') }}
-        env:
-          PR: ${{ steps.release-plz.outputs.pr }}
-        run: |
-          # Ensure we're on a clean main branch
-          git checkout main
-          git pull origin main
-
-          # Extract the new version of c2pa from the release PR output JSON
-          NEW_VERSION=$(echo "$PR" | jq -r '.releases[] | select(.package_name == "c2pa") | .version')
-
-          # Update the c2pa dependency version in c2pa_c_ffi/Cargo.toml
-          sed -i.bak "s/\(c2pa = { path = \"..\/sdk\", version = \"\)[^\"]*\"/\1$NEW_VERSION\"/" c2pa_c_ffi/Cargo.toml
-          rm c2pa_c_ffi/Cargo.toml.bak
-
-          # Configure git and commit the changes only if there are changes
-          git config user.name "CAI Open Source Builds"
-          git config user.email "caiopensrc@adobe.com"
-          git add c2pa_c_ffi/Cargo.toml
-          if ! git diff --staged --quiet; then
-            git commit -m "fix: Update c2pa dependency to $NEW_VERSION"
-            git push origin main
-          fi
-
-      - name: Force update of c2patool if only c2pa-rs is updated
-        if: ${{ contains(steps.release-plz.outputs.pr, '"c2pa"') && !contains(steps.release-plz.outputs.pr, 'c2patool') }}
-        env:
-          PR: ${{ steps.release-plz.outputs.pr }}
-        run: |
-          # Ensure we're on a clean main branch
-          git checkout main
-          git pull origin main
-
-          # Extract the new version of c2pa from the release PR output JSON
-          NEW_VERSION=$(echo "$PR" | jq -r '.releases[] | select(.package_name == "c2pa") | .version')
-
-          # Update the c2pa dependency version in cli/Cargo.toml
-          sed -i.bak "s/\(c2pa = { path = \"..\/sdk\", version = \"\)[^\"]*\"/\1$NEW_VERSION\"/" cli/Cargo.toml
-          rm cli/Cargo.toml.bak
-
-          # Configure git and commit the changes only if there are changes
-          git config user.name "CAI Open Source Builds"
-          git config user.email "caiopensrc@adobe.com"
-          git add cli/Cargo.toml
-          if ! git diff --staged --quiet; then
-            git commit -m "fix: Update c2pa dependency to $NEW_VERSION"
-            git push origin main
-          fi
-
       - name: Clean up stale release-plz branches
         run: |
           git --no-pager branch --remote |\

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 version = "0.86.0"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", default-features = false }
+c2pa = { path = "sdk", version = "0.86.0", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/c2pa_c_ffi/Cargo.toml
+++ b/c2pa_c_ffi/Cargo.toml
@@ -28,7 +28,7 @@ http = ["c2pa/http_reqwest", "c2pa/http_reqwest_blocking"]
 add_thumbnails = ["c2pa/add_thumbnails"]
 
 [dependencies]
-c2pa = { path = "../sdk", version = "0.86.0", default-features = false, features = [
+c2pa = { workspace = true, features = [
     "fetch_remote_manifests",
     "file_io",
     "pdf",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-c2pa = { path = "../sdk", version = "0.86.0", features = [
+c2pa = { workspace = true, features = [
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { path = "../sdk", features = ["json_schema"], default-features = false }
+c2pa = { workspace = true, features = ["json_schema"] }
 schemars = "1.2.1"
 serde_json = "1.0.150"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -8,13 +8,13 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { path = "../sdk", version = "0.86.0", features = [
+c2pa = { workspace = true, features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
     "default_http"
-]}
+] }
 env_logger = "0.11"
 lazy_static = "1.5.0"
 image = { version = "0.25.10", default-features = false, features = [

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -199,7 +199,7 @@ fn default_format() -> String {
 
 // TryFrom implementations for ManifestDefinition
 
-/// Implement TryFrom for &str (JSON string)
+/// Implement TryFrom for &str (JSON string).
 impl TryFrom<&str> for ManifestDefinition {
     type Error = Error;
 
@@ -208,7 +208,7 @@ impl TryFrom<&str> for ManifestDefinition {
     }
 }
 
-/// Implement TryFrom for String
+/// Implement TryFrom for String.
 impl TryFrom<String> for ManifestDefinition {
     type Error = Error;
 


### PR DESCRIPTION
Updates `release-plz` and cleans up the patches used to fix https://github.com/release-plz/release-plz/issues/2299 which is now resolved. This should solve the issue that forced us to sometimes create noop PRs.

There is also now a dry run of `release-plz` on release PRs so we can catch issues before merging the release PR. `c2pa` dependency versions are also now specified in the workspace so there is less churn in the diff.

I've tested updating and releasing locally with a dry run although when this is merged I'll create a noop release just to be sure.