### PR TITLE
feat!: enable verify after sign by default

### DIFF
--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -424,8 +424,7 @@ impl Default for Verify {
     fn default() -> Self {
         Self {
             verify_after_reading: true,
-            // TODO: set this to true [#1875](https://github.com/contentauth/c2pa-rs/issues/1875)
-            verify_after_sign: cfg!(test),
+            verify_after_sign: true,
             verify_after_sign_hash: cfg!(test),
             verify_trust: true,
             verify_timestamp_trust: !cfg!(test), // verify timestamp trust unless in test mode


### PR DESCRIPTION
Re-enables verify after sign by default (minus hashing) to ensure manifests are created properly. 