### PR TITLE
feat: report CAWG identity trust with cawg.identity.* status codes

### DIFF
--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -2103,7 +2103,8 @@ pub mod tests {
     ///    - The active manifest carries the expected title and format.
     ///    - Both the `c2pa.actions` and `c2pa.hash` assertions are present.
     ///    - No hard validation failures exist (only `signingCredential.untrusted`
-    ///      is accepted, because the test CA is self-signed).
+    ///      or `cawg.identity.untrusted` is accepted, because the test CA is
+    ///      self-signed).
     ///    - Claim-signature validation succeeded (signature is cryptographically
     ///      valid even though the cert is not in a production trust store).
     ///
@@ -2214,8 +2215,9 @@ pub mod tests {
             "manifest must contain a c2pa.actions assertion; got: {:?}",
             assertions.iter().map(|a| a.label()).collect::<Vec<_>>()
         );
-        // Check validation results: only `signingCredential.untrusted` is
-        // acceptable as a failure (test CA is not in the production trust store).
+        // Check validation results: only an untrusted-credential failure
+        // (`signingCredential.untrusted` or `cawg.identity.untrusted`) is
+        // acceptable (test CA is not in the production trust store).
         // All other failure codes indicate a real problem in the signing or
         // embedding pipeline.
         if let Some(results) = reader.validation_results() {
@@ -2223,7 +2225,7 @@ pub mod tests {
                 let hard_failures: Vec<_> = active
                     .failure()
                     .iter()
-                    .filter(|f| f.code() != "signingCredential.untrusted")
+                    .filter(|f| !crate::validation_results::is_untrusted_failure(f.code()))
                     .collect();
                 assert!(
                     hard_failures.is_empty(),

--- a/sdk/src/crypto/cose/mod.rs
+++ b/sdk/src/crypto/cose/mod.rs
@@ -55,4 +55,4 @@ mod time_stamp_storage;
 pub use time_stamp_storage::TimeStampStorage;
 
 mod verifier;
-pub use verifier::Verifier;
+pub use verifier::{CredentialKind, CredentialVerifier, Verifier};

--- a/sdk/src/crypto/cose/verifier.rs
+++ b/sdk/src/crypto/cose/verifier.rs
@@ -33,10 +33,46 @@ use crate::{
     log_item,
     status_tracker::StatusTracker,
     validation_results::validation_codes::{
-        ALGORITHM_UNSUPPORTED, SIGNING_CREDENTIAL_INVALID, SIGNING_CREDENTIAL_TRUSTED,
-        SIGNING_CREDENTIAL_UNTRUSTED,
+        ALGORITHM_UNSUPPORTED, CAWG_IDENTITY_TRUSTED, CAWG_IDENTITY_UNTRUSTED,
+        SIGNING_CREDENTIAL_INVALID, SIGNING_CREDENTIAL_TRUSTED, SIGNING_CREDENTIAL_UNTRUSTED,
     },
 };
+
+/// Identifies which kind of credential a COSE signature represents, so that the
+/// trust-check result is reported with the appropriate validation status codes.
+///
+/// The same trust check is shared by the C2PA claim signer and the CAWG
+/// creator-identity credential; this selects which namespace the resulting
+/// status codes belong to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CredentialKind {
+    /// A C2PA claim signer. Trust results use the `signingCredential.*` codes.
+    #[default]
+    C2paSigning,
+
+    /// A CAWG creator-identity credential. Trust results use the
+    /// `cawg.identity.*` codes ([`CAWG_IDENTITY_TRUSTED`] /
+    /// [`CAWG_IDENTITY_UNTRUSTED`]) instead of the `signingCredential.*` codes.
+    CawgIdentity,
+}
+
+impl CredentialKind {
+    /// The validation status code to report when the credential is trusted.
+    fn trusted_status(self) -> &'static str {
+        match self {
+            CredentialKind::C2paSigning => SIGNING_CREDENTIAL_TRUSTED,
+            CredentialKind::CawgIdentity => CAWG_IDENTITY_TRUSTED,
+        }
+    }
+
+    /// The validation status code to report when the credential is not trusted.
+    fn untrusted_status(self) -> &'static str {
+        match self {
+            CredentialKind::C2paSigning => SIGNING_CREDENTIAL_UNTRUSTED,
+            CredentialKind::CawgIdentity => CAWG_IDENTITY_UNTRUSTED,
+        }
+    }
+}
 
 /// A `Verifier` reads a COSE signature and reports on its validity.
 ///
@@ -60,7 +96,11 @@ pub enum Verifier<'a> {
 }
 
 impl Verifier<'_> {
-    /// Verify a COSE signature according to the configured policies.
+    /// Verify a COSE signature according to the configured policies, reporting
+    /// trust results for a C2PA claim signer.
+    ///
+    /// To report trust results for a different credential (e.g. a CAWG
+    /// creator-identity credential), use [`Verifier::with_credential_kind`].
     #[async_generic]
     pub fn verify_signature(
         &self,
@@ -68,6 +108,49 @@ impl Verifier<'_> {
         data: &[u8],
         additional_data: &[u8],
         tst_info: Option<&TstInfo>,
+        validation_log: &mut StatusTracker,
+    ) -> Result<CertificateInfo, CoseError> {
+        if _sync {
+            self.verify_signature_with_kind(
+                cose_sign1,
+                data,
+                additional_data,
+                tst_info,
+                CredentialKind::C2paSigning,
+                validation_log,
+            )
+        } else {
+            self.verify_signature_with_kind_async(
+                cose_sign1,
+                data,
+                additional_data,
+                tst_info,
+                CredentialKind::C2paSigning,
+                validation_log,
+            )
+            .await
+        }
+    }
+
+    /// Bind a [`CredentialKind`] to this verifier so trust results are reported
+    /// with the status codes appropriate to that credential. The returned
+    /// [`CredentialVerifier`] exposes the same `verify_signature` API.
+    pub fn with_credential_kind(&self, credential_kind: CredentialKind) -> CredentialVerifier<'_, '_> {
+        CredentialVerifier {
+            verifier: self,
+            credential_kind,
+        }
+    }
+
+    /// Verify a COSE signature according to the configured policies.
+    #[async_generic]
+    pub(crate) fn verify_signature_with_kind(
+        &self,
+        cose_sign1: &[u8],
+        data: &[u8],
+        additional_data: &[u8],
+        tst_info: Option<&TstInfo>,
+        credential_kind: CredentialKind,
         validation_log: &mut StatusTracker,
     ) -> Result<CertificateInfo, CoseError> {
         let mut sign1 = parse_cose_sign1(cose_sign1, data, validation_log)?;
@@ -108,9 +191,9 @@ impl Verifier<'_> {
         .ok(); // Ignore errors here - they have already been logged.
 
         if _sync {
-            self.verify_trust(&sign1, tst_info, validation_log)
+            self.verify_trust(&sign1, tst_info, credential_kind, validation_log)
         } else {
-            self.verify_trust_async(&sign1, tst_info, validation_log)
+            self.verify_trust_async(&sign1, tst_info, credential_kind, validation_log)
                 .await
         }
         .ok(); // Ignore errors here - they have already been logged.
@@ -210,6 +293,7 @@ impl Verifier<'_> {
         &self,
         sign1: &CoseSign1,
         tst_info_res: Option<&TstInfo>,
+        credential_kind: CredentialKind,
         validation_log: &mut StatusTracker,
     ) -> Result<TrustAnchorType, CoseError> {
         // IMPORTANT: This function assumes that verify_profile has already been called.
@@ -252,16 +336,62 @@ impl Verifier<'_> {
                     ),
                     "verify_cose"
                 )
-                .validation_status(SIGNING_CREDENTIAL_TRUSTED)
+                .validation_status(credential_kind.trusted_status())
                 .success(validation_log);
 
                 Ok(tat)
             }
             Err(e) => Err(
                 log_item!("", "signing certificate untrusted", "verify_cose")
-                    .validation_status(SIGNING_CREDENTIAL_UNTRUSTED)
+                    .validation_status(credential_kind.untrusted_status())
                     .failure_as_err(validation_log, e.into()),
             ),
+        }
+    }
+}
+
+/// A [`Verifier`] bound to a specific [`CredentialKind`], so that trust results
+/// are reported with the status codes appropriate to that credential.
+///
+/// Created via [`Verifier::with_credential_kind`].
+#[derive(Debug)]
+pub struct CredentialVerifier<'v, 'a> {
+    verifier: &'v Verifier<'a>,
+    credential_kind: CredentialKind,
+}
+
+impl CredentialVerifier<'_, '_> {
+    /// Verify a COSE signature according to the bound verifier's policies,
+    /// reporting trust results for the bound [`CredentialKind`].
+    #[async_generic]
+    pub fn verify_signature(
+        &self,
+        cose_sign1: &[u8],
+        data: &[u8],
+        additional_data: &[u8],
+        tst_info: Option<&TstInfo>,
+        validation_log: &mut StatusTracker,
+    ) -> Result<CertificateInfo, CoseError> {
+        if _sync {
+            self.verifier.verify_signature_with_kind(
+                cose_sign1,
+                data,
+                additional_data,
+                tst_info,
+                self.credential_kind,
+                validation_log,
+            )
+        } else {
+            self.verifier
+                .verify_signature_with_kind_async(
+                    cose_sign1,
+                    data,
+                    additional_data,
+                    tst_info,
+                    self.credential_kind,
+                    validation_log,
+                )
+                .await
         }
     }
 }

--- a/sdk/src/identity/identity_assertion/assertion.rs
+++ b/sdk/src/identity/identity_assertion/assertion.rs
@@ -306,7 +306,7 @@ impl IdentityAssertion {
         status_tracker: &mut StatusTracker,
         context: &Context,
     ) -> Result<serde_json::Value, ValidationError<String>> {
-        let settings = Context::new().settings().clone();
+        let settings = context.settings().clone();
         self.check_padding(status_tracker)?;
 
         self.signer_payload

--- a/sdk/src/identity/identity_assertion/assertion.rs
+++ b/sdk/src/identity/identity_assertion/assertion.rs
@@ -23,7 +23,7 @@ use serde_bytes::ByteBuf;
 
 use crate::{
     crypto::{
-        cose::{parse_cose_sign1, CertificateTrustPolicy, CoseError, Verifier},
+        cose::{parse_cose_sign1, CertificateTrustPolicy, CoseError, CredentialKind, Verifier},
         raw_signature::RawSignatureValidationError,
     },
     dynamic_assertion::PartialClaim,
@@ -351,8 +351,12 @@ impl IdentityAssertion {
                 parse_cose_sign1(&self.signature, &signer_payload_cbor, status_tracker)
                     .map_err(|e| ValidationError::SignatureError(e.to_string()))?;
 
+            // Verify as a CAWG creator-identity credential so trust results are
+            // reported with the `cawg.identity.*` status codes rather than the
+            // C2PA claim-signer `signingCredential.*` codes.
+            let cawg_verifier = cose_verifier.with_credential_kind(CredentialKind::CawgIdentity);
             let cert_info = if _sync {
-                cose_verifier.verify_signature(
+                cawg_verifier.verify_signature(
                     &self.signature,
                     &signer_payload_cbor,
                     &[],
@@ -360,7 +364,7 @@ impl IdentityAssertion {
                     status_tracker,
                 )
             } else {
-                cose_verifier
+                cawg_verifier
                     .verify_signature_async(
                         &self.signature,
                         &signer_payload_cbor,
@@ -390,8 +394,9 @@ impl IdentityAssertion {
             )
             .validation_status("cawg.identity.well-formed")
             .success(status_tracker);
-            // TO DO (CAI-7980): Should instead issue `cawg.identity.trusted` if the
-            // signing cert is found on a configured trust list.
+            // NOTE (CAI-7980): when the signing cert is on a configured CAWG trust
+            // list, `verify_signature` above additionally logs `cawg.identity.trusted`
+            // (and `cawg.identity.untrusted` when it is not).
 
             serde_json::to_value(result)
                 .map_err(|e| ValidationError::UnknownSignatureType(e.to_string()))

--- a/sdk/src/identity/tests/validation_method/continue_when_possible.rs
+++ b/sdk/src/identity/tests/validation_method/continue_when_possible.rs
@@ -208,7 +208,7 @@ async fn assertion_not_in_claim_v1() {
 
     assert_eq!(
         log.validation_status.as_ref().unwrap().as_ref() as &str,
-        "signingCredential.trusted"
+        "cawg.identity.trusted"
     );
 
     let cert_info = &sig_info.cert_info;
@@ -319,7 +319,7 @@ async fn duplicate_assertion_reference() {
     );
     assert_eq!(
         log.validation_status.as_ref().unwrap().as_ref() as &str,
-        "signingCredential.trusted"
+        "cawg.identity.trusted"
     );
 
     let cert_info = &sig_info.cert_info;
@@ -410,7 +410,7 @@ async fn no_hard_binding() {
 
     assert_eq!(
         log.validation_status.as_ref().unwrap().as_ref() as &str,
-        "signingCredential.trusted"
+        "cawg.identity.trusted"
     );
 
     let cert_info = &sig_info.cert_info;
@@ -681,7 +681,7 @@ async fn pad1_invalid() {
 
     assert_eq!(
         log.validation_status.as_ref().unwrap().as_ref() as &str,
-        "signingCredential.trusted"
+        "cawg.identity.trusted"
     );
 
     let cert_info = &sig_info.cert_info;
@@ -772,7 +772,7 @@ async fn pad2_invalid() {
 
     assert_eq!(
         log.validation_status.as_ref().unwrap().as_ref() as &str,
-        "signingCredential.trusted"
+        "cawg.identity.trusted"
     );
 
     let cert_info = &sig_info.cert_info;

--- a/sdk/src/identity/x509/x509_signature_verifier.rs
+++ b/sdk/src/identity/x509/x509_signature_verifier.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 
 use crate::{
     crypto::{
-        cose::{parse_cose_sign1, CertificateInfo, CoseError, Verifier},
+        cose::{parse_cose_sign1, CertificateInfo, CoseError, CredentialKind, Verifier},
         raw_signature::RawSignatureValidationError,
     },
     identity::{
@@ -76,6 +76,7 @@ impl SignatureVerifier for X509SignatureVerifier<'_> {
 
         let cert_info = self
             .cose_verifier
+            .with_credential_kind(CredentialKind::CawgIdentity)
             .verify_signature(signature, &signer_payload_cbor, &[], None, status_tracker)
             .map_err(|e| match e {
                 CoseError::RawSignatureValidationError(
@@ -122,6 +123,7 @@ impl SignatureVerifier for X509SignatureVerifier<'_> {
 
         let cert_info = self
             .cose_verifier
+            .with_credential_kind(CredentialKind::CawgIdentity)
             .verify_signature_async(signature, &signer_payload_cbor, &[], None, status_tracker)
             .await
             .map_err(|e| match e {
@@ -307,7 +309,7 @@ mod tests {
 
         assert_eq!(
             log.validation_status.as_ref().unwrap().as_ref() as &str,
-            "signingCredential.untrusted"
+            "cawg.identity.untrusted"
         );
     }
 }

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -811,7 +811,7 @@ impl Reader {
                 // if there are any errors, the state is invalid unless the only error is an untrusted credential
                 let errs = status
                     .iter()
-                    .any(|s| s.code() != crate::validation_status::SIGNING_CREDENTIAL_UNTRUSTED);
+                    .any(|s| !crate::validation_results::is_untrusted_failure(s.code()));
                 if errs {
                     ValidationState::Invalid
                 } else if verify_trust {

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -27,6 +27,23 @@ use crate::{
     validation_status::{self, log_kind, ValidationStatus},
 };
 
+/// Returns `true` if `code` is an untrusted-credential failure that does not, by
+/// itself, invalidate a manifest.
+///
+/// This tolerates both the C2PA claim signer ([`SIGNING_CREDENTIAL_UNTRUSTED`])
+/// and the CAWG creator-identity credential ([`CAWG_IDENTITY_UNTRUSTED`]). CAWG
+/// identity trust is outside the scope of C2PA validity, so an untrusted CAWG
+/// identity is treated like an untrusted C2PA claim signer for the purpose of
+/// the C2PA validation state (i.e. the manifest may still be `Valid`, but never
+/// `Trusted`).
+///
+/// [`SIGNING_CREDENTIAL_UNTRUSTED`]: validation_status::SIGNING_CREDENTIAL_UNTRUSTED
+/// [`CAWG_IDENTITY_UNTRUSTED`]: validation_status::CAWG_IDENTITY_UNTRUSTED
+pub(crate) fn is_untrusted_failure(code: &str) -> bool {
+    code == validation_status::SIGNING_CREDENTIAL_UNTRUSTED
+        || code == validation_status::CAWG_IDENTITY_UNTRUSTED
+}
+
 /// Represents the levels of assurance a manifest store achieves when evaluated against the C2PA
 /// specifications structural, cryptographic, and trust requirements.
 ///
@@ -232,7 +249,7 @@ impl ValidationResults {
                 // Then check if the manifest contains either no failures or that it's only untrusted.
                 && (active_manifest.failure().is_empty()
                     || active_manifest.failure().iter().all(|status| {
-                        status.code() == validation_status::SIGNING_CREDENTIAL_UNTRUSTED
+                        is_untrusted_failure(status.code())
                     }))
                 // Finally check if the ingredients contain either no failures or the only failure is
                 // that the ingredient is untrusted.
@@ -241,7 +258,7 @@ impl ValidationResults {
                         let deltas = idv.validation_deltas();
                         deltas.failure().is_empty()
                             || deltas.failure().iter().all(|status| {
-                                status.code() == validation_status::SIGNING_CREDENTIAL_UNTRUSTED
+                                is_untrusted_failure(status.code())
                             })
                     })
                 });
@@ -460,7 +477,7 @@ impl Display for ValidationFailureSummary<'_> {
             let failures = active_manifest
                 .failure
                 .iter()
-                .filter(|status| status.code() != validation_status::SIGNING_CREDENTIAL_UNTRUSTED)
+                .filter(|status| !is_untrusted_failure(status.code()))
                 .collect::<Vec<_>>();
             if !failures.is_empty() {
                 output_lines.push("failures:".to_string());
@@ -479,7 +496,7 @@ impl Display for ValidationFailureSummary<'_> {
                     .failure
                     .iter()
                     .filter(|status| {
-                        status.code() != validation_status::SIGNING_CREDENTIAL_UNTRUSTED
+                        !is_untrusted_failure(status.code())
                     })
                     .collect::<Vec<_>>();
                 if !failures.is_empty() {
@@ -559,6 +576,15 @@ pub mod validation_codes {
     ///
     /// Any corresponding URL should point to a C2PA claim signature box.
     pub const SIGNING_CREDENTIAL_TRUSTED: &str = "signingCredential.trusted";
+
+    /// The CAWG creator-identity credential is listed on the validator's CAWG
+    /// trust list.
+    ///
+    /// This is the CAWG identity-assertion counterpart of
+    /// [`SIGNING_CREDENTIAL_TRUSTED`].
+    ///
+    /// Any corresponding URL should point to a CAWG identity assertion.
+    pub const CAWG_IDENTITY_TRUSTED: &str = "cawg.identity.trusted";
 
     /// The signing credential for the manifest has not been revoked:
     ///
@@ -778,6 +804,17 @@ pub mod validation_codes {
     ///
     /// Any corresponding URL should point to a C2PA claim signature box.
     pub const SIGNING_CREDENTIAL_UNTRUSTED: &str = "signingCredential.untrusted";
+
+    /// The CAWG creator-identity credential is not listed on the validator's
+    /// CAWG trust list.
+    ///
+    /// This is the CAWG identity-assertion counterpart of
+    /// [`SIGNING_CREDENTIAL_UNTRUSTED`]. CAWG identity trust is outside the
+    /// scope of C2PA validity, so this status does not by itself invalidate a
+    /// manifest.
+    ///
+    /// Any corresponding URL should point to a CAWG identity assertion.
+    pub const CAWG_IDENTITY_UNTRUSTED: &str = "cawg.identity.untrusted";
 
     /// The signing credential is not valid for signing.
     ///
@@ -1082,6 +1119,7 @@ pub mod validation_codes {
             CLAIM_SIGNATURE_VALIDATED
             | CLAIM_SIGNATURE_INSIDE_VALIDITY
             | SIGNING_CREDENTIAL_TRUSTED
+            | CAWG_IDENTITY_TRUSTED
             | SIGNING_CREDENTIAL_NOT_REVOKED
             | TIMESTAMP_TRUSTED
             | TIMESTAMP_VALIDATED
@@ -1121,12 +1159,27 @@ pub mod tests {
         jumbf::labels,
         log_item,
         validation_status::{
-            ASSERTION_DATAHASH_MISMATCH, ASSERTION_HASHEDURI_MISMATCH, CLAIM_MALFORMED,
-            CLAIM_SIGNATURE_INSIDE_VALIDITY, CLAIM_SIGNATURE_VALIDATED, SIGNING_CREDENTIAL_TRUSTED,
-            SIGNING_CREDENTIAL_UNTRUSTED,
+            ASSERTION_DATAHASH_MISMATCH, ASSERTION_HASHEDURI_MISMATCH, CAWG_IDENTITY_TRUSTED,
+            CAWG_IDENTITY_UNTRUSTED, CLAIM_MALFORMED, CLAIM_SIGNATURE_INSIDE_VALIDITY,
+            CLAIM_SIGNATURE_VALIDATED, SIGNING_CREDENTIAL_TRUSTED, SIGNING_CREDENTIAL_UNTRUSTED,
         },
         HashedUri, Relationship,
     };
+
+    #[test]
+    fn trust_status_codes_classify_consistently() {
+        // The C2PA claim signer and the CAWG creator-identity credential each
+        // have a trusted/untrusted pair; both pairs must classify the same way.
+        for trusted in [SIGNING_CREDENTIAL_TRUSTED, CAWG_IDENTITY_TRUSTED] {
+            assert_eq!(log_kind(trusted), LogKind::Success);
+            assert!(!is_untrusted_failure(trusted));
+        }
+        for untrusted in [SIGNING_CREDENTIAL_UNTRUSTED, CAWG_IDENTITY_UNTRUSTED] {
+            assert_eq!(log_kind(untrusted), LogKind::Failure);
+            // Untrusted credentials are tolerated: Valid, but never Trusted.
+            assert!(is_untrusted_failure(untrusted));
+        }
+    }
 
     #[test]
     fn trusted_state() {


### PR DESCRIPTION
Addresses Issue: https://github.com/contentauth/c2pa-rs/issues/2247.

Distinguish an untrusted (or trusted) CAWG creator-identity credential from the C2PA claim signer by emitting cawg.identity.untrusted / cawg.identity.trusted instead of the signingCredential.* codes.

- Add CredentialKind and a non-breaking Verifier::with_credential_kind builder so the shared COSE trust check selects the right status namespace; CAWG paths bind CredentialKind::CawgIdentity.
- Add CAWG_IDENTITY_TRUSTED/UNTRUSTED constants and classify them in log_kind; treat cawg.identity.untrusted like signingCredential.untrusted for validity (Valid, never Trusted) via is_untrusted_failure.

Implements cawg.identity.trusted (ref CAI-7980).

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
