### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.87.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.86.1...c2pa-v0.87.0)
+_11 June 2026_
+
+### Added
+
+* [**breaking**] Split c2pa-raw-crypto into its own crate ([#2202](https://github.com/contentauth/c2pa-rs/pull/2202))
+
+### Fixed
+
+* Improve ingredientMismatch error messages ([#2225](https://github.com/contentauth/c2pa-rs/pull/2225))
+* Noop test new release workflow ([#2221](https://github.com/contentauth/c2pa-rs/pull/2221))
+
+### Other
+
+* Revert "feat!: Split c2pa-raw-crypto into its own crate ([#2202](https://github.com/contentauth/c2pa-rs/pull/2202))"
+* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
+
 ## [0.86.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.86.0...c2pa-v0.86.1)
 _08 June 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.86.1"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.86.1"
+version = "0.87.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.86.1"
+version = "0.87.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.65"
+version = "0.26.66"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.3"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "clap",
  "heck",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.86.1"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2518,7 +2518,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.86.1"
+version = "0.87.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -5607,18 +5607,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.86.1"
+version = "0.87.0"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.86.0", default-features = false }
+c2pa = { path = "sdk", version = "0.87.0", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.86.1...c2pa-c-ffi-v0.87.0)
+_11 June 2026_
+
+### Other
+
+* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
+
 ## [0.86.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.86.0...c2pa-c-ffi-v0.86.1)
 _08 June 2026_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.66](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.65...c2patool-v0.26.66)
+_11 June 2026_
+
+### Fixed
+
+* Enable c2pa features in sub-crates since default-features is disabled at the workspace-level ([#2219](https://github.com/contentauth/c2pa-rs/pull/2219))
+
+### Other
+
+* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
+
 ## [0.26.65](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.64...c2patool-v0.26.65)
 _09 June 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.65"
+version = "0.26.66"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.86.1 -> 0.87.0 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.86.1 -> 0.87.0
* `c2patool`: 0.26.65 -> 0.26.66

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.87.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.86.1...c2pa-v0.87.0)

_11 June 2026_

### Added

* [**breaking**] Split c2pa-raw-crypto into its own crate ([#2202](https://github.com/contentauth/c2pa-rs/pull/2202))

### Fixed

* Improve ingredientMismatch error messages ([#2225](https://github.com/contentauth/c2pa-rs/pull/2225))
* Noop test new release workflow ([#2221](https://github.com/contentauth/c2pa-rs/pull/2221))

### Other

* Revert "feat!: Split c2pa-raw-crypto into its own crate ([#2202](https://github.com/contentauth/c2pa-rs/pull/2202))"
* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.87.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.86.1...c2pa-c-ffi-v0.87.0)

_11 June 2026_

### Other

* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
</blockquote>

## `c2patool`

<blockquote>

## [0.26.66](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.65...c2patool-v0.26.66)

_11 June 2026_

### Fixed

* Enable c2pa features in sub-crates since default-features is disabled at the workspace-level ([#2219](https://github.com/contentauth/c2pa-rs/pull/2219))

### Other

* Use latest `release-plz` and add a dry run job on release PRs ([#2217](https://github.com/contentauth/c2pa-rs/pull/2217))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).