### PR TITLE
fix: use xmp.iid: (dot) prefix in default_instance_id

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -190,7 +190,7 @@ pub struct ManifestDefinition {
 }
 
 fn default_instance_id() -> String {
-    format!("xmp:iid:{}", Uuid::new_v4())
+    format!("xmp.iid:{}", Uuid::new_v4())
 }
 
 fn default_format() -> String {
@@ -2067,7 +2067,7 @@ impl Builder {
             self.add_assertion(labels::DATA_HASH, &ph)?;
         }
         self.definition.format = format.to_string();
-        self.definition.instance_id = format!("xmp:iid:{}", Uuid::new_v4());
+        self.definition.instance_id = format!("xmp.iid:{}", Uuid::new_v4());
         let mut store = self.to_store()?;
         let placeholder = store.get_data_hashed_manifest_placeholder(reserve_size, format)?;
         Ok(placeholder)
@@ -2822,7 +2822,7 @@ impl Builder {
         signer: &dyn Signer,
         format: &str,
     ) -> Result<Vec<u8>> {
-        self.definition.instance_id = format!("xmp:iid:{}", Uuid::new_v4());
+        self.definition.instance_id = format!("xmp.iid:{}", Uuid::new_v4());
 
         let mut store = self.to_store()?;
         let bytes = if _sync {
@@ -3023,7 +3023,7 @@ impl Builder {
 
         self.definition.format =
             crate::format_from_path(path).ok_or(crate::Error::UnsupportedType)?;
-        self.definition.instance_id = format!("xmp:iid:{}", Uuid::new_v4());
+        self.definition.instance_id = format!("xmp.iid:{}", Uuid::new_v4());
         if self.definition.title.is_none() {
             if let Some(title) = path.file_name() {
                 self.definition.title = Some(title.to_string_lossy().to_string());

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -157,7 +157,8 @@ pub struct Ingredient {
 }
 
 fn default_instance_id() -> String {
-    format!("xmp:iid:{}", Uuid::new_v4())
+    // "xmp.iid:" (dot) is the correct Adobe/XMP convention, not "xmp:iid:" (colon).
+    format!("xmp.iid:{}", Uuid::new_v4())
 }
 
 fn default_relationship() -> Relationship {
@@ -2399,6 +2400,19 @@ mod tests_file_io {
         assert_eq!(
             image,
             include_bytes!("../tests/fixtures/sample1.svg").to_vec()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "file_io")]
+    fn test_default_instance_id_uses_dot_separator() {
+        // libpng-test.png has no xmpMM:InstanceID, so default_instance_id() is used.
+        let ap = fixture_path("libpng-test.png");
+        let ingredient = Ingredient::from_file(ap).unwrap();
+        assert!(
+            ingredient.instance_id().starts_with("xmp.iid:"),
+            "expected xmp.iid: prefix, got: {}",
+            ingredient.instance_id()
         );
     }
 }

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -145,7 +145,7 @@ pub struct Manifest {
 }
 
 fn default_instance_id() -> String {
-    format!("xmp:iid:{}", Uuid::new_v4())
+    format!("xmp.iid:{}", Uuid::new_v4())
 }
 
 fn default_format() -> String {


### PR DESCRIPTION
Real XMP writers (Photoshop, Lightroom, etc.) consistently use `xmp.iid:` and not `xmp:iid:`, which is also what all fixture files and hardcoded constants in this codebase use. There were tests exercising the `xmp.iid:` prefix but those are on files that don't exercise the generated fallback ID so I added a regression test for this

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
