### PR TITLE
fix: Make openssl optional when building export_schema.

### DIFF
--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -8,6 +8,11 @@ rust-version = "1.88.0"
 
 [dependencies]
 anyhow = "1.0.103"
-c2pa = { workspace = true, features = ["openssl", "json_schema"] }
+c2pa = { workspace = true, features = ["json_schema"] }
 schemars = "1.2.1"
 serde_json = "1.0.150"
+
+[features]
+default = ["openssl"]
+openssl = ["c2pa/openssl"]
+rust_native_crypto = ["c2pa/rust_native_crypto"]


### PR DESCRIPTION
Default uses OpenSSL but can be changed to use Rust native crypto as well. Improves build time and performance on platforms like windows.

## Changes in this pull request
Make OpenSSL dependency on export_schema tool optional

## Checklist
- [x ] This PR represents a single feature, fix, or change.
- [x ] All applicable changes have been documented.
- [x ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

Fixes #2233 