### PR TITLE
fix: Don't serialize empty values

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -91,11 +91,17 @@ pub struct UserHashInfo {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ExclusionsMap {
     pub xpath: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Vec<DataMap>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subset: Option<Vec<SubsetMap>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<ByteBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exact: Option<bool>,
 }
 


### PR DESCRIPTION
## Changes in this pull request
Don't serialize empty values in exclusion-map

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
