### PR TITLE
fix: Bind OCSP response certId to the signing certificate (CAI-11829)

### DIFF
--- a/sdk/src/crypto/cose/ocsp.rs
+++ b/sdk/src/crypto/cose/ocsp.rs
@@ -350,9 +350,14 @@ fn check_stapled_ocsp_response(
         Err(_) => (None, None),
     };
 
+    // The OCSP response must pertain to the certificate that signed this
+    // manifest, so bind it to that signer's certificate chain.
+    let signing_cert_chain = cert_chain_from_sign1(sign1)?;
+
     let mut current_validation_log = StatusTracker::default();
     let Ok(ocsp_data) = OcspResponse::from_der_checked(
         ocsp_response_der,
+        &signing_cert_chain,
         signing_time,
         &mut current_validation_log,
     ) else {
@@ -449,11 +454,16 @@ pub(crate) fn fetch_and_check_ocsp_response(
 
     // Check the OCSP response, but only if it is well-formed.
     // Revocation errors are reported in the validation log.
-    let ocsp_data =
-        match OcspResponse::from_der_checked(&ocsp_response_der, signing_time, validation_log) {
-            Ok(data) => data,
-            Err(_) => return Ok(OcspResponse::default()),
-        };
+    // `certs` is the signing certificate chain; bind the OCSP response to it.
+    let ocsp_data = match OcspResponse::from_der_checked(
+        &ocsp_response_der,
+        &certs,
+        signing_time,
+        validation_log,
+    ) {
+        Ok(data) => data,
+        Err(_) => return Ok(OcspResponse::default()),
+    };
 
     // If we get a valid response validate the certs.
     if let Some(ocsp_certs) = &ocsp_data.ocsp_certs {

--- a/sdk/src/crypto/ocsp/mod.rs
+++ b/sdk/src/crypto/ocsp/mod.rs
@@ -16,8 +16,8 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use rasn_ocsp::{BasicOcspResponse, CertStatus, OcspResponseStatus};
-use rasn_pkix::CrlReason;
+use rasn_ocsp::{BasicOcspResponse, CertId, CertStatus, OcspResponseStatus};
+use rasn_pkix::{Certificate, CrlReason};
 use thiserror::Error;
 
 use crate::{
@@ -63,8 +63,16 @@ impl OcspResponse {
     /// The correct usage when there is no attested signing time
     /// to pass a signing_time of None.  The OCSP responses the
     /// follow the current time rules as outlined in the C2PA spec.
+    ///
+    /// `signing_cert_chain` is the certificate chain of the credential whose
+    /// revocation status is being checked (`chain[0]` is the end-entity
+    /// certificate, `chain[1]` its issuer).  Per RFC 6960 §4.1.1/§4.2.1 every
+    /// single response in the OCSP response whose `certId` does not identify
+    /// that certificate is ignored, so a validly-signed response issued for an
+    /// unrelated certificate cannot produce a status for the signer.
     pub(crate) fn from_der_checked(
         der: &[u8],
+        signing_cert_chain: &[Vec<u8>],
         signing_time: Option<DateTime<Utc>>,
         validation_log: &mut StatusTracker,
     ) -> Result<Self, OcspError> {
@@ -154,6 +162,16 @@ impl OcspResponse {
         }
 
         for single_response in &response_data.responses {
+            // RFC 6960 §4.1.1/§4.2.1: only a single response whose `certId`
+            // identifies the signing certificate tells us anything about that
+            // certificate. Skip any response for a different certificate;
+            // otherwise an attacker could staple a validly-signed "good"
+            // response issued for an unrelated certificate and obtain a false
+            // "not revoked" attestation for a revoked signing certificate.
+            if !cert_id_matches_signer(&single_response.cert_id, signing_cert_chain) {
+                continue;
+            }
+
             let cert_status = &single_response.cert_status;
 
             // Extract certificate serial number from cert_id
@@ -357,6 +375,72 @@ fn validate_ocsp_sig(
     }
 }
 
+/// Returns `true` only if `cert_id` identifies the end-entity certificate
+/// described by `signing_cert_chain` (`chain[0]` = end-entity certificate,
+/// `chain[1]` = its issuer), per RFC 6960 §4.1.1.
+///
+/// The `serialNumber`, `issuerNameHash`, and `issuerKeyHash` must all match.
+/// Fails closed (returns `false`) if the chain, the issuer certificate, or the
+/// `certId` hash algorithm is missing or cannot be reconstructed.
+fn cert_id_matches_signer(cert_id: &CertId, signing_cert_chain: &[Vec<u8>]) -> bool {
+    // Both the end-entity certificate and its issuer are required to
+    // reconstruct the certId: the serial number comes from the end-entity
+    // certificate, and the issuer hashes come from the issuer certificate.
+    let (Some(subject_der), Some(issuer_der)) =
+        (signing_cert_chain.first(), signing_cert_chain.get(1))
+    else {
+        return false;
+    };
+
+    let Ok(subject) = rasn::der::decode::<Certificate>(subject_der) else {
+        return false;
+    };
+    let Ok(issuer) = rasn::der::decode::<Certificate>(issuer_der) else {
+        return false;
+    };
+
+    // serialNumber identifies the end-entity certificate.
+    if cert_id.serial_number != subject.tbs_certificate.serial_number {
+        return false;
+    }
+
+    // issuerNameHash and issuerKeyHash are computed over the issuer using the
+    // hash algorithm named in the response's certId (this matches how the OCSP
+    // request is constructed in `ocsp/fetch.rs`).
+    let Ok(issuer_name_raw) = rasn::der::encode(&issuer.tbs_certificate.subject) else {
+        return false;
+    };
+    let issuer_key_raw = issuer
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .as_raw_slice();
+
+    let Some(expected_name_hash) = hash_by_oid(&cert_id.hash_algorithm.algorithm, &issuer_name_raw)
+    else {
+        return false;
+    };
+    let Some(expected_key_hash) = hash_by_oid(&cert_id.hash_algorithm.algorithm, issuer_key_raw)
+    else {
+        return false;
+    };
+
+    cert_id.issuer_name_hash.as_ref() == expected_name_hash.as_slice()
+        && cert_id.issuer_key_hash.as_ref() == expected_key_hash.as_slice()
+}
+
+/// Hashes `data` with the digest algorithm identified by `alg`, or returns
+/// `None` if it is not an OCSP `certId` digest algorithm we support.
+fn hash_by_oid(alg: &rasn::types::ObjectIdentifier, data: &[u8]) -> Option<Vec<u8>> {
+    match alg.to_string().as_str() {
+        // SHA-1 (the default OCSP certId digest per RFC 6960)
+        "1.3.14.3.2.26" => Some(crate::crypto::hash::sha1(data)),
+        // SHA-256
+        "2.16.840.1.101.3.4.2.1" => Some(crate::crypto::hash::sha256(data)),
+        _ => None,
+    }
+}
+
 /// Return the hash algorithm oid for the given signature algorithm.
 fn hash_alg_for_sig_alg(sig_alg: &rasn::types::ObjectIdentifier) -> Option<bcder::Oid> {
     match sig_alg.to_string().as_ref() {
@@ -417,6 +501,18 @@ mod tests {
         },
     };
 
+    /// The signing certificate chain (end-entity + issuer) that the
+    /// `response_*.der` fixtures were issued for. Used to satisfy the RFC 6960
+    /// certId binding check.
+    fn signing_cert_chain() -> Vec<Vec<u8>> {
+        let pem = include_bytes!("../../../tests/fixtures/crypto/ocsp/ocsp_chain.pem");
+        pem::parse_many(pem)
+            .unwrap()
+            .into_iter()
+            .map(|p| p.into_contents())
+            .collect()
+    }
+
     #[test]
     #[cfg_attr(
         all(target_arch = "wasm32", not(target_os = "wasi")),
@@ -429,8 +525,13 @@ mod tests {
 
         let test_time = Utc.with_ymd_and_hms(2023, 2, 1, 8, 0, 0).unwrap();
 
-        let ocsp_data =
-            OcspResponse::from_der_checked(rsp_data, Some(test_time), &mut validation_log).unwrap();
+        let ocsp_data = OcspResponse::from_der_checked(
+            rsp_data,
+            &signing_cert_chain(),
+            Some(test_time),
+            &mut validation_log,
+        )
+        .unwrap();
 
         assert_eq!(ocsp_data.revoked_at, None);
         assert!(ocsp_data.ocsp_certs.is_some());
@@ -449,8 +550,13 @@ mod tests {
 
         let test_time = Utc.with_ymd_and_hms(2024, 2, 1, 8, 0, 0).unwrap();
 
-        let ocsp_data =
-            OcspResponse::from_der_checked(rsp_data, Some(test_time), &mut validation_log).unwrap();
+        let ocsp_data = OcspResponse::from_der_checked(
+            rsp_data,
+            &signing_cert_chain(),
+            Some(test_time),
+            &mut validation_log,
+        )
+        .unwrap();
 
         assert!(ocsp_data.revoked_at.is_some());
         assert!(validation_log.has_status(SIGNING_CREDENTIAL_REVOKED));
@@ -468,8 +574,13 @@ mod tests {
 
         let test_time = Utc.with_ymd_and_hms(2024, 2, 1, 8, 0, 0).unwrap();
 
-        let ocsp_data =
-            OcspResponse::from_der_checked(rsp_data, Some(test_time), &mut validation_log).unwrap();
+        let ocsp_data = OcspResponse::from_der_checked(
+            rsp_data,
+            &signing_cert_chain(),
+            Some(test_time),
+            &mut validation_log,
+        )
+        .unwrap();
 
         assert!(ocsp_data.revoked_at.is_none());
         assert!(validation_log.has_any_error());
@@ -524,7 +635,7 @@ mod tests {
         // `basic_response.certs = Some([])`.  The fix uses `.first()` and
         // returns Ok(output) (with ocsp_certs = None) instead of panicking.
         let mut log = StatusTracker::default();
-        let result = OcspResponse::from_der_checked(OCSP_EMPTY_CERTS_DER, None, &mut log);
+        let result = OcspResponse::from_der_checked(OCSP_EMPTY_CERTS_DER, &[], None, &mut log);
         assert!(result.is_ok());
         // certs were empty so no cert data flows through
         assert!(result.unwrap().ocsp_certs.is_none());
@@ -542,11 +653,49 @@ mod tests {
 
         let test_time = Utc.with_ymd_and_hms(2026, 2, 1, 8, 0, 0).unwrap();
 
-        let ocsp_data =
-            OcspResponse::from_der_checked(rsp_data, Some(test_time), &mut validation_log).unwrap();
+        let ocsp_data = OcspResponse::from_der_checked(
+            rsp_data,
+            &signing_cert_chain(),
+            Some(test_time),
+            &mut validation_log,
+        )
+        .unwrap();
 
         assert!(ocsp_data.revoked_at.is_none());
         assert!(validation_log.has_any_error());
         assert!(validation_log.has_status(SIGNING_CREDENTIAL_REVOKED));
+    }
+
+    #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test
+    )]
+    fn good_response_for_wrong_cert_is_ignored() {
+        // Regression test for VULN-34623: a validly-signed "good" OCSP response
+        // whose certId does not identify the signing certificate must not
+        // produce a SIGNING_CREDENTIAL_NOT_REVOKED attestation.
+        let rsp_data = include_bytes!("../../../tests/fixtures/crypto/ocsp/response_good.der");
+
+        let mut validation_log = StatusTracker::default();
+
+        let test_time = Utc.with_ymd_and_hms(2023, 2, 1, 8, 0, 0).unwrap();
+
+        // Reverse the chain so chain[0] is the root, whose serial number does
+        // not match the response's certId serial number.
+        let mut wrong_chain = signing_cert_chain();
+        wrong_chain.reverse();
+
+        let ocsp_data = OcspResponse::from_der_checked(
+            rsp_data,
+            &wrong_chain,
+            Some(test_time),
+            &mut validation_log,
+        )
+        .unwrap();
+
+        // No single response bound to the signer, so no status was learned.
+        assert!(ocsp_data.certificate_serial_num.is_empty());
+        assert!(!validation_log.has_status(SIGNING_CREDENTIAL_NOT_REVOKED));
     }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -43,8 +43,9 @@ use crate::{
     crypto::{
         asn1::rfc3161::TstInfo,
         cose::{
-            fetch_and_check_ocsp_response, fetch_and_check_ocsp_response_async, parse_cose_sign1,
-            CertificateTrustPolicy, TimeStampStorage,
+            cert_chain_from_sign1, fetch_and_check_ocsp_response,
+            fetch_and_check_ocsp_response_async, parse_cose_sign1, CertificateTrustPolicy,
+            TimeStampStorage,
         },
         hash::sha256,
         ocsp::OcspResponse,
@@ -1963,11 +1964,23 @@ impl Store {
                 let certificate_status_assertion =
                     CertificateStatus::from_assertion(csa.assertion())?;
 
+                // The certificate status assertion carries OCSP responses for
+                // this manifest's own signing certificate, so bind each
+                // response to that certificate's chain (RFC 6960 §4.1.1).
+                let signing_cert_chain = found_claim
+                    .cose_sign1()
+                    .ok()
+                    .and_then(|sign1| cert_chain_from_sign1(&sign1).ok())
+                    .unwrap_or_default();
+
                 // save the ocsp_ders stored in the StoreValidationInfo
                 for ocsp_der in certificate_status_assertion.as_ref() {
-                    if let Ok(response) =
-                        OcspResponse::from_der_checked(ocsp_der, None, validation_log)
-                    {
+                    if let Ok(response) = OcspResponse::from_der_checked(
+                        ocsp_der,
+                        &signing_cert_chain,
+                        None,
+                        validation_log,
+                    ) {
                         let ocsp_ders = svi
                             .certificate_statuses
                             .entry(response.certificate_serial_num)


### PR DESCRIPTION
## Summary

OCSP responses are validated for signature and trust, but the response's `certId` (`serialNumber`, `issuerNameHash`, `issuerKeyHash`) was never compared to the certificate whose revocation status is being checked. [RFC 6960 §4.1.1/§4.2.1](https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1) requires a relying party to confirm the `certId` identifies that certificate.

This PR adds that binding at the parse layer so it applies to every OCSP code path.

Tracking: **CAI-11829**.

## Changes

- `sdk/src/crypto/ocsp/mod.rs` — `OcspResponse::from_der_checked` now takes the signing certificate chain. A new `cert_id_matches_signer` helper compares the three RFC-mandated `certId` fields against the signer (issuer hashes computed with the `certId`'s own digest algorithm, matching the request-building logic in `ocsp/fetch.rs`). Any single response that does not identify the signer is ignored, and the check fails closed if the chain, issuer, or hash algorithm is missing/unsupported (SHA-1 and SHA-256 supported).
- `sdk/src/crypto/cose/ocsp.rs` — the stapled (`check_stapled_ocsp_response`) and fetched (`fetch_and_check_ocsp_response`) paths pass the signer's chain from `cert_chain_from_sign1`.
- `sdk/src/store.rs` — the certificate-status assertion path binds each response to the manifest's own signing certificate.

## Tests

- New regression test `good_response_for_wrong_cert_is_ignored`: a valid "good" response bound to the wrong certificate yields no `SIGNING_CREDENTIAL_NOT_REVOKED`.
- Existing `good` / `revoked` / `unknown` / `validity` tests now supply the matching chain and still pass, confirming legitimate binding computes correctly against real fixtures.