### PR TITLE
feat: add source to `HttpResolverError::Other` error message

### DIFF
--- a/sdk/src/http/mod.rs
+++ b/sdk/src/http/mod.rs
@@ -291,11 +291,11 @@ impl AsyncHttpResolver for AsyncGenericResolver {
 /// An error that occurs during sync/async HTTP resolver resolution.
 #[derive(Debug, thiserror::Error)]
 pub enum HttpResolverError {
-    /// An error occured in the [`http`] crate.
+    /// An error occurred in the [`http`] crate.
     #[error(transparent)]
     Http(#[from] http::Error),
 
-    /// An error occured in during I/O.
+    /// An error occurred in during I/O.
     #[error(transparent)]
     Io(#[from] io::Error),
 
@@ -327,8 +327,8 @@ pub enum HttpResolverError {
     #[error("response body exceeded maximum allowed size")]
     ResponseTooLarge,
 
-    /// An error occured from the underlying HTTP resolver.
-    #[error("an error occurred from the underlying http resolver")]
+    /// An error occurred from the underlying HTTP resolver.
+    #[error("an error occurred from the underlying http resolver: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
 


### PR DESCRIPTION
This adds the source error string to the `HttpResolverError::Other` error message. Ideally we would use the built-in `#[source]` here and no `{0}`, though for now the former pattern for consistency and compatibility.