### PR TITLE
ci: remove `release_commits` setting for `release-plz.toml` to fix release lockstep

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -37,7 +37,8 @@ dependencies_update = true
 features_always_increment_minor = false
 pr_labels = ["release"]
 release_always = false
-release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
+# https://github.com/contentauth/c2pa-rs/issues/2229
+# release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
 
 [[package]]
 name = "c2pa"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -37,7 +37,7 @@ dependencies_update = true
 features_always_increment_minor = false
 pr_labels = ["release"]
 release_always = false
-# https://github.com/contentauth/c2pa-rs/issues/2229
+# TODO: https://github.com/contentauth/c2pa-rs/issues/2229
 # release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
 
 [[package]]


### PR DESCRIPTION
Removes the `release_commits` setting for `release-plz.toml` as it breaks version groups. As a temporary fix we would create noop PRs. This change should fix the issue more thoroughly until the upstream is fixed in https://github.com/release-plz/release-plz/issues/2891.

- Tracking issue: #2229