### PR TITLE
fix: enable c2pa features in sub-crates since default-features is disabled at the workspace-level

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,6 @@ anyhow = "1.0"
 atree = "0.5.4"
 c2pa = { workspace = true, features = [
     "openssl",
-    "default_http",
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,8 @@ networking = [
 anyhow = "1.0"
 atree = "0.5.4"
 c2pa = { workspace = true, features = [
+    "openssl",
+    "default_http",
     "fetch_remote_manifests",
     "file_io",
     "add_thumbnails",

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.102"
-c2pa = { workspace = true, features = ["json_schema"] }
+c2pa = { workspace = true, features = ["openssl", "json_schema"] }
 schemars = "1.2.1"
 serde_json = "1.0.150"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.88.0"
 [dependencies]
 anyhow = "1.0.102"
 c2pa = { workspace = true, features = [
+    "openssl",
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",


### PR DESCRIPTION
`default-features = false` is now being inherited at the workspace-level, causing sub-crates in the workspace to not maintain the same feature set as before. This PR explicitly adds the features each sub-crate needs enabled.