### PR TITLE
fix: Update spin to 0.9.9 to avoid yanked 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,9 +4310,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

The `spin` crate **v0.9.8** — pulled in transitively via `lazy_static` — was yanked. This updates the locked version to **0.9.9** so builds no longer resolve to the yanked release.

This is a `Cargo.lock`-only change (`cargo update -p spin`); no source or public API changes.

## Details

`spin` dependency chain:
```
spin v0.9.8 -> lazy_static v1.5.0 -> c2pa (sdk), c2patool, make_test_images, ...
```

## Verification

- `cargo check --workspace` passes.

## Release

This `fix:` commit will let release-plz open a patch-release PR (following the usual flow, e.g. #2295).

🤖 Generated with [Claude Code](https://claude.com/claude-code)