### PR TITLE
fix: correct features output reference in tier-1b rust-native-crypto job

### DIFF
--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run tests
         env:
           RUST_BACKTRACE: "1"
-          FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
+          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
         run: |
           cargo test --features "$FEATURES"
 


### PR DESCRIPTION
## Problem

In `.github/workflows/tier-1b.yml`, the `tests-rust-native-crypto` job set:

```yaml
FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
```

But the `get-features` job only defines two outputs — `rust-native-features` and `openssl-features`. There is no `rust_native_crypto-features` output, so `FEATURES` expanded to an empty string and the job ran `cargo test --features ""`, silently testing with **no features** instead of the rust-native-crypto feature set. This defeated the entire purpose of that job.

## Fix

Point the reference at the correct output name:

```diff
-          FEATURES: ${{needs.get-features.outputs.rust_native_crypto-features}}
+          FEATURES: ${{needs.get-features.outputs.rust-native-features}}
```

## Verification

- `actionlint .github/workflows/tier-1b.yml` no longer reports an expression error on that line (only pre-existing shellcheck style notes on the unrelated `get-features` script remain).
- The output name now matches the `get-features` `outputs:` block and its `>> "$GITHUB_OUTPUT"` line exactly.

This is a pre-existing bug on `main` and is independent of the release-process work in #2250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)