### PR TITLE
ci: Publish binaries for each release-candidate build

### DIFF
--- a/.github/workflows/c2patool-release.yml
+++ b/.github/workflows/c2patool-release.yml
@@ -1,0 +1,111 @@
+name: Publish c2patool binaries
+
+# Triggered by `c2patool-v*` tags. Those tags come from two places (see
+# docs/release-process.md):
+#   * release-plz, when a release PR merges on a release-line branch -> a real
+#     release tag like `c2patool-v0.27.0`.
+#   * release-rc.yml, when a release-candidate build is cut -> a prerelease tag
+#     like `c2patool-v0.27.0-rc.1`.
+#
+# Either way the tag carries the version, so this workflow is fully tag-driven
+# and independent of how the tag was created. `-rc.` tags produce *prerelease*
+# GitHub releases; real tags produce normal releases. Nothing here touches
+# crates.io. Git tags are repo-global, so no branch filter is needed.
+
+on:
+  push:
+    tags:
+      - "c2patool-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build c2patool binary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            artifact_name: c2patool_mac_universal.zip
+            asset_name: ${{ github.ref_name }}-universal-apple-darwin.zip
+            sbom_asset_name: ${{ github.ref_name }}-universal-apple-darwin-sbom.json
+          - os: ubuntu-latest
+            artifact_name: c2patool_linux_intel.tar.gz
+            asset_name: ${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+            sbom_asset_name: ${{ github.ref_name }}-x86_64-unknown-linux-gnu-sbom.json
+          - os: windows-latest
+            artifact_name: c2patool_win_intel.zip
+            asset_name: ${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+            sbom_asset_name: ${{ github.ref_name }}-x86_64-pc-windows-msvc-sbom.json
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Install cargo-sbom
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-sbom
+          version: "0.9.1"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run make release
+        run: cd cli && make release
+
+      - name: Generate SBOM
+        run: cd cli && cargo sbom > c2patool-sbom.json
+
+      - name: Stage named artifacts
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/${{ matrix.artifact_name }}" "dist/${{ matrix.asset_name }}"
+          cp "cli/c2patool-sbom.json" "dist/${{ matrix.sbom_asset_name }}"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: c2patool-${{ matrix.os }}
+          path: dist/
+
+  release:
+    name: Publish c2patool release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: c2patool-*
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lh dist
+
+      # Creates the release if it does not exist yet (the release-candidate
+      # case, where release-plz never ran) and updates it in place otherwise
+      # (the promotion case, where release-plz already opened the release). A
+      # `-rc.` tag is marked as a prerelease.
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc.') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-no-patch-deps.yml
+++ b/.github/workflows/check-no-patch-deps.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - stable
       - 'v0.*'
-      - '*-rc.*'
+      - '*-rc*'
 
 jobs:
   check:

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -1,10 +1,13 @@
 name: Publish c2pa-library binaries
 
-# Triggered by `c2pa-v*` tags. Under the open-source release process these tags
-# are created by release-plz on a release-line branch (never on `main`, and
-# never on a release-candidate branch -- RCs are not published and therefore
-# never produce a `c2pa-v*` tag). Git tags are repo-global, so no branch filter
-# is needed here.
+# Triggered by `c2pa-v*` tags, which come from two places (see
+# docs/release-process.md):
+#   * release-plz, on a release-line branch -> a real tag like `c2pa-v0.90.0`.
+#   * release-rc.yml, when a release-candidate build is cut -> a prerelease tag
+#     like `c2pa-v0.90.0-rc.1`.
+# Either way the binaries are built here; the GitHub release is always marked as
+# a prerelease (pre-1.0). Nothing here publishes to crates.io. Git tags are
+# repo-global, so no branch filter is needed.
 
 on:
   push:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,141 @@
+name: Cut release-candidate build
+
+# Cuts a numbered release-candidate BUILD (-rc.1, -rc.2, ...) from a release-
+# candidate BRANCH (e.g. `0.90.0-rc`). This is what lets downstream consumers
+# who depend on pre-built binaries validate a breaking train during its bake:
+# each RC build is tagged and gets a *prerelease* GitHub release with binaries
+# attached, but it is NEVER published to crates.io.
+#
+# How it fits together (see docs/release-process.md):
+#   * `release-train-cut.yml` creates the `0.N.0-rc` branch and invokes this
+#     workflow once to produce the first build, `-rc.1`.
+#   * A maintainer re-runs this workflow (workflow_dispatch on the RC branch)
+#     to cut `-rc.2`, `-rc.3`, ... after bugfixes have been cherry-picked onto
+#     the RC branch during the bake.
+#
+# This workflow only sets versions and pushes tags. The tags then drive the
+# binary builds: `c2pa-v*` -> library-release.yml, `c2patool-v*` ->
+# c2patool-release.yml, both of which mark `-rc.` tags as prereleases.
+#
+# Publishing is gated by branch/tag names, not by this workflow: the tags
+# contain `-rc.` and never match a crates.io publish trigger (release.yml only
+# runs on `stable` / `v0.*` branch pushes), so an RC build can never reach
+# crates.io by construction.
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cut-rc:
+    name: Cut release-candidate build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to run outside a release-candidate branch
+        run: |
+          # An RC branch is named `<version>-rc` (no numeric suffix; the number
+          # lives on the build tag, not the branch). Guard against accidentally
+          # dispatching this against main / stable / a v0.x line.
+          case "${{ github.ref_name }}" in
+            *-rc) echo "Running on RC branch ${{ github.ref_name }}." ;;
+            *)
+              echo "::error::release-rc must be dispatched on a *-rc branch, not '${{ github.ref_name }}'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout RC branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      # `cargo set-version` (from cargo-edit) keeps intra-workspace dependency
+      # requirements in sync when it bumps a crate -- e.g. c2patool's dependency
+      # on c2pa -- which a hand edit would miss.
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-edit
+          version: "0.13.6"
+
+      - name: Compute release-candidate versions
+        id: ver
+        run: |
+          meta() { cargo metadata --format-version=1 --no-deps | jq -r ".packages[]|select(.name==\"$1\")|.version"; }
+          CUR_C2PA=$(meta c2pa); CUR_TOOL=$(meta c2patool)
+
+          # Strip any `-rc.N` or `-dev` prerelease suffix to get the base release
+          # version each crate is heading toward.
+          base() { local b="${1%-rc.*}"; echo "${b%-dev}"; }
+          BASE_C2PA=$(base "$CUR_C2PA"); BASE_TOOL=$(base "$CUR_TOOL")
+
+          # The build number is derived from c2pa and applied in lockstep to
+          # both crates, so "-rc.N" identifies one coherent candidate. On a
+          # freshly cut branch the version is still `-dev` (no `-rc.`), so we
+          # start at 1; otherwise we increment the current number.
+          if [[ "$CUR_C2PA" == *-rc.* ]]; then
+            N=$(( ${CUR_C2PA##*-rc.} + 1 ))
+          else
+            N=1
+          fi
+
+          RC_C2PA="${BASE_C2PA}-rc.${N}"
+          RC_TOOL="${BASE_TOOL}-rc.${N}"
+          {
+            echo "rc_c2pa=$RC_C2PA"
+            echo "rc_tool=$RC_TOOL"
+            echo "tag_c2pa=c2pa-v${RC_C2PA}"
+            echo "tag_tool=c2patool-v${RC_TOOL}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Cutting c2pa $RC_C2PA / c2patool $RC_TOOL (build #$N)."
+
+      - name: Fail if build tags already exist
+        run: |
+          for tag in "${{ steps.ver.outputs.tag_c2pa }}" "${{ steps.ver.outputs.tag_tool }}"; do
+            if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
+              echo "::error::Tag $tag already exists; a build with this number was already cut."
+              exit 1
+            fi
+          done
+
+      - name: Set release-candidate versions
+        run: |
+          # `-p c2pa` also moves c2pa-c-ffi, which shares the workspace version.
+          cargo set-version -p c2pa "${{ steps.ver.outputs.rc_c2pa }}"
+          cargo set-version -p c2patool "${{ steps.ver.outputs.rc_tool }}"
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: set ${{ github.ref_name }} to ${{ steps.ver.outputs.rc_c2pa }}"
+          # Push the commit and the build tags. The tags trigger the binary
+          # builds (library-release.yml / c2patool-release.yml). Pushing with a
+          # PAT (RELEASE_PLZ_TOKEN) is required so those tag-triggered workflows
+          # actually run -- pushes made with the default GITHUB_TOKEN do not
+          # cascade into other workflows.
+          git tag "${{ steps.ver.outputs.tag_c2pa }}"
+          git tag "${{ steps.ver.outputs.tag_tool }}"
+          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "${{ steps.ver.outputs.tag_c2pa }}" "${{ steps.ver.outputs.tag_tool }}"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Release-candidate build cut"
+            echo ""
+            echo "- \`c2pa\` / \`c2pa-c-ffi\`: **${{ steps.ver.outputs.rc_c2pa }}** (tag \`${{ steps.ver.outputs.tag_c2pa }}\`)"
+            echo "- \`c2patool\`: **${{ steps.ver.outputs.rc_tool }}** (tag \`${{ steps.ver.outputs.tag_tool }}\`)"
+            echo ""
+            echo "Prerelease GitHub releases with binaries are building for these tags."
+            echo "Nothing is published to crates.io."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-train-cut.yml
+++ b/.github/workflows/release-train-cut.yml
@@ -76,6 +76,14 @@ jobs:
         with:
           toolchain: stable
 
+      # `cargo set-version` (from cargo-edit) is used to advance `main` to the
+      # next dev cycle; it keeps intra-workspace dependency requirements in sync.
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-edit
+          version: "0.13.6"
+
       - name: Compute train versions and RC branch
         id: ver
         run: |
@@ -103,11 +111,13 @@ jobs:
           # matches the Tier CI triggers (*-rc*) but NOT the publish triggers
           # (stable / v0.*), so a candidate branch can never be published by
           # construction. The per-build versions/tags are set by release-rc.yml.
+          DEV_C2PA=$(next_dev "$REL_C2PA")
           {
             echo "rel_c2pa=$REL_C2PA"
             echo "rel_tool=$REL_TOOL"
-            echo "dev_c2pa=$(next_dev "$REL_C2PA")"
+            echo "dev_c2pa=$DEV_C2PA"
             echo "dev_tool=$(next_dev "$REL_TOOL")"
+            echo "dev_cycle=${DEV_C2PA%-dev}" # e.g. 0.91.0, for the commit message
             echo "branch=${REL_C2PA}-rc" # e.g. 0.90.0-rc
           } >> "$GITHUB_OUTPUT"
 
@@ -154,6 +164,24 @@ jobs:
         run: |
           gh workflow run release-rc.yml --ref "${{ steps.ver.outputs.branch }}"
 
+      # Advance `main` to the next dev cycle so ongoing development is always
+      # numbered ahead of the line that's baking. This runs AFTER the RC branch
+      # is cut, so the candidate is taken from pre-bump `main` and `main` then
+      # moves forward. Committed directly to `main` (no PR) -- this requires the
+      # RELEASE_PLZ_TOKEN to be allowed to bypass `main`'s pull-request rule.
+      - name: Advance main to next dev cycle
+        if: steps.exists.outputs.skip != 'true' && steps.empty.outputs.skip != 'true'
+        run: |
+          # The working tree is `main` (checked out above). set-version updates
+          # the workspace version (c2pa + c2pa-c-ffi), c2patool, the intra-repo
+          # dependency references, and Cargo.lock.
+          cargo set-version -p c2pa "${{ steps.ver.outputs.dev_c2pa }}"
+          cargo set-version -p c2patool "${{ steps.ver.outputs.dev_tool }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: begin ${{ steps.ver.outputs.dev_cycle }} dev cycle (c2pa ${{ steps.ver.outputs.dev_c2pa }}, c2patool ${{ steps.ver.outputs.dev_tool }})"
+          git push origin HEAD:main
+
       - name: Open tracking issue for the train
         if: steps.exists.outputs.skip != 'true' && steps.empty.outputs.skip != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -175,11 +203,7 @@ jobs:
                 '',
                 `The first build, **${relC2pa}-rc.1** (c2patool \`${relTool}-rc.1\`), is being cut automatically by \`release-rc.yml\`. Each build is tagged and gets a **prerelease GitHub release with binaries** so downstream binary consumers can validate during the bake.`,
                 '',
-                '**Bump `main` to the next dev versions** (open a PR):',
-                '```sh',
-                `cargo set-version -p c2pa ${devC2pa}`,
-                `cargo set-version -p c2patool ${devTool}`,
-                '```',
+                `\`main\` has been advanced automatically to the next dev cycle (**c2pa \`${devC2pa}\`, c2patool \`${devTool}\`**), so development stays numbered ahead of the baking line. No action needed unless that step failed.`,
                 '',
                 '- Bake at least **3 business days**; hold longer if downstream validation needs it.',
                 '- Only **bugfixes** are accepted during the bake, upstream-first: fix on `main`, then cherry-pick onto the RC branch.',

--- a/.github/workflows/release-train-cut.yml
+++ b/.github/workflows/release-train-cut.yml
@@ -98,17 +98,17 @@ jobs:
           CUR_C2PA=$(meta c2pa); CUR_TOOL=$(meta c2patool)
           REL_C2PA=$(rel_minor "$CUR_C2PA"); REL_TOOL=$(rel_minor "$CUR_TOOL")
 
-          # The RC branch name contains "-rc." so it matches the Tier CI triggers
-          # (*-rc.*) but NOT the publish triggers (stable / v0.*) -- a release
-          # candidate can never be published by construction.
+          # The RC branch is named "<version>-rc" (no numeric suffix): the number
+          # belongs to each build (-rc.1, -rc.2, ...), not the branch. The name
+          # matches the Tier CI triggers (*-rc*) but NOT the publish triggers
+          # (stable / v0.*), so a candidate branch can never be published by
+          # construction. The per-build versions/tags are set by release-rc.yml.
           {
             echo "rel_c2pa=$REL_C2PA"
             echo "rel_tool=$REL_TOOL"
-            echo "rc_c2pa=${REL_C2PA}-rc.1"
-            echo "rc_tool=${REL_TOOL}-rc.1"
             echo "dev_c2pa=$(next_dev "$REL_C2PA")"
             echo "dev_tool=$(next_dev "$REL_TOOL")"
-            echo "branch=${REL_C2PA}-rc.1" # e.g. 0.90.0-rc.1
+            echo "branch=${REL_C2PA}-rc" # e.g. 0.90.0-rc
           } >> "$GITHUB_OUTPUT"
 
       - name: Skip if RC branch already exists
@@ -143,6 +143,17 @@ jobs:
         run: |
           git push origin "main:refs/heads/${{ steps.ver.outputs.branch }}"
 
+      # Cut the first build (-rc.1) on the new branch: release-rc.yml sets the
+      # -rc.1 versions, tags them, and those tags build prerelease binaries.
+      # Dispatched with the PAT so its subsequent tag pushes trigger the binary
+      # workflows.
+      - name: Cut first release-candidate build (-rc.1)
+        if: steps.exists.outputs.skip != 'true' && steps.empty.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          gh workflow run release-rc.yml --ref "${{ steps.ver.outputs.branch }}"
+
       - name: Open tracking issue for the train
         if: steps.exists.outputs.skip != 'true' && steps.empty.outputs.skip != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -150,8 +161,6 @@ jobs:
           script: |
             const relC2pa = '${{ steps.ver.outputs.rel_c2pa }}';
             const relTool = '${{ steps.ver.outputs.rel_tool }}';
-            const rcC2pa  = '${{ steps.ver.outputs.rc_c2pa }}';
-            const rcTool  = '${{ steps.ver.outputs.rc_tool }}';
             const devC2pa = '${{ steps.ver.outputs.dev_c2pa }}';
             const devTool = '${{ steps.ver.outputs.dev_tool }}';
             const branch  = '${{ steps.ver.outputs.branch }}';
@@ -162,15 +171,9 @@ jobs:
               labels: ['release-train'],
               body: [
                 `Release-candidate branch \`${branch}\` was cut from \`main\` for the **${relC2pa}** train.`,
-                'It is not published to crates.io; it only bakes under the Tier CI suites.',
+                'It is **not** published to crates.io; it bakes under the Tier CI suites.',
                 '',
-                '**Set the release-candidate versions on the RC branch** (forced minor bump; see docs/release-process.md → "Version numbering across a train"):',
-                '```sh',
-                `git switch ${branch}`,
-                `cargo set-version -p c2pa ${rcC2pa}        # also sets c2pa-c-ffi (shared workspace version)`,
-                `cargo set-version -p c2patool ${rcTool}`,
-                `git commit -am "chore: set ${branch} release-candidate versions" && git push`,
-                '```',
+                `The first build, **${relC2pa}-rc.1** (c2patool \`${relTool}-rc.1\`), is being cut automatically by \`release-rc.yml\`. Each build is tagged and gets a **prerelease GitHub release with binaries** so downstream binary consumers can validate during the bake.`,
                 '',
                 '**Bump `main` to the next dev versions** (open a PR):',
                 '```sh',
@@ -180,6 +183,7 @@ jobs:
                 '',
                 '- Bake at least **3 business days**; hold longer if downstream validation needs it.',
                 '- Only **bugfixes** are accepted during the bake, upstream-first: fix on `main`, then cherry-pick onto the RC branch.',
+                `- To cut a fresh candidate build after fixes land, run the **Cut release-candidate build** workflow (\`release-rc.yml\`) on \`${branch}\` — it bumps to the next \`-rc.N\` and rebuilds the binaries.`,
                 `- When green, **manually promote**: snapshot the outgoing \`stable\` as \`v0.<old>\` (for backports), then merge the RC branch into \`stable\`. release-plz then publishes \`${relC2pa}\` (c2patool \`${relTool}\`).`,
                 '- The previous line is retired once this train ships.',
               ].join('\n'),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ name: Release-plz publish
 # nightly-like and intentionally unpublished) and never from release-candidate
 # branches (which bake before promotion). A push to a release-line branch
 # happens when a release-plz release PR (see release-pr.yml) is merged.
+#
+# release-plz creates the `c2pa-v*` and `c2patool-v*` tags here; those tags then
+# drive the binary builds in library-release.yml and c2patool-release.yml. This
+# workflow no longer builds binaries itself -- keeping binary builds tag-driven
+# means release-candidate builds (which never reach this workflow) produce the
+# same binaries via release-rc.yml's tags.
 
 permissions:
   pull-requests: write
@@ -33,11 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: guard-no-patch-deps
     # Defense in depth: release-candidate branches must never publish, even if
-    # one were ever added to the triggers above.
-    if: ${{ !contains(github.ref_name, '-rc.') }}
-
-    outputs:
-      c2patool-release-tag: ${{ steps.sniff-c2patool-release-tag.outputs.tag }}
+    # one were ever added to the triggers above. RC branches are named
+    # `<version>-rc` (no numeric suffix), so match on `-rc` rather than `-rc.`.
+    if: ${{ !contains(github.ref_name, '-rc') }}
 
     steps:
       - name: Checkout repository
@@ -76,88 +80,3 @@ jobs:
           echo "=== Release-plz releases ==="
           echo "$RELEASES"
           echo "==========================="
-
-      - name: Identify c2patool release
-        id: sniff-c2patool-release-tag
-        env:
-          RELEASES: ${{ steps.release-plz.outputs.releases }}
-        run: |
-          tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "c2patool") | .tag // empty')
-          echo "c2patool tag: ${tag:-<none>}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-  publish-c2patool-binaries:
-    name: Publish c2patool binaries
-    runs-on: ${{ matrix.os }}
-    needs: release-plz
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        rust_version: [stable]
-        experimental: [false]
-        include:
-          - os: macos-latest
-            artifact_name: c2patool_mac_universal.zip
-            uploaded_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-universal-apple-darwin.zip
-            sbom_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-universal-apple-darwin-sbom.json
-          - os: ubuntu-latest
-            artifact_name: c2patool_linux_intel.tar.gz
-            uploaded_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-x86_64-unknown-linux-gnu.tar.gz
-            sbom_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-x86_64-unknown-linux-gnu-sbom.json
-          - os: windows-latest
-            artifact_name: c2patool_win_intel.zip
-            uploaded_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-x86_64-pc-windows-msvc.zip
-            sbom_asset_name: ${{ needs.release-plz.outputs.c2patool-release-tag }}-x86_64-pc-windows-msvc-sbom.json
-
-    steps:
-      - name: Checkout repository
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install Rust toolchain
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
-        with:
-          toolchain: ${{ matrix.rust_version }}
-          components: llvm-tools-preview
-
-      - name: Install cargo-sbom
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
-        with:
-          crate: cargo-sbom
-          version: "0.9.1"
-
-      - name: Cache Rust dependencies
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: Run make release
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        run: cd cli && make release
-
-      - name: Upload binary to GitHub
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.uploaded_asset_name }}
-          tag: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-          overwrite: true
-
-      - name: Generate SBOM
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        run: cd cli && cargo sbom > c2patool-sbom.json
-
-      - name: Upload SBOM to Github
-        if: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: cli/c2patool-sbom.json
-          asset_name: ${{ matrix.sbom_asset_name }}
-          tag: ${{ needs.release-plz.outputs.c2patool-release-tag }}
-          overwrite: true

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,7 +6,7 @@ name: Semver checks
 # backport.yml -- and baselines the public API against the latest crates.io
 # release.
 #
-# This deliberately does NOT run on release-candidate (`*-rc.*`) branches: the
+# This deliberately does NOT run on release-candidate (`*-rc*`) branches: the
 # breaking train IS the intended place for breaking changes.
 
 on:

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -20,7 +20,7 @@ on:
       - main
       - stable
       - 'v0.*'
-      - '*-rc.*'
+      - '*-rc*'
     types:
       - opened
       - reopened
@@ -31,7 +31,7 @@ on:
       - main
       - stable
       - 'v0.*'
-      - '*-rc.*'
+      - '*-rc*'
 
 jobs:
   get-features:

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -5,7 +5,7 @@
 
 # Gating (see docs/support-tiers.md and docs/release-process.md): Tier 1B runs
 # automatically on any PR whose base is a release-line (`stable`, `v0.*`) or
-# release-candidate (`*-rc.*`) branch -- this includes backport PRs and the
+# release-candidate (`*-rc*`) branch -- this includes backport PRs and the
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
 
@@ -28,13 +28,13 @@ on:
   # per-job `if:` conditions below also accept `github.event_name == 'push'`.)
   push:
     branches:
-      - '*-rc.*'
+      - '*-rc*'
 
 jobs:
   get-features:
     name: Get features
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     outputs:
       rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
       openssl-features: ${{ steps.get-features.outputs.openssl-features }}
@@ -60,7 +60,7 @@ jobs:
   tests-openssl:
     name: Unit tests (with OpenSSL installed)
     needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -91,7 +91,7 @@ jobs:
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
     needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -122,7 +122,7 @@ jobs:
   tests-cross:
     name: Unit tests
     needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ubuntu-latest
 
     strategy:
@@ -159,7 +159,7 @@ jobs:
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
     needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -188,7 +188,7 @@ jobs:
   unused_deps:
     name: Check for unused dependencies
     needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -5,7 +5,7 @@
 
 # Gating (see docs/support-tiers.md and docs/release-process.md): Tier 2 runs
 # automatically on any PR whose base is a release-line (`stable`, `v0.*`) or
-# release-candidate (`*-rc.*`) branch -- this includes backport PRs and the
+# release-candidate (`*-rc*`) branch -- this includes backport PRs and the
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
 
@@ -27,12 +27,12 @@ on:
   # below also accept `github.event_name == 'push'`).
   push:
     branches:
-      - '*-rc.*'
+      - '*-rc*'
 
 jobs:
   c-library-mobile-builds:
     name: C library mobile builds
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc.') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/upstream-first-check.yml
+++ b/.github/workflows/upstream-first-check.yml
@@ -2,7 +2,7 @@ name: Upstream-first check
 
 # Proactive guard for the upstream-first rule (see docs/release-process.md):
 # every change must land on `main` before it is brought onto a release-line
-# (`stable`, `v0.*`) or release-candidate (`*-rc.*`) branch. This blocks a PR to
+# (`stable`, `v0.*`) or release-candidate (`*-rc*`) branch. This blocks a PR to
 # such a branch if it introduces a commit whose change is not already present on
 # `main`, so drift is prevented rather than merely detected after the fact.
 #
@@ -24,7 +24,7 @@ on:
     branches:
       - stable
       - 'v0.*'
-      - '*-rc.*'
+      - '*-rc*'
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -76,7 +76,7 @@ The convention:
 
 * **`main` always carries the *next* release's version with a `-dev` suffix** — e.g. `0.91.0-dev`. Because `main` is never published, the `-dev` prerelease is purely a label that says "work in progress toward 0.91.0."
 * **Cutting the train** for `0.N.0` produces the release-candidate branch `0.N.0-rc` (dropping the numeric suffix from the branch name; the number belongs to each *build*). Its builds are versioned `0.N.0-rc.1`, `0.N.0-rc.2`, … and, while never published to crates.io, are tagged and get prerelease GitHub-release binaries. On promotion the line becomes `0.N.0`.
-* **Right after the cut, `main` moves to `0.(N+1).0-dev`** so ongoing development is always numbered ahead of the line that's baking.
+* **Right after the cut, `main` moves to `0.(N+1).0-dev`** so ongoing development is always numbered ahead of the line that's baking. This bump is committed to `main` automatically by [`release-train-cut.yml`](#release-train-cut) as part of the cut — no separate PR.
 * **`c2patool` follows the same pattern on its own numbering** (its own next minor), independent of `c2pa`. RC build numbers are kept in lockstep across the crates, so `-rc.N` identifies one coherent candidate.
 
 Worked example (the first train, which is also the transition onto this convention):
@@ -173,7 +173,7 @@ As a backstop to the proactive check above, a scheduled job, [`reconciliation.ym
 
 ### Release-train cut
 
-[`release-train-cut.yml`](../.github/workflows/release-train-cut.yml) runs every Monday and gates on a date check so it only acts on the second Monday of an odd-numbered month (or when dispatched manually with `force: true`). When it fires it computes the next breaking version, applies skip-if-empty, and — if there's breaking work to ship — pushes a new `0.(x+1).0-rc` candidate branch from `main`, kicks off its first build by dispatching [`release-rc.yml`](#release-candidate-builds), and opens a `release-train` tracking issue describing the bake and the manual-promotion step.
+[`release-train-cut.yml`](../.github/workflows/release-train-cut.yml) runs every Monday and gates on a date check so it only acts on the second Monday of an odd-numbered month (or when dispatched manually with `force: true`). When it fires it computes the next breaking version, applies skip-if-empty, and — if there's breaking work to ship — pushes a new `0.(x+1).0-rc` candidate branch from `main`, kicks off its first build by dispatching [`release-rc.yml`](#release-candidate-builds), **advances `main` to the next `0.(x+2).0-dev` cycle** (committed directly, no PR), and opens a `release-train` tracking issue describing the bake and the manual-promotion step. The `main` bump happens after the RC branch is cut, so the candidate is taken from pre-bump `main`. (Committing to `main` directly requires the `RELEASE_PLZ_TOKEN` to be allowed to bypass `main`'s pull-request rule; see [branch protection](#branch-protection).)
 
 ### Release-candidate builds
 
@@ -261,6 +261,10 @@ The upstream-first guarantees rely on release-line and release-candidate branche
 * **Require status checks to pass**, including Tier 1A on `main`, and Tier 1A + 1B + 2, `cargo-semver-checks`, and the upstream-first check on release-line/RC branches (see [validation gating](#validation-gating)).
 
 Branch-name patterns (`v0.*`, `*-rc*`) can be covered with a single ruleset each so new release lines and candidates are protected automatically.
+
+Some release automation pushes directly to protected branches and so must be on the ruleset **bypass list** — grant this to the identity behind `RELEASE_PLZ_TOKEN`:
+
+* [`release-train-cut.yml`](#release-train-cut) commits the next-dev-cycle bump straight to `main`, and [`release-rc.yml`](#release-candidate-builds) commits `-rc.N` version bumps straight to the RC branch. Both bypass the pull-request rule by design (they are mechanical version bumps, not reviewed changes).
 
 ## One-time setup
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -27,9 +27,9 @@ Most changes never wait for the train: anything additive ships fairly quickly by
 | `main` | Always green but API-unstable ("nightly-like"). It must always compile and pass tests, but its public API is **not** guaranteed stable — it may contain unstabilized or feature-gated work. | **No** |
 | `stable` | Tracks the most-recent crates.io release and is the currently-active release line. Additive (`0.x.y`) releases, and the promoted breaking (`0.x.0`) release, are published from here. | **Yes** |
 | `v0.x` (e.g. `v0.89`) | A long-lived branch for a **retired** release line, snapshotted from `stable` when that line is retired. A potential target if a security or other critical bug fix is made to a retired line. | Yes (rare backports) |
-| `0.(x+1).0-rc.N` (release-candidate branch) | A transient breaking candidate, cut from `main`, that bakes before promotion. Its name contains `-rc.` so it is validated by CI but **never** matches a publish trigger. | **No** |
+| `0.(x+1).0-rc` (release-candidate branch) | A transient breaking candidate, cut from `main`, that bakes before promotion. Its name ends in `-rc` so it is validated by CI but **never** matches a crates.io publish trigger. Individual **builds** cut from it (`-rc.1`, `-rc.2`, …) are tagged and get *prerelease* GitHub releases with binaries, but are never published to crates.io. | crates.io: **No**; GitHub-release binaries: **yes** |
 
-The branch-name conventions are also the publish guard: the publish workflow only ever runs on `stable` and `v0.*`, and the `-rc.`-named candidate matches neither, so a candidate can never be published by construction.
+The branch-name conventions are also the crates.io publish guard: the publish workflow only ever runs on `stable` and `v0.*`, and the `-rc`-named candidate branch matches neither, so a candidate can never be published to crates.io by construction. (Its build tags carry the `-rc.` prerelease marker and drive binary-only GitHub releases; see [RC builds](#release-candidate-builds).)
 
 Two rules keep this coherent:
 
@@ -55,8 +55,8 @@ Key points:
 
 Breaking changes and larger refactors are batched onto a scheduled train:
 
-1. On the scheduled date, a release-candidate branch `0.(x+1).0-rc.1` is cut from `main`. **RC branches are not published to crates.io** (their name keeps them off every publish trigger).
-2. **Bake period: minimum 3 business days.** Only bug fixes are accepted during the bake, and they follow upstream-first (fix on `main`, cherry-pick to the candidate). Hold longer than 3 business days if needed to validate across the downstream projects we maintain.
+1. On the scheduled date, a release-candidate branch `0.(x+1).0-rc` is cut from `main`, and its first build `0.(x+1).0-rc.1` is cut immediately (versions set, tagged, prerelease binaries built). **RC branches are not published to crates.io** (their name keeps them off every crates.io publish trigger), but each build **does** get a prerelease GitHub release with binaries so downstream consumers that depend on pre-built binaries can validate during the bake. See [RC builds](#release-candidate-builds).
+2. **Bake period: minimum 3 business days.** Only bug fixes are accepted during the bake, and they follow upstream-first (fix on `main`, cherry-pick to the candidate). After fixes land, cut a fresh build (`-rc.2`, `-rc.3`, …) so downstream has updated binaries to test. Hold longer than 3 business days if needed to validate across the downstream projects we maintain.
 3. **Promote** (a deliberate, manual step): first snapshot the outgoing `stable` as `v0.<old>` so the retiring line is available for backports, then merge the candidate into `stable`. `release-plz` then opens the `0.(x+1).0` version/changelog PR on `stable`; merging it publishes the breaking release.
 
 ### Cadence: scheduled, but not forced
@@ -75,16 +75,16 @@ Every train advances the **minor** number by one, regardless of whether `cargo-s
 The convention:
 
 * **`main` always carries the *next* release's version with a `-dev` suffix** — e.g. `0.91.0-dev`. Because `main` is never published, the `-dev` prerelease is purely a label that says "work in progress toward 0.91.0."
-* **Cutting the train** for `0.N.0` produces the release-candidate branch `0.N.0-rc.1` (the RC bakes but is never published). On promotion it becomes `0.N.0`.
+* **Cutting the train** for `0.N.0` produces the release-candidate branch `0.N.0-rc` (dropping the numeric suffix from the branch name; the number belongs to each *build*). Its builds are versioned `0.N.0-rc.1`, `0.N.0-rc.2`, … and, while never published to crates.io, are tagged and get prerelease GitHub-release binaries. On promotion the line becomes `0.N.0`.
 * **Right after the cut, `main` moves to `0.(N+1).0-dev`** so ongoing development is always numbered ahead of the line that's baking.
-* **`c2patool` follows the same pattern on its own numbering** (its own next minor), independent of `c2pa`.
+* **`c2patool` follows the same pattern on its own numbering** (its own next minor), independent of `c2pa`. RC build numbers are kept in lockstep across the crates, so `-rc.N` identifies one coherent candidate.
 
 Worked example (the first train, which is also the transition onto this convention):
 
-| Crate | current `main` | RC branch (baking) | promoted | `main` after cut |
-| -- | -- | -- | -- | -- |
-| `c2pa` / `c2pa-c-ffi` | `0.89.3` | `0.90.0-rc.1` | `0.90.0` | `0.91.0-dev` |
-| `c2patool` | `0.26.72` | `0.27.0-rc.1` | `0.27.0` | `0.28.0-dev` |
+| Crate | current `main` | RC branch | RC builds (baking) | promoted | `main` after cut |
+| -- | -- | -- | -- | -- | -- |
+| `c2pa` / `c2pa-c-ffi` | `0.89.3` | `0.90.0-rc` | `0.90.0-rc.1`, `0.90.0-rc.2`, … | `0.90.0` | `0.91.0-dev` |
+| `c2patool` | `0.26.72` | `0.27.0-rc` | `0.27.0-rc.1`, `0.27.0-rc.2`, … | `0.27.0` | `0.28.0-dev` |
 
 Steadily thereafter, `main` already carries `0.N.0-dev`, so the train's release version is that number with `-dev` dropped, and `main` advances to `0.(N+1).0-dev`.
 
@@ -127,7 +127,14 @@ Cutting a release is mostly a CI action rather than manual toil. The pieces:
 We use [`release-plz`](https://release-plz.dev) (via the [GitHub Action wrapper](https://github.com/release-plz/action)), configured by [`release-plz.toml`](../release-plz.toml). Its two responsibilities are split across two workflows, both of which run on the **release-line and release-candidate branches** — never on `main`:
 
 * [`release-pr.yml`](../.github/workflows/release-pr.yml) runs `release-plz release-pr`: for each published crate it inspects commits since the last tag and opens/updates a **release PR** that bumps the version and updates the changelog. Because that PR targets a release-line branch, it runs the full Tier 1A + 1B + 2 suite (see [validation gating](#validation-gating)).
-* [`release.yml`](../.github/workflows/release.yml) runs `release-plz release`: when a release PR merges (a push to the release-line branch), it publishes the changed crates to crates.io, creates GitHub releases, and tags them `(crate-name)-v(version)`. It then builds and uploads the `c2patool` binaries and SBOMs. A push whose ref contains `-rc.` never publishes.
+* [`release.yml`](../.github/workflows/release.yml) runs `release-plz release`: when a release PR merges (a push to the release-line branch), it publishes the changed crates to crates.io, creates GitHub releases, and tags them `(crate-name)-v(version)`. Those tags then drive the binary builds ([`library-release.yml`](../.github/workflows/library-release.yml) on `c2pa-v*`, [`c2patool-release.yml`](../.github/workflows/c2patool-release.yml) on `c2patool-v*`) — `release.yml` no longer builds binaries itself, which is what lets release-candidate builds produce the same binaries from the same tags (see [RC builds](#release-candidate-builds)). A push whose ref contains `-rc` never publishes to crates.io.
+
+Binary builds are therefore entirely **tag-driven**, independent of how a tag was created:
+
+* [`library-release.yml`](../.github/workflows/library-release.yml) builds the `c2pa` / `c2pa-c-ffi` native libraries for every supported target on any `c2pa-v*` tag.
+* [`c2patool-release.yml`](../.github/workflows/c2patool-release.yml) builds the `c2patool` CLI binaries and SBOMs on any `c2patool-v*` tag.
+
+A tag whose name contains `-rc.` yields a **prerelease** GitHub release; nothing on either path publishes to crates.io.
 
 How `release-plz` chooses a version, per crate:
 
@@ -158,7 +165,7 @@ As a backstop to the proactive check above, a scheduled job, [`reconciliation.ym
 
 ### Semver checks
 
-[`semver-checks.yml`](../.github/workflows/semver-checks.yml) runs [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) on every PR targeting a release-line branch (including backport PRs), baselining against the latest crates.io release. It catches a change that would be an accidental break shipping as an additive release. It does **not** run on `-rc.*` branches — the train is the intended place for breaking changes.
+[`semver-checks.yml`](../.github/workflows/semver-checks.yml) runs [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) on every PR targeting a release-line branch (including backport PRs), baselining against the latest crates.io release. It catches a change that would be an accidental break shipping as an additive release. It does **not** run on `-rc` branches — the train is the intended place for breaking changes.
 
 ### Patch-dependency guard
 
@@ -166,7 +173,13 @@ As a backstop to the proactive check above, a scheduled job, [`reconciliation.ym
 
 ### Release-train cut
 
-[`release-train-cut.yml`](../.github/workflows/release-train-cut.yml) runs every Monday and gates on a date check so it only acts on the second Monday of an odd-numbered month (or when dispatched manually with `force: true`). When it fires it computes the next breaking version, applies skip-if-empty, and — if there's breaking work to ship — pushes a new `0.(x+1).0-rc.1` candidate branch from `main` and opens a `release-train` tracking issue describing the bake and the manual-promotion step.
+[`release-train-cut.yml`](../.github/workflows/release-train-cut.yml) runs every Monday and gates on a date check so it only acts on the second Monday of an odd-numbered month (or when dispatched manually with `force: true`). When it fires it computes the next breaking version, applies skip-if-empty, and — if there's breaking work to ship — pushes a new `0.(x+1).0-rc` candidate branch from `main`, kicks off its first build by dispatching [`release-rc.yml`](#release-candidate-builds), and opens a `release-train` tracking issue describing the bake and the manual-promotion step.
+
+### Release-candidate builds
+
+[`release-rc.yml`](../.github/workflows/release-rc.yml) cuts a numbered candidate **build** (`-rc.1`, `-rc.2`, …) from a candidate **branch** (`0.N.0-rc`). It sets the `-rc.N` versions on the branch (bumping `c2pa`/`c2pa-c-ffi` and `c2patool` in lockstep on the build number), commits, and pushes the `c2pa-v…-rc.N` and `c2patool-v…-rc.N` tags. Those tags trigger the tag-driven binary workflows above, which publish **prerelease** GitHub releases with binaries. Nothing here reaches crates.io — the build exists so downstream projects that consume pre-built binaries (rather than building from source) can validate the candidate during its bake.
+
+The first build (`-rc.1`) is cut automatically when the train is cut. A maintainer re-runs this workflow (via `workflow_dispatch` on the RC branch) to cut a fresh build after bugfixes have been cherry-picked onto the branch during the bake. Tags are pushed with a PAT (`RELEASE_PLZ_TOKEN`) so the tag-driven binary workflows actually run — pushes made with the default `GITHUB_TOKEN` do not cascade into other workflows.
 
 ### Cross-repo canary
 
@@ -181,8 +194,8 @@ Labels the process depends on are version-controlled in [`.github/labels.yml`](.
 The [support tiers](support-tiers.md) map directly onto the branching model:
 
 * **Merging to `main`** requires **Tier 1A** — the merge gate for everyday development.
-* **Any PR targeting a release-line (`stable`, `v0.x`) or release-candidate (`*-rc.*`) branch** must pass the **full Tier 1A + 1B + 2 suite** before it can merge. This includes **backport PRs**, RC bake bugfix PRs, and the `release-plz` release PR — anything headed for a published (or soon-to-be-published) artifact gets the most thorough validation we have. PRs targeting release lines additionally run [`cargo-semver-checks`](#semver-checks).
-* During a train's bake, Tier 1A + 1B + 2 also run on every push to the `*-rc.*` branch.
+* **Any PR targeting a release-line (`stable`, `v0.x`) or release-candidate (`*-rc*`) branch** must pass the **full Tier 1A + 1B + 2 suite** before it can merge. This includes **backport PRs**, RC bake bugfix PRs, and the `release-plz` release PR — anything headed for a published (or soon-to-be-published) artifact gets the most thorough validation we have. PRs targeting release lines additionally run [`cargo-semver-checks`](#semver-checks).
+* During a train's bake, Tier 1A + 1B + 2 also run on every push to the `*-rc*` branch.
 * **All three tiers also run against `main` on a daily schedule** (a nightly run), catching regressions that only appear under the heavier Tier 1B/2 configurations even when no release-targeting PR is open.
 * On a `main` PR you can opt into the full suite on demand by adding the `check-release` label (useful to assess release-readiness before a change is backported).
 
@@ -242,12 +255,12 @@ To vet a new version of `release-plz` or a config change, CAI team members can u
 
 ## Branch protection
 
-The upstream-first guarantees rely on release-line and release-candidate branches only receiving changes through PRs. Configure branch protection (a repository setting, not something this repo can commit) on `main`, `stable`, and each `v0.*` / `*-rc.*` branch to:
+The upstream-first guarantees rely on release-line and release-candidate branches only receiving changes through PRs. Configure branch protection (a repository setting, not something this repo can commit) on `main`, `stable`, and each `v0.*` / `*-rc*` branch to:
 
 * **Require a pull request before merging** — so nothing is pushed directly, which is what makes the [upstream-first check](#upstream-first-check-proactive) an effective gate rather than an after-the-fact report.
 * **Require status checks to pass**, including Tier 1A on `main`, and Tier 1A + 1B + 2, `cargo-semver-checks`, and the upstream-first check on release-line/RC branches (see [validation gating](#validation-gating)).
 
-Branch-name patterns (`v0.*`, `*-rc.*`) can be covered with a single ruleset each so new release lines and candidates are protected automatically.
+Branch-name patterns (`v0.*`, `*-rc*`) can be covered with a single ruleset each so new release lines and candidates are protected automatically.
 
 ## One-time setup
 

--- a/docs/support-tiers.md
+++ b/docs/support-tiers.md
@@ -24,7 +24,7 @@ A _build configuration_ will specify:
 The tiers map directly onto the branching model in the [release process](release-process.md):
 
 * **Tier 1A is the merge gate for `main`.** Every pull request must pass Tier 1A before it can merge — on `main` and on every release-line and release-candidate branch.
-* **Tiers 1B and 2 are additionally required for any pull request targeting a release-line (`stable`, `v0.x`) or release-candidate (`*-rc.*`) branch.** This includes [backport PRs](release-process.md#backport-bot), release-candidate bake bugfixes, and the [`release-plz` release PR](release-process.md#release-plz). In short, anything headed for a published (or soon-to-be-published) artifact must pass all three tiers.
+* **Tiers 1B and 2 are additionally required for any pull request targeting a release-line (`stable`, `v0.x`) or release-candidate (`*-rc*`) branch.** This includes [backport PRs](release-process.md#backport-bot), release-candidate bake bugfixes, and the [`release-plz` release PR](release-process.md#release-plz). In short, anything headed for a published (or soon-to-be-published) artifact must pass all three tiers.
 * **All three tiers also run against `main` on a daily schedule** (a nightly run), so regressions that only surface under the heavier Tier 1B/2 configurations are caught even when no release-targeting PR is open.
 * On a `main` pull request you can run the full Tier 1B + 2 suite on demand by adding the `check-release` label — handy for assessing release-readiness before a change is backported.
 
@@ -35,7 +35,7 @@ See [validation gating](release-process.md#validation-gating) in the release pro
 Tier 1A configurations are the most actively supported.
 A Tier 1A configuration will:
 
-* Have continuous integration tests that build and pass for this build configuration on every commit to `main`, as well as to the release-line (`stable`, `v0.x`) and release-candidate (`*-rc.*`) branches described in the [release process](release-process.md).
+* Have continuous integration tests that build and pass for this build configuration on every commit to `main`, as well as to the release-line (`stable`, `v0.x`) and release-candidate (`*-rc*`) branches described in the [release process](release-process.md).
 A pull request will be blocked if the tests do not pass. This is the merge gate for `main` (see [How the tiers gate merges and releases](#how-the-tiers-gate-merges-and-releases)).
 * This test suite is the most complete set of tests available for this component.
 * Tier 1A configurations _may_ also have built artifacts generated for each versioned release.


### PR DESCRIPTION
## Problem

The first bug in the new open-source release process: too many downstream projects consume our **pre-built binary libraries** and can't easily build from source. Under the current process, release candidates are never published in *any* form (crates.io *or* GitHub-release binaries), so during a breaking train's ≥3-business-day bake those consumers have nothing to validate against.

## Fix

Give each RC **build** a *prerelease* GitHub release with binaries attached, while preserving the invariant that **RCs never reach crates.io**.

### Branch/version model
- RC branch is renamed to `0.N.0-rc` (dot-less) — the build number now belongs to each **build tag** (`-rc.1`, `-rc.2`, …), not the branch.
- All `*-rc.*` CI-trigger globs become `*-rc*`, and the PR-base `contains(…, '-rc.')` conditions become `-rc`, so the dot-less branch still matches the Tier suites and upstream-first check.
- The crates.io publish guard in `release.yml` matches `-rc` instead of `-rc.`.

### New workflows
- **`release-rc.yml`** — cuts a numbered build: sets the `-rc.N` versions on the branch (`c2pa`/`c2pa-c-ffi` and `c2patool` bumped in lockstep on the build number via `cargo set-version`), commits, and pushes the `c2pa-v…-rc.N` / `c2patool-v…-rc.N` tags **with the PAT** (so the tag-driven binary workflows actually fire). Guarded to run only on a `*-rc` branch.
- **`c2patool-release.yml`** — builds the `c2patool` CLI binaries + SBOMs on any `c2patool-v*` tag (moved out of `release.yml`). `-rc.` tags produce prereleases.

### Tag-driven binaries
Binary builds are now entirely tag-driven for **both** crates (`library-release.yml` already handled `c2pa-v*`), so RC tags produce the exact same artifacts as a real release. `release.yml` no longer builds binaries itself — it just runs `release-plz` publish and lets the resulting tags drive the binary workflows.

### Automation
- `release-train-cut.yml` creates the `0.N.0-rc` branch and then **auto-cuts the first build (`-rc.1`)** by dispatching `release-rc.yml`. Subsequent builds (`-rc.2`, …) are a manual `release-rc.yml` dispatch after bugfixes are cherry-picked during the bake.
- **`release-train-cut.yml` also now auto-advances `main` to the next `0.(N+1).0-dev` cycle** — committed directly to `main` (no PR), replacing the manual step done by hand in #2303. It runs *after* the RC branch is cut, so the candidate is taken from pre-bump `main`. The tracking issue no longer asks for this. *(Scoping note: this is a self-contained step folded into this PR because it edits the same `cut` job; happy to split it into its own PR if preferred.)*

### Docs
`docs/release-process.md` and `docs/support-tiers.md` updated (branching table, version-numbering + worked example, new *Release-candidate builds* section, auto-advance note, branch-protection bypass note, glob patterns).

## Notes / follow-ups
- **crates.io is untouched for RCs** — this publishes GitHub-release binaries only, per the design decision confirmed for this change.
- Real-release behavior is preserved: `library-release.yml` keeps its existing `prerelease: true`; `c2patool-release.yml` marks only `-rc.` tags as prereleases (matching c2patool's prior real-release behavior).
- **`RELEASE_PLZ_TOKEN` must be on the branch-protection bypass list** for `main` (next-dev commit) and RC branches (`-rc.N` commits), and needs `actions:write` for `gh workflow run`. Documented in the branch-protection section.
- **Backport:** per plan, this should be backported to the current RC branch — which also means renaming `0.90.0-rc.1` → `0.90.0-rc` (the `release-rc.yml` branch guard expects the dot-less name).
- Validated with `actionlint` (new/changed workflows clean; only pre-existing info-level notes remain elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)