### PR TITLE
ci: dry-run on PR HEAD instead of detatched HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          ref: ${{ github.head_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Release-plz requires the HEAD to match the PR branch rather than the implicit merge GitHub makes in actions/checkout.

I made this change already in the release PR, although new commits to main will overwrite it so creating an official PR here.