### PR TITLE
chore: begin 0.91.0 dev cycle (c2pa 0.91.0-dev, c2patool 0.28.0-dev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.89.3"
+version = "0.91.0-dev"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.89.3"
+version = "0.91.0-dev"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.89.3"
+version = "0.91.0-dev"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.26.72"
+version = "0.28.0-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.89.3"
+version = "0.91.0-dev"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2598,7 +2598,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.89.3"
+version = "0.91.0-dev"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.89.3"
+version = "0.91.0-dev"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.89.3", default-features = false }
+c2pa = { path = "sdk", version = "0.91.0-dev", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.26.72"
+version = "0.28.0-dev"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION
Bumps `main` to the next dev versions now that the 0.90.0 release train has been cut (RC branch `0.90.0-rc.1`).

Per the [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md#version-numbering-across-a-train), `main` always carries the *next* release's version with a `-dev` suffix:

| Crate | was | now |
|---|---|---|
| `c2pa` / `c2pa-c-ffi` | 0.89.3 | **0.91.0-dev** |
| `c2patool` | 0.26.72 | **0.28.0-dev** |

(`0.90.0` / `0.27.0` are baking on the `0.90.0-rc.1` branch.) `main` is never published, so the `-dev` prerelease is purely a "work in progress toward 0.91.0" label. Versions set with `cargo set-version`; workspace resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)