### PR TITLE
fix: Harden against memory amplification attacks in copy of strip, tile and big table of TIFF file

### DIFF
--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -599,6 +599,34 @@ where
     c2pa_mode: bool,
 }
 
+/// Accumulates one strip/tile/BigTable byte count into `copied` and rejects the
+/// tag once the running total exceeds the source stream length.
+///
+/// TIFF strip/tile/BigTable data lives inside the source file, so a legitimate
+/// `sum(byte_counts)` is at most the file size. A crafted file can instead list
+/// many entries whose offsets all point at the same bytes and whose counts sum
+/// to far more than the file, making the clone re-copy the input over and over
+/// and grow the in-memory output to gigabytes (memory amplification → OOM
+/// abort; ~4.9 GB from a 293 KB input in the reported PoC). Capping the
+/// cumulative copy length at the source length stops that while leaving
+/// well-formed files untouched.
+///
+/// `kind` labels the error ("strip", "tile", "BigTable"). The error is returned
+/// via `Result` so the caller propagates it with `?`. Note that `with_order!`
+/// inlines its body into a `match` arm — it is not a real closure — so that `?`
+/// (like a bare `return`) exits `clone_image_data` directly, not just a closure.
+fn accumulate_copy_len(copied: &mut u64, cnt: u64, source_len: u64, kind: &str) -> Result<()> {
+    *copied = copied
+        .checked_add(cnt)
+        .ok_or_else(|| Error::InvalidAsset(format!("TIFF {kind} byte counts overflow")))?;
+    if *copied > source_len {
+        return Err(Error::InvalidAsset(format!(
+            "TIFF {kind} byte counts exceed source length"
+        )));
+    }
+    Ok(())
+}
+
 impl<T: Read + Write + Seek> TiffCloner<T> {
     pub fn new(endianness: Endianness, big_tiff: bool, writer: T) -> Result<TiffCloner<T>> {
         let bo = ByteOrdered::runtime(writer, endianness);
@@ -1462,14 +1490,7 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             _ => return Err(Error::InvalidAsset("invalid TIFF strip".to_string())),
                         };
 
-                        copied = copied.checked_add(*cnt).ok_or_else(|| {
-                            Error::InvalidAsset("TIFF strip byte counts overflow".to_string())
-                        })?;
-                        if copied > source_len {
-                            return Err(Error::InvalidAsset(
-                                "TIFF strip byte counts exceed source length".to_string(),
-                            ));
-                        }
+                        accumulate_copy_len(&mut copied, *cnt, source_len, "strip")?;
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1573,14 +1594,7 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             _ => return Err(Error::InvalidAsset("invalid TIFF tile".to_string())),
                         };
 
-                        copied = copied.checked_add(*cnt).ok_or_else(|| {
-                            Error::InvalidAsset("TIFF tile byte counts overflow".to_string())
-                        })?;
-                        if copied > source_len {
-                            return Err(Error::InvalidAsset(
-                                "TIFF tile byte counts exceed source length".to_string(),
-                            ));
-                        }
+                        accumulate_copy_len(&mut copied, *cnt, source_len, "tile")?;
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1707,14 +1721,7 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                         _ => return Err(Error::InvalidAsset("invalid TIFF BigTable".to_string())),
                     };
 
-                    copied = copied.checked_add(*cnt).ok_or_else(|| {
-                        Error::InvalidAsset("TIFF BigTable byte counts overflow".to_string())
-                    })?;
-                    if copied > source_len {
-                        return Err(Error::InvalidAsset(
-                            "TIFF BigTable byte counts exceed source length".to_string(),
-                        ));
-                    }
+                    accumulate_copy_len(&mut copied, *cnt, source_len, "BigTable")?;
 
                     let dest_offset = self.writer.stream_position()?;
                     dest_offsets.push(dest_offset); // save offset where the new BigTable block is written for patching later
@@ -2698,6 +2705,7 @@ pub enum TiffError {
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(clippy::expect_used)]
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
@@ -3345,6 +3353,35 @@ pub mod tests {
         cloner
             .clone_image_data(&mut ifd, &mut asset_reader)
             .expect("valid strip byte counts should copy successfully");
+    }
+
+    // Unit test for the shared cap helper used by the strip, tile, and BigTable
+    // copy loops. Covers the running-total accounting, the exceed-source-length
+    // rejection (with the per-kind label), and the checked_add overflow guard.
+    #[test]
+    fn accumulate_copy_len_caps_and_labels() {
+        // Accumulates within the cap.
+        let mut copied = 0u64;
+        accumulate_copy_len(&mut copied, 40, 100, "strip").expect("within cap");
+        accumulate_copy_len(&mut copied, 60, 100, "strip").expect("exactly at cap");
+        assert_eq!(copied, 100);
+
+        // One more byte exceeds the source length and is rejected with the label.
+        let err = accumulate_copy_len(&mut copied, 1, 100, "tile").unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidAsset(msg)
+                if msg.contains("tile") && msg.contains("exceed source length")),
+            "got {err:?}",
+        );
+
+        // A count that overflows the u64 running total is rejected too.
+        let mut copied = u64::MAX;
+        let err = accumulate_copy_len(&mut copied, 1, u64::MAX, "BigTable").unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidAsset(msg)
+                if msg.contains("BigTable") && msg.contains("overflow")),
+            "got {err:?}",
+        );
     }
 
     /*  disable until I find smaller DNG

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -1476,6 +1476,10 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                 // copy the strips
                 with_order!(so_entry.value_bytes.as_slice(), self.endianness, |src| {
                     for cnt in sbcs.iter() {
+                        // Reject byte counts that would push the cumulative copy
+                        // past the source length before doing any per-strip work.
+                        accumulate_copy_len(&mut copied, *cnt, source_len, "strip")?;
+
                         // get the offset
                         let so: u64 = match so_entry.entry_type {
                             4u16 => {
@@ -1489,8 +1493,6 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             16u16 => src.read_u64()?,
                             _ => return Err(Error::InvalidAsset("invalid TIFF strip".to_string())),
                         };
-
-                        accumulate_copy_len(&mut copied, *cnt, source_len, "strip")?;
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1584,6 +1586,10 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                 // copy the tiles
                 with_order!(to_entry.value_bytes.as_slice(), self.endianness, |src| {
                     for cnt in tbcs.iter() {
+                        // Reject byte counts that would push the cumulative copy
+                        // past the source length before doing any per-tile work.
+                        accumulate_copy_len(&mut copied, *cnt, source_len, "tile")?;
+
                         // get the offset
                         let to: u64 = match to_entry.entry_type {
                             4u16 => {
@@ -1593,8 +1599,6 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             16u16 => src.read_u64()?,
                             _ => return Err(Error::InvalidAsset("invalid TIFF tile".to_string())),
                         };
-
-                        accumulate_copy_len(&mut copied, *cnt, source_len, "tile")?;
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1708,6 +1712,10 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
             // copy the BigTable blocks
             with_order!(bo_entry.value_bytes.as_slice(), self.endianness, |src| {
                 for cnt in bbcs.iter() {
+                    // Reject byte counts that would push the cumulative copy past
+                    // the source length before doing any per-block work.
+                    accumulate_copy_len(&mut copied, *cnt, source_len, "BigTable")?;
+
                     let bo: u64 = match bo_entry.entry_type {
                         4u16 => {
                             let s = src.read_u32()?;
@@ -1720,8 +1728,6 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                         16u16 => src.read_u64()?,
                         _ => return Err(Error::InvalidAsset("invalid TIFF BigTable".to_string())),
                     };
-
-                    accumulate_copy_len(&mut copied, *cnt, source_len, "BigTable")?;
 
                     let dest_offset = self.writer.stream_position()?;
                     dest_offsets.push(dest_offset); // save offset where the new BigTable block is written for patching later

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -1436,6 +1436,15 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                 let current_offset = self.offset()?;
                 self.writer.seek(SeekFrom::Start(current_offset))?;
 
+                // Cap cumulative copy bytes at the source stream length. Legit
+                // TIFF strip data lives inside the file, so sum(byte_counts)
+                // is at most the file size. A crafted file where 50 000 strip
+                // offsets all point to byte 0 could otherwise cause each strip
+                // to re-copy the whole file (~5 GiB output from a 293 KiB
+                // input, OOM abort).
+                let source_len = stream_len(asset_reader)?;
+                let mut copied: u64 = 0;
+
                 // copy the strips
                 with_order!(so_entry.value_bytes.as_slice(), self.endianness, |src| {
                     for cnt in sbcs.iter() {
@@ -1452,6 +1461,15 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             16u16 => src.read_u64()?,
                             _ => return Err(Error::InvalidAsset("invalid TIFF strip".to_string())),
                         };
+
+                        copied = copied.checked_add(*cnt).ok_or_else(|| {
+                            Error::InvalidAsset("TIFF strip byte counts overflow".to_string())
+                        })?;
+                        if copied > source_len {
+                            return Err(Error::InvalidAsset(
+                                "TIFF strip byte counts exceed source length".to_string(),
+                            ));
+                        }
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1537,6 +1555,11 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                 let current_offset = self.offset()?;
                 self.writer.seek(SeekFrom::Start(current_offset))?;
 
+                // Cap cumulative copy bytes at the source stream length (see
+                // the strip path above for rationale).
+                let source_len = stream_len(asset_reader)?;
+                let mut copied: u64 = 0;
+
                 // copy the tiles
                 with_order!(to_entry.value_bytes.as_slice(), self.endianness, |src| {
                     for cnt in tbcs.iter() {
@@ -1549,6 +1572,15 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                             16u16 => src.read_u64()?,
                             _ => return Err(Error::InvalidAsset("invalid TIFF tile".to_string())),
                         };
+
+                        copied = copied.checked_add(*cnt).ok_or_else(|| {
+                            Error::InvalidAsset("TIFF tile byte counts overflow".to_string())
+                        })?;
+                        if copied > source_len {
+                            return Err(Error::InvalidAsset(
+                                "TIFF tile byte counts exceed source length".to_string(),
+                            ));
+                        }
 
                         let dest_offset = self.writer.stream_position()?;
                         dest_offsets.push(dest_offset);
@@ -1654,6 +1686,11 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
             let current_offset = self.offset()?;
             self.writer.seek(SeekFrom::Start(current_offset))?;
 
+            // Cap cumulative copy bytes at the source stream length (see
+            // clone_image_data strip path for rationale).
+            let source_len = stream_len(asset_reader)?;
+            let mut copied: u64 = 0;
+
             // copy the BigTable blocks
             with_order!(bo_entry.value_bytes.as_slice(), self.endianness, |src| {
                 for cnt in bbcs.iter() {
@@ -1669,6 +1706,15 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
                         16u16 => src.read_u64()?,
                         _ => return Err(Error::InvalidAsset("invalid TIFF BigTable".to_string())),
                     };
+
+                    copied = copied.checked_add(*cnt).ok_or_else(|| {
+                        Error::InvalidAsset("TIFF BigTable byte counts overflow".to_string())
+                    })?;
+                    if copied > source_len {
+                        return Err(Error::InvalidAsset(
+                            "TIFF BigTable byte counts exceed source length".to_string(),
+                        ));
+                    }
 
                     let dest_offset = self.writer.stream_position()?;
                     dest_offsets.push(dest_offset); // save offset where the new BigTable block is written for patching later
@@ -3201,6 +3247,104 @@ pub mod tests {
         // After the fix: must return Err(Error::InvalidAsset) without any allocation.
         let locations = tiff_io.get_object_locations_from_stream(&mut stream);
         assert!(matches!(locations, Err(Error::InvalidAsset(_))));
+    }
+
+    // Helper: build an IfdClonedEntry of LONG (u32) values in little-endian.
+    fn u32_strip_entry(tag: u16, values: &[u32]) -> IfdClonedEntry {
+        let mut value_bytes = Vec::with_capacity(values.len() * 4);
+        for v in values {
+            value_bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        IfdClonedEntry {
+            entry_tag: tag,
+            entry_type: 4, // LONG
+            value_count: values.len() as u64,
+            value_bytes,
+        }
+    }
+
+    // Regression: a TIFF whose strip byte counts sum to more than the actual
+    // source stream length must be rejected. Pre-fix, `clone_image_data`
+    // would honor an attacker-chosen sum (50 000 strips × source_len) and
+    // grow the in-memory output to gigabytes, aborting with OOM (~4.9 GB
+    // from a 293 KB input in the reported PoC).
+    #[test]
+    fn clone_image_data_rejects_strip_byte_count_amplification() {
+        // 100-byte source; 10 strips claiming 200 bytes each → sum 2000 > 100.
+        let mut asset_reader = Cursor::new(vec![0u8; 100]);
+
+        let n = 10;
+        let byte_counts: Vec<u32> = vec![200u32; n];
+        let offsets: Vec<u32> = vec![0u32; n];
+
+        let mut ifd: BTreeMap<u16, IfdClonedEntry> = BTreeMap::new();
+        ifd.insert(
+            STRIPBYTECOUNTS,
+            u32_strip_entry(STRIPBYTECOUNTS, &byte_counts),
+        );
+        ifd.insert(STRIPOFFSETS, u32_strip_entry(STRIPOFFSETS, &offsets));
+
+        let writer = Cursor::new(Vec::<u8>::new());
+        let mut cloner = TiffCloner::new(Endianness::Little, false, writer).unwrap();
+        let result = cloner.clone_image_data(&mut ifd, &mut asset_reader);
+
+        assert!(
+            matches!(&result, Err(Error::InvalidAsset(msg)) if msg.contains("exceed source length")),
+            "expected InvalidAsset for over-cap strip byte counts, got {result:?}",
+        );
+    }
+
+    // Regression: same amplification pattern in the tile branch of
+    // `clone_image_data`. `sum(tile_byte_counts) > source_len` must be
+    // rejected before any copy is performed.
+    #[test]
+    fn clone_image_data_rejects_tile_byte_count_amplification() {
+        let mut asset_reader = Cursor::new(vec![0u8; 100]);
+
+        let n = 8;
+        let byte_counts: Vec<u32> = vec![u32::MAX / n as u32; n]; // huge sum
+        let offsets: Vec<u32> = vec![0u32; n];
+
+        let mut ifd: BTreeMap<u16, IfdClonedEntry> = BTreeMap::new();
+        ifd.insert(
+            TILEBYTECOUNTS,
+            u32_strip_entry(TILEBYTECOUNTS, &byte_counts),
+        );
+        ifd.insert(TILEOFFSETS, u32_strip_entry(TILEOFFSETS, &offsets));
+
+        let writer = Cursor::new(Vec::<u8>::new());
+        let mut cloner = TiffCloner::new(Endianness::Little, false, writer).unwrap();
+        let result = cloner.clone_image_data(&mut ifd, &mut asset_reader);
+
+        assert!(
+            matches!(&result, Err(Error::InvalidAsset(msg)) if msg.contains("exceed source length")),
+            "expected InvalidAsset for over-cap tile byte counts, got {result:?}",
+        );
+    }
+
+    // Happy path: strip byte counts that legitimately sum to <= source_len
+    // must still copy successfully. Guards against a future refactor that
+    // makes the cap too strict.
+    #[test]
+    fn clone_image_data_accepts_valid_strip_byte_counts() {
+        let mut asset_reader = Cursor::new(vec![0xaau8; 100]);
+
+        // 5 strips × 10 bytes = 50 bytes, well within 100.
+        let byte_counts: Vec<u32> = vec![10u32; 5];
+        let offsets: Vec<u32> = vec![0u32; 5];
+
+        let mut ifd: BTreeMap<u16, IfdClonedEntry> = BTreeMap::new();
+        ifd.insert(
+            STRIPBYTECOUNTS,
+            u32_strip_entry(STRIPBYTECOUNTS, &byte_counts),
+        );
+        ifd.insert(STRIPOFFSETS, u32_strip_entry(STRIPOFFSETS, &offsets));
+
+        let writer = Cursor::new(Vec::<u8>::new());
+        let mut cloner = TiffCloner::new(Endianness::Little, false, writer).unwrap();
+        cloner
+            .clone_image_data(&mut ifd, &mut asset_reader)
+            .expect("valid strip byte counts should copy successfully");
     }
 
     /*  disable until I find smaller DNG


### PR DESCRIPTION
## Changes in this pull request
# Security Fix: TIFF Strip / Tile / BigTable Amplification OOM

## Vulnerability

`c2patool` crashed with an OOM abort (exit code 134) when signing a crafted
293 KB TIFF file. The strip / tile / BigTable clone logic in
[sdk/src/asset_handlers/tiff_io.rs](sdk/src/asset_handlers/tiff_io.rs)
(`TiffCloner::clone_image_data` and `clone_dng_bigtable_data`) copies each
strip's data to the output writer without any cap on cumulative bytes
written. Both the strip **offsets** and the strip **byte counts** are
attacker-controlled TIFF IFD fields. A file whose 50 000 strip offsets all
point to byte 0, each with a `byte_count = source_len`, produces
`O(strip_count × source_len)` output — 4.9 GB from a 293 KB input in the
reported PoC.

### Vulnerable pattern (three copies)

Strip path — [tiff_io.rs:824-849](sdk/src/asset_handlers/tiff_io.rs#L824):

```rust
with_order!(so_entry.value_bytes.as_slice(), self.endianness, |src| {
    for cnt in sbcs.iter() {
        let so: u64 = /* attacker-controlled */;
        asset_reader.seek(SeekFrom::Start(so))?;
        let mut data_reader = asset_reader.take(*cnt);   // *cnt attacker-controlled
        std::io::copy(&mut data_reader, &mut self.writer)?;   // no cumulative cap
    }
});
```

Same shape in the tile branch (~line 925) and in
`clone_dng_bigtable_data` (~line 1042). Any of the three can drive the
output buffer to gigabytes from a small input.

## Fix

Introduce a running byte counter and cap it against the actual source
stream length. Legitimate TIFF strip / tile / BigTable data lives inside
the file, so `sum(byte_counts) <= source_len` is a genuine format
invariant — the cap rejects only crafted or corrupt inputs.

Applied identically to all three copy loops:

```rust
let source_len = stream_len(asset_reader)?;
let mut copied: u64 = 0;

with_order!(so_entry.value_bytes.as_slice(), self.endianness, |src| {
    for cnt in sbcs.iter() {
        let so: u64 = /* … */;

        copied = copied.checked_add(*cnt).ok_or_else(||
            Error::InvalidAsset("TIFF strip byte counts overflow".to_string()))?;
        if copied > source_len {
            return Err(Error::InvalidAsset(
                "TIFF strip byte counts exceed source length".to_string()));
        }

        asset_reader.seek(SeekFrom::Start(so))?;
        let mut data_reader = asset_reader.take(*cnt);
        std::io::copy(&mut data_reader, &mut self.writer)?;
    }
});
```

- `checked_add` prevents the counter itself from wrapping (defence against
  a follow-on `u64` overflow attempt with `u64::MAX` byte counts).
- `copied > source_len` fires **before** the next `std::io::copy`, so the
  output writer never grows past `source_len` bytes on the malicious path.
- Existing per-entry parsing (`sbc_entry.value_count`, `safe_vec`) already
  bounds the number of iterations; this fix bounds cumulative bytes.

### Sites touched

- [tiff_io.rs:824](sdk/src/asset_handlers/tiff_io.rs#L824) — `clone_image_data` strip path
- [tiff_io.rs:925](sdk/src/asset_handlers/tiff_io.rs#L925) — `clone_image_data` tile path
- [tiff_io.rs:1042](sdk/src/asset_handlers/tiff_io.rs#L1042) — `clone_dng_bigtable_data`

## Tests Added

Three regression tests in `tiff_io::tests` using a helper that builds
`IfdClonedEntry` values directly (no fixture files required):

| Test | Payload | Validates |
|---|---|---|
| `clone_image_data_rejects_strip_byte_count_amplification` | 100-byte source; 10 strips × 200 bytes = 2000-byte sum | `Err(Error::InvalidAsset(msg))` with `msg` containing `"exceed source length"` |
| `clone_image_data_rejects_tile_byte_count_amplification` | 100-byte source; 8 tiles × `u32::MAX/8` bytes | Same — the tile branch is guarded identically |
| `clone_image_data_accepts_valid_strip_byte_counts` | 100-byte source; 5 strips × 10 bytes = 50-byte sum | Happy path succeeds — regression guard against an over-tight future cap |

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
