### PR TITLE
chore: Update fixable vulnerable dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1748,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2503,9 +2515,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lopdf"
-version = "0.39.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
  "aes",
  "bitflags",
@@ -2514,15 +2526,14 @@ dependencies = [
  "ecb",
  "encoding_rs",
  "flate2",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "indexmap 2.14.0",
  "itoa",
  "jiff",
  "log",
  "md-5",
  "nom 8.0.0",
- "nom_locate",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
  "sha2 0.10.9",
@@ -2728,17 +2739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom_locate"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
 ]
 
 [[package]]
@@ -3327,9 +3327,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3356,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3438,6 +3438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3485,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 rust-version = "1.88.0"
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 c2pa = { workspace = true, features = ["openssl", "json_schema"] }
 schemars = "1.2.1"
 serde_json = "1.0.150"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 c2pa = { workspace = true, features = [
     "openssl",
 	"fetch_remote_manifests",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -127,7 +127,7 @@ img-parts = "0.4.0"
 iref = { version = "3.2.2", features = ["serde"] }
 jfifdump = "0.6.0"
 log = "0.4.30"
-lopdf = { version = "0.39.0", optional = true }
+lopdf = { version = "0.42.0", optional = true }
 lazy_static = "1.5.0"
 memchr = "2.8.1"
 mp4 = "0.14.0"
@@ -146,7 +146,7 @@ pem = "3.0.6"
 pkcs1 = { version = "0.7.5", optional = true }
 pkcs8 = "0.10.2"
 png_pong = "0.10.0"
-quick-xml = "0.39.4"
+quick-xml = "0.41.0"
 rand = "0.8.6"
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 range-set = "0.1.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -271,7 +271,7 @@ web-sys = { version = "0.3.99", features = [
 ] }
 
 [dev-dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 env_logger = "0.11.10"
 glob = "0.3.3"
 hex-literal = "1.1.0"

--- a/sdk/src/utils/xmp_inmemory_utils.rs
+++ b/sdk/src/utils/xmp_inmemory_utils.rs
@@ -79,7 +79,9 @@ fn extract_xmp_key(xmp: &str, key: &str) -> Option<String> {
                 } else if e.name() == QName(key.as_bytes()) {
                     // tag case
                     if let Ok(s) = reader.read_text(e.name()) {
-                        return Some(s.to_string());
+                        if let Ok(s) = s.xml10_content() {
+                            return Some(s.into_owned());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Changes in this pull request

This PR updates fixable vulnerable dependencies reported by `cargo audit`: `lopdf`, `quick-xml` and `quinn-proto`.

Also, it adjusts XMP text decoding for the `quick-xml` 0.41 API where [`Reader::read_text`](https://docs.rs/quick-xml/0.41.0/quick_xml/reader/struct.Reader.html#method.read_text) returns `BytesText`. The text is decoded with [`BytesText::xml10_content`](https://docs.rs/quick-xml/0.41.0/quick_xml/events/struct.BytesText.html#method.xml10_content).

<details>
<summary>`cargo audit` output before this update</summary>

```text
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1152 security advisories (from /Users/vadim/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (559 crate dependencies)
Crate:     lopdf
Version:   0.39.0
Title:     Stack overflow in lopdf via deeply nested PDF objects
Date:      2026-06-21
ID:        RUSTSEC-2026-0187
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0187
Severity:  7.5 (high)
Solution:  Upgrade to >=0.42.0

Crate:     quick-xml
Version:   0.39.4
Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
Date:      2026-06-29
ID:        RUSTSEC-2026-0195
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

Crate:     quick-xml
Version:   0.39.4
Title:     Quadratic run time when checking a start tag for duplicate attribute names
Date:      2026-06-29
ID:        RUSTSEC-2026-0194
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0194
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

Crate:     quinn-proto
Version:   0.11.14
Title:      Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
Date:      2026-06-22
ID:        RUSTSEC-2026-0185
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0185
Severity:  7.5 (high)
Solution:  Upgrade to >=0.11.15

Crate:     rsa
Version:   0.9.10
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Severity:  5.9 (medium)
Solution:  No fixed upgrade is available!

Crate:     proc-macro-error
Version:   1.0.4
Warning:   unmaintained
Title:     proc-macro-error is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0370
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370

Crate:     ttf-parser
Version:   0.25.1
Warning:   unmaintained
Title:     `ttf-parser` is unmaintained
Date:      2026-06-28
ID:        RUSTSEC-2026-0192
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0192

Crate:     anyhow
Version:   1.0.102
Warning:   unsound
Title:     Unsoundness in `Error::downcast_mut()`
Date:      2026-06-25
ID:        RUSTSEC-2026-0190
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0190

error: 5 vulnerabilities found!
warning: 3 allowed warnings found
```
</details>

### Update (2026-07-07)

More vulnerabilities were reported, so these crates were updated too:

- `anyhow` from `1.0.102` to `1.0.103`,
- `crossbeam-epoch` from `0.9.18` to `0.9.20`.


## Checklist

- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any TO DO items (or similar) have been entered as GitHub issues and the link to
  that issue has been included in a comment.
