### PR TITLE
feat(sdk): add Builder action/ingredient removal API

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -767,43 +767,64 @@ impl Action {
         Ok(self)
     }
 
-    /// Extracts ingredient IDs from the action
-    /// There are many deprecated ways to specify ingredient IDs
-    /// priority: parameters.ingredientIds, parameters.org.cai.ingredientIds, parameters.instanceId, instanceId.
-    /// This is used to map actions to their associated ingredients.
-    /// We don't want any of these fields in the final CBOR, so we remove them after extracting.
-    pub(crate) fn extract_ingredient_ids(&mut self) -> Option<Vec<String>> {
-        let ingredient_ids = self.remove_parameter(INGREDIENT_IDS);
-        let cai_ingredient_ids = self.remove_parameter("org.cai.ingredientIds");
-        let param_instance_id = self.remove_parameter("instanceId");
-        #[allow(deprecated)]
-        let instance_id = self.instance_id.take();
-        let mut ids: Vec<String> = Vec::new();
-
-        let mut convert_ids = |val: Option<c2pa_cbor::Value>| {
-            if let Some(val) = val {
-                match val {
-                    c2pa_cbor::Value::Array(arr) => {
-                        for v in arr {
-                            if let c2pa_cbor::Value::Text(s) = v {
-                                ids.push(s);
-                            }
-                        }
-                    }
-                    c2pa_cbor::Value::Text(s) => ids.push(s),
-                    _ => {}
-                }
+    /// Reads the ingredient IDs an action references, without mutating the action.
+    ///
+    /// There are many deprecated ways to specify ingredient IDs; this checks every linking
+    /// mechanism in priority order: `parameters.ingredientIds`, `parameters.org.cai.ingredientIds`,
+    /// `parameters.instanceId`, then the deprecated `instanceId` field (only when none of the
+    /// parameters are present). Used to map actions to their associated ingredients.
+    ///
+    /// This is the read-only counterpart of [`Self::extract_ingredient_ids`], which additionally
+    /// removes the parameters it reads. Use this when the action must stay intact (e.g. computing
+    /// which ingredients are referenced during a prune).
+    pub(crate) fn ingredient_ids(&self) -> Vec<String> {
+        let convert = |val: Option<c2pa_cbor::Value>| -> Vec<String> {
+            match val {
+                Some(c2pa_cbor::Value::Array(arr)) => arr
+                    .into_iter()
+                    .filter_map(|v| match v {
+                        c2pa_cbor::Value::Text(s) => Some(s),
+                        _ => None,
+                    })
+                    .collect(),
+                Some(c2pa_cbor::Value::Text(s)) => vec![s],
+                _ => vec![],
             }
         };
 
-        convert_ids(ingredient_ids);
-        convert_ids(cai_ingredient_ids);
-        convert_ids(param_instance_id);
+        let mut ids = Vec::new();
+        ids.extend(convert(self.get_parameter(INGREDIENT_IDS)));
+        ids.extend(convert(self.get_parameter("org.cai.ingredientIds")));
+        ids.extend(convert(self.get_parameter("instanceId")));
+        if ids.is_empty() {
+            #[allow(deprecated)]
+            if let Some(id) = self.instance_id.as_deref() {
+                ids.push(id.to_owned());
+            }
+        }
+        ids
+    }
 
-        if !ids.is_empty() {
-            Some(ids)
+    /// Extracts ingredient IDs from the action, removing the parameters it reads.
+    ///
+    /// Reads the same links as [`Self::ingredient_ids`], then removes the temporary
+    /// `ingredientIds` / `org.cai.ingredientIds` / `instanceId` parameters and the deprecated
+    /// `instanceId` field, because we don't want any of them in the final CBOR.
+    pub(crate) fn extract_ingredient_ids(&mut self) -> Option<Vec<String>> {
+        let ids = self.ingredient_ids();
+
+        self.remove_parameter(INGREDIENT_IDS);
+        self.remove_parameter("org.cai.ingredientIds");
+        self.remove_parameter("instanceId");
+        #[allow(deprecated)]
+        {
+            self.instance_id = None;
+        }
+
+        if ids.is_empty() {
+            None
         } else {
-            instance_id.map(|s| vec![s])
+            Some(ids)
         }
     }
 }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -902,6 +902,199 @@ impl Builder {
         Ok(self)
     }
 
+    /// Retains only the actions for which `keep` returns true.
+    ///
+    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept regardless of `keep`,
+    /// and is moved to index 0 if needed, so the manifest stays valid per the C2PA spec. Sets
+    /// `allActionsIncluded = false` when anything is removed. This does not touch ingredients —
+    /// call [`Builder::retain_ingredients`] (`retain_ingredients(|_| false)` to drop all orphans)
+    /// afterwards if you also want to drop ingredients now orphaned by the removed actions.
+    ///
+    /// # Arguments
+    /// * `keep` - A predicate; the action is retained when it returns true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`]. A no-op if there is no actions assertion.
+    /// # Errors
+    /// * Returns an [`Error::BadParam`] if retention would leave zero actions (a `c2pa.actions`
+    ///   assertion must have a non-empty `actions` array).
+    pub fn retain_actions<F>(&mut self, mut keep: F) -> Result<&mut Self>
+    where
+        F: FnMut(&Action) -> bool,
+    {
+        // Find the actions assertion; no-op when there isn't one.
+        let Some(pos) = self
+            .definition
+            .assertions
+            .iter()
+            .position(|a| a.label().starts_with(Actions::LABEL))
+        else {
+            return Ok(self);
+        };
+
+        // Isolate: remove, mutate a local copy, re-add. This mirrors `add_action` and keeps the
+        // `FnMut` `&Action` borrow off `self.definition`.
+        let assertion_def = self.definition.assertions.remove(pos);
+        let original_label = assertion_def.label.clone();
+        let mut actions: Actions = assertion_def.to_assertion()?;
+
+        let original_len = actions.actions.len();
+        // The C2PA spec requires exactly one c2pa.created/c2pa.opened action, so keep it
+        // regardless of the caller predicate.
+        actions.actions.retain(|a| {
+            a.action() == c2pa_action::CREATED
+                || a.action() == c2pa_action::OPENED
+                || keep(a)
+        });
+
+        if actions.actions.is_empty() {
+            return Err(Error::BadParam(
+                "retain_actions would remove every action; at least one action is required"
+                    .to_string(),
+            ));
+        }
+
+        // The inception action must be at index 0. This is usually a no-op since
+        // Actions::add_action already inserts it there.
+        if let Some(idx) = actions.actions.iter().position(|a| {
+            a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
+        }) {
+            if idx != 0 {
+                let inception = actions.actions.remove(idx);
+                actions.actions.insert(0, inception);
+            }
+        }
+
+        if actions.actions.len() < original_len {
+            actions.all_actions_included = Some(false);
+        }
+
+        // Preserve the original `.v1`/`.v2` label on rebuild.
+        self.add_assertion(original_label, &actions)?;
+        Ok(self)
+    }
+
+    /// Removes the actions for which `remove` returns true; the convenience inverse of
+    /// [`Builder::retain_actions`].
+    ///
+    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept, as with
+    /// [`Builder::retain_actions`].
+    ///
+    /// # Arguments
+    /// * `remove` - A predicate; the action is removed when it returns true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`]. A no-op if there is no actions assertion.
+    /// # Errors
+    /// * Returns an [`Error::BadParam`] if removal would leave zero actions.
+    pub fn remove_actions<F>(&mut self, mut remove: F) -> Result<&mut Self>
+    where
+        F: FnMut(&Action) -> bool,
+    {
+        self.retain_actions(|a| !remove(a))
+    }
+
+    /// Retains ingredients, then rewrites positional ingredient references so surviving actions
+    /// stay valid.
+    ///
+    /// An ingredient is kept if any of the following hold:
+    /// - it is referenced by a current action (via `parameters.ingredients` URLs or the
+    ///   `ingredientIds`/`instanceId` parameters),
+    /// - it is a [`Relationship::ParentOf`] ingredient (lineage for `c2pa.opened`), or
+    /// - `keep` returns true for it.
+    ///
+    /// `keep` therefore only ever rescues an otherwise-orphaned ingredient — it can never drop a
+    /// referenced or lineage ingredient (that would break spec validation). Use `keep` for
+    /// provenance-aware policy, e.g. "this ingredient's embedded manifest chain contains a signal
+    /// of interest, so retain the whole ingredient (and its nested chain)"; the closure may inspect
+    /// the ingredient's [`manifest_data`](Ingredient::manifest_data) to decide. Prune all orphans
+    /// with `retain_ingredients(|_| false)`. Call [`Builder::retain_actions`] first if you are also
+    /// removing actions: the keep-set is computed from whatever actions currently remain.
+    ///
+    /// # Arguments
+    /// * `keep` - A predicate that can rescue an otherwise-orphaned ingredient by returning true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`].
+    /// # Errors
+    /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
+    pub fn retain_ingredients<F>(&mut self, mut keep: F) -> Result<&mut Self>
+    where
+        F: FnMut(&Ingredient) -> bool,
+    {
+        // Snapshot ingredient ids in positional order BEFORE pruning so the positional `__N`
+        // references can be remapped afterwards. The id is label-or-instance_id, matching how
+        // `to_claim` keys ingredients (builder.rs `ingredient_map`) and how `ingredientIds`
+        // parameters resolve.
+        let pre_filter_ids: Vec<String> = self
+            .definition
+            .ingredients
+            .iter()
+            .map(ingredient_effective_id)
+            .collect();
+
+        // Pull out the actions assertion (if any) so we can compute the referenced-ingredient
+        // keep-set and later rewrite its positional URLs. Isolating it also keeps the `keep`
+        // `&Ingredient` borrow off `self.definition`.
+        let actions_pos = self
+            .definition
+            .assertions
+            .iter()
+            .position(|a| a.label().starts_with(Actions::LABEL));
+
+        let mut keep_set: HashSet<String> = HashSet::new();
+        let mut actions_opt: Option<(String, Actions)> = None;
+        if let Some(pos) = actions_pos {
+            let assertion_def = self.definition.assertions.remove(pos);
+            let original_label = assertion_def.label.clone();
+            let actions: Actions = assertion_def.to_assertion()?;
+            for action in &actions.actions {
+                // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
+                // deprecated instance_id. Relationship-agnostic — any referenced ingredient is
+                // kept whatever its relationship (e.g. `c2pa.edited` -> `inputTo`).
+                for id in action_ingredient_ids(action) {
+                    keep_set.insert(id);
+                }
+                // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
+                if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
+                    for uri in uris {
+                        let url = uri.url();
+                        let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
+                        let (_, idx) = parse_positional_label(&url[label_start..]);
+                        if let Some(id) = pre_filter_ids.get(idx) {
+                            keep_set.insert(id.clone());
+                        }
+                    }
+                }
+            }
+            actions_opt = Some((original_label, actions));
+        }
+
+        // Prune: keep referenced, `parentOf`, or caller-rescued ingredients; drop the rest.
+        self.definition.ingredients.retain(|ing| {
+            keep_set.contains(&ingredient_effective_id(ing))
+                || matches!(ing.relationship(), &Relationship::ParentOf)
+                || keep(ing)
+        });
+
+        // Rewrite surviving positional `__N` references to the ingredients' new positions, then
+        // re-add the actions assertion (preserving its original label).
+        if let Some((original_label, mut actions)) = actions_opt {
+            let new_ids: Vec<String> = self
+                .definition
+                .ingredients
+                .iter()
+                .map(ingredient_effective_id)
+                .collect();
+            let id_to_new_idx: HashMap<&str, usize> = new_ids
+                .iter()
+                .enumerate()
+                .map(|(i, id)| (id.as_str(), i))
+                .collect();
+            rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx);
+            self.add_assertion(original_label, &actions)?;
+        }
+
+        Ok(self)
+    }
+
     /// Request a trusted timestamp for manifests with the given label.
     ///
     /// This only records the label on the builder. During signing, any matching manifest(s) will
@@ -3328,6 +3521,158 @@ impl std::fmt::Display for Builder {
         let output = serde_json::to_string_pretty(&json).map_err(|_| std::fmt::Error)?;
         f.write_str(&output)
     }
+}
+
+/// Collects all ingredient instance IDs an action references, checking every linking mechanism:
+/// `ingredientIds`, `org.cai.ingredientIds`, `instanceId` parameter, and the deprecated
+/// `action.instance_id` field.
+///
+/// Read-only: unlike [`Action::extract_ingredient_ids`](crate::assertions::Action), which is
+/// mutating (it removes the params it reads), this must not corrupt the action during a prune.
+fn action_ingredient_ids(action: &Action) -> Vec<String> {
+    let extract = |opt: Option<c2pa_cbor::Value>| -> Vec<String> {
+        match opt {
+            Some(c2pa_cbor::Value::Array(arr)) => arr
+                .into_iter()
+                .filter_map(|v| match v {
+                    c2pa_cbor::Value::Text(s) => Some(s),
+                    _ => None,
+                })
+                .collect(),
+            Some(c2pa_cbor::Value::Text(s)) => vec![s],
+            _ => vec![],
+        }
+    };
+    let mut ids = Vec::new();
+    ids.extend(extract(action.get_parameter::<c2pa_cbor::Value>("ingredientIds")));
+    ids.extend(extract(
+        action.get_parameter::<c2pa_cbor::Value>("org.cai.ingredientIds"),
+    ));
+    ids.extend(extract(action.get_parameter::<c2pa_cbor::Value>("instanceId")));
+    if ids.is_empty() {
+        #[allow(deprecated)]
+        if let Some(id) = action.instance_id() {
+            ids.push(id.to_owned());
+        }
+    }
+    ids
+}
+
+/// The id used to reference an ingredient: its `label` when non-empty, otherwise its
+/// `instance_id`. Mirrors how `to_claim` keys the `ingredient_map` and how `ingredientIds`
+/// action parameters resolve.
+fn ingredient_effective_id(ing: &Ingredient) -> String {
+    ing.label()
+        .filter(|label| !label.is_empty())
+        .map(|label| label.to_string())
+        .unwrap_or_else(|| ing.instance_id().to_string())
+}
+
+/// Splits a positional ingredient label into its base and `__N` index.
+/// `c2pa.ingredient.v3__2` becomes (`c2pa.ingredient.v3`, 2); `c2pa.ingredient.v3` becomes
+/// (label, 0).
+fn parse_positional_label(label: &str) -> (&str, usize) {
+    if let Some(pos) = label.rfind("__") {
+        if let Ok(n) = label[pos + 2..].parse::<usize>() {
+            return (&label[..pos], n);
+        }
+    }
+    (label, 0)
+}
+
+/// Builds a positional label from a base and 0-based index.
+fn make_positional_label(base: &str, idx: usize) -> String {
+    if idx == 0 {
+        base.to_owned()
+    } else {
+        format!("{base}__{idx}")
+    }
+}
+
+/// Rewrites a single `HashedUri` whose URL ends in a positional ingredient label.
+/// Returns `None` when no rewrite is needed (index unchanged) or the lookup fails.
+fn rewrite_one_ingredient_uri(
+    hu: &HashedUri,
+    pre_filter_ids: &[String],
+    id_to_new_idx: &HashMap<&str, usize>,
+) -> Option<HashedUri> {
+    let url = hu.url();
+    let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
+    let (base, old_idx) = parse_positional_label(&url[label_start..]);
+    let instance_id = pre_filter_ids.get(old_idx)?;
+    let new_idx = *id_to_new_idx.get(instance_id.as_str())?;
+    if new_idx == old_idx {
+        return None;
+    }
+    let new_url = format!(
+        "{}{}",
+        &url[..label_start],
+        make_positional_label(base, new_idx)
+    );
+    Some(HashedUri::new(new_url, hu.alg(), &hu.hash()))
+}
+
+/// Rewrites `parameters.ingredients[].url` on every action so positional labels
+/// (`c2pa.ingredient.v3__N`) point at the new positions of the surviving ingredients.
+///
+/// Required after any ingredient is pruned: `to_claim` re-emits the surviving ingredients
+/// positionally at sign time, so any stale `__N` reference would otherwise dangle.
+fn rewrite_action_ingredient_urls(
+    actions: &mut Actions,
+    pre_filter_ids: &[String],
+    id_to_new_idx: &HashMap<&str, usize>,
+) {
+    actions.actions = actions
+        .actions
+        .drain(..)
+        .map(|action| {
+            let Some(ingredient_uris) = action.parameters().and_then(|p| p.ingredients.as_ref())
+            else {
+                return action;
+            };
+
+            let mut rewrote = false;
+            let remapped_uris: Vec<HashedUri> = ingredient_uris
+                .iter()
+                .map(|uri| match rewrite_one_ingredient_uri(uri, pre_filter_ids, id_to_new_idx) {
+                    Some(new) => {
+                        rewrote = true;
+                        new
+                    }
+                    None => {
+                        // Either no rewrite needed or the lookup failed (stale ref).
+                        let url = uri.url();
+                        let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
+                        let (_, old_idx) = parse_positional_label(&url[label_start..]);
+                        if let Some(instance_id) = pre_filter_ids.get(old_idx) {
+                            if !id_to_new_idx.contains_key(instance_id.as_str()) {
+                                log::warn!(
+                                    "action '{}' has stale ingredient ref '{}' (instance_id '{}')",
+                                    action.action(),
+                                    &url[label_start..],
+                                    instance_id,
+                                );
+                            }
+                        }
+                        uri.clone()
+                    }
+                })
+                .collect();
+
+            if !rewrote {
+                return action;
+            }
+
+            let label = action.action().to_owned();
+            match action.clone().set_parameter("ingredients", remapped_uris) {
+                Ok(rewritten) => rewritten,
+                Err(e) => {
+                    log::error!("failed to remap ingredient URLs on action '{label}': {e:?}");
+                    action
+                }
+            }
+        })
+        .collect();
 }
 
 #[cfg(test)]
@@ -9673,5 +10018,569 @@ mod tests {
 
         let future = builder.sign_async(&signer, "image/jpeg", &mut src, &mut dst);
         assert_send(future);
+    }
+
+    /// Build a `Builder` (with test context) from a JSON manifest definition.
+    fn removal_builder(def: serde_json::Value) -> Builder {
+        Builder::from_context(test_context())
+            .with_definition(def.to_string())
+            .expect("with_definition")
+    }
+
+    /// Extract the current `Actions` assertion off a builder.
+    fn builder_actions(b: &Builder) -> Actions {
+        b.definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .expect("actions assertion present")
+            .to_assertion()
+            .expect("actions assertion decodes")
+    }
+
+    /// The url of an action's first positional ingredient reference, if any.
+    fn first_ing_url(a: &Action) -> Option<String> {
+        a.parameters()
+            .and_then(|p| p.ingredients.as_ref())
+            .and_then(|v| v.first())
+            .map(|u| u.url())
+    }
+
+    /// A componentOf ingredient (label == instance_id) referenced by positional URL tests.
+    fn positional_ingredient(label: &str) -> serde_json::Value {
+        json!({
+            "title": label,
+            "format": "image/jpeg",
+            "relationship": "componentOf",
+            "label": label,
+            "instance_id": label,
+        })
+    }
+
+    /// A `c2pa.placed` action referencing a single positional ingredient label.
+    fn positional_placed(idx: usize) -> serde_json::Value {
+        let label = make_positional_label("c2pa.ingredient.v3", idx);
+        json!({
+            "action": "c2pa.placed",
+            "parameters": {
+                "ingredients": [{
+                    "url": format!("self#jumbf=c2pa.assertions/{label}"),
+                    "alg": "sha256",
+                    "hash": [1, 2, 3, 4],
+                }]
+            }
+        })
+    }
+
+    fn created_action() -> serde_json::Value {
+        json!({
+            "action": "c2pa.created",
+            "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty",
+        })
+    }
+
+    fn sign_and_read(mut b: Builder) -> Vec<crate::validation_status::ValidationStatus> {
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE),
+            &mut dest,
+        )
+        .expect("sign");
+        dest.rewind().unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .expect("read");
+        assert!(reader.active_manifest().is_some());
+        reader
+            .validation_status()
+            .map(|s| s.to_vec())
+            .unwrap_or_default()
+    }
+
+    fn assert_no_action_failures(status: Vec<crate::validation_status::ValidationStatus>) {
+        for s in &status {
+            assert_ne!(s.code(), "assertion.action.malformed", "action malformed: {s:?}");
+            assert_ne!(
+                s.code(),
+                "assertion.action.ingredientMismatch",
+                "action ingredient mismatch: {s:?}"
+            );
+        }
+    }
+
+    // the inception action is force-kept and moved to index 0; allActionsIncluded=false.
+    #[test]
+    fn retain_actions_guards_inception() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.color_adjustments" },
+                created_action(),
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        // Predicate would drop everything, including c2pa.created.
+        b.retain_actions(|_| false).unwrap();
+        let actions = builder_actions(&b);
+        assert_eq!(actions.actions.len(), 1);
+        assert_eq!(actions.actions[0].action(), c2pa_action::CREATED);
+        assert_eq!(actions.all_actions_included, Some(false));
+    }
+
+    // targeted middle action is removed; order/count preserved, first still inception.
+    #[test]
+    fn retain_actions_removes_middle_keeps_order() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
+            .unwrap();
+        let actions = builder_actions(&b);
+        assert_eq!(actions.actions.len(), 2);
+        assert_eq!(actions.actions[0].action(), c2pa_action::CREATED);
+        assert_eq!(actions.actions[1].action(), "c2pa.cropped");
+        assert_eq!(actions.all_actions_included, Some(false));
+    }
+
+    // removing every action with no inception present errors.
+    #[test]
+    fn retain_actions_empty_errors() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.color_adjustments" },
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        let err = b.retain_actions(|_| false).unwrap_err();
+        assert!(matches!(err, Error::BadParam(_)));
+    }
+
+    // no-op when there is no actions assertion.
+    #[test]
+    fn retain_actions_noop_without_actions() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "org.test.assertion", "data": "x" }]
+        }));
+        b.retain_actions(|_| false).unwrap();
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .all(|a| !a.label().starts_with(Actions::LABEL)));
+    }
+
+    // the v1 `c2pa.actions` label is preserved on rebuild.
+    #[test]
+    fn retain_actions_preserves_v1_label() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+            ]}}]
+        }));
+        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
+            .unwrap();
+        let label = b
+            .definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .unwrap()
+            .label()
+            .to_string();
+        assert_eq!(label, "c2pa.actions");
+    }
+
+    // an ingredient referenced only by a removed action is pruned.
+    #[test]
+    fn retain_ingredients_prunes_orphan_after_action_removal() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "keep", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_keep", "instance_id": "id_keep" },
+                { "title": "drop", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_drop", "instance_id": "id_drop" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_keep"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_drop"] } },
+            ]}}]
+        }));
+        b.remove_actions(|a| {
+            a.get_parameter::<Vec<String>>("ingredientIds")
+                .map(|ids| ids.iter().any(|i| i == "ing_drop"))
+                .unwrap_or(false)
+        })
+        .unwrap();
+        b.retain_ingredients(|_| false).unwrap();
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing_keep"]);
+    }
+
+    // a parentOf ingredient is kept even when no surviving action references it.
+    #[test]
+    fn retain_ingredients_keeps_parent_of() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "parent", "format": "image/jpeg", "relationship": "parentOf", "label": "ing_parent", "instance_id": "id_parent" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+        }));
+        b.retain_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].label(), Some("ing_parent"));
+    }
+
+    // remove the middle ingredient (via its action); __2 collapses to __1, __1 -> base.
+    #[test]
+    fn retain_ingredients_reindex_middle_hole() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("ing0"),
+                positional_ingredient("ing1"),
+                positional_ingredient("ing2"),
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                positional_placed(0),
+                positional_placed(1),
+                positional_placed(2),
+            ]}}]
+        }));
+        // Remove the action referencing ingredient[1] (__1), orphaning it.
+        b.remove_actions(|a| first_ing_url(a).is_some_and(|u| u.ends_with("__1")))
+            .unwrap();
+        b.retain_ingredients(|_| false).unwrap();
+
+        // ingredient[1] gone; ingredient[2] shifted to index 1.
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing0", "ing2"]);
+
+        let urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3"))); // idx0 base
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3__1"))); // was __2 -> __1
+        assert!(!urls.iter().any(|u| u.ends_with("__2")));
+    }
+
+    // multiple / non-contiguous removals leave no dangling or colliding __N.
+    #[test]
+    fn retain_ingredients_reindex_noncontiguous() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("ing0"),
+                positional_ingredient("ing1"),
+                positional_ingredient("ing2"),
+                positional_ingredient("ing3"),
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                positional_placed(0),
+                positional_placed(1),
+                positional_placed(2),
+                positional_placed(3),
+            ]}}]
+        }));
+        // Remove the actions referencing ingredients at index 0 (base) and 2 (__2).
+        b.remove_actions(|a| {
+            first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3") || u.ends_with("__2"))
+        })
+        .unwrap();
+        b.retain_ingredients(|_| false).unwrap();
+
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing1", "ing3"]); // idx1 -> 0, idx3 -> 1
+
+        let urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3"))); // ing1 -> idx0
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3__1"))); // ing3 -> idx1
+        assert!(!urls.iter().any(|u| u.ends_with("__2") || u.ends_with("__3")));
+    }
+
+    // `c2pa.edited` + `inputTo` ingredient survives while its action survives; pruned when removed.
+    #[test]
+    fn retain_ingredients_edited_input_to() {
+        let def = json!({
+            "ingredients": [
+                { "title": "edit", "format": "image/jpeg", "relationship": "inputTo", "label": "ing_edit", "instance_id": "id_edit" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.edited", "parameters": { "ingredientIds": ["ing_edit"] } },
+            ]}}]
+        });
+
+        // edited survives -> inputTo ingredient kept, relationship unchanged.
+        let mut kept = removal_builder(def.clone());
+        kept.retain_ingredients(|_| false).unwrap();
+        assert_eq!(kept.definition.ingredients.len(), 1);
+        assert_eq!(
+            kept.definition.ingredients[0].relationship(),
+            &Relationship::InputTo
+        );
+
+        // edited removed -> inputTo ingredient pruned.
+        let mut dropped = removal_builder(def);
+        dropped
+            .remove_actions(|a| a.action() == "c2pa.edited")
+            .unwrap();
+        dropped.retain_ingredients(|_| false).unwrap();
+        assert!(dropped.definition.ingredients.is_empty());
+    }
+
+    // a parentOf ingredient at a non-zero index survives and its opened link re-indexes.
+    #[test]
+    fn retain_ingredients_parent_of_nonzero_index() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("comp"),
+                { "title": "parent", "format": "image/jpeg", "relationship": "parentOf", "label": "parent", "instance_id": "parent" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.opened", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                    "alg": "sha256", "hash": [9, 9]
+                }]}},
+                positional_placed(0),
+            ]}}]
+        }));
+        // Remove the placed action (ref __0), orphaning the componentOf ingredient at index 0.
+        b.remove_actions(|a| first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3")))
+            .unwrap();
+        b.retain_ingredients(|_| false).unwrap();
+
+        // Only the parentOf ingredient remains, now at index 0.
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(
+            b.definition.ingredients[0].relationship(),
+            &Relationship::ParentOf
+        );
+        // opened's __1 reference re-indexed to the base label (idx 0).
+        let opened_url = builder_actions(&b)
+            .actions
+            .iter()
+            .find(|a| a.action() == c2pa_action::OPENED)
+            .and_then(first_ing_url)
+            .unwrap();
+        assert!(opened_url.ends_with("c2pa.ingredient.v3"));
+    }
+
+    // a diamond ingredient shared by two actions re-indexes consistently and is kept
+    // while at least one referencing action survives.
+    #[test]
+    fn retain_ingredients_diamond_shared() {
+        let base_def = json!({
+            "ingredients": [
+                positional_ingredient("orphan"), // idx0, referenced by nothing
+                positional_ingredient("shared"), // idx1, referenced by two actions
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.edited", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [1] }]}},
+                { "action": "c2pa.placed", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [1] }]}},
+            ]}}]
+        });
+
+        // Prune the orphan at idx0 -> shared moves to idx0; both actions must remap to base.
+        let mut b = removal_builder(base_def.clone());
+        b.retain_ingredients(|_| false).unwrap();
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["shared"]); // kept exactly once
+        let ref_urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert_eq!(ref_urls.len(), 2);
+        assert!(ref_urls
+            .iter()
+            .all(|u| u.ends_with("c2pa.ingredient.v3")));
+
+        // Remove only one of the two referring actions -> shared still referenced, not pruned.
+        let mut b2 = removal_builder(base_def);
+        b2.remove_actions(|a| a.action() == "c2pa.placed").unwrap();
+        b2.retain_ingredients(|_| false).unwrap();
+        let labels2: Vec<_> = b2
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels2, vec!["shared"]);
+    }
+
+    /// Produce a signed JPEG (single `c2pa.created`) for use as a nested ingredient.
+    fn signed_created_jpeg() -> Vec<u8> {
+        let mut b = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+        }));
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE_CLEAN),
+            &mut dest,
+        )
+        .unwrap();
+        dest.into_inner()
+    }
+
+    // a kept ingredient's embedded manifest chain is untouched by top-level pruning.
+    #[test]
+    fn retain_ingredients_preserves_nested_chain() {
+        let nested = signed_created_jpeg();
+        let mut b = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["nested"] } },
+            ]}}]
+        }));
+        b.add_ingredient_from_stream(
+            json!({ "title": "nested", "relationship": "componentOf", "label": "nested" }).to_string(),
+            "image/jpeg",
+            &mut Cursor::new(nested),
+        )
+        .unwrap();
+
+        // The nested ingredient is referenced, so it survives an orphan prune with its chain.
+        b.retain_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert!(b.definition.ingredients[0].active_manifest().is_some());
+
+        // Sign the top-level builder and confirm the nested chain reads back intact.
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE_CLEAN),
+            &mut dest,
+        )
+        .unwrap();
+        dest.rewind().unwrap();
+        let reader = Reader::default().with_stream("image/jpeg", &mut dest).unwrap();
+        let active = reader.active_manifest().unwrap();
+        let ing = &active.ingredients()[0];
+        let nested_label = ing.active_manifest().expect("nested active_manifest");
+        assert!(
+            reader.get_manifest(nested_label).is_some(),
+            "nested manifest chain must survive top-level pruning"
+        );
+    }
+
+    // a deep-nested orphan is pruned by default but rescued by a manifest_data predicate.
+    #[test]
+    fn retain_ingredients_predicate_rescues_orphan() {
+        let nested = signed_created_jpeg();
+        let make = || {
+            let mut b = removal_builder(json!({
+                "format": "image/jpeg",
+                "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+            }));
+            // Orphan ingredient: no action references it, but it carries an embedded manifest chain.
+            b.add_ingredient_from_stream(
+                json!({ "title": "orphan", "relationship": "componentOf", "label": "orphan" })
+                    .to_string(),
+                "image/jpeg",
+                &mut Cursor::new(nested.clone()),
+            )
+            .unwrap();
+            b
+        };
+
+        // Default prune drops the orphan.
+        let mut pruned = make();
+        pruned.retain_ingredients(|_| false).unwrap();
+        assert!(pruned.definition.ingredients.is_empty());
+
+        // A predicate that inspects manifest_data rescues it (whole chain rides along).
+        let mut rescued = make();
+        rescued
+            .retain_ingredients(|ing| ing.manifest_data().is_some())
+            .unwrap();
+        assert_eq!(rescued.definition.ingredients.len(), 1);
+        assert!(rescued.definition.ingredients[0].active_manifest().is_some());
+    }
+
+    // end-to-end sign + re-read produces no action/ingredient validation failures.
+    #[test]
+    fn retain_removal_end_to_end() {
+        // Case A: c2pa.created, remove a non-inception action and prune.
+        let mut created = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+            ]}}]
+        }));
+        created
+            .remove_actions(|a| a.action() == "c2pa.color_adjustments")
+            .unwrap();
+        created.retain_ingredients(|_| false).unwrap();
+        assert_no_action_failures(sign_and_read(created));
+
+        // Case B: c2pa.opened + parentOf; remove the placed action and prune its ingredient.
+        let mut source = Cursor::new(TEST_IMAGE);
+        let mut opened = Builder::default().with_definition(manifest_json()).unwrap();
+        opened
+            .add_ingredient_from_stream(parent_json(), "image/jpeg", &mut source)
+            .unwrap();
+        opened
+            .resources
+            .add("thumbnail.jpg", TEST_THUMBNAIL.to_vec())
+            .unwrap();
+        opened
+            .remove_actions(|a| a.action() == "c2pa.placed")
+            .unwrap();
+        opened.retain_ingredients(|_| false).unwrap();
+        // The parentOf (CA.jpg) ingredient survives; the componentOf INGREDIENT_2 is gone.
+        assert!(opened
+            .definition
+            .ingredients
+            .iter()
+            .any(|i| i.is_parent()));
+        assert!(!opened
+            .definition
+            .ingredients
+            .iter()
+            .any(|i| i.label() == Some("INGREDIENT_2")));
+        assert_no_action_failures(sign_and_read(opened));
     }
 }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -902,101 +902,92 @@ impl Builder {
         Ok(self)
     }
 
-    /// Retains only the actions for which `keep` returns true.
+    /// Retains only the actions for which `keep` returns true, across every actions assertion.
     ///
-    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept regardless of `keep`,
-    /// and is moved to index 0 if needed, so the manifest stays valid per the C2PA spec. Sets
-    /// `allActionsIncluded = false` when anything is removed. This does not touch ingredients —
-    /// call [`Builder::retain_ingredients`] (`retain_ingredients(|_| false)` to drop all orphans)
-    /// afterwards if you also want to drop ingredients now orphaned by the removed actions.
+    /// `keep` is applied to each action in each `c2pa.actions*` assertion. A manifest may carry
+    /// more than one (a created-list actions assertion, which holds the inception action, plus a
+    /// gathered-list actions assertion of user actions), and all are filtered. When anything is
+    /// removed from an assertion, its `allActionsIncluded` is set to `false`. An actions assertion
+    /// left with no actions is dropped entirely.
+    ///
+    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept regardless of `keep`, and
+    /// is moved to index 0 of its assertion if needed, so a manifest that already carries an
+    /// inception stays valid per the C2PA spec. This only ever affects the created-list actions
+    /// assertion; a gathered-list assertion has no inception action to keep.
+    ///
+    /// This does not touch ingredients. Call [`Builder::filter_ingredients`]
+    /// (`filter_ingredients(|_| false)` to drop all orphans) afterwards if you also want to drop
+    /// ingredients now orphaned by the removed actions.
     ///
     /// # Arguments
     /// * `keep` - A predicate; the action is retained when it returns true.
     /// # Returns
     /// * A mutable reference to the [`Builder`]. A no-op if there is no actions assertion.
     /// # Errors
-    /// * Returns an [`Error::BadParam`] if retention would leave zero actions (a `c2pa.actions`
-    ///   assertion must have a non-empty `actions` array).
-    pub fn retain_actions<F>(&mut self, mut keep: F) -> Result<&mut Self>
+    /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
+    pub fn filter_actions<F>(&mut self, mut keep: F) -> Result<&mut Self>
     where
         F: FnMut(&Action) -> bool,
     {
-        // Find the actions assertion; no-op when there isn't one.
-        let Some(pos) = self
+        // Every actions assertion (created-list and gathered-list), in positional order.
+        let positions: Vec<usize> = self
             .definition
             .assertions
             .iter()
-            .position(|a| a.label().starts_with(Actions::LABEL))
-        else {
-            return Ok(self);
-        };
+            .enumerate()
+            .filter(|(_, a)| a.label().starts_with(Actions::LABEL))
+            .map(|(i, _)| i)
+            .collect();
 
-        // Decode a working copy WITHOUT mutating `self`, so any error below leaves the Builder
-        // intact — nothing is removed until all the fallible work is done.
-        let original_label = self.definition.assertions[pos].label.clone();
-        let original_created = self.definition.assertions[pos].created;
-        let mut actions: Actions = self.definition.assertions[pos].to_assertion()?;
+        let mut emptied: Vec<usize> = Vec::new();
+        for pos in positions {
+            // Decode a working copy; all fallible work happens before any mutation of `self`.
+            let mut actions: Actions = self.definition.assertions[pos].to_assertion()?;
+            let original_len = actions.actions.len();
 
-        let original_len = actions.actions.len();
-        // The v2.x C2PA spec requires exactly one c2pa.created/c2pa.opened action, so keep it
-        // regardless of the caller predicate.
-        actions.actions.retain(|a| {
-            a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED || keep(a)
-        });
+            // Force-keep the inception action regardless of the predicate. Only the created-list
+            // assertion contains one, so this never affects a gathered-list assertion.
+            actions.actions.retain(|a| {
+                keep(a) || a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
+            });
 
-        if actions.actions.is_empty() {
-            return Err(Error::BadParam(
-                "at least one action is required".to_string(),
-            ));
-        }
-
-        // The inception action must be at index 0.
-        if let Some(idx) = actions
-            .actions
-            .iter()
-            .position(|a| a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED)
-        {
-            if idx != 0 {
-                let inception = actions.actions.remove(idx);
-                actions.actions.insert(0, inception);
+            if actions.actions.is_empty() {
+                // A c2pa.actions assertion must have a non-empty actions array. Only a gathered
+                // assertion can reach empty (the created one keeps its inception); drop it rather
+                // than erroring, mirroring how an empty actions assertion is otherwise omitted.
+                emptied.push(pos);
+                continue;
             }
+
+            // Keep the surviving inception at index 0 of its assertion. A no-op for valid input
+            // where it is already first.
+            if let Some(idx) = actions.actions.iter().position(|a| {
+                a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
+            }) {
+                if idx != 0 {
+                    let inception = actions.actions.remove(idx);
+                    actions.actions.insert(0, inception);
+                }
+            }
+
+            if actions.actions.len() < original_len {
+                // `allActionsIncluded` is a v2 actions-assertion field; the SDK always writes the
+                // latest assertion version, so this is always safe when anything was removed.
+                actions.all_actions_included = Some(false);
+            }
+
+            // Replace the data in place: preserves the entry's label, `created` flag, and kind,
+            // and never leaves the Builder without its assertion on error.
+            self.definition.assertions[pos].data =
+                AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
         }
 
-        // `allActionsIncluded` is a v2.x actions-assertion field; only emit it for v2+ claims,
-        // which the SDK can still write older (v1) claims alongside.
-        if actions.actions.len() < original_len && self.claim_version() >= 2 {
-            actions.all_actions_included = Some(false);
+        // Remove emptied assertions from the back so earlier indices stay valid.
+        for pos in emptied.into_iter().rev() {
+            self.definition.assertions.remove(pos);
         }
 
-        // Encode first, then swap in place: `self` is never left without its actions assertion on
-        // error. Preserves the original `.v1`/`.v2` label and created/gathered flag.
-        let data = AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
-        self.definition.assertions[pos] = AssertionDefinition {
-            label: original_label,
-            data,
-            kind: None,
-            created: original_created,
-        };
         Ok(self)
-    }
-
-    /// Removes the actions for which `remove` returns true; the convenience inverse of
-    /// [`Builder::retain_actions`].
-    ///
-    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept, as with
-    /// [`Builder::retain_actions`].
-    ///
-    /// # Arguments
-    /// * `remove` - A predicate; the action is removed when it returns true.
-    /// # Returns
-    /// * A mutable reference to the [`Builder`]. A no-op if there is no actions assertion.
-    /// # Errors
-    /// * Returns an [`Error::BadParam`] if removal would leave zero actions.
-    pub fn remove_actions<F>(&mut self, mut remove: F) -> Result<&mut Self>
-    where
-        F: FnMut(&Action) -> bool,
-    {
-        self.retain_actions(|a| !remove(a))
     }
 
     /// Retains ingredients, then rewrites positional ingredient references so linked actions
@@ -1004,16 +995,16 @@ impl Builder {
     ///
     /// An ingredient is kept if any of the following hold:
     /// - it is referenced by a current action (via `parameters.ingredients` URLs or the
-    ///   `ingredientIds`/`instanceId` parameters),
+    ///   `ingredientIds`/`instanceId` parameters) in any actions assertion,
     /// - it is a [`Relationship::ParentOf`] ingredient (lineage for `c2pa.opened`), or
     /// - `rescue` returns true for it.
     ///
-    /// `rescue` therefore only ever rescues an otherwise-orphaned ingredient — it can never drop a
+    /// `rescue` therefore only ever rescues an otherwise-orphaned ingredient; it can never drop a
     /// referenced or lineage ingredient (that would break spec validation). Use `rescue` for
     /// provenance-aware policy, e.g. "this ingredient's embedded manifest chain contains a signal
     /// of interest, so retain the whole ingredient (and its nested chain)"; the closure may inspect
     /// the ingredient's [`manifest_data`](Ingredient::manifest_data) to decide. Prune all orphans
-    /// with `retain_ingredients(|_| false)`. Call [`Builder::retain_actions`] first if you are also
+    /// with `filter_ingredients(|_| false)`. Call [`Builder::filter_actions`] first if you are also
     /// removing actions: the keep-set is computed from whatever actions currently remain.
     ///
     /// # Arguments
@@ -1022,7 +1013,7 @@ impl Builder {
     /// * A mutable reference to the [`Builder`].
     /// # Errors
     /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
-    pub fn retain_ingredients<F>(&mut self, mut rescue: F) -> Result<&mut Self>
+    pub fn filter_ingredients<F>(&mut self, mut rescue: F) -> Result<&mut Self>
     where
         F: FnMut(&Ingredient) -> bool,
     {
@@ -1037,23 +1028,26 @@ impl Builder {
             .map(Ingredient::effective_id)
             .collect();
 
-        // Decode the actions assertion (if any) WITHOUT removing it, so an error leaves the
-        // Builder intact. We record its position to swap the rewritten copy back in place later.
-        let actions_pos = self
+        // Every actions assertion (created-list and gathered-list): references can live in any of
+        // them, and each must have its positional URLs rewritten after the prune.
+        let actions_positions: Vec<usize> = self
             .definition
             .assertions
             .iter()
-            .position(|a| a.label().starts_with(Actions::LABEL));
+            .enumerate()
+            .filter(|(_, a)| a.label().starts_with(Actions::LABEL))
+            .map(|(i, _)| i)
+            .collect();
 
+        // Decode each actions assertion (WITHOUT mutating self) and union the referenced-ingredient
+        // keep-set across all of them.
         let mut keep_set: HashSet<String> = HashSet::new();
-        let mut actions_opt: Option<(usize, String, bool, Actions)> = None;
-        if let Some(pos) = actions_pos {
-            let original_label = self.definition.assertions[pos].label.clone();
-            let original_created = self.definition.assertions[pos].created;
+        let mut decoded: Vec<(usize, Actions)> = Vec::with_capacity(actions_positions.len());
+        for pos in actions_positions {
             let actions: Actions = self.definition.assertions[pos].to_assertion()?;
             for action in &actions.actions {
                 // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
-                // deprecated instance_id. Relationship-agnostic — any referenced ingredient is
+                // deprecated instance_id. Relationship-agnostic: any referenced ingredient is
                 // kept whatever its relationship (e.g. `c2pa.edited` -> `inputTo`).
                 for id in action_ingredient_ids(action) {
                     keep_set.insert(id);
@@ -1070,7 +1064,7 @@ impl Builder {
                     }
                 }
             }
-            actions_opt = Some((pos, original_label, original_created, actions));
+            decoded.push((pos, actions));
         }
 
         // Prune: keep referenced, `parentOf`, or caller-rescued ingredients; drop the rest.
@@ -1080,29 +1074,24 @@ impl Builder {
                 || rescue(ing)
         });
 
-        // Rewrite surviving positional `__N` references to the ingredients' new positions, then
-        // swap the actions assertion back in place. Encoding is the only fallible step and runs
-        // before the mutation, so an error leaves the Builder intact.
-        if let Some((pos, original_label, original_created, mut actions)) = actions_opt {
-            let new_ids: Vec<String> = self
-                .definition
-                .ingredients
-                .iter()
-                .map(Ingredient::effective_id)
-                .collect();
-            let id_to_new_idx: HashMap<&str, usize> = new_ids
-                .iter()
-                .enumerate()
-                .map(|(i, id)| (id.as_str(), i))
-                .collect();
+        // Rewrite each actions assertion's positional `__N` references to the ingredients' new
+        // positions, then replace its data in place. Encoding runs before the mutation, so an
+        // error leaves the Builder intact.
+        let new_ids: Vec<String> = self
+            .definition
+            .ingredients
+            .iter()
+            .map(Ingredient::effective_id)
+            .collect();
+        let id_to_new_idx: HashMap<&str, usize> = new_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.as_str(), i))
+            .collect();
+        for (pos, mut actions) in decoded {
             rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx)?;
-            let data = AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
-            self.definition.assertions[pos] = AssertionDefinition {
-                label: original_label,
-                data,
-                kind: None,
-                created: original_created,
-            };
+            self.definition.assertions[pos].data =
+                AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
         }
 
         Ok(self)
@@ -10030,7 +10019,7 @@ mod tests {
             .expect("with_definition")
     }
 
-    /// Extract the current `Actions` assertion off a builder.
+    /// Extract the first `Actions` assertion off a builder.
     fn builder_actions(b: &Builder) -> Actions {
         b.definition
             .assertions
@@ -10039,6 +10028,16 @@ mod tests {
             .expect("actions assertion present")
             .to_assertion()
             .expect("actions assertion decodes")
+    }
+
+    /// Extract every `Actions` assertion off a builder, in positional order.
+    fn builder_all_actions(b: &Builder) -> Vec<Actions> {
+        b.definition
+            .assertions
+            .iter()
+            .filter(|a| a.label().starts_with(Actions::LABEL))
+            .map(|a| a.to_assertion().expect("actions assertion decodes"))
+            .collect()
     }
 
     /// The url of an action's first positional ingredient reference, if any.
@@ -10118,9 +10117,9 @@ mod tests {
         }
     }
 
-    // the inception action is force-kept and moved to index 0; allActionsIncluded=false.
+    // the inception action is force-kept even when the predicate would drop it, and moved to index 0.
     #[test]
-    fn retain_actions_guards_inception() {
+    fn filter_actions_force_keeps_inception() {
         let mut b = removal_builder(json!({
             "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
                 { "action": "c2pa.color_adjustments" },
@@ -10128,17 +10127,17 @@ mod tests {
                 { "action": "c2pa.cropped" },
             ]}}]
         }));
-        // Predicate would drop everything, including c2pa.created.
-        b.retain_actions(|_| false).unwrap();
+        // Predicate drops everything, but c2pa.created is force-kept and moved to index 0.
+        b.filter_actions(|_| false).unwrap();
         let actions = builder_actions(&b);
         assert_eq!(actions.actions.len(), 1);
         assert_eq!(actions.actions[0].action(), c2pa_action::CREATED);
         assert_eq!(actions.all_actions_included, Some(false));
     }
 
-    // targeted middle action is removed; order/count preserved, first still inception.
+    // targeted middle action is removed; surviving order/count preserved.
     #[test]
-    fn retain_actions_removes_middle_keeps_order() {
+    fn filter_actions_removes_middle_keeps_order() {
         let mut b = removal_builder(json!({
             "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
                 created_action(),
@@ -10146,7 +10145,7 @@ mod tests {
                 { "action": "c2pa.cropped" },
             ]}}]
         }));
-        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
             .unwrap();
         let actions = builder_actions(&b);
         assert_eq!(actions.actions.len(), 2);
@@ -10155,26 +10154,39 @@ mod tests {
         assert_eq!(actions.all_actions_included, Some(false));
     }
 
-    // removing every action with no inception present errors.
+    // filtering every action out drops the emptied assertion (no error); other assertions remain.
     #[test]
-    fn retain_actions_empty_errors() {
+    fn filter_actions_empty_drops_assertion() {
         let mut b = removal_builder(json!({
-            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
-                { "action": "c2pa.color_adjustments" },
-                { "action": "c2pa.cropped" },
-            ]}}]
+            "assertions": [
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                    { "action": "c2pa.cropped" },
+                ]}},
+                { "label": "org.test.assertion", "data": "x" },
+            ]
         }));
-        let err = b.retain_actions(|_| false).unwrap_err();
-        assert!(matches!(err, Error::BadParam(_)));
+        b.filter_actions(|_| false).unwrap();
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .all(|a| !a.label().starts_with(Actions::LABEL)));
+        // Non-actions assertions are untouched.
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .any(|a| a.label() == "org.test.assertion"));
     }
 
     // no-op when there is no actions assertion.
     #[test]
-    fn retain_actions_noop_without_actions() {
+    fn filter_actions_noop_without_actions() {
         let mut b = removal_builder(json!({
             "assertions": [{ "label": "org.test.assertion", "data": "x" }]
         }));
-        b.retain_actions(|_| false).unwrap();
+        b.filter_actions(|_| false).unwrap();
         assert!(b
             .definition
             .assertions
@@ -10184,14 +10196,14 @@ mod tests {
 
     // the v1 `c2pa.actions` label is preserved on rebuild.
     #[test]
-    fn retain_actions_preserves_v1_label() {
+    fn filter_actions_preserves_v1_label() {
         let mut b = removal_builder(json!({
             "assertions": [{ "label": "c2pa.actions", "data": { "actions": [
                 created_action(),
                 { "action": "c2pa.color_adjustments" },
             ]}}]
         }));
-        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
             .unwrap();
         let label = b
             .definition
@@ -10204,9 +10216,83 @@ mod tests {
         assert_eq!(label, "c2pa.actions");
     }
 
+    // the created/gathered flag on the actions assertion survives the in-place rebuild.
+    #[test]
+    fn filter_actions_preserves_created_flag() {
+        let mut b = removal_builder(json!({
+            "assertions": [{
+                "label": "c2pa.actions.v2",
+                "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.color_adjustments" },
+                ]},
+                "created": true
+            }]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let def = b
+            .definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .unwrap();
+        assert!(def.created(), "created flag must survive the rebuild");
+    }
+
+    // filter_actions applies to EVERY actions assertion (created-list and gathered-list).
+    #[test]
+    fn filter_actions_spans_all_assertions() {
+        let mut b = removal_builder(json!({
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.color_adjustments" },
+                ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                    { "action": "c2pa.cropped" },
+                ]}},
+            ]
+        }));
+        // Drop color_adjustments from BOTH the created and the gathered actions assertion.
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let all = builder_all_actions(&b);
+        assert_eq!(all.len(), 2);
+        // created-list keeps the inception action.
+        assert_eq!(
+            all[0].actions.iter().map(|a| a.action()).collect::<Vec<_>>(),
+            vec![c2pa_action::CREATED]
+        );
+        // gathered-list keeps cropped.
+        assert_eq!(
+            all[1].actions.iter().map(|a| a.action()).collect::<Vec<_>>(),
+            vec!["c2pa.cropped"]
+        );
+    }
+
+    // filtering a gathered actions assertion to empty drops only it; the created one stays.
+    #[test]
+    fn filter_actions_drops_only_emptied_gathered_assertion() {
+        let mut b = removal_builder(json!({
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [ created_action() ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                ]}},
+            ]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let all = builder_all_actions(&b);
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].actions[0].action(), c2pa_action::CREATED);
+    }
+
     // an ingredient referenced only by a removed action is pruned.
     #[test]
-    fn retain_ingredients_prunes_orphan_after_action_removal() {
+    fn filter_ingredients_prunes_orphan_after_action_removal() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 { "title": "keep", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_keep", "instance_id": "id_keep" },
@@ -10218,13 +10304,13 @@ mod tests {
                 { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_drop"] } },
             ]}}]
         }));
-        b.remove_actions(|a| {
-            a.get_parameter::<Vec<String>>("ingredientIds")
+        b.filter_actions(|a| {
+            !a.get_parameter::<Vec<String>>("ingredientIds")
                 .map(|ids| ids.iter().any(|i| i == "ing_drop"))
                 .unwrap_or(false)
         })
         .unwrap();
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         let labels: Vec<_> = b
             .definition
             .ingredients
@@ -10236,14 +10322,14 @@ mod tests {
 
     // a parentOf ingredient is kept even when no surviving action references it.
     #[test]
-    fn retain_ingredients_keeps_parent_of() {
+    fn filter_ingredients_keeps_parent_of() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 { "title": "parent", "format": "image/jpeg", "relationship": "parentOf", "label": "ing_parent", "instance_id": "id_parent" },
             ],
             "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
         }));
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         assert_eq!(b.definition.ingredients.len(), 1);
         assert_eq!(b.definition.ingredients[0].label(), Some("ing_parent"));
     }
@@ -10251,7 +10337,7 @@ mod tests {
     // an ingredient reference keeps it whether the ingredient carries a label only, an
     // instance_id only, or both (label is the effective id when present).
     #[test]
-    fn retain_ingredients_matches_label_or_instance_id() {
+    fn filter_ingredients_matches_label_or_instance_id() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 // label only
@@ -10269,14 +10355,14 @@ mod tests {
             ]}}]
         }));
         // Nothing is rescued by the predicate; all three survive purely via their references.
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         assert_eq!(b.definition.ingredients.len(), 3);
     }
 
     // when an ingredient has both a label and an instance_id, the label is its effective id, so a
     // reference by instance_id alone does not keep it (mirrors how ingredientIds resolve).
     #[test]
-    fn retain_ingredients_label_prevails_over_instance_id() {
+    fn filter_ingredients_label_prevails_over_instance_id() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 { "title": "c", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_both", "instance_id": "id_both" },
@@ -10286,53 +10372,35 @@ mod tests {
                 { "action": "c2pa.placed", "parameters": { "ingredientIds": ["id_both"] } },
             ]}}]
         }));
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         // Referenced only by its instance_id, but the label is the effective id, so it is orphaned.
         assert!(b.definition.ingredients.is_empty());
     }
 
-    // the Builder is left intact (actions assertion still present) when retain_actions errors.
+    // the keep-set spans EVERY actions assertion: an ingredient referenced only from the
+    // gathered-list actions assertion must survive an orphan prune.
     #[test]
-    fn retain_actions_error_leaves_builder_intact() {
+    fn filter_ingredients_keep_set_spans_all_assertions() {
         let mut b = removal_builder(json!({
-            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
-                { "action": "c2pa.color_adjustments" },
-                { "action": "c2pa.cropped" },
-            ]}}]
+            "ingredients": [
+                { "title": "g", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_gathered", "instance_id": "ing_gathered" },
+            ],
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [ created_action() ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_gathered"] } },
+                ]}},
+            ]
         }));
-        assert!(b.retain_actions(|_| false).is_err());
-        // The actions assertion must not have been dropped by the failed call.
-        let actions = builder_actions(&b);
-        assert_eq!(actions.actions.len(), 2);
-    }
-
-    // the created/gathered flag on the actions assertion survives a retain/remove rebuild.
-    #[test]
-    fn retain_actions_preserves_created_flag() {
-        let mut b = removal_builder(json!({
-            "assertions": [{
-                "label": "c2pa.actions.v2",
-                "data": { "actions": [
-                    created_action(),
-                    { "action": "c2pa.color_adjustments" },
-                ]},
-                "created": true
-            }]
-        }));
-        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
-            .unwrap();
-        let def = b
-            .definition
-            .assertions
-            .iter()
-            .find(|a| a.label().starts_with(Actions::LABEL))
-            .unwrap();
-        assert!(def.created(), "created flag must survive the rebuild");
+        // The ingredient is referenced only by the gathered assertion; it must not be pruned.
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].label(), Some("ing_gathered"));
     }
 
     // remove the middle ingredient (via its action); __2 collapses to __1, __1 -> base.
     #[test]
-    fn retain_ingredients_reindex_middle_hole() {
+    fn filter_ingredients_reindex_middle_hole() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 positional_ingredient("ing0"),
@@ -10347,9 +10415,9 @@ mod tests {
             ]}}]
         }));
         // Remove the action referencing ingredient[1] (__1), orphaning it.
-        b.remove_actions(|a| first_ing_url(a).is_some_and(|u| u.ends_with("__1")))
+        b.filter_actions(|a| !first_ing_url(a).is_some_and(|u| u.ends_with("__1")))
             .unwrap();
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
 
         // ingredient[1] gone; ingredient[2] shifted to index 1.
         let labels: Vec<_> = b
@@ -10372,7 +10440,7 @@ mod tests {
 
     // multiple / non-contiguous removals leave no dangling or colliding __N.
     #[test]
-    fn retain_ingredients_reindex_noncontiguous() {
+    fn filter_ingredients_reindex_noncontiguous() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 positional_ingredient("ing0"),
@@ -10389,12 +10457,12 @@ mod tests {
             ]}}]
         }));
         // Remove the actions referencing ingredients at index 0 (base) and 2 (__2).
-        b.remove_actions(|a| {
-            first_ing_url(a)
+        b.filter_actions(|a| {
+            !first_ing_url(a)
                 .is_some_and(|u| u.ends_with("c2pa.ingredient.v3") || u.ends_with("__2"))
         })
         .unwrap();
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
 
         let labels: Vec<_> = b
             .definition
@@ -10418,7 +10486,7 @@ mod tests {
 
     // `c2pa.edited` + `inputTo` ingredient survives while its action survives; pruned when removed.
     #[test]
-    fn retain_ingredients_edited_input_to() {
+    fn filter_ingredients_edited_input_to() {
         let def = json!({
             "ingredients": [
                 { "title": "edit", "format": "image/jpeg", "relationship": "inputTo", "label": "ing_edit", "instance_id": "id_edit" },
@@ -10431,7 +10499,7 @@ mod tests {
 
         // edited survives -> inputTo ingredient kept, relationship unchanged.
         let mut kept = removal_builder(def.clone());
-        kept.retain_ingredients(|_| false).unwrap();
+        kept.filter_ingredients(|_| false).unwrap();
         assert_eq!(kept.definition.ingredients.len(), 1);
         assert_eq!(
             kept.definition.ingredients[0].relationship(),
@@ -10441,15 +10509,15 @@ mod tests {
         // edited removed -> inputTo ingredient pruned.
         let mut dropped = removal_builder(def);
         dropped
-            .remove_actions(|a| a.action() == "c2pa.edited")
+            .filter_actions(|a| a.action() != "c2pa.edited")
             .unwrap();
-        dropped.retain_ingredients(|_| false).unwrap();
+        dropped.filter_ingredients(|_| false).unwrap();
         assert!(dropped.definition.ingredients.is_empty());
     }
 
     // a parentOf ingredient at a non-zero index survives and its opened link re-indexes.
     #[test]
-    fn retain_ingredients_parent_of_nonzero_index() {
+    fn filter_ingredients_parent_of_nonzero_index() {
         let mut b = removal_builder(json!({
             "ingredients": [
                 positional_ingredient("comp"),
@@ -10464,9 +10532,9 @@ mod tests {
             ]}}]
         }));
         // Remove the placed action (ref __0), orphaning the componentOf ingredient at index 0.
-        b.remove_actions(|a| first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3")))
+        b.filter_actions(|a| !first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3")))
             .unwrap();
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
 
         // Only the parentOf ingredient remains, now at index 0.
         assert_eq!(b.definition.ingredients.len(), 1);
@@ -10487,7 +10555,7 @@ mod tests {
     // a diamond ingredient shared by two actions re-indexes consistently and is kept
     // while at least one referencing action survives.
     #[test]
-    fn retain_ingredients_diamond_shared() {
+    fn filter_ingredients_diamond_shared() {
         let base_def = json!({
             "ingredients": [
                 positional_ingredient("orphan"), // idx0, referenced by nothing
@@ -10504,7 +10572,7 @@ mod tests {
 
         // Prune the orphan at idx0 -> shared moves to idx0; both actions must remap to base.
         let mut b = removal_builder(base_def.clone());
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         let labels: Vec<_> = b
             .definition
             .ingredients
@@ -10522,8 +10590,8 @@ mod tests {
 
         // Remove only one of the two referring actions -> shared still referenced, not pruned.
         let mut b2 = removal_builder(base_def);
-        b2.remove_actions(|a| a.action() == "c2pa.placed").unwrap();
-        b2.retain_ingredients(|_| false).unwrap();
+        b2.filter_actions(|a| a.action() != "c2pa.placed").unwrap();
+        b2.filter_ingredients(|_| false).unwrap();
         let labels2: Vec<_> = b2
             .definition
             .ingredients
@@ -10553,7 +10621,7 @@ mod tests {
 
     // a kept ingredient's embedded manifest chain is untouched by top-level pruning.
     #[test]
-    fn retain_ingredients_preserves_nested_chain() {
+    fn filter_ingredients_preserves_nested_chain() {
         let nested = signed_created_jpeg();
         let mut b = removal_builder(json!({
             "format": "image/jpeg",
@@ -10571,7 +10639,7 @@ mod tests {
         .unwrap();
 
         // The nested ingredient is referenced, so it survives an orphan prune with its chain.
-        b.retain_ingredients(|_| false).unwrap();
+        b.filter_ingredients(|_| false).unwrap();
         assert_eq!(b.definition.ingredients.len(), 1);
         assert!(b.definition.ingredients[0].active_manifest().is_some());
 
@@ -10600,7 +10668,7 @@ mod tests {
 
     // a deep-nested orphan is pruned by default but rescued by a manifest_data predicate.
     #[test]
-    fn retain_ingredients_predicate_rescues_orphan() {
+    fn filter_ingredients_predicate_rescues_orphan() {
         let nested = signed_created_jpeg();
         let make = || {
             let mut b = removal_builder(json!({
@@ -10620,13 +10688,13 @@ mod tests {
 
         // Default prune drops the orphan.
         let mut pruned = make();
-        pruned.retain_ingredients(|_| false).unwrap();
+        pruned.filter_ingredients(|_| false).unwrap();
         assert!(pruned.definition.ingredients.is_empty());
 
         // A predicate that inspects manifest_data rescues it (whole chain rides along).
         let mut rescued = make();
         rescued
-            .retain_ingredients(|ing| ing.manifest_data().is_some())
+            .filter_ingredients(|ing| ing.manifest_data().is_some())
             .unwrap();
         assert_eq!(rescued.definition.ingredients.len(), 1);
         assert!(rescued.definition.ingredients[0]
@@ -10636,7 +10704,7 @@ mod tests {
 
     // end-to-end sign + re-read produces no action/ingredient validation failures.
     #[test]
-    fn retain_removal_end_to_end() {
+    fn filter_removal_end_to_end() {
         // Case A: c2pa.created, remove a non-inception action and prune.
         let mut created = removal_builder(json!({
             "format": "image/jpeg",
@@ -10646,9 +10714,9 @@ mod tests {
             ]}}]
         }));
         created
-            .remove_actions(|a| a.action() == "c2pa.color_adjustments")
+            .filter_actions(|a| a.action() != "c2pa.color_adjustments")
             .unwrap();
-        created.retain_ingredients(|_| false).unwrap();
+        created.filter_ingredients(|_| false).unwrap();
         assert_no_action_failures(sign_and_read(created));
 
         // Case B: c2pa.opened + parentOf; remove the placed action and prune its ingredient.
@@ -10662,9 +10730,9 @@ mod tests {
             .add("thumbnail.jpg", TEST_THUMBNAIL.to_vec())
             .unwrap();
         opened
-            .remove_actions(|a| a.action() == "c2pa.placed")
+            .filter_actions(|a| a.action() != "c2pa.placed")
             .unwrap();
-        opened.retain_ingredients(|_| false).unwrap();
+        opened.filter_ingredients(|_| false).unwrap();
         // The parentOf (CA.jpg) ingredient survives; the componentOf INGREDIENT_2 is gone.
         assert!(opened.definition.ingredients.iter().any(|i| i.is_parent()));
         assert!(!opened

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -44,7 +44,7 @@ use crate::{
     crypto::cose,
     error::{Error, Result},
     hash_utils::hash_by_alg,
-    jumbf::labels::manifest_label_from_uri,
+    jumbf::labels::{assertion_label_from_uri, manifest_label_from_uri},
     jumbf_io,
     maybe_send_sync::MaybeSend,
     resource_store::{ResourceRef, ResourceResolver, ResourceStore},
@@ -1034,7 +1034,7 @@ impl Builder {
             .definition
             .ingredients
             .iter()
-            .map(ingredient_effective_id)
+            .map(Ingredient::effective_id)
             .collect();
 
         // Decode the actions assertion (if any) WITHOUT removing it, so an error leaves the
@@ -1061,9 +1061,11 @@ impl Builder {
                 // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
                 if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
                     for uri in uris {
-                        let (_, idx) = parse_positional_label(ingredient_ref_label(&uri.url()));
-                        if let Some(id) = pre_filter_ids.get(idx) {
-                            keep_set.insert(id.clone());
+                        if let Some(label) = assertion_label_from_uri(&uri.url()) {
+                            let (_, idx) = parse_positional_label(&label);
+                            if let Some(id) = pre_filter_ids.get(idx) {
+                                keep_set.insert(id.clone());
+                            }
                         }
                     }
                 }
@@ -1073,7 +1075,7 @@ impl Builder {
 
         // Prune: keep referenced, `parentOf`, or caller-rescued ingredients; drop the rest.
         self.definition.ingredients.retain(|ing| {
-            keep_set.contains(&ingredient_effective_id(ing))
+            keep_set.contains(&ing.effective_id())
                 || matches!(ing.relationship(), &Relationship::ParentOf)
                 || rescue(ing)
         });
@@ -1086,7 +1088,7 @@ impl Builder {
                 .definition
                 .ingredients
                 .iter()
-                .map(ingredient_effective_id)
+                .map(Ingredient::effective_id)
                 .collect();
             let id_to_new_idx: HashMap<&str, usize> = new_ids
                 .iter()
@@ -1597,11 +1599,7 @@ impl Builder {
 
         for ingredient in &definition.ingredients {
             // use the label if it exists and is not empty, otherwise use the instance_id
-            let id = ingredient
-                .label()
-                .filter(|label| !label.is_empty())
-                .map(|label| label.to_string())
-                .unwrap_or_else(|| ingredient.instance_id().to_string());
+            let id = ingredient.effective_id();
 
             // add it to the claim
             let uri = ingredient.add_to_claim(
@@ -3573,16 +3571,6 @@ fn action_ingredient_ids(action: &Action) -> Vec<String> {
     ids
 }
 
-/// The id used to reference an ingredient: its `label` when non-empty, otherwise its
-/// `instance_id`. Mirrors how `to_claim` keys the `ingredient_map` and how `ingredientIds`
-/// action parameters resolve.
-fn ingredient_effective_id(ing: &Ingredient) -> String {
-    ing.label()
-        .filter(|label| !label.is_empty())
-        .map(|label| label.to_string())
-        .unwrap_or_else(|| ing.instance_id().to_string())
-}
-
 /// Splits a positional ingredient label into its base and `__N` index.
 /// `c2pa.ingredient.v3__2` becomes (`c2pa.ingredient.v3`, 2); `c2pa.ingredient.v3` becomes
 /// (label, 0).
@@ -3598,6 +3586,11 @@ fn parse_positional_label(label: &str) -> (&str, usize) {
 /// The trailing assertion-label segment of an ingredient reference URL, e.g.
 /// `self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2` -> `c2pa.ingredient.v3__2`.
 /// When the URL has no path separator, the whole URL is treated as the label.
+///
+/// This borrows a slice of `url` (rather than reusing [`assertion_label_from_uri`], which returns
+/// an owned, normalized `String`) so callers can compute the label's byte offset within the
+/// original URL and rebuild the prefix. Where only the label value is needed, prefer
+/// [`assertion_label_from_uri`].
 fn ingredient_ref_label(url: &str) -> &str {
     url.rsplit('/').next().unwrap_or(url)
 }
@@ -9136,12 +9129,7 @@ mod tests {
         )?;
 
         let mut ingredient_archive = Cursor::new(Vec::new());
-        let ingredient_id = {
-            let ing = &builder.definition.ingredients[0];
-            ing.label()
-                .map(String::from)
-                .unwrap_or_else(|| ing.instance_id().to_string())
-        };
+        let ingredient_id = builder.definition.ingredients[0].effective_id();
         builder.write_ingredient_archive(&ingredient_id, &mut ingredient_archive)?;
 
         let archive_bytes = ingredient_archive.into_inner();

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -10325,6 +10325,66 @@ mod tests {
         assert!(b.definition.ingredients.is_empty());
     }
 
+    // an action that references its ingredient only via the deprecated top-level `instanceId`
+    // field still keeps that ingredient (exercises the Action::ingredient_ids fallback path).
+    #[test]
+    fn filter_ingredients_deprecated_instance_id_reference() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "d", "format": "image/jpeg", "relationship": "componentOf", "instance_id": "dep_id" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                // `instanceId` at the action top level maps to the deprecated `Action::instance_id`
+                // field, not a parameter.
+                { "action": "c2pa.placed", "instanceId": "dep_id" },
+            ]}}]
+        }));
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].instance_id(), "dep_id");
+    }
+
+    // rewrite_action_ingredient_urls (and rewrite_one_ingredient_uri) directly: a positional ref
+    // whose ingredient was pruned degrades to a logged Stale ref kept as-is, an out-of-range ref
+    // is left Unchanged, and a valid shift is Rewritten. Driven directly because filter_ingredients
+    // never prunes an ingredient that a surviving action still references.
+    #[test]
+    fn rewrite_action_ingredient_urls_stale_shift_and_out_of_range() {
+        use std::collections::HashMap;
+        let mut actions: Actions = serde_json::from_value(json!({ "actions": [
+            { "action": "c2pa.placed", "parameters": { "ingredients": [
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3", "alg": "sha256", "hash": [1] },
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [2] },
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__9", "alg": "sha256", "hash": [3] },
+            ]}},
+        ]}))
+        .unwrap();
+
+        // Pre-prune order was [id0, id1]; id0 was pruned, id1 survives at new index 0.
+        let pre_filter_ids = vec!["id0".to_string(), "id1".to_string()];
+        let mut id_to_new_idx: HashMap<&str, usize> = HashMap::new();
+        id_to_new_idx.insert("id1", 0);
+
+        rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx).unwrap();
+
+        let urls: Vec<String> = actions.actions[0]
+            .parameters()
+            .unwrap()
+            .ingredients
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|u| u.url())
+            .collect();
+        // idx0 -> id0 pruned: Stale, left as-is.
+        assert!(urls[0].ends_with("c2pa.ingredient.v3"));
+        // __1 -> id1 moved to index 0: Rewritten to the base label.
+        assert!(urls[1].ends_with("c2pa.ingredient.v3"));
+        // __9 out of range: Unchanged.
+        assert!(urls[2].ends_with("c2pa.ingredient.v3__9"));
+    }
+
     // the keep-set spans EVERY actions assertion: an ingredient referenced only from the
     // gathered-list actions assertion must survive an orphan prune.
     #[test]

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -931,45 +931,52 @@ impl Builder {
             return Ok(self);
         };
 
-        // Isolate: remove, mutate a local copy, re-add. This mirrors `add_action` and keeps the
-        // `FnMut` `&Action` borrow off `self.definition`.
-        let assertion_def = self.definition.assertions.remove(pos);
-        let original_label = assertion_def.label.clone();
-        let mut actions: Actions = assertion_def.to_assertion()?;
+        // Decode a working copy WITHOUT mutating `self`, so any error below leaves the Builder
+        // intact — nothing is removed until all the fallible work is done.
+        let original_label = self.definition.assertions[pos].label.clone();
+        let original_created = self.definition.assertions[pos].created;
+        let mut actions: Actions = self.definition.assertions[pos].to_assertion()?;
 
         let original_len = actions.actions.len();
-        // The C2PA spec requires exactly one c2pa.created/c2pa.opened action, so keep it
+        // The v2.x C2PA spec requires exactly one c2pa.created/c2pa.opened action, so keep it
         // regardless of the caller predicate.
         actions.actions.retain(|a| {
-            a.action() == c2pa_action::CREATED
-                || a.action() == c2pa_action::OPENED
-                || keep(a)
+            a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED || keep(a)
         });
 
         if actions.actions.is_empty() {
             return Err(Error::BadParam(
-                "retain_actions would remove every action; at least one action is required"
-                    .to_string(),
+                "at least one action is required".to_string(),
             ));
         }
 
-        // The inception action must be at index 0. This is usually a no-op since
-        // Actions::add_action already inserts it there.
-        if let Some(idx) = actions.actions.iter().position(|a| {
-            a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
-        }) {
+        // The inception action must be at index 0.
+        if let Some(idx) = actions
+            .actions
+            .iter()
+            .position(|a| a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED)
+        {
             if idx != 0 {
                 let inception = actions.actions.remove(idx);
                 actions.actions.insert(0, inception);
             }
         }
 
-        if actions.actions.len() < original_len {
+        // `allActionsIncluded` is a v2.x actions-assertion field; only emit it for v2+ claims,
+        // which the SDK can still write older (v1) claims alongside.
+        if actions.actions.len() < original_len && self.claim_version() >= 2 {
             actions.all_actions_included = Some(false);
         }
 
-        // Preserve the original `.v1`/`.v2` label on rebuild.
-        self.add_assertion(original_label, &actions)?;
+        // Encode first, then swap in place: `self` is never left without its actions assertion on
+        // error. Preserves the original `.v1`/`.v2` label and created/gathered flag.
+        let data = AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
+        self.definition.assertions[pos] = AssertionDefinition {
+            label: original_label,
+            data,
+            kind: None,
+            created: original_created,
+        };
         Ok(self)
     }
 
@@ -992,17 +999,17 @@ impl Builder {
         self.retain_actions(|a| !remove(a))
     }
 
-    /// Retains ingredients, then rewrites positional ingredient references so surviving actions
+    /// Retains ingredients, then rewrites positional ingredient references so linked actions
     /// stay valid.
     ///
     /// An ingredient is kept if any of the following hold:
     /// - it is referenced by a current action (via `parameters.ingredients` URLs or the
     ///   `ingredientIds`/`instanceId` parameters),
     /// - it is a [`Relationship::ParentOf`] ingredient (lineage for `c2pa.opened`), or
-    /// - `keep` returns true for it.
+    /// - `rescue` returns true for it.
     ///
-    /// `keep` therefore only ever rescues an otherwise-orphaned ingredient — it can never drop a
-    /// referenced or lineage ingredient (that would break spec validation). Use `keep` for
+    /// `rescue` therefore only ever rescues an otherwise-orphaned ingredient — it can never drop a
+    /// referenced or lineage ingredient (that would break spec validation). Use `rescue` for
     /// provenance-aware policy, e.g. "this ingredient's embedded manifest chain contains a signal
     /// of interest, so retain the whole ingredient (and its nested chain)"; the closure may inspect
     /// the ingredient's [`manifest_data`](Ingredient::manifest_data) to decide. Prune all orphans
@@ -1010,12 +1017,12 @@ impl Builder {
     /// removing actions: the keep-set is computed from whatever actions currently remain.
     ///
     /// # Arguments
-    /// * `keep` - A predicate that can rescue an otherwise-orphaned ingredient by returning true.
+    /// * `rescue` - A predicate that can rescue an otherwise-orphaned ingredient by returning true.
     /// # Returns
     /// * A mutable reference to the [`Builder`].
     /// # Errors
     /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
-    pub fn retain_ingredients<F>(&mut self, mut keep: F) -> Result<&mut Self>
+    pub fn retain_ingredients<F>(&mut self, mut rescue: F) -> Result<&mut Self>
     where
         F: FnMut(&Ingredient) -> bool,
     {
@@ -1030,9 +1037,8 @@ impl Builder {
             .map(ingredient_effective_id)
             .collect();
 
-        // Pull out the actions assertion (if any) so we can compute the referenced-ingredient
-        // keep-set and later rewrite its positional URLs. Isolating it also keeps the `keep`
-        // `&Ingredient` borrow off `self.definition`.
+        // Decode the actions assertion (if any) WITHOUT removing it, so an error leaves the
+        // Builder intact. We record its position to swap the rewritten copy back in place later.
         let actions_pos = self
             .definition
             .assertions
@@ -1040,11 +1046,11 @@ impl Builder {
             .position(|a| a.label().starts_with(Actions::LABEL));
 
         let mut keep_set: HashSet<String> = HashSet::new();
-        let mut actions_opt: Option<(String, Actions)> = None;
+        let mut actions_opt: Option<(usize, String, bool, Actions)> = None;
         if let Some(pos) = actions_pos {
-            let assertion_def = self.definition.assertions.remove(pos);
-            let original_label = assertion_def.label.clone();
-            let actions: Actions = assertion_def.to_assertion()?;
+            let original_label = self.definition.assertions[pos].label.clone();
+            let original_created = self.definition.assertions[pos].created;
+            let actions: Actions = self.definition.assertions[pos].to_assertion()?;
             for action in &actions.actions {
                 // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
                 // deprecated instance_id. Relationship-agnostic — any referenced ingredient is
@@ -1055,28 +1061,27 @@ impl Builder {
                 // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
                 if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
                     for uri in uris {
-                        let url = uri.url();
-                        let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
-                        let (_, idx) = parse_positional_label(&url[label_start..]);
+                        let (_, idx) = parse_positional_label(ingredient_ref_label(&uri.url()));
                         if let Some(id) = pre_filter_ids.get(idx) {
                             keep_set.insert(id.clone());
                         }
                     }
                 }
             }
-            actions_opt = Some((original_label, actions));
+            actions_opt = Some((pos, original_label, original_created, actions));
         }
 
         // Prune: keep referenced, `parentOf`, or caller-rescued ingredients; drop the rest.
         self.definition.ingredients.retain(|ing| {
             keep_set.contains(&ingredient_effective_id(ing))
                 || matches!(ing.relationship(), &Relationship::ParentOf)
-                || keep(ing)
+                || rescue(ing)
         });
 
         // Rewrite surviving positional `__N` references to the ingredients' new positions, then
-        // re-add the actions assertion (preserving its original label).
-        if let Some((original_label, mut actions)) = actions_opt {
+        // swap the actions assertion back in place. Encoding is the only fallible step and runs
+        // before the mutation, so an error leaves the Builder intact.
+        if let Some((pos, original_label, original_created, mut actions)) = actions_opt {
             let new_ids: Vec<String> = self
                 .definition
                 .ingredients
@@ -1088,8 +1093,14 @@ impl Builder {
                 .enumerate()
                 .map(|(i, id)| (id.as_str(), i))
                 .collect();
-            rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx);
-            self.add_assertion(original_label, &actions)?;
+            rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx)?;
+            let data = AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
+            self.definition.assertions[pos] = AssertionDefinition {
+                label: original_label,
+                data,
+                kind: None,
+                created: original_created,
+            };
         }
 
         Ok(self)
@@ -3544,11 +3555,15 @@ fn action_ingredient_ids(action: &Action) -> Vec<String> {
         }
     };
     let mut ids = Vec::new();
-    ids.extend(extract(action.get_parameter::<c2pa_cbor::Value>("ingredientIds")));
+    ids.extend(extract(
+        action.get_parameter::<c2pa_cbor::Value>("ingredientIds"),
+    ));
     ids.extend(extract(
         action.get_parameter::<c2pa_cbor::Value>("org.cai.ingredientIds"),
     ));
-    ids.extend(extract(action.get_parameter::<c2pa_cbor::Value>("instanceId")));
+    ids.extend(extract(
+        action.get_parameter::<c2pa_cbor::Value>("instanceId"),
+    ));
     if ids.is_empty() {
         #[allow(deprecated)]
         if let Some(id) = action.instance_id() {
@@ -3580,36 +3595,51 @@ fn parse_positional_label(label: &str) -> (&str, usize) {
     (label, 0)
 }
 
-/// Builds a positional label from a base and 0-based index.
-fn make_positional_label(base: &str, idx: usize) -> String {
-    if idx == 0 {
-        base.to_owned()
-    } else {
-        format!("{base}__{idx}")
-    }
+/// The trailing assertion-label segment of an ingredient reference URL, e.g.
+/// `self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2` -> `c2pa.ingredient.v3__2`.
+/// When the URL has no path separator, the whole URL is treated as the label.
+fn ingredient_ref_label(url: &str) -> &str {
+    url.rsplit('/').next().unwrap_or(url)
 }
 
-/// Rewrites a single `HashedUri` whose URL ends in a positional ingredient label.
-/// Returns `None` when no rewrite is needed (index unchanged) or the lookup fails.
+/// Outcome of rewriting one positional ingredient reference after pruning.
+enum UriRewrite {
+    /// Already points at the correct index (or is not a tracked positional ref); leave as-is.
+    Unchanged,
+    /// The referenced ingredient was pruned, so the reference now dangles.
+    Stale,
+    /// Repointed to the ingredient's new index.
+    Rewritten(HashedUri),
+}
+
+/// Rewrites a single `HashedUri` whose URL ends in a positional ingredient label so it points at
+/// the ingredient's new position after pruning.
 fn rewrite_one_ingredient_uri(
     hu: &HashedUri,
     pre_filter_ids: &[String],
     id_to_new_idx: &HashMap<&str, usize>,
-) -> Option<HashedUri> {
+) -> UriRewrite {
     let url = hu.url();
-    let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
-    let (base, old_idx) = parse_positional_label(&url[label_start..]);
-    let instance_id = pre_filter_ids.get(old_idx)?;
-    let new_idx = *id_to_new_idx.get(instance_id.as_str())?;
+    let label = ingredient_ref_label(&url);
+    let label_start = url.len() - label.len();
+    let (base, old_idx) = parse_positional_label(label);
+    // An out-of-range index is not a positional ingredient ref we track; leave it untouched
+    // rather than guessing (`get` bounds-checks, so this never panics on malformed input).
+    let Some(instance_id) = pre_filter_ids.get(old_idx) else {
+        return UriRewrite::Unchanged;
+    };
+    let Some(&new_idx) = id_to_new_idx.get(instance_id.as_str()) else {
+        return UriRewrite::Stale;
+    };
     if new_idx == old_idx {
-        return None;
+        return UriRewrite::Unchanged;
     }
     let new_url = format!(
         "{}{}",
         &url[..label_start],
-        make_positional_label(base, new_idx)
+        Claim::label_with_instance(base, new_idx)
     );
-    Some(HashedUri::new(new_url, hu.alg(), &hu.hash()))
+    UriRewrite::Rewritten(HashedUri::new(new_url, hu.alg(), &hu.hash()))
 }
 
 /// Rewrites `parameters.ingredients[].url` on every action so positional labels
@@ -3621,58 +3651,43 @@ fn rewrite_action_ingredient_urls(
     actions: &mut Actions,
     pre_filter_ids: &[String],
     id_to_new_idx: &HashMap<&str, usize>,
-) {
-    actions.actions = actions
-        .actions
-        .drain(..)
-        .map(|action| {
-            let Some(ingredient_uris) = action.parameters().and_then(|p| p.ingredients.as_ref())
-            else {
-                return action;
-            };
+) -> Result<()> {
+    let mut rewritten = Vec::with_capacity(actions.actions.len());
+    for action in actions.actions.drain(..) {
+        let Some(ingredient_uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) else {
+            rewritten.push(action);
+            continue;
+        };
 
-            let mut rewrote = false;
-            let remapped_uris: Vec<HashedUri> = ingredient_uris
-                .iter()
-                .map(|uri| match rewrite_one_ingredient_uri(uri, pre_filter_ids, id_to_new_idx) {
-                    Some(new) => {
-                        rewrote = true;
-                        new
-                    }
-                    None => {
-                        // Either no rewrite needed or the lookup failed (stale ref).
-                        let url = uri.url();
-                        let label_start = url.rfind('/').map(|p| p + 1).unwrap_or(0);
-                        let (_, old_idx) = parse_positional_label(&url[label_start..]);
-                        if let Some(instance_id) = pre_filter_ids.get(old_idx) {
-                            if !id_to_new_idx.contains_key(instance_id.as_str()) {
-                                log::warn!(
-                                    "action '{}' has stale ingredient ref '{}' (instance_id '{}')",
-                                    action.action(),
-                                    &url[label_start..],
-                                    instance_id,
-                                );
-                            }
-                        }
-                        uri.clone()
-                    }
-                })
-                .collect();
-
-            if !rewrote {
-                return action;
-            }
-
-            let label = action.action().to_owned();
-            match action.clone().set_parameter("ingredients", remapped_uris) {
-                Ok(rewritten) => rewritten,
-                Err(e) => {
-                    log::error!("failed to remap ingredient URLs on action '{label}': {e:?}");
-                    action
+        let mut changed = false;
+        let mut remapped_uris: Vec<HashedUri> = Vec::with_capacity(ingredient_uris.len());
+        for uri in ingredient_uris {
+            match rewrite_one_ingredient_uri(uri, pre_filter_ids, id_to_new_idx) {
+                UriRewrite::Rewritten(new) => {
+                    changed = true;
+                    remapped_uris.push(new);
                 }
+                UriRewrite::Stale => {
+                    log::warn!(
+                        "action '{}' has stale ingredient ref '{}'",
+                        action.action(),
+                        ingredient_ref_label(&uri.url()),
+                    );
+                    remapped_uris.push(uri.clone());
+                }
+                UriRewrite::Unchanged => remapped_uris.push(uri.clone()),
             }
-        })
-        .collect();
+        }
+
+        if changed {
+            // Propagate rather than swallow: a failed remap would silently dangle references.
+            rewritten.push(action.set_parameter("ingredients", remapped_uris)?);
+        } else {
+            rewritten.push(action);
+        }
+    }
+    actions.actions = rewritten;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -10020,7 +10035,7 @@ mod tests {
         assert_send(future);
     }
 
-    /// Build a `Builder` (with test context) from a JSON manifest definition.
+    /// Create a `Builder` (with test context) from a JSON manifest definition.
     fn removal_builder(def: serde_json::Value) -> Builder {
         Builder::from_context(test_context())
             .with_definition(def.to_string())
@@ -10059,7 +10074,7 @@ mod tests {
 
     /// A `c2pa.placed` action referencing a single positional ingredient label.
     fn positional_placed(idx: usize) -> serde_json::Value {
-        let label = make_positional_label("c2pa.ingredient.v3", idx);
+        let label = Claim::label_with_instance("c2pa.ingredient.v3", idx);
         json!({
             "action": "c2pa.placed",
             "parameters": {
@@ -10102,7 +10117,11 @@ mod tests {
 
     fn assert_no_action_failures(status: Vec<crate::validation_status::ValidationStatus>) {
         for s in &status {
-            assert_ne!(s.code(), "assertion.action.malformed", "action malformed: {s:?}");
+            assert_ne!(
+                s.code(),
+                "assertion.action.malformed",
+                "action malformed: {s:?}"
+            );
             assert_ne!(
                 s.code(),
                 "assertion.action.ingredientMismatch",
@@ -10241,6 +10260,88 @@ mod tests {
         assert_eq!(b.definition.ingredients[0].label(), Some("ing_parent"));
     }
 
+    // an ingredient reference keeps it whether the ingredient carries a label only, an
+    // instance_id only, or both (label is the effective id when present).
+    #[test]
+    fn retain_ingredients_matches_label_or_instance_id() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                // label only
+                { "title": "a", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_label" },
+                // instance_id only (no label)
+                { "title": "b", "format": "image/jpeg", "relationship": "componentOf", "instance_id": "id_only" },
+                // both present: label prevails as the effective id
+                { "title": "c", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_both", "instance_id": "id_both" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_label"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["id_only"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_both"] } },
+            ]}}]
+        }));
+        // Nothing is rescued by the predicate; all three survive purely via their references.
+        b.retain_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 3);
+    }
+
+    // when an ingredient has both a label and an instance_id, the label is its effective id, so a
+    // reference by instance_id alone does not keep it (mirrors how ingredientIds resolve).
+    #[test]
+    fn retain_ingredients_label_prevails_over_instance_id() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "c", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_both", "instance_id": "id_both" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["id_both"] } },
+            ]}}]
+        }));
+        b.retain_ingredients(|_| false).unwrap();
+        // Referenced only by its instance_id, but the label is the effective id, so it is orphaned.
+        assert!(b.definition.ingredients.is_empty());
+    }
+
+    // the Builder is left intact (actions assertion still present) when retain_actions errors.
+    #[test]
+    fn retain_actions_error_leaves_builder_intact() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.color_adjustments" },
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        assert!(b.retain_actions(|_| false).is_err());
+        // The actions assertion must not have been dropped by the failed call.
+        let actions = builder_actions(&b);
+        assert_eq!(actions.actions.len(), 2);
+    }
+
+    // the created/gathered flag on the actions assertion survives a retain/remove rebuild.
+    #[test]
+    fn retain_actions_preserves_created_flag() {
+        let mut b = removal_builder(json!({
+            "assertions": [{
+                "label": "c2pa.actions.v2",
+                "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.color_adjustments" },
+                ]},
+                "created": true
+            }]
+        }));
+        b.remove_actions(|a| a.action() == "c2pa.color_adjustments")
+            .unwrap();
+        let def = b
+            .definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .unwrap();
+        assert!(def.created(), "created flag must survive the rebuild");
+    }
+
     // remove the middle ingredient (via its action); __2 collapses to __1, __1 -> base.
     #[test]
     fn retain_ingredients_reindex_middle_hole() {
@@ -10301,7 +10402,8 @@ mod tests {
         }));
         // Remove the actions referencing ingredients at index 0 (base) and 2 (__2).
         b.remove_actions(|a| {
-            first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3") || u.ends_with("__2"))
+            first_ing_url(a)
+                .is_some_and(|u| u.ends_with("c2pa.ingredient.v3") || u.ends_with("__2"))
         })
         .unwrap();
         b.retain_ingredients(|_| false).unwrap();
@@ -10321,7 +10423,9 @@ mod tests {
             .collect();
         assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3"))); // ing1 -> idx0
         assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3__1"))); // ing3 -> idx1
-        assert!(!urls.iter().any(|u| u.ends_with("__2") || u.ends_with("__3")));
+        assert!(!urls
+            .iter()
+            .any(|u| u.ends_with("__2") || u.ends_with("__3")));
     }
 
     // `c2pa.edited` + `inputTo` ingredient survives while its action survives; pruned when removed.
@@ -10426,9 +10530,7 @@ mod tests {
             .filter_map(first_ing_url)
             .collect();
         assert_eq!(ref_urls.len(), 2);
-        assert!(ref_urls
-            .iter()
-            .all(|u| u.ends_with("c2pa.ingredient.v3")));
+        assert!(ref_urls.iter().all(|u| u.ends_with("c2pa.ingredient.v3")));
 
         // Remove only one of the two referring actions -> shared still referenced, not pruned.
         let mut b2 = removal_builder(base_def);
@@ -10473,7 +10575,8 @@ mod tests {
             ]}}]
         }));
         b.add_ingredient_from_stream(
-            json!({ "title": "nested", "relationship": "componentOf", "label": "nested" }).to_string(),
+            json!({ "title": "nested", "relationship": "componentOf", "label": "nested" })
+                .to_string(),
             "image/jpeg",
             &mut Cursor::new(nested),
         )
@@ -10495,7 +10598,9 @@ mod tests {
         )
         .unwrap();
         dest.rewind().unwrap();
-        let reader = Reader::default().with_stream("image/jpeg", &mut dest).unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .unwrap();
         let active = reader.active_manifest().unwrap();
         let ing = &active.ingredients()[0];
         let nested_label = ing.active_manifest().expect("nested active_manifest");
@@ -10536,7 +10641,9 @@ mod tests {
             .retain_ingredients(|ing| ing.manifest_data().is_some())
             .unwrap();
         assert_eq!(rescued.definition.ingredients.len(), 1);
-        assert!(rescued.definition.ingredients[0].active_manifest().is_some());
+        assert!(rescued.definition.ingredients[0]
+            .active_manifest()
+            .is_some());
     }
 
     // end-to-end sign + re-read produces no action/ingredient validation failures.
@@ -10571,11 +10678,7 @@ mod tests {
             .unwrap();
         opened.retain_ingredients(|_| false).unwrap();
         // The parentOf (CA.jpg) ingredient survives; the componentOf INGREDIENT_2 is gone.
-        assert!(opened
-            .definition
-            .ingredients
-            .iter()
-            .any(|i| i.is_parent()));
+        assert!(opened.definition.ingredients.iter().any(|i| i.is_parent()));
         assert!(!opened
             .definition
             .ingredients

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -44,7 +44,10 @@ use crate::{
     crypto::cose,
     error::{Error, Result},
     hash_utils::hash_by_alg,
-    jumbf::labels::{assertion_label_from_uri, manifest_label_from_uri},
+    jumbf::labels::{
+        assertion_label_from_uri, label_segment_from_uri, manifest_label_from_uri,
+        parse_positional_label,
+    },
     jumbf_io,
     maybe_send_sync::MaybeSend,
     resource_store::{ResourceRef, ResourceResolver, ResourceStore},
@@ -1049,7 +1052,7 @@ impl Builder {
                 // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
                 // deprecated instance_id. Relationship-agnostic: any referenced ingredient is
                 // kept whatever its relationship (e.g. `c2pa.edited` -> `inputTo`).
-                for id in action_ingredient_ids(action) {
+                for id in action.ingredient_ids() {
                     keep_set.insert(id);
                 }
                 // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
@@ -3521,69 +3524,6 @@ impl std::fmt::Display for Builder {
     }
 }
 
-/// Collects all ingredient instance IDs an action references, checking every linking mechanism:
-/// `ingredientIds`, `org.cai.ingredientIds`, `instanceId` parameter, and the deprecated
-/// `action.instance_id` field.
-///
-/// Read-only: unlike [`Action::extract_ingredient_ids`](crate::assertions::Action), which is
-/// mutating (it removes the params it reads), this must not corrupt the action during a prune.
-fn action_ingredient_ids(action: &Action) -> Vec<String> {
-    let extract = |opt: Option<c2pa_cbor::Value>| -> Vec<String> {
-        match opt {
-            Some(c2pa_cbor::Value::Array(arr)) => arr
-                .into_iter()
-                .filter_map(|v| match v {
-                    c2pa_cbor::Value::Text(s) => Some(s),
-                    _ => None,
-                })
-                .collect(),
-            Some(c2pa_cbor::Value::Text(s)) => vec![s],
-            _ => vec![],
-        }
-    };
-    let mut ids = Vec::new();
-    ids.extend(extract(
-        action.get_parameter::<c2pa_cbor::Value>("ingredientIds"),
-    ));
-    ids.extend(extract(
-        action.get_parameter::<c2pa_cbor::Value>("org.cai.ingredientIds"),
-    ));
-    ids.extend(extract(
-        action.get_parameter::<c2pa_cbor::Value>("instanceId"),
-    ));
-    if ids.is_empty() {
-        #[allow(deprecated)]
-        if let Some(id) = action.instance_id() {
-            ids.push(id.to_owned());
-        }
-    }
-    ids
-}
-
-/// Splits a positional ingredient label into its base and `__N` index.
-/// `c2pa.ingredient.v3__2` becomes (`c2pa.ingredient.v3`, 2); `c2pa.ingredient.v3` becomes
-/// (label, 0).
-fn parse_positional_label(label: &str) -> (&str, usize) {
-    if let Some(pos) = label.rfind("__") {
-        if let Ok(n) = label[pos + 2..].parse::<usize>() {
-            return (&label[..pos], n);
-        }
-    }
-    (label, 0)
-}
-
-/// The trailing assertion-label segment of an ingredient reference URL, e.g.
-/// `self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2` -> `c2pa.ingredient.v3__2`.
-/// When the URL has no path separator, the whole URL is treated as the label.
-///
-/// This borrows a slice of `url` (rather than reusing [`assertion_label_from_uri`], which returns
-/// an owned, normalized `String`) so callers can compute the label's byte offset within the
-/// original URL and rebuild the prefix. Where only the label value is needed, prefer
-/// [`assertion_label_from_uri`].
-fn ingredient_ref_label(url: &str) -> &str {
-    url.rsplit('/').next().unwrap_or(url)
-}
-
 /// Outcome of rewriting one positional ingredient reference after pruning.
 enum UriRewrite {
     /// Already points at the correct index (or is not a tracked positional ref); leave as-is.
@@ -3602,7 +3542,7 @@ fn rewrite_one_ingredient_uri(
     id_to_new_idx: &HashMap<&str, usize>,
 ) -> UriRewrite {
     let url = hu.url();
-    let label = ingredient_ref_label(&url);
+    let label = label_segment_from_uri(&url);
     let label_start = url.len() - label.len();
     let (base, old_idx) = parse_positional_label(label);
     // An out-of-range index is not a positional ingredient ref we track; leave it untouched
@@ -3653,7 +3593,7 @@ fn rewrite_action_ingredient_urls(
                     log::warn!(
                         "action '{}' has stale ingredient ref '{}'",
                         action.action(),
-                        ingredient_ref_label(&uri.url()),
+                        label_segment_from_uri(&uri.url()),
                     );
                     remapped_uris.push(uri.clone());
                 }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -10262,12 +10262,20 @@ mod tests {
         assert_eq!(all.len(), 2);
         // created-list keeps the inception action.
         assert_eq!(
-            all[0].actions.iter().map(|a| a.action()).collect::<Vec<_>>(),
+            all[0]
+                .actions
+                .iter()
+                .map(|a| a.action())
+                .collect::<Vec<_>>(),
             vec![c2pa_action::CREATED]
         );
         // gathered-list keeps cropped.
         assert_eq!(
-            all[1].actions.iter().map(|a| a.action()).collect::<Vec<_>>(),
+            all[1]
+                .actions
+                .iter()
+                .map(|a| a.action())
+                .collect::<Vec<_>>(),
             vec!["c2pa.cropped"]
         );
     }

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -252,6 +252,19 @@ impl Ingredient {
         self.instance_id.as_deref().unwrap_or("None") // todo: deprecate and change to Option<&str>
     }
 
+    /// Returns the id used to reference this ingredient from a claim: its [`label`](Self::label)
+    /// when present and non-empty, otherwise its [`instance_id`](Self::instance_id).
+    ///
+    /// This is how the [`Builder`](crate::Builder) keys ingredients when resolving action
+    /// `ingredientIds` and emitting positional assertion labels, so any code matching actions to
+    /// ingredients must use the same rule.
+    pub fn effective_id(&self) -> String {
+        self.label()
+            .filter(|label| !label.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.instance_id().to_string())
+    }
+
     /// Returns the provenance URI if available.
     pub fn provenance(&self) -> Option<&str> {
         self.provenance.as_deref()

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -258,7 +258,7 @@ impl Ingredient {
     /// This is how the [`Builder`](crate::Builder) keys ingredients when resolving action
     /// `ingredientIds` and emitting positional assertion labels, so any code matching actions to
     /// ingredients must use the same rule.
-    pub fn effective_id(&self) -> String {
+    pub(crate) fn effective_id(&self) -> String {
         self.label()
             .filter(|label| !label.is_empty())
             .map(str::to_string)

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -257,8 +257,10 @@ impl Ingredient {
     ///
     /// This is how the [`Builder`](crate::Builder) keys ingredients when resolving action
     /// `ingredientIds` and emitting positional assertion labels, so any code matching actions to
-    /// ingredients must use the same rule.
-    pub(crate) fn effective_id(&self) -> String {
+    /// ingredients must use the same rule. It is public for exactly that reason: external code
+    /// filtering or matching actions against ingredients must not reimplement (and risk diverging
+    /// from) this rule.
+    pub fn effective_id(&self) -> String {
         self.label()
             .filter(|label| !label.is_empty())
             .map(str::to_string)

--- a/sdk/src/jumbf/labels.rs
+++ b/sdk/src/jumbf/labels.rs
@@ -549,4 +549,35 @@ pub mod tests {
             "acme:urn:uuid:F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4"
         );
     }
+
+    #[test]
+    fn test_label_segment_from_uri() {
+        assert_eq!(
+            label_segment_from_uri("self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2"),
+            "c2pa.ingredient.v3__2"
+        );
+        // No path separator: the whole string is treated as the label.
+        assert_eq!(
+            label_segment_from_uri("c2pa.ingredient.v3"),
+            "c2pa.ingredient.v3"
+        );
+    }
+
+    #[test]
+    fn test_parse_positional_label() {
+        assert_eq!(
+            parse_positional_label("c2pa.ingredient.v3__2"),
+            ("c2pa.ingredient.v3", 2)
+        );
+        // No instance suffix.
+        assert_eq!(
+            parse_positional_label("c2pa.ingredient.v3"),
+            ("c2pa.ingredient.v3", 0)
+        );
+        // A non-numeric `__` suffix is not an instance index.
+        assert_eq!(
+            parse_positional_label("c2pa.foo__bar"),
+            ("c2pa.foo__bar", 0)
+        );
+    }
 }

--- a/sdk/src/jumbf/labels.rs
+++ b/sdk/src/jumbf/labels.rs
@@ -186,6 +186,35 @@ pub(crate) fn box_name_from_uri(uri: &str) -> Option<String> {
     parts.last().map(|b| b.to_string())
 }
 
+// Returns the trailing label segment of a JUMBF URI as a slice of the input, e.g.
+// `self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2` -> `c2pa.ingredient.v3__2`.
+// When the URI has no path separator, the whole string is treated as the label.
+//
+// Sibling of `box_name_from_uri` (which returns an owned, normalized `String`) and
+// `assertion_label_from_uri` (which additionally validates the assertion structure). This variant
+// exists because it borrows a slice of the original `uri`, so callers can compute the label's byte
+// offset within `uri` and rebuild the prefix. Where only the label value is needed, prefer
+// `assertion_label_from_uri`.
+pub(crate) fn label_segment_from_uri(uri: &str) -> &str {
+    uri.rsplit('/').next().unwrap_or(uri)
+}
+
+// Splits a positional label into its base and `__N` instance index, e.g.
+// `c2pa.ingredient.v3__2` -> (`c2pa.ingredient.v3`, 2); `c2pa.ingredient.v3` -> (label, 0).
+//
+// Sibling of `parse_label`, which returns `(base, version, instance)` and strips BOTH the `.vN`
+// version and the `__N` instance off the base. This variant strips only the instance and keeps the
+// version in the returned base, so the base round-trips through `Claim::label_with_instance` to
+// rebuild the exact positional label. Prefer `parse_label` when the version is wanted separately.
+pub(crate) fn parse_positional_label(label: &str) -> (&str, usize) {
+    if let Some(pos) = label.rfind("__") {
+        if let Ok(n) = label[pos + 2..].parse::<usize>() {
+            return (&label[..pos], n);
+        }
+    }
+    (label, 0)
+}
+
 // Struct deconstructed manifest label
 #[derive(Clone, Debug)]
 pub(crate) struct ManifestParts {


### PR DESCRIPTION
The retain_actions/remove_actions methods filter actions by a caller predicate, always keeping the inception action (c2pa.created/opened) at index 0, setting allActionsIncluded=false on removal, rejecting an empty result, and preserving the original .v1/.v2 label.

The retain_ingredients method prunes ingredients while keeping any referenced by a surviving action or marked parentOf (the keep predicate can only rescue an orphan, never drop a referenced one), rewriting positional c2pa.ingredient.v3__N references afterward so they don't dangle.

The API carries no domain logic; referenced-ingredient matching uses label-or-instance_id to mirror how to_claim resolves ingredientIds. Adds tests covering inception guarding, re-index holes, edited+inputTo, parentOf at a non-zero index, diamonds, nested-chain preservation, predicate rescue, and an end-to-end sign+read asserting no action malformed/ingredientMismatch errors.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
