### PR TITLE
chore: remove deprecated assertions from examples

### DIFF
--- a/sdk/examples/client/client.rs
+++ b/sdk/examples/client/client.rs
@@ -16,13 +16,13 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-#[allow(deprecated)]
 use c2pa::{
-    assertions::{labels, Actions, CreativeWork, Exif},
+    assertions::{labels, Actions},
     create_signer,
     crypto::raw_signature::SigningAlg,
     Builder, BuilderIntent, ClaimGeneratorInfo, Reader,
 };
+use serde_json::json;
 
 const GENERATOR: &str = "test_app";
 const INDENT_SPACE: usize = 2;
@@ -50,19 +50,9 @@ fn show_manifest(reader: &Reader, manifest_label: &str, level: usize) -> Result<
                         println!("{}{}", indent, action.action());
                     }
                 }
-                #[allow(deprecated)]
-                labels::CREATIVE_WORK => {
-                    let creative_work: CreativeWork = assertion.to_assertion()?;
-                    if let Some(authors) = creative_work.author() {
-                        for author in authors {
-                            if let Some(name) = author.name() {
-                                println!("{indent}author = {name} ");
-                            }
-                        }
-                    }
-                    if let Some(url) = creative_work.get::<String>("url") {
-                        println!("{indent}url = {url} ");
-                    }
+                labels::METADATA => {
+                    let metadata: serde_json::Value = assertion.to_assertion()?;
+                    println!("{indent}metadata = {metadata}");
                 }
                 _ => {}
             }
@@ -110,20 +100,6 @@ pub fn main() -> Result<()> {
         std::fs::remove_file(&dest)?;
     }
 
-    let exif = Exif::from_json_str(
-        r#"{
-        "@context" : {
-          "exif": "http://ns.adobe.com/exif/1.0/"
-        },
-        "exif:GPSVersionID": "2.2.0.0",
-        "exif:GPSLatitude": "39,21.102N",
-        "exif:GPSLongitude": "74,26.5737W",
-        "exif:GPSAltitudeRef": 0,
-        "exif:GPSAltitude": "100963/29890",
-        "exif:GPSTimeStamp": "2019-09-22T18:22:57Z"
-    }"#,
-    )?;
-
     // create a new Manifest
     let mut builder = Builder::default();
     builder.definition.claim_version = Some(2);
@@ -132,7 +108,20 @@ pub fn main() -> Result<()> {
     builder
         .set_intent(BuilderIntent::Edit)
         .set_claim_generator_info(generator)
-        .add_assertion(Exif::LABEL, &exif)?;
+        .add_assertion(
+            "c2pa.metadata",
+            &json!({
+                "@context": {
+                    "exif": "http://ns.adobe.com/exif/1.0/"
+                },
+                "exif:GPSVersionID": "2.2.0.0",
+                "exif:GPSLatitude": "39,21.102N",
+                "exif:GPSLongitude": "74,26.5737W",
+                "exif:GPSAltitudeRef": 0,
+                "exif:GPSAltitude": "100963/29890",
+                "exif:GPSTimeStamp": "2019-09-22T18:22:57Z"
+            }),
+        )?;
 
     // sign and embed into the target file
     let signcert_path = "sdk/tests/fixtures/certs/es256.pub";

--- a/sdk/src/assertions/exif.rs
+++ b/sdk/src/assertions/exif.rs
@@ -12,6 +12,7 @@
 // each license.
 
 //! Exif Assertion
+#![allow(deprecated)]
 use std::collections::HashMap;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -27,7 +28,10 @@ use crate::{
 ///
 /// This does not yet define or validate individual fields, but will ensure the correct assertion structure.
 // NOTE: Hidden because it's now part of standard metadata assertions.
-#[doc(hidden)]
+#[deprecated(
+    since = "0.88.0",
+    note = "The Exif assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity and/or metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Exif {
     #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -47,6 +47,7 @@ mod creative_work;
 pub use creative_work::CreativeWork;
 
 mod exif;
+#[allow(deprecated)]
 pub use exif::Exif;
 
 #[allow(dead_code)] // will become public later

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -28,6 +28,10 @@ use crate::{
 const ASSERTION_CREATION_VERSION: usize = 1;
 
 /// Assertion that implements various schema.org-based assertions.
+#[deprecated(
+    since = "0.88.0",
+    note = "The CreativeWork assertion is no longer part of the C2PA Technical Specification. Please use the CAWG identity and/or metadata assertion instead (https://opensource.contentauthenticity.org/docs/manifest/cawg-id)."
+)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SchemaDotOrg {
     #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -29,14 +29,14 @@ use uuid::Uuid;
 use zip::ZipArchive;
 
 #[allow(deprecated)]
-use crate::assertions::CreativeWork;
+use crate::assertions::{CreativeWork, Exif};
 use crate::{
     assertion::{AssertionBase, AssertionDecodeError},
     assertions::{
         c2pa_action,
         labels::{self, parse_label},
         Action, ActionTemplate, Actions, AssertionMetadata, BmffHash, BoxHash, DataHash,
-        DigitalSourceType, EmbeddedData, ExclusionsMap, Exif, MerkleMap, Metadata, SoftwareAgent,
+        DigitalSourceType, EmbeddedData, ExclusionsMap, MerkleMap, Metadata, SoftwareAgent,
         SubsetMap, Thumbnail, TimeStamp, User, UserCbor,
     },
     claim::Claim,
@@ -1519,6 +1519,7 @@ impl Builder {
                     let cw: CreativeWork = manifest_assertion.to_assertion()?;
                     claim.add_assertion(&cw)
                 }
+                #[allow(deprecated)]
                 Exif::LABEL => {
                     let exif: Exif = manifest_assertion.to_assertion()?;
                     add_assertion(&mut claim, &exif, manifest_assertion.created())

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 use crate::{
     assertions::{
         labels, Action, Actions, DigitalSourceType, EmbeddedData, Ingredient, Relationship,
-        ReviewRating, SchemaDotOrg, Thumbnail, User,
+        ReviewRating, Thumbnail, User,
     },
     asset_io::CAIReadWrite,
     claim::Claim,
@@ -343,7 +343,7 @@ pub fn create_test_claim_v1() -> Result<Claim> {
             "alternateName": "False"
         }
     }"#;
-    let claim_review = SchemaDotOrg::from_json_str(cr)?;
+    let claim_review = User::new("schema.org", cr);
     let thumbnail_claim = Thumbnail::new(labels::JPEG_CLAIM_THUMBNAIL, some_binary_data.clone());
     let thumbnail_ingred = Thumbnail::new(labels::JPEG_INGREDIENT_THUMBNAIL, some_binary_data);
     let user_assertion = User::new(TEST_USER_ASSERTION, user_assertion_data);


### PR DESCRIPTION
Also deprecates exit and schema.org assertions which should have been deprecated long ago. Note: this does not clean up deprecated assertions in unit tests - that can come later.
