### PR TITLE
docs: Update README.md doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can also read the documentation directly in GitHub:
 - [Usage](https://github.com/contentauth/c2pa-rs/blob/main/docs/usage.md)
 - [Supported formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md)
 - [Using the CAWG identity assertion](https://github.com/contentauth/c2pa-rs/blob/main/docs/cawg-id.md)
-- [Configuring SDK settings](https://github.com/contentauth/c2pa-rs/blob/main/docs/settings.md)
+- [Configuring SDK settings](https://github.com/contentauth/c2pa-rs/blob/main/docs/context-settings.md)
 - [Using intents](https://github.com/contentauth/c2pa-rs/blob/main/docs/intents.md)
 - [Using working stores and archives](https://github.com/contentauth/c2pa-rs/blob/main/docs/working-stores.md)
 - [Using the embeddable API](https://github.com/contentauth/c2pa-rs/blob/main/docs/embeddable-api.md) that provides explicit control over how a C2PA manifest is embedded into an asset. 
@@ -73,7 +73,7 @@ The library uses a `Context` structure to configure C2PA operations, replacing t
 - **Backwards compatible**: All existing Settings (JSON/TOML) files work unchanged with Context
 - **Automatic signer creation**: Signers are created automatically from settings when needed
 
-See [Configuring SDK settings](docs/settings.md) for details. 
+See [Configuring SDK settings](docs/context-settings.md) for details.
 
 ## Installation
 


### PR DESCRIPTION
## Changes in this pull request

This PR updates the README.md documentation to reflect the current recommended entry points for configuring the SDK.

What changed:
    Deleted: Links to several legacy general SDK settings entry.
    Added: Kept the README’s “Configuring SDK settings” reference consistent with the documentation paths used elsewhere in the repo.

## Checklist
- [ x] This PR represents a single feature, fix, or change.
- [ x] All applicable changes have been documented.
- [ x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
