### PR TITLE
fix: emit empty redacted_assertions for claim.v2 with no redactions

### DIFF
--- a/sdk/src/crjson.rs
+++ b/sdk/src/crjson.rs
@@ -302,13 +302,14 @@ impl<'a> CrJsonExporter<'a> {
             alg: Some(claim.alg().to_string()),
             alg_soft: claim.alg_soft().map(|s| s.to_string()),
             title: claim.title().map(|s| s.to_string()),
-            redacted_assertions: claim.redactions().and_then(|r| {
-                if r.is_empty() {
-                    None
-                } else {
-                    Some(r.to_vec())
-                }
-            }),
+            redacted_assertions: if is_v1 {
+                claim
+                    .redactions()
+                    .and_then(|r| if r.is_empty() { None } else { Some(r.to_vec()) })
+            } else {
+                // crJSON 3.5.1: absent redactions are still serialised, as an empty array.
+                Some(claim.redactions().map(|r| r.to_vec()).unwrap_or_default())
+            },
             metadata: claim.metadata().and_then(|m| {
                 if m.is_empty() {
                     None

--- a/sdk/tests/crjson/created_gathered.rs
+++ b/sdk/tests/crjson/created_gathered.rs
@@ -106,6 +106,16 @@ fn test_created_and_gathered_assertions_separated() -> Result<()> {
         created_assertions.len()
     );
 
+    // crJSON 3.5.1: redacted_assertions is present as an empty array when nothing is redacted
+    let redacted_assertions = claim_v2["redacted_assertions"]
+        .as_array()
+        .expect("redacted_assertions should be present as an array");
+
+    assert!(
+        redacted_assertions.is_empty(),
+        "redacted_assertions should be empty when no assertions are redacted"
+    );
+
     // Find the created assertion - should be in created_assertions
     let has_created_ref = created_assertions.iter().any(|assertion_ref| {
         if let Some(url) = assertion_ref.get("url") {

--- a/sdk/tests/crjson/schema_compliance.rs
+++ b/sdk/tests/crjson/schema_compliance.rs
@@ -455,12 +455,13 @@ fn test_claim_v2_required_fields() -> Result<()> {
                 "claim.v2.gathered_assertions must be an array"
             );
         }
-        if let Some(redacted) = obj.get("redacted_assertions") {
-            assert!(
-                redacted.is_array(),
-                "claim.v2.redacted_assertions must be an array"
-            );
-        }
+        // crJSON 3.5.1: absent redactions are still serialised, as an empty array.
+        assert!(
+            obj.get("redacted_assertions")
+                .map(|v| v.is_array())
+                .unwrap_or(false),
+            "claim.v2.redacted_assertions must be present as an array"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Changes in this pull request

A `claim.v2` with no redactions omitted `redacted_assertions` entirely.

specs-core moved this rule out of crJSON Claims/General and into the `claim.v2` **Required** list, where `gathered_assertions` and `redacted_assertions` are both specified as "set to an empty array if it's missing in the source" (c2pa-org/specs-core#2345, for c2pa-org/specs-core#2344). `crJSON.schema.json` matches: `definitions/claim`, which `claim.v2` `$ref`s, requires both fields, while `definitions/claimV1` leaves `redacted_assertions` optional.

So this is v2-only and v1 output is unchanged. The published 2.4 HTML still carries the older version-agnostic wording in §3.5.1; specs-core is ahead of it here.

`gathered_assertions` already behaved this way; `redacted_assertions` didn't.

Rebased onto latest main, and the b64 delimiter half of this PR is dropped — #2266 landed separately as #2333.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

Fixes #2267
