### PR TITLE
chore: Add breaking-changes label automation to verify dependent crates

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -1,0 +1,154 @@
+# When a PR is labeled `breaking-changes`, fan out to every downstream binding
+# repo in the org and verify it still builds against this PR's branch. Each
+# dependent reports a commit status back here; a single always-present gate
+# context (`breaking-changes-gate`) aggregates those results and is the only
+# context branch protection needs to require.
+#
+# This uses `pull_request_target` (not `pull_request`) so the gate status can be
+# posted even on fork PRs — under `pull_request` the token is read-only for
+# forks, which would leave the required gate context unset and block every fork
+# PR. SECURITY: the fan-out job never checks out or executes PR code; it only
+# reads trusted event metadata and posts statuses / dispatches. Do not add a
+# checkout of the PR head to this workflow.
+#
+# See docs/breaking-change-automation/README.md for setup (the CROSS_ORG_PR_TOKEN
+# secret, the per-repo receiver workflow, and the branch-protection required check).
+
+name: Breaking changes
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  status:
+
+permissions:
+  contents: read
+  statuses: write
+
+env:
+  GATE_CONTEXT: breaking-changes-gate
+  DISPATCH_TYPE: c2pa-rs-breaking-change
+  # Downstream binding repos in this org. Keep in sync with the contexts the
+  # per-repo receiver workflows post back.
+  DEPENDENTS: "c2pa-node-v2 c2pa-js c2pa-python c2pa-cpp c2pa-android c2pa-ios"
+
+jobs:
+  # Runs on every PR. Always posts the required `breaking-changes-gate` context
+  # so unlabeled (and fork) PRs are never left waiting, and fans out to the
+  # dependents when a same-repo PR carries the label.
+  fan-out:
+    name: Fan out to dependents
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate gate and dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repo token: write access to the dependent repos + statuses.
+          DISPATCH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-changes') }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+
+          gate() {
+            gh api -X POST "repos/$REPO/statuses/$SHA" \
+              -f "state=$1" -f "context=$GATE_CONTEXT" -f "description=$2" >/dev/null
+          }
+
+          if [ "$HAS_LABEL" != "true" ]; then
+            gate success "No breaking-changes label; nothing to verify."
+            exit 0
+          fi
+
+          # A fork's branch does not live in contentauth/c2pa-rs, so dependents
+          # cannot re-target to it. Pass the gate with a note rather than block.
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::warning::breaking-changes verification is skipped for fork PRs;" \
+              "push the branch to contentauth/c2pa-rs to verify dependents."
+            gate success "Fork PR — breaking-change verification skipped (branch not in canonical repo)."
+            exit 0
+          fi
+
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "::error::CROSS_ORG_PR_TOKEN is not set; cannot dispatch to dependents." \
+              "See docs/breaking-change-automation/README.md."
+            exit 1
+          fi
+
+          # Gate goes pending until every dependent reports back.
+          gate pending "Verifying dependent crates against this branch..."
+
+          for dep in $DEPENDENTS; do
+            # Informational per-dependent context, also seeded as pending.
+            gh api -X POST "repos/$REPO/statuses/$SHA" \
+              -f state=pending \
+              -f "context=breaking-changes / $dep" \
+              -f "description=Awaiting $dep verification..." >/dev/null
+
+            # Trigger the receiver workflow in the dependent repo.
+            jq -n \
+              --arg ref "$REF" \
+              --arg pr "$PR_NUMBER" \
+              --arg sha "$SHA" \
+              --arg src "$REPO" \
+              '{event_type: env.DISPATCH_TYPE,
+                client_payload: {ref: $ref, pr_number: $pr, head_sha: $sha, source_repo: $src}}' \
+              | GH_TOKEN="$DISPATCH_TOKEN" gh api -X POST \
+                  "repos/contentauth/$dep/dispatches" --input -
+
+            echo "Dispatched $DISPATCH_TYPE to contentauth/$dep"
+          done
+
+  # Fires whenever a commit status changes. We only act on the per-dependent
+  # `breaking-changes / *` contexts and recompute the aggregate gate from the
+  # latest state of all dependents on that commit.
+  aggregate:
+    name: Aggregate dependent results
+    if: >
+      github.event_name == 'status' &&
+      startsWith(github.event.context, 'breaking-changes /')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Recompute gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.sha }}
+        run: |
+          set -euo pipefail
+          statuses=$(gh api --paginate "repos/$REPO/commits/$SHA/statuses")
+
+          failed=0
+          pending=0
+          for dep in $DEPENDENTS; do
+            ctx="breaking-changes / $dep"
+            state=$(echo "$statuses" | jq -r --arg c "$ctx" \
+              '[.[] | select(.context == $c)] | sort_by(.updated_at) | last | .state // "missing"')
+            echo "$ctx => $state"
+            case "$state" in
+              success) ;;
+              failure|error) failed=1 ;;
+              *) pending=1 ;;   # pending or missing
+            esac
+          done
+
+          if [ "$failed" = "1" ]; then
+            state=failure
+            desc="One or more dependent crates need changes before this PR can land."
+          elif [ "$pending" = "1" ]; then
+            state=pending
+            desc="Waiting on dependent crate verification..."
+          else
+            state=success
+            desc="All dependent crates build against this branch."
+          fi
+
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
+            -f "state=$state" \
+            -f "context=$GATE_CONTEXT" \
+            -f "description=$desc" >/dev/null

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -34,6 +34,13 @@ env:
   # blocks the gate. c2pa-ios and c2pa-android join once their artifact-bridge
   # receivers ship (see docs/breaking-change-automation/README.md, Phase 2).
   DEPENDENTS: "c2pa-node-v2 c2pa-js c2pa-python c2pa-cpp"
+  # Subset of DEPENDENTS that consume prebuilt native libraries and therefore
+  # need a branch build of library-release.yml to download. When non-empty, the
+  # orchestrator triggers one library build per labeled PR (the receivers locate
+  # it by SHA). Populate with "c2pa-ios c2pa-android" once those receivers are
+  # live AND library-release.yml's verify_sha input has landed on the default
+  # branch. Empty = no library build is triggered.
+  BINARY_DEPENDENTS: ""
 
 jobs:
   # Runs on every PR. Always posts the required `breaking-changes-gate` context
@@ -85,6 +92,18 @@ jobs:
 
           # Gate goes pending until every dependent reports back.
           gate pending "Verifying dependent crates against this branch..."
+
+          # If any dependent needs prebuilt native libraries, trigger ONE branch
+          # build of library-release.yml; the binary receivers locate it by SHA.
+          # Must use the cross-repo token: a workflow triggered by GITHUB_TOKEN
+          # does not start a new run.
+          if [ -n "$BINARY_DEPENDENTS" ]; then
+            jq -n --arg ref "$REF" --arg sha "$SHA" \
+              '{ref: $ref, inputs: {verify_sha: $sha}}' \
+              | GH_TOKEN="$DISPATCH_TOKEN" gh api -X POST \
+                  "repos/$REPO/actions/workflows/library-release.yml/dispatches" --input -
+            echo "Triggered library-release.yml branch build for $REF (verify_sha=$SHA)"
+          fi
 
           for dep in $DEPENDENTS; do
             # Informational per-dependent context, also seeded as pending.

--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -28,9 +28,12 @@ permissions:
 env:
   GATE_CONTEXT: breaking-changes-gate
   DISPATCH_TYPE: c2pa-rs-breaking-change
-  # Downstream binding repos in this org. Keep in sync with the contexts the
-  # per-repo receiver workflows post back.
-  DEPENDENTS: "c2pa-node-v2 c2pa-js c2pa-python c2pa-cpp c2pa-android c2pa-ios"
+  # Downstream binding repos that have a receiver workflow deployed. The gate
+  # waits for every repo listed here, so only add a repo once its
+  # test-c2pa-rs-branch.yml is live — otherwise its context stays pending and
+  # blocks the gate. c2pa-ios and c2pa-android join once their artifact-bridge
+  # receivers ship (see docs/breaking-change-automation/README.md, Phase 2).
+  DEPENDENTS: "c2pa-node-v2 c2pa-js c2pa-python c2pa-cpp"
 
 jobs:
   # Runs on every PR. Always posts the required `breaking-changes-gate` context

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - "c2pa-v*" # Trigger on version tags (e.g., v1.0.0)
+  # Can also be dispatched against an arbitrary branch (e.g.
+  # `gh workflow run library-release.yml --ref <branch>`) to produce the native
+  # library binaries as downloadable workflow artifacts WITHOUT cutting a
+  # release. This is the artifact bridge that lets the breaking-change
+  # automation verify the prebuilt-binary dependents (c2pa-cpp, c2pa-ios,
+  # c2pa-android, c2pa-js) against a PR branch. See
+  # docs/breaking-change-automation/README.md.
   workflow_dispatch:
 
 jobs:
@@ -128,7 +135,11 @@ jobs:
 
   release:
     needs: build
-    if: always()
+    # Only publish a GitHub Release for version-tag pushes. On a branch
+    # workflow_dispatch the build job still uploads per-target workflow
+    # artifacts (release-artifacts-*) for downstreams to download; we skip the
+    # release itself (there is no tag, and tag_name extraction would fail).
+    if: always() && startsWith(github.ref, 'refs/tags/c2pa-v')
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -1,5 +1,9 @@
 name: Publish c2pa-library binaries
 
+# When dispatched with `verify_sha`, name the run so the breaking-change
+# receivers can locate it (they match on this SHA via `gh run list`).
+run-name: ${{ inputs.verify_sha != '' && format('Library build — verify {0}', inputs.verify_sha) || 'Publish c2pa-library binaries' }}
+
 on:
   push:
     tags:
@@ -8,10 +12,15 @@ on:
   # `gh workflow run library-release.yml --ref <branch>`) to produce the native
   # library binaries as downloadable workflow artifacts WITHOUT cutting a
   # release. This is the artifact bridge that lets the breaking-change
-  # automation verify the prebuilt-binary dependents (c2pa-cpp, c2pa-ios,
-  # c2pa-android, c2pa-js) against a PR branch. See
-  # docs/breaking-change-automation/README.md.
+  # automation verify the prebuilt-binary dependents (c2pa-ios, c2pa-android)
+  # against a PR branch. See docs/breaking-change-automation/README.md.
   workflow_dispatch:
+    inputs:
+      verify_sha:
+        description: "c2pa-rs commit SHA being verified (breaking-change automation). Leave blank for normal builds."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:

--- a/docs/breaking-change-automation/README.md
+++ b/docs/breaking-change-automation/README.md
@@ -80,7 +80,8 @@ ones where they exist:
 | `c2pa-js` | [`receivers/c2pa-js.yml`](./receivers/c2pa-js.yml) | Variant A (git-branch dep, builds wasm), opens a draft PR |
 | `c2pa-python` | [`receivers/c2pa-python.yml`](./receivers/c2pa-python.yml) | `build-from-source` via `C2PA_RS_PATH`, status-only |
 | `c2pa-cpp` | [`receivers/c2pa-cpp.yml`](./receivers/c2pa-cpp.yml) | `build-from-source` via `C2PA_BUILD_FROM_SOURCE`, status-only |
-| `c2pa-ios`, `c2pa-android` | start from [`test-c2pa-rs-branch.yml`](./test-c2pa-rs-branch.yml) (Variant B) | need the artifact bridge — see Phase 2 |
+| `c2pa-ios` | [`receivers/c2pa-ios.yml`](./receivers/c2pa-ios.yml) | downloads branch artifacts → `C2PA_LOCAL_ARTIFACTS`, status-only (unvalidated) |
+| `c2pa-android` | [`receivers/c2pa-android.yml`](./receivers/c2pa-android.yml) | stages branch `.so` into `jniLibs`, `assembleRelease`, status-only (unvalidated) |
 
 When adapting the generic template, edit the two marked sections:
 
@@ -127,28 +128,47 @@ branch produces downloadable artifacts without cutting a release:
 gh workflow run library-release.yml --ref <pr-branch>
 ```
 
-### Remaining receiver-side work (per repo)
+### How the build is triggered and located
 
-- **Who triggers the build / run-id delivery.** Recommended: the orchestrator
-  triggers one branch build and the iOS/Android receivers locate it (cheaper
-  than N builds). Add a `verify_sha` input + a correlating `run-name:` to
-  `library-release.yml`, then a receiver finds the run with `gh run list
-  --workflow library-release.yml`, waits with `gh run watch`, and downloads with
-  `gh run download <id> --pattern 'release-artifacts-*'`. NOTE: triggering a
-  workflow with the default `GITHUB_TOKEN` does **not** start a new run, so the
-  orchestrator must use `CROSS_ORG_PR_TOKEN` — which then also needs
-  **Actions: write** on c2pa-rs (a scope beyond Phase 1).
-- **`c2pa-ios`**: macOS runner; stage the downloaded zips into the dir named by
+The orchestrator triggers **one** branch build of `library-release.yml` per
+labeled PR (only when `BINARY_DEPENDENTS` is non-empty) and the iOS/Android
+receivers locate it by SHA — cheaper than each receiver building its own. The
+mechanics:
+
+- `library-release.yml` takes a `verify_sha` input and sets a `run-name:` that
+  embeds it. Receivers find the run with `gh run list --workflow
+  library-release.yml` (matching `displayTitle`), wait with `gh run watch`, and
+  download with `gh run download <id> --pattern 'release-artifacts-*'`.
+- Triggering a workflow with the default `GITHUB_TOKEN` does **not** start a new
+  run, so the orchestrator triggers it with `CROSS_ORG_PR_TOKEN`, which needs
+  **Actions: write** on c2pa-rs.
+
+The receivers are drafted in [`receivers/c2pa-ios.yml`](./receivers/c2pa-ios.yml)
+and [`receivers/c2pa-android.yml`](./receivers/c2pa-android.yml):
+
+- **`c2pa-ios`** (macOS runner): stages downloaded zips into the dir named by
   `C2PA_LOCAL_ARTIFACTS` (the build prefers local artifacts over the release
-  download). The artifact filenames embed the crate version, so the branch's
-  version must match the repo's `C2PA_VERSION` (`Configurations/Base.xcconfig`)
-  or that pin must be overridden. Build/test via `make test-library`.
-- **`c2pa-android`**: its gradle `downloadNativeLibraries` task only fetches from
-  release URLs — it needs a local-artifacts override (e.g. a
-  `-PlocalC2paArtifactsPath=` property that stages `.so` files into
-  `library/src/main/jniLibs/<abi>/`). That's a build-tooling change in the repo.
-  `assembleRelease` verifies the build on ubuntu; instrumented tests need an
-  emulator.
+  download) and overrides `C2PA_VERSION` with the version detected from the
+  artifact filenames, so the pin in `Configurations/Base.xcconfig` need not
+  match. Build/test via `make test-library`.
+- **`c2pa-android`** (ubuntu runner): pre-stages the branch `.so` files and the
+  patched `c2pa.h` into the exact locations gradle expects; because the
+  `downloadNativeLibraries` task skips any arch whose `.so` already exists, it
+  no-ops and `assembleRelease` builds against the staged libs — no gradle change
+  needed. Verifies the build only; instrumented tests need an emulator.
+
+> ⚠️ Both iOS/Android receivers are **unvalidated** — they need a real labeled-PR
+> run (token + runners) to confirm the make/gradle invocations, artifact layout,
+> and version handling.
+
+### To activate iOS/Android
+
+1. Merge their receiver PRs.
+2. Ensure `library-release.yml` (with the `verify_sha` input) is on the default
+   branch — i.e. this PR is merged.
+3. Add `c2pa-ios c2pa-android` to **both** `DEPENDENTS` and `BINARY_DEPENDENTS`
+   in `breaking-changes.yml`.
+4. Confirm `CROSS_ORG_PR_TOKEN` has **Actions: write** on c2pa-rs.
 
 ## Limitations
 

--- a/docs/breaking-change-automation/README.md
+++ b/docs/breaking-change-automation/README.md
@@ -104,7 +104,7 @@ How "use the PR branch" is implemented differs by how each repo consumes c2pa-rs
 | `c2pa-node-v2` | crates.io `c2pa` dep in its root `Cargo.toml` | Variant A: rewrite to `git`+`branch`, `cargo update -p c2pa` (commits a diff → draft PR) |
 | `c2pa-js` | builds wasm from a `c2pa` dep in its root `Cargo.toml` | Variant A: rewrite to `git`+`branch`, `pnpm ci:check` (commits a diff → draft PR) |
 | `c2pa-python` | downloads prebuilt artifacts; has a `build-from-source` path | check out the branch, `make build-from-source C2PA_RS_PATH=...` (no diff → status-only) |
-| `c2pa-cpp` | prebuilt libs via CMake; has a `build-from-source` path | check out the branch, `C2PA_BUILD_FROM_SOURCE=ON C2PA_RS_PATH=... make test` (status-only) |
+| `c2pa-cpp` | prebuilt libs via CMake; has a `build-from-source` path | check out the branch as a sibling dir, `C2PA_BUILD_FROM_SOURCE=ON C2PA_RS_PATH=... make test-release` with `LD_LIBRARY_PATH` set (status-only) |
 | `c2pa-ios` | prebuilt native libs from releases (xcframework) | Variant B: stage branch artifacts (see Phase 2) |
 | `c2pa-android` | prebuilt `.so` libs from releases (jniLibs) | Variant B: stage branch artifacts (see Phase 2) |
 

--- a/docs/breaking-change-automation/README.md
+++ b/docs/breaking-change-automation/README.md
@@ -74,11 +74,13 @@ Each dependent gets `.github/workflows/test-c2pa-rs-branch.yml`. Because the
 repos consume c2pa-rs differently, the receivers differ — use the ready-made
 ones where they exist:
 
-| Dependent | Receiver to install | Phase |
+| Dependent | Receiver to install | Notes |
 | --- | --- | --- |
-| `c2pa-node-v2` | [`receivers/c2pa-node-v2.yml`](./receivers/c2pa-node-v2.yml) — Variant A, opens a draft PR | 1 (ready) |
-| `c2pa-python` | [`receivers/c2pa-python.yml`](./receivers/c2pa-python.yml) — `build-from-source`, status-only | 1 (ready) |
-| `c2pa-cpp`, `c2pa-ios`, `c2pa-android`, `c2pa-js` | start from [`test-c2pa-rs-branch.yml`](./test-c2pa-rs-branch.yml) (Variant B) | 2 (blocked on the artifact bridge) |
+| `c2pa-node-v2` | [`receivers/c2pa-node-v2.yml`](./receivers/c2pa-node-v2.yml) | Variant A (git-branch dep), opens a draft PR |
+| `c2pa-js` | [`receivers/c2pa-js.yml`](./receivers/c2pa-js.yml) | Variant A (git-branch dep, builds wasm), opens a draft PR |
+| `c2pa-python` | [`receivers/c2pa-python.yml`](./receivers/c2pa-python.yml) | `build-from-source` via `C2PA_RS_PATH`, status-only |
+| `c2pa-cpp` | [`receivers/c2pa-cpp.yml`](./receivers/c2pa-cpp.yml) | `build-from-source` via `C2PA_BUILD_FROM_SOURCE`, status-only |
+| `c2pa-ios`, `c2pa-android` | start from [`test-c2pa-rs-branch.yml`](./test-c2pa-rs-branch.yml) (Variant B) | need the artifact bridge — see Phase 2 |
 
 When adapting the generic template, edit the two marked sections:
 
@@ -99,23 +101,25 @@ How "use the PR branch" is implemented differs by how each repo consumes c2pa-rs
 | Repo | Consumes c2pa-rs as | Re-target in receiver |
 | --- | --- | --- |
 | `c2pa-node-v2` | crates.io `c2pa` dep in its root `Cargo.toml` | Variant A: rewrite to `git`+`branch`, `cargo update -p c2pa` (commits a diff → draft PR) |
-| `c2pa-python` | downloads prebuilt artifacts; has a `build-from-source` path | check out the branch and `make build-from-source C2PA_RS_PATH=...` (no diff → status-only) |
-| `c2pa-cpp` | prebuilt native libs from c2pa-rs **releases** | Variant B: download branch artifacts (bridge ready; receiver TODO) |
-| `c2pa-ios` | prebuilt native libs from releases | Variant B (receiver TODO) |
-| `c2pa-android` | prebuilt native libs from releases | Variant B (receiver TODO) |
-| `c2pa-js` | wasm / `c2pa-node` artifacts | Variant B (receiver TODO) |
+| `c2pa-js` | builds wasm from a `c2pa` dep in its root `Cargo.toml` | Variant A: rewrite to `git`+`branch`, `pnpm ci:check` (commits a diff → draft PR) |
+| `c2pa-python` | downloads prebuilt artifacts; has a `build-from-source` path | check out the branch, `make build-from-source C2PA_RS_PATH=...` (no diff → status-only) |
+| `c2pa-cpp` | prebuilt libs via CMake; has a `build-from-source` path | check out the branch, `C2PA_BUILD_FROM_SOURCE=ON C2PA_RS_PATH=... make test` (status-only) |
+| `c2pa-ios` | prebuilt native libs from releases (xcframework) | Variant B: stage branch artifacts (see Phase 2) |
+| `c2pa-android` | prebuilt `.so` libs from releases (jniLibs) | Variant B: stage branch artifacts (see Phase 2) |
 
-Ready receivers exist for `c2pa-node-v2` and `c2pa-python` (see step 3). Variant
-B in the generic template is a placeholder pending the per-repo receiver work.
+Ready receivers exist for `c2pa-node-v2`, `c2pa-js`, `c2pa-python`, and
+`c2pa-cpp` (see step 3). Variant B in the generic template is a placeholder
+pending the iOS/Android receiver work.
 
-## Phase 2 — branch artifacts for prebuilt-binary dependents
+## Phase 2 — branch artifacts for the prebuilt-binary dependents
 
-`c2pa-cpp`, `c2pa-ios`, `c2pa-android`, and `c2pa-js` consume prebuilt native
-libraries that c2pa-rs publishes from
-[`library-release.yml`](../../.github/workflows/library-release.yml).
+Only `c2pa-ios` and `c2pa-android` truly need prebuilt native libraries (the
+other four build from source). They consume the binaries that c2pa-rs publishes
+from [`library-release.yml`](../../.github/workflows/library-release.yml).
 
-**The artifact bridge is now in place.** That workflow already uploads per-target
-workflow artifacts (`release-artifacts-<os>-<target>`) on every run, and its
+**The artifact bridge is in place.** That workflow already uploads per-target
+workflow artifacts (`release-artifacts-<os>-<target>`, containing the same
+`c2pa-v*-<target>.zip` files as the release assets) on every run, and its
 `release` job is gated to `c2pa-v*` tag pushes — so dispatching it against a
 branch produces downloadable artifacts without cutting a release:
 
@@ -123,16 +127,28 @@ branch produces downloadable artifacts without cutting a release:
 gh workflow run library-release.yml --ref <pr-branch>
 ```
 
-A Variant B receiver then downloads them (e.g. `gh run download <run-id>
---pattern 'release-artifacts-*'`) and stages them where the build expects the
-release-downloaded libraries.
+### Remaining receiver-side work (per repo)
 
-**Still TODO (receiver side, per repo):** decide who triggers the branch build
-and how the run id reaches the receivers — either the orchestrator builds once
-and passes the run id in the dispatch payload (cheaper; one build per labeled
-PR), or each receiver triggers and polls its own build (simpler; N builds). Then
-wire the download + stage + build steps into each of the four repos. Phase 1
-fully covers the Rust-dependency dependents.
+- **Who triggers the build / run-id delivery.** Recommended: the orchestrator
+  triggers one branch build and the iOS/Android receivers locate it (cheaper
+  than N builds). Add a `verify_sha` input + a correlating `run-name:` to
+  `library-release.yml`, then a receiver finds the run with `gh run list
+  --workflow library-release.yml`, waits with `gh run watch`, and downloads with
+  `gh run download <id> --pattern 'release-artifacts-*'`. NOTE: triggering a
+  workflow with the default `GITHUB_TOKEN` does **not** start a new run, so the
+  orchestrator must use `CROSS_ORG_PR_TOKEN` — which then also needs
+  **Actions: write** on c2pa-rs (a scope beyond Phase 1).
+- **`c2pa-ios`**: macOS runner; stage the downloaded zips into the dir named by
+  `C2PA_LOCAL_ARTIFACTS` (the build prefers local artifacts over the release
+  download). The artifact filenames embed the crate version, so the branch's
+  version must match the repo's `C2PA_VERSION` (`Configurations/Base.xcconfig`)
+  or that pin must be overridden. Build/test via `make test-library`.
+- **`c2pa-android`**: its gradle `downloadNativeLibraries` task only fetches from
+  release URLs — it needs a local-artifacts override (e.g. a
+  `-PlocalC2paArtifactsPath=` property that stages `.so` files into
+  `library/src/main/jniLibs/<abi>/`). That's a build-tooling change in the repo.
+  `assembleRelease` verifies the build on ubuntu; instrumented tests need an
+  emulator.
 
 ## Limitations
 

--- a/docs/breaking-change-automation/README.md
+++ b/docs/breaking-change-automation/README.md
@@ -1,0 +1,144 @@
+# Breaking-change verification across dependent crates
+
+When a c2pa-rs change breaks API/ABI compatibility, the downstream binding repos
+may need code changes before the c2pa-rs PR can land. This automation surfaces
+that *before* merge: apply the **`breaking-changes`** label to a c2pa-rs PR and
+every dependent repo is built against the PR's branch, with the results gating
+the PR as a required status check.
+
+Dependent repos covered: `c2pa-node-v2`, `c2pa-js`, `c2pa-python`, `c2pa-cpp`,
+`c2pa-android`, `c2pa-ios`.
+
+## How it works
+
+```
+c2pa-rs PR  --label: breaking-changes-->  .github/workflows/breaking-changes.yml
+                                              |
+                          repository_dispatch (c2pa-rs-breaking-change)
+                                              v
+        each dependent repo's .github/workflows/test-c2pa-rs-branch.yml
+            re-targets to the PR branch, opens a draft PR, builds/tests
+                                              |
+                       commit status "breaking-changes / <repo>"
+                                              v
+        breaking-changes.yml (status event) aggregates -> breaking-changes-gate
+```
+
+- **`breaking-changes-gate`** is the single required context. Because GitHub
+  branch-protection required checks fire on *every* PR (there's no "only when
+  labeled"), the gate is always posted:
+  - PR **without** the label → gate reports **success** immediately.
+  - PR **with** the label → gate goes **pending**, then **success** once all
+    dependents report green, or **failure** if any dependent fails.
+- **`breaking-changes / <repo>`** are informational per-dependent contexts that
+  link to the draft PR opened in each dependent.
+- On a new push to a labeled PR (`synchronize`), dependents are re-dispatched
+  against the new commit. Removing the label passes the gate again.
+
+The orchestrator runs on **`pull_request_target`** rather than `pull_request`.
+That's required so the gate status can be posted on fork PRs too — under
+`pull_request` the `GITHUB_TOKEN` is read-only for forks, which would leave the
+required gate context unset and block every external-contributor PR. The
+fan-out job is safe under `pull_request_target` because it never checks out or
+executes PR code; it only reads trusted event metadata and posts statuses /
+dispatches. **Do not add a checkout of the PR head to that workflow.**
+
+## One-time setup
+
+### 1. Create the label
+
+```sh
+gh label create breaking-changes \
+  --repo contentauth/c2pa-rs \
+  --color B60205 \
+  --description "Verify all dependent crates against this PR's branch before merging"
+```
+
+### 2. Create the `CROSS_ORG_PR_TOKEN` secret
+
+The default `GITHUB_TOKEN` is scoped to c2pa-rs only, so it cannot dispatch to
+or open PRs in the dependent repos. Create a token with:
+
+- **`contents: write`** and **`pull-requests: write`** on each dependent repo
+  (push the re-target branch + open the draft PR), and
+- **`statuses: write`** on `contentauth/c2pa-rs` (report results back).
+
+Either a fine-grained PAT or (preferred) a GitHub App installation token works.
+Store it as an **organization secret** named `CROSS_ORG_PR_TOKEN`, shared with
+c2pa-rs and all six dependent repos. (Rename throughout if you prefer a different
+name — it appears in `breaking-changes.yml` and the receiver template.)
+
+### 3. Install the receiver in each dependent repo
+
+Each dependent gets `.github/workflows/test-c2pa-rs-branch.yml`. Because the
+repos consume c2pa-rs differently, the receivers differ — use the ready-made
+ones where they exist:
+
+| Dependent | Receiver to install | Phase |
+| --- | --- | --- |
+| `c2pa-node-v2` | [`receivers/c2pa-node-v2.yml`](./receivers/c2pa-node-v2.yml) — Variant A, opens a draft PR | 1 (ready) |
+| `c2pa-python` | [`receivers/c2pa-python.yml`](./receivers/c2pa-python.yml) — `build-from-source`, status-only | 1 (ready) |
+| `c2pa-cpp`, `c2pa-ios`, `c2pa-android`, `c2pa-js` | start from [`test-c2pa-rs-branch.yml`](./test-c2pa-rs-branch.yml) (Variant B) | 2 (blocked on the artifact bridge) |
+
+When adapting the generic template, edit the two marked sections:
+
+- `REPO_NAME` — this repo's short name; must match its entry in the `DEPENDENTS`
+  list in `breaking-changes.yml`.
+- the **re-target** and **build/test** steps — see "Per-repo re-targeting" below.
+
+### 4. Require the gate in branch protection
+
+In c2pa-rs branch protection for `main` (and `v1_api`), add **`breaking-changes-gate`**
+to the required status checks. Do **not** add the per-dependent contexts — they
+are informational, and requiring them would block every unlabeled PR.
+
+## Per-repo re-targeting
+
+How "use the PR branch" is implemented differs by how each repo consumes c2pa-rs:
+
+| Repo | Consumes c2pa-rs as | Re-target in receiver |
+| --- | --- | --- |
+| `c2pa-node-v2` | crates.io `c2pa` dep in its root `Cargo.toml` | Variant A: rewrite to `git`+`branch`, `cargo update -p c2pa` (commits a diff → draft PR) |
+| `c2pa-python` | downloads prebuilt artifacts; has a `build-from-source` path | check out the branch and `make build-from-source C2PA_RS_PATH=...` (no diff → status-only) |
+| `c2pa-cpp` | prebuilt native libs from c2pa-rs **releases** | Variant B: download branch artifacts (bridge ready; receiver TODO) |
+| `c2pa-ios` | prebuilt native libs from releases | Variant B (receiver TODO) |
+| `c2pa-android` | prebuilt native libs from releases | Variant B (receiver TODO) |
+| `c2pa-js` | wasm / `c2pa-node` artifacts | Variant B (receiver TODO) |
+
+Ready receivers exist for `c2pa-node-v2` and `c2pa-python` (see step 3). Variant
+B in the generic template is a placeholder pending the per-repo receiver work.
+
+## Phase 2 — branch artifacts for prebuilt-binary dependents
+
+`c2pa-cpp`, `c2pa-ios`, `c2pa-android`, and `c2pa-js` consume prebuilt native
+libraries that c2pa-rs publishes from
+[`library-release.yml`](../../.github/workflows/library-release.yml).
+
+**The artifact bridge is now in place.** That workflow already uploads per-target
+workflow artifacts (`release-artifacts-<os>-<target>`) on every run, and its
+`release` job is gated to `c2pa-v*` tag pushes — so dispatching it against a
+branch produces downloadable artifacts without cutting a release:
+
+```sh
+gh workflow run library-release.yml --ref <pr-branch>
+```
+
+A Variant B receiver then downloads them (e.g. `gh run download <run-id>
+--pattern 'release-artifacts-*'`) and stages them where the build expects the
+release-downloaded libraries.
+
+**Still TODO (receiver side, per repo):** decide who triggers the branch build
+and how the run id reaches the receivers — either the orchestrator builds once
+and passes the run id in the dispatch payload (cheaper; one build per labeled
+PR), or each receiver triggers and polls its own build (simpler; N builds). Then
+wire the download + stage + build steps into each of the four repos. Phase 1
+fully covers the Rust-dependency dependents.
+
+## Limitations
+
+- **Fork PRs are not verified.** A fork's branch doesn't live in
+  `contentauth/c2pa-rs`, so dependents can't re-target to it. If a fork PR is
+  labeled, the gate passes with a note (it does not block) and emits a warning;
+  to actually verify, push the branch to `contentauth/c2pa-rs` and open the PR
+  from there.
+- Each labeled push re-dispatches to all six dependents.

--- a/docs/breaking-change-automation/receivers/c2pa-android.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-android.yml
@@ -1,0 +1,126 @@
+# Receiver for c2pa-android. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-android.
+#
+# c2pa-android consumes prebuilt .so libraries from c2pa-rs releases via a gradle
+# `downloadNativeLibraries` task. That task SKIPS any arch whose .so already
+# exists, so this receiver pre-stages the branch-built .so files (and the patched
+# c2pa.h header) into the exact locations gradle expects; the download task then
+# no-ops and `assembleRelease` builds against the staged libs. No gradle change
+# needed. STATUS-ONLY (no committable diff); the status links to this run.
+#
+# This verifies the BUILD only. Instrumented tests (connectedAndroidTest) need an
+# emulator and are out of scope here.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret with Actions:read on c2pa-rs. See
+# contentauth/c2pa-rs docs/breaking-change-automation/README.md.
+#
+# UNVALIDATED: needs a real run to confirm staging paths and the assembleRelease
+# build. If c2pa-android's header-patch logic changes, update the sed below.
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: read
+
+env:
+  REPO_NAME: c2pa-android
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+  GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout c2pa-android
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Report start to c2pa-rs
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - name: Locate, await, and download the c2pa-rs branch build
+        run: |
+          set -euo pipefail
+          run_id=""
+          for _ in $(seq 1 90); do
+            run_id=$(gh run list --repo contentauth/c2pa-rs \
+              --workflow library-release.yml --limit 40 \
+              --json databaseId,displayTitle \
+              -q "[.[] | select(.displayTitle | contains(\"$C2PA_RS_SHA\"))][0].databaseId")
+            [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
+            sleep 20
+          done
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "::error::Could not find a library-release run for $C2PA_RS_SHA"; exit 1
+          fi
+          echo "Found library build run $run_id; waiting for completion..."
+          gh run watch "$run_id" --repo contentauth/c2pa-rs || true
+          gh run download "$run_id" --repo contentauth/c2pa-rs \
+            --pattern 'release-artifacts-*-android*' --dir dl
+
+      - name: Stage native libs into jniLibs (so the download task no-ops)
+        run: |
+          set -euo pipefail
+          # ABI (jniLibs dir) <- c2pa-rs target
+          declare -A MAP=(
+            [arm64-v8a]=aarch64-linux-android
+            [armeabi-v7a]=armv7-linux-androideabi
+            [x86]=i686-linux-android
+            [x86_64]=x86_64-linux-android
+          )
+          header_done=""
+          for abi in "${!MAP[@]}"; do
+            target="${MAP[$abi]}"
+            zip=$(find dl -name "c2pa-*-${target}.zip" | head -1)
+            if [ -z "$zip" ]; then
+              echo "::error::missing artifact zip for $target"; exit 1
+            fi
+            tmp=$(mktemp -d); unzip -q "$zip" -d "$tmp"
+            mkdir -p "library/src/main/jniLibs/$abi"
+            cp "$tmp/lib/libc2pa_c.so" "library/src/main/jniLibs/$abi/libc2pa_c.so"
+            if [ -z "$header_done" ] && [ -f "$tmp/include/c2pa.h" ]; then
+              mkdir -p library/src/main/jni
+              # Replicate c2pa-android's header patch.
+              sed 's/typedef struct C2paSigner C2paSigner;/typedef struct C2paSigner { } C2paSigner;/' \
+                "$tmp/include/c2pa.h" > library/src/main/jni/c2pa.h
+              header_done=1
+            fi
+          done
+          echo "Staged jniLibs:"; find library/src/main/jniLibs -name '*.so'
+
+      - name: Build (assembleRelease)
+        id: build
+        continue-on-error: true
+        # downloadNativeLibraries detects the staged .so files and skips fetching.
+        run: ./gradlew :library:assembleRelease
+
+      - name: Report result to c2pa-rs
+        if: always()
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=$run_url" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-cpp.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-cpp.yml
@@ -1,0 +1,82 @@
+# Receiver for c2pa-cpp. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-cpp.
+#
+# c2pa-cpp normally downloads prebuilt native libs from c2pa-rs releases via
+# CMake FetchContent, but its CMakeLists supports a build-from-source path:
+# setting C2PA_BUILD_FROM_SOURCE=ON and C2PA_RS_PATH=<c2pa-rs checkout> builds
+# c2pa_c_ffi locally with cargo. So we re-target by checking out c2pa-rs at the
+# PR branch and building against it. There is no committable diff, so this
+# receiver is STATUS-ONLY (no draft PR); the status links to this workflow run.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md).
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: read
+
+env:
+  REPO_NAME: c2pa-cpp
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout c2pa-cpp
+        uses: actions/checkout@v6
+
+      - name: Checkout c2pa-rs @ PR branch
+        uses: actions/checkout@v6
+        with:
+          repository: contentauth/c2pa-rs
+          ref: ${{ github.event.client_payload.ref }}
+          path: c2pa-rs
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake
+
+      - name: Build against local c2pa-rs and test
+        id: build
+        continue-on-error: true
+        env:
+          C2PA_BUILD_FROM_SOURCE: "ON"
+          C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
+        run: make test
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=$run_url" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-cpp.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-cpp.yml
@@ -30,10 +30,14 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
+      # c2pa-cpp's build-from-source expects c2pa-rs as a filesystem neighbor,
+      # so check both out as siblings under the workspace.
       - name: Checkout c2pa-cpp
         uses: actions/checkout@v6
+        with:
+          path: c2pa-cpp
 
-      - name: Checkout c2pa-rs @ PR branch
+      - name: Checkout c2pa-rs @ PR branch (sibling of c2pa-cpp)
         uses: actions/checkout@v6
         with:
           repository: contentauth/c2pa-rs
@@ -54,13 +58,19 @@ jobs:
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y ninja-build cmake
 
+      # Follows c2pa-cpp's documented "Building using local sources" flow
+      # (README): C2PA_BUILD_FROM_SOURCE + C2PA_RS_PATH, with LD_LIBRARY_PATH set
+      # so the tests can load the freshly built libc2pa_c at runtime.
       - name: Build against local c2pa-rs and test
         id: build
         continue-on-error: true
+        working-directory: c2pa-cpp
         env:
           C2PA_BUILD_FROM_SOURCE: "ON"
           C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
-        run: make test
+        run: |
+          export LD_LIBRARY_PATH="$PWD/build/release/tests:${LD_LIBRARY_PATH:-}"
+          make test-release
 
       - name: Report result to c2pa-rs
         if: always()

--- a/docs/breaking-change-automation/receivers/c2pa-ios.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-ios.yml
@@ -1,0 +1,100 @@
+# Receiver for c2pa-ios. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-ios.
+#
+# c2pa-ios consumes prebuilt Apple native libraries from c2pa-rs releases, but
+# its build prefers local artifacts when C2PA_LOCAL_ARTIFACTS points at a dir
+# containing c2pa-<version>-<suffix>.zip files. So this receiver downloads the
+# branch build artifacts produced by c2pa-rs's library-release.yml (triggered by
+# the orchestrator), stages them, and builds/tests against them. STATUS-ONLY
+# (no committable diff); the status links to this workflow run.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret with Actions:read on c2pa-rs (to find +
+# download the build run). See contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md.
+#
+# UNVALIDATED: this needs a real run to confirm the make target, the
+# C2PA_LOCAL_ARTIFACTS layout, and version handling.
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: read
+
+env:
+  REPO_NAME: c2pa-ios
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+  GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+
+jobs:
+  verify:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout c2pa-ios
+        uses: actions/checkout@v6
+
+      - name: Report start to c2pa-rs
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - name: Locate, await, and download the c2pa-rs branch build
+        run: |
+          set -euo pipefail
+          # The orchestrator triggers library-release.yml with run-name embedding
+          # our head SHA. Poll until that run appears.
+          run_id=""
+          for _ in $(seq 1 90); do
+            run_id=$(gh run list --repo contentauth/c2pa-rs \
+              --workflow library-release.yml --limit 40 \
+              --json databaseId,displayTitle \
+              -q "[.[] | select(.displayTitle | contains(\"$C2PA_RS_SHA\"))][0].databaseId")
+            [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
+            sleep 20
+          done
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "::error::Could not find a library-release run for $C2PA_RS_SHA"; exit 1
+          fi
+          echo "Found library build run $run_id; waiting for completion..."
+          gh run watch "$run_id" --repo contentauth/c2pa-rs || true
+
+          mkdir -p dl staged
+          gh run download "$run_id" --repo contentauth/c2pa-rs \
+            --pattern 'release-artifacts-*apple-ios*' \
+            --pattern 'release-artifacts-*apple-darwin*' --dir dl
+          # Flatten the per-target zips into one dir for C2PA_LOCAL_ARTIFACTS.
+          find dl -name 'c2pa-*.zip' -exec cp {} staged/ \;
+          ls -1 staged
+          # Detect the crate version from a downloaded zip name (c2pa-vX.Y.Z-...).
+          ver=$(ls staged | sed -E 's/^c2pa-(v[0-9.]+)-.*/\1/' | head -1)
+          echo "C2PA_LOCAL_ARTIFACTS=$PWD/staged" >> "$GITHUB_ENV"
+          echo "C2PA_VERSION=$ver" >> "$GITHUB_ENV"
+
+      - name: Build and test
+        id: build
+        continue-on-error: true
+        run: make test-library
+
+      - name: Report result to c2pa-rs
+        if: always()
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=$run_url" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-js.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-js.yml
@@ -1,0 +1,120 @@
+# Receiver for c2pa-js. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-js.
+#
+# c2pa-js builds wasm directly from the `c2pa` crate declared in its root
+# Cargo.toml ([workspace.dependencies]). So, like c2pa-node-v2, we re-target by
+# rewriting that to a git+branch source, which produces a real diff: we commit
+# it to a branch, open a draft PR, build/test, and report status back.
+#
+# Mirrors c2pa-js's own CI (.github/workflows/ci.yml): the composite
+# install-dependencies action sets up the Rust + wasm + pnpm toolchain, then
+# `pnpm ci:check` lints/tests/builds all packages (c2pa-wasm, c2pa-types,
+# c2pa-web).
+#
+# Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md).
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  REPO_NAME: c2pa-js
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+          fetch-depth: 0
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Point c2pa dependency at the PR branch
+        run: |
+          python3 - "$C2PA_RS_REF" <<'PY'
+          import re, sys, pathlib
+          ref = sys.argv[1]
+          p = pathlib.Path("Cargo.toml")
+          t = p.read_text()
+          t = re.sub(
+              r'(?m)^(c2pa\s*=\s*\{)\s*version\s*=\s*"[^"]*"\s*,?',
+              r'\1 git = "https://github.com/contentauth/c2pa-rs", branch = "%s",' % ref,
+              t,
+          )
+          p.write_text(t)
+          print(t)
+          PY
+          cargo update -p c2pa
+
+      - name: Install headless Chromium + Chromedriver
+        working-directory: ./packages/c2pa-web
+        run: pnpm exec playwright install --with-deps
+
+      - name: Build and test
+        id: build
+        continue-on-error: true
+        run: pnpm ci:check
+
+      - name: Open / update draft PR
+        id: pr
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          branch="breaking/c2pa-rs-pr-${C2PA_RS_PR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Cargo.toml Cargo.lock
+          git commit -m "test: re-target c2pa to c2pa-rs#${C2PA_RS_PR} (${C2PA_RS_REF})" \
+            || echo "No changes to commit."
+          git push -u origin "$branch" --force
+          url=$(gh pr view "$branch" --json url -q .url 2>/dev/null || true)
+          if [ -z "$url" ]; then
+            url=$(gh pr create --draft \
+              --title "Verify against c2pa-rs#${C2PA_RS_PR} (breaking change)" \
+              --body "Automated verification of c2pa-rs PR #${C2PA_RS_PR} (branch \`${C2PA_RS_REF}\`). Build outcome: ${{ steps.build.outcome }}." \
+              --head "$branch")
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=${{ steps.pr.outputs.url }}" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-node-v2.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-node-v2.yml
@@ -1,0 +1,116 @@
+# Receiver for c2pa-node-v2. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-node-v2.
+#
+# c2pa-node-v2 depends on the `c2pa` crate from crates.io in its root
+# Cargo.toml, so we re-target by rewriting that to a git+branch source. This
+# produces a real diff, so we commit it to a branch and open a draft PR, then
+# build/test and report status back to the originating c2pa-rs PR.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md).
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  REPO_NAME: c2pa-node-v2
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Point c2pa dependency at the PR branch
+        run: |
+          python3 - "$C2PA_RS_REF" <<'PY'
+          import re, sys, pathlib
+          ref = sys.argv[1]
+          p = pathlib.Path("Cargo.toml")
+          t = p.read_text()
+          t = re.sub(
+              r'(?m)^(c2pa\s*=\s*\{)\s*version\s*=\s*"[^"]*"\s*,?',
+              r'\1 git = "https://github.com/contentauth/c2pa-rs", branch = "%s",' % ref,
+              t,
+          )
+          p.write_text(t)
+          print(t)
+          PY
+          cargo update -p c2pa
+
+      - name: Install and test
+        id: build
+        continue-on-error: true
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm test
+
+      - name: Open / update draft PR
+        id: pr
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          branch="breaking/c2pa-rs-pr-${C2PA_RS_PR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Cargo.toml Cargo.lock
+          git commit -m "test: re-target c2pa to c2pa-rs#${C2PA_RS_PR} (${C2PA_RS_REF})" \
+            || echo "No changes to commit."
+          git push -u origin "$branch" --force
+          url=$(gh pr view "$branch" --json url -q .url 2>/dev/null || true)
+          if [ -z "$url" ]; then
+            url=$(gh pr create --draft \
+              --title "Verify against c2pa-rs#${C2PA_RS_PR} (breaking change)" \
+              --body "Automated verification of c2pa-rs PR #${C2PA_RS_PR} (branch \`${C2PA_RS_REF}\`). Build outcome: ${{ steps.build.outcome }}." \
+              --head "$branch")
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=${{ steps.pr.outputs.url }}" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-python.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-python.yml
@@ -1,0 +1,89 @@
+# Receiver for c2pa-python. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-python.
+#
+# c2pa-python has no `c2pa` Cargo dependency to rewrite: it normally downloads
+# prebuilt native artifacts, but the Makefile exposes a `build-from-source`
+# path driven by C2PA_RS_PATH. So we re-target by checking out c2pa-rs at the PR
+# branch and building against it. There is no committable diff, so this receiver
+# is STATUS-ONLY (no draft PR); the status links to this workflow run. A red
+# status means a human needs to make changes in c2pa-python.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md).
+#
+# NOTE: verify the `make` invocations below against c2pa-python's Makefile
+# (the PYTHON variable and target names) before relying on this in production.
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: read
+
+env:
+  REPO_NAME: c2pa-python
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout c2pa-python
+        uses: actions/checkout@v6
+
+      - name: Checkout c2pa-rs @ PR branch
+        uses: actions/checkout@v6
+        with:
+          repository: contentauth/c2pa-rs
+          ref: ${{ github.event.client_payload.ref }}
+          path: c2pa-rs
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build against local c2pa-rs and test
+        id: build
+        continue-on-error: true
+        env:
+          C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          make install-deps PYTHON=python
+          make build-from-source C2PA_RS_PATH="$C2PA_RS_PATH" PYTHON=python
+          make test PYTHON=python
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=$run_url" >/dev/null

--- a/docs/breaking-change-automation/receivers/c2pa-python.yml
+++ b/docs/breaking-change-automation/receivers/c2pa-python.yml
@@ -10,9 +10,6 @@
 #
 # Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
 # docs/breaking-change-automation/README.md).
-#
-# NOTE: verify the `make` invocations below against c2pa-python's Makefile
-# (the PYTHON variable and target names) before relying on this in production.
 
 name: Test against c2pa-rs branch
 
@@ -57,17 +54,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Follows c2pa-python's documented "Building from local c2pa-rs sources"
+      # flow (README). The make targets honor the active virtualenv.
       - name: Build against local c2pa-rs and test
         id: build
         continue-on-error: true
         env:
           C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
         run: |
-          python3 -m venv .venv
+          make create-venv
           . .venv/bin/activate
-          make install-deps PYTHON=python
-          make build-from-source C2PA_RS_PATH="$C2PA_RS_PATH" PYTHON=python
-          make test PYTHON=python
+          make install-deps
+          make build-from-source C2PA_RS_PATH="$C2PA_RS_PATH"
+          make test
 
       - name: Report result to c2pa-rs
         if: always()

--- a/docs/breaking-change-automation/test-c2pa-rs-branch.yml
+++ b/docs/breaking-change-automation/test-c2pa-rs-branch.yml
@@ -1,0 +1,143 @@
+# TEMPLATE — do not run from c2pa-rs. Copy this file into each dependent repo
+# as `.github/workflows/test-c2pa-rs-branch.yml` and adjust the two marked
+# sections (REPO_NAME and the re-target / build steps) for that repo.
+#
+# It receives a repository_dispatch from contentauth/c2pa-rs when a PR there is
+# labeled `breaking-changes`, re-targets this repo's build to the c2pa-rs PR
+# branch, opens a draft PR here with that change, builds/tests, and reports a
+# commit status back to the originating c2pa-rs PR.
+#
+# Requires a secret CROSS_ORG_PR_TOKEN (PAT or GitHub App token) with:
+#   - contents: write + pull-requests: write on THIS repo (push branch, open PR)
+#   - statuses:  write on contentauth/c2pa-rs (report back)
+# See contentauth/c2pa-rs docs/breaking-change-automation/README.md.
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  # CHANGE ME: must match the context the c2pa-rs orchestrator seeds, i.e. this
+  # repo's short name as listed in c2pa-rs `DEPENDENTS` (e.g. c2pa-python).
+  REPO_NAME: c2pa-node-v2
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..."
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # ======================================================================
+      # CHANGE ME — re-target this repo's build to the c2pa-rs PR branch.
+      #
+      # Variant A (Rust dependency: c2pa-node-v2, c2pa-python build-from-source):
+      #   swap the crates.io `c2pa` dependency for a git+branch source.
+      # ======================================================================
+      - name: Point c2pa dependency at the PR branch
+        run: |
+          python3 - "$C2PA_RS_REF" <<'PY'
+          import re, sys, pathlib
+          ref = sys.argv[1]
+          p = pathlib.Path("Cargo.toml")
+          t = p.read_text()
+          # Rewrite `c2pa = { version = "x", ... }` to a git + branch source,
+          # preserving the remaining keys (features, default-features, ...).
+          t = re.sub(
+              r'(?m)^(c2pa\s*=\s*\{)\s*version\s*=\s*"[^"]*"\s*,?',
+              r'\1 git = "https://github.com/contentauth/c2pa-rs", branch = "%s",' % ref,
+              t,
+          )
+          p.write_text(t)
+          print(t)
+          PY
+          cargo update -p c2pa
+
+      # ----------------------------------------------------------------------
+      # Variant B (prebuilt native libs: c2pa-cpp, c2pa-ios, c2pa-android,
+      # c2pa-js) — instead of the step above, download the c2pa-rs branch build
+      # artifacts and stage them where the build expects the release-downloaded
+      # libraries. The artifact bridge in c2pa-rs `library-release.yml` is ready:
+      #
+      #   gh workflow run library-release.yml --repo contentauth/c2pa-rs \
+      #     --ref "$C2PA_RS_REF"
+      #   # ...wait for the run, then:
+      #   gh run download <run-id> --repo contentauth/c2pa-rs \
+      #     --pattern 'release-artifacts-*' --dir native/
+      #
+      # See README "Phase 2" for who-triggers-the-build / run-id-delivery design.
+      # ----------------------------------------------------------------------
+
+      # ======================================================================
+      # CHANGE ME — this repo's real build + test entry point. Examples:
+      #   make test  |  pnpm install && pnpm test  |  ./gradlew test
+      # ======================================================================
+      - name: Build and test
+        id: build
+        continue-on-error: true
+        run: make test
+
+      - name: Open / update draft PR
+        id: pr
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          branch="breaking/c2pa-rs-pr-${C2PA_RS_PR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add -A
+          git commit -m "test: re-target to c2pa-rs#${C2PA_RS_PR} (${C2PA_RS_REF})" \
+            || echo "No changes to commit."
+          git push -u origin "$branch" --force
+
+          url=$(gh pr view "$branch" --json url -q .url 2>/dev/null || true)
+          if [ -z "$url" ]; then
+            url=$(gh pr create --draft \
+              --title "Verify against c2pa-rs#${C2PA_RS_PR} (breaking change)" \
+              --body "Automated verification of c2pa-rs PR #${C2PA_RS_PR} (branch \`${C2PA_RS_REF}\`). Build outcome: ${{ steps.build.outcome }}." \
+              --head "$branch")
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=${{ steps.pr.outputs.url }}"


### PR DESCRIPTION
## What

Adds a `breaking-changes` label that, when applied to a c2pa-rs PR, fans out to the org's downstream binding repos and verifies each still builds against the PR's branch — gating the PR on the results as a required status check.

## How it works

- **`.github/workflows/breaking-changes.yml`** (orchestrator + aggregator):
  - On every PR it posts a single always-present required context, **`breaking-changes-gate`** (success when the label is absent, so unlabeled PRs never hang).
  - When a same-repo PR carries the label, the gate goes pending and a `repository_dispatch` (`c2pa-rs-breaking-change`) fans out to each dependent in `DEPENDENTS`. If `BINARY_DEPENDENTS` is non-empty, it also triggers one branch build of `library-release.yml` (via `CROSS_ORG_PR_TOKEN`, since `GITHUB_TOKEN` can't start a run).
  - A `status`-triggered job aggregates the per-dependent `breaking-changes / <repo>` results back into the gate.
  - Uses `pull_request_target` (never checks out PR code) so the gate can be posted on fork PRs too; fork PRs pass-through with a note.

- **Receivers** under `docs/breaking-change-automation/receivers/` — one per dependent, tailored to how each consumes c2pa-rs:
  - `c2pa-node-v2`, `c2pa-js` — rewrite the Cargo `c2pa` dep to a git+branch source, build, open a draft PR (Variant A).
  - `c2pa-python`, `c2pa-cpp` — build from a local c2pa-rs checkout, status-only.
  - `c2pa-ios`, `c2pa-android` — download the branch's `library-release.yml` artifacts, stage them, build, status-only. **Unvalidated** (need a real run + runners).

- **`library-release.yml`**: `release` job gated to `c2pa-v*` tags (so branch dispatch produces artifacts without a release), plus a `verify_sha` input + `run-name` so receivers can locate the branch build.

## Required follow-up before this is live

1. ✅ **Done** — org secret **`CROSS_ORG_PR_TOKEN`** is live (Contents + Pull requests write on the dependents; Commit statuses + Actions write on c2pa-rs).
2. Add **`breaking-changes-gate`** as a required status check on `main` / `v1_api`. Do **not** require the per-dependent contexts.
3. Merge the receiver PRs, then add each live repo to `DEPENDENTS` (and `BINARY_DEPENDENTS` for ios/android). See the README's "To activate iOS/Android".

## Receiver PRs

- Source-buildable (ready): contentauth/c2pa-node-v2#70, contentauth/c2pa-js#131, contentauth/c2pa-python#284, contentauth/c2pa-cpp#234
- Prebuilt-binary (unvalidated drafts): contentauth/c2pa-ios#116, contentauth/c2pa-android#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)