### PR TITLE
fix: convert remote signer certificate to DER

### DIFF
--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use c2pa_raw_crypto::{signer_from_private_key, RawSigner, RawSignerError, SigningAlg};
 use http::Request;
 use serde::{Deserialize, Serialize};
+use x509_parser::{error::PEMError, pem::Pem};
 
 use crate::{
     create_signer,
@@ -124,13 +125,22 @@ impl SignerSettings {
                 tsa_url,
                 referenced_assertions: _,
                 roles: _,
-            } => Ok(Box::new(RemoteSigner {
-                url,
-                alg,
-                reserve_size: 10000 + sign_cert.len(),
-                certs: vec![sign_cert.into_bytes()],
-                tsa_url,
-            })),
+            } => {
+                // Convert to DER; the certificate profile check runs before the remote call.
+                let certs = Pem::iter_from_buffer(sign_cert.as_bytes())
+                    .map(|r| r.map(|pem| pem.contents))
+                    .collect::<std::result::Result<Vec<Vec<u8>>, PEMError>>()
+                    .map_err(|e| {
+                        Error::BadParam(format!("invalid remote signer certificate: {e}"))
+                    })?;
+                Ok(Box::new(RemoteSigner {
+                    url,
+                    alg,
+                    reserve_size: 10000 + certs.iter().map(|c| c.len()).sum::<usize>(),
+                    certs,
+                    tsa_url,
+                }))
+            }
         }
     }
 
@@ -522,6 +532,19 @@ pub mod tests {
         assert_eq!(signer.alg(), alg);
         assert_eq!(signer.time_authority_url(), None);
         assert_eq!(signer.sign(&[1, 2, 3]).unwrap(), signed_bytes);
+
+        // Regression: certs must be DER, not raw PEM.
+        let certs = signer.certs().unwrap();
+        assert!(!certs.is_empty());
+        assert!(
+            !certs[0].starts_with(b"-----BEGIN"),
+            "certs must be DER, not PEM"
+        );
+        assert_eq!(
+            certs[0].first(),
+            Some(&0x30),
+            "DER cert starts with SEQUENCE tag"
+        );
 
         mock.assert();
     }


### PR DESCRIPTION
## Changes in this pull request

A remote signer configured via `[signer.remote]` failed validation with "the certificate is invalid". `SignerSettings::c2pa_signer` stored `sign_cert` as raw PEM, but the certificate profile check runs before the remote call and needs DER. The local signer converts PEM→DER internally, so only the remote path was affected.

The `Remote` arm now parses `sign_cert` into a DER chain via `Pem::iter_from_buffer`, as the `rust_native` signers do; malformed PEM returns `Error::BadParam`. `test_make_remote_signer` asserts `certs()` returns DER and fails against the old code.

Overlaps #2075, which fixes the same bug and predates this. Adopted its `reserve_size` calculation, which sums the DER chain rather than using the PEM string length. This adds the regression test and an actionable parse error — happy to close in favour of #2075 if you'd rather take that one.

Fixes #1903 (still reproducible on `main`; #1865 was closed unmerged).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
