### PR TITLE
fix: ensure created has a dst and don't add parent when actions already exist

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1130,6 +1130,9 @@ fn main() -> Result<()> {
             add_ingredient(&mut builder, &parent_path, true)?
         }
 
+        // Default to Edit intent unless --create/--update override it. If the manifest already
+        // declares its own c2pa.created or c2pa.opened action, Builder itself guards against
+        // auto-adding a conflicting parentOf ingredient or action.
         let intent = if let Some(source_type_str) = &args.create {
             let source_type: DigitalSourceType =
                 serde_json::from_value(serde_json::Value::String(source_type_str.clone()))

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1823,7 +1823,33 @@ impl Builder {
             self.intent(),
             Some(BuilderIntent::Edit | BuilderIntent::Update)
         );
-        if auto_parent && !self.definition.ingredients.iter().any(|i| i.is_parent()) {
+        // Don't auto-add a parentOf ingredient if the user's manifest already declares a
+        // c2pa.created or c2pa.opened action — those are mutually exclusive with auto-parent.
+        let has_created_or_opened = self.definition.assertions.iter().any(|a| {
+            if !a.label.starts_with(crate::assertions::Actions::LABEL) {
+                return false;
+            }
+            let AssertionData::Json(value) = &a.data else {
+                return false;
+            };
+            value
+                .get("actions")
+                .and_then(|arr| arr.as_array())
+                .map(|acts| {
+                    acts.iter().any(|act| {
+                        matches!(
+                            act.get("action").and_then(|v| v.as_str()),
+                            Some(crate::assertions::c2pa_action::CREATED)
+                                | Some(crate::assertions::c2pa_action::OPENED)
+                        )
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if auto_parent
+            && !has_created_or_opened
+            && !self.definition.ingredients.iter().any(|i| i.is_parent())
+        {
             let parent_def = serde_json::json!({
                 "relationship": "parentOf",
             });

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1829,22 +1829,16 @@ impl Builder {
             if !a.label.starts_with(crate::assertions::Actions::LABEL) {
                 return false;
             }
-            let AssertionData::Json(value) = &a.data else {
+            let Ok(actions) = a.to_assertion::<crate::assertions::Actions>() else {
                 return false;
             };
-            value
-                .get("actions")
-                .and_then(|arr| arr.as_array())
-                .map(|acts| {
-                    acts.iter().any(|act| {
-                        matches!(
-                            act.get("action").and_then(|v| v.as_str()),
-                            Some(crate::assertions::c2pa_action::CREATED)
-                                | Some(crate::assertions::c2pa_action::OPENED)
-                        )
-                    })
-                })
-                .unwrap_or(false)
+            actions.actions().iter().any(|act| {
+                matches!(
+                    act.action(),
+                    crate::assertions::c2pa_action::CREATED
+                        | crate::assertions::c2pa_action::OPENED
+                )
+            })
         });
         if auto_parent
             && !has_created_or_opened

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2274,10 +2274,10 @@ impl Claim {
                             "verify_actions"
                         )
                         .validation_status(validation_status::ASSERTION_ACTION_INGREDIENT_MISMATCH)
-                        .failure_no_throw(
+                        .failure(
                             validation_log,
                             Error::ValidationRule("opened, placed and removed items must have ingredient(s) parameters".into()),
-                        );
+                        )?;
                         continue;
                     }
 
@@ -2290,10 +2290,10 @@ impl Claim {
                                 "verify_actions"
                             )
                             .validation_status(validation_status::ASSERTION_ACTION_INGREDIENT_MISMATCH)
-                            .failure_no_throw(
+                            .failure(
                                 validation_log,
                                 Error::ValidationRule("opened, placed and removed items must have ingredients parameter must be non empty array".into()),
-                            );
+                            )?;
                         }
                     }
 
@@ -2413,6 +2413,22 @@ impl Claim {
                                 .failure_no_throw(validation_log, Error::ValidationRule(msg));
                         }
                     }
+                }
+
+                // 2.b.v c2pa.created must have a digitalSourceType
+                if action.action() == c2pa_action::CREATED && action.source_type().is_none() {
+                    log_item!(
+                        label.clone(),
+                        "c2pa.created action must have a digitalSourceType",
+                        "verify_actions"
+                    )
+                    .validation_status(validation_status::ASSERTION_ACTION_MALFORMED)
+                    .failure_no_throw(
+                        validation_log,
+                        Error::ValidationRule(
+                            "c2pa.created action must have a digitalSourceType".into(),
+                        ),
+                    );
                 }
 
                 // 2.c if ingredient is present it must be a valid parentOf reference

--- a/sdk/tests/test_failures.rs
+++ b/sdk/tests/test_failures.rs
@@ -81,3 +81,37 @@ fn test_bad_data_hash() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_created_action_missing_digital_source_type() -> Result<()> {
+    let context = test_context().into_shared();
+
+    const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
+    let format = "image/jpeg";
+    let mut source = Cursor::new(TEST_IMAGE);
+
+    let mut builder = Builder::from_shared_context(&context);
+
+    // Manually craft a c2pa.created action without a digitalSourceType, bypassing
+    // the BuilderIntent::Create API (which requires a DigitalSourceType at the type level).
+    builder.add_action(serde_json::json!({
+        "action": "c2pa.created"
+    }))?;
+
+    let mut dest = Cursor::new(Vec::new());
+    let err = builder
+        .sign(context.signer()?, format, &mut source, &mut dest)
+        .unwrap_err();
+
+    let validation_results = match err {
+        Error::InvalidManifest(validation_results) => validation_results,
+        other => panic!("{other:?}"),
+    };
+
+    assert_eq!(
+        validation_results.active_manifest().unwrap().failure[0].code(),
+        validation_status::ASSERTION_ACTION_MALFORMED
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Do not automatically add a parent ingredient and opened action if a created or opened action already exists.
Ensures that c2pa_created has an associated digitalSourceType