### PR TITLE
fix: Correct tag, commit, and changelog for tag-driven binary releases

### DIFF
--- a/.github/workflows/c2patool-release.yml
+++ b/.github/workflows/c2patool-release.yml
@@ -95,6 +95,36 @@ jobs:
       - name: List artifacts
         run: ls -lh dist
 
+      # Generate the release notes ourselves, scoped to the previous tag of THIS
+      # crate. Tags are repo-global and interleaved across crates (c2pa-v*,
+      # c2patool-v*, c2pa-c-ffi-v*), and GitHub's automatic "previous tag" is the
+      # chronologically previous tag regardless of crate, producing nonsense
+      # ranges. Picking the previous same-crate tag keeps the changelog within
+      # this crate's history.
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          PREFIX="c2patool-v"
+          repo="${{ github.repository }}"
+          matching=$(gh api --paginate "repos/$repo/git/matching-refs/tags/$PREFIX" \
+                       --jq '.[].ref' | sed 's#refs/tags/##')
+          sorted=$(printf '%s\n%s\n' "$matching" "$TAG" | sort -V -u)
+          prev=$(printf '%s\n' "$sorted" | { grep -F -x -B1 -- "$TAG" || true; } | head -n1)
+          [ "$prev" = "$TAG" ] && prev=""
+          if [ -n "$prev" ]; then
+            echo "Previous $PREFIX tag: $prev"
+            gh api "repos/$repo/releases/generate-notes" \
+              -f tag_name="$TAG" -f previous_tag_name="$prev" --jq .body > release-notes.md
+          else
+            echo "No previous $PREFIX tag; letting GitHub choose the range."
+            gh api "repos/$repo/releases/generate-notes" \
+              -f tag_name="$TAG" --jq .body > release-notes.md
+          fi
+          echo "----- release notes -----"; cat release-notes.md
+
       # Creates the release if it does not exist yet (the release-candidate
       # case, where release-plz never ran) and updates it in place otherwise
       # (the promotion case, where release-plz already opened the release). A
@@ -103,9 +133,10 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          body_path: release-notes.md
           files: dist/*
           draft: false
           prerelease: ${{ contains(github.ref_name, '-rc.') }}
-          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -146,11 +146,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-artifacts-*
-          path: .
+          path: dist
           merge-multiple: true
 
       - name: List downloaded artifacts
-        run: ls -lh
+        run: ls -lh dist
 
       - name: Resolve release tag
         id: extract_tag
@@ -176,16 +176,50 @@ jobs:
           echo "Releasing tag: $TAG_NAME"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
 
+      # Generate the release notes ourselves, scoped to the previous tag of THIS
+      # crate. Tags are repo-global and interleaved across crates (c2pa-v*,
+      # c2patool-v*, c2pa-c-ffi-v*), and GitHub's automatic "previous tag" is the
+      # chronologically previous tag regardless of crate -- which produced
+      # nonsense ranges like `c2patool-v0.26.72...c2pa-v0.90.0`. Picking the
+      # previous same-crate tag keeps the changelog within this crate's history.
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.extract_tag.outputs.tag_name }}"
+          PREFIX="c2pa-v"
+          repo="${{ github.repository }}"
+          # All tags for this crate, plus the current one, sorted ascending.
+          matching=$(gh api --paginate "repos/$repo/git/matching-refs/tags/$PREFIX" \
+                       --jq '.[].ref' | sed 's#refs/tags/##')
+          sorted=$(printf '%s\n%s\n' "$matching" "$TAG" | sort -V -u)
+          # The line immediately before the current tag is its predecessor.
+          prev=$(printf '%s\n' "$sorted" | { grep -F -x -B1 -- "$TAG" || true; } | head -n1)
+          [ "$prev" = "$TAG" ] && prev=""
+          if [ -n "$prev" ]; then
+            echo "Previous $PREFIX tag: $prev"
+            gh api "repos/$repo/releases/generate-notes" \
+              -f tag_name="$TAG" -f previous_tag_name="$prev" --jq .body > release-notes.md
+          else
+            echo "No previous $PREFIX tag; letting GitHub choose the range."
+            gh api "repos/$repo/releases/generate-notes" \
+              -f tag_name="$TAG" --jq .body > release-notes.md
+          fi
+          echo "----- release notes -----"; cat release-notes.md
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.extract_tag.outputs.tag_name }}
-
-          files: ./*
+          # Attach the release to the commit the triggering tag points at, never
+          # the default branch (a safety net against creating a stray tag).
+          target_commitish: ${{ github.sha }}
+          body_path: release-notes.md
+          files: dist/*
           draft: false
           prerelease: true
-          generate_release_notes: true
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -152,18 +152,29 @@ jobs:
       - name: List downloaded artifacts
         run: ls -lh
 
-      - name: Extract tag_name from zip file
+      - name: Resolve release tag
         id: extract_tag
         run: |
-          ZIP=$(find . -name "c2pa-v*-*.zip" | head -n1)
-          if [ -n "$ZIP" ]; then
-            TAG_NAME=$(echo "$ZIP" | sed -E 's/.*\/(c2pa-v[0-9]+\.[0-9]+\.[0-9]+)-.*\.zip/\1/')
-            echo "Found tag: $TAG_NAME"
-            echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          else
-            echo "No zip files found"
-            exit 1
-          fi
+          # Use the exact ref that triggered this run as the release tag.
+          #
+          # The previous approach re-derived the tag from a built zip's
+          # filename with a regex (`c2pa-v[0-9]+\.[0-9]+\.[0-9]+`) that assumed
+          # a bare X.Y.Z version. That silently dropped any `-rc.N` prerelease
+          # suffix, so a release-candidate build was published under the FINAL
+          # release name -- e.g. `c2pa-v0.90.0-rc.2` was released as
+          # `c2pa-v0.90.0`, burning the name reserved for the post-bake release.
+          # The triggering ref is authoritative; trust it and never reconstruct
+          # the version from a filename.
+          TAG_NAME="${{ github.ref_name }}"
+          case "$TAG_NAME" in
+            c2pa-v*) ;;
+            *)
+              echo "::error::Expected a c2pa-v* tag ref, got '$TAG_NAME'. Run this workflow on a c2pa-v* tag."
+              exit 1
+              ;;
+          esac
+          echo "Releasing tag: $TAG_NAME"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
Three related defects in the tag-driven binary release step, all visible on the mislabeled `c2pa-v0.90.0` release that a `c2pa-v0.90.0-rc.2` build produced. Applies to both [`library-release.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/library-release.yml) and [`c2patool-release.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/c2patool-release.yml).

## 1. Release published under the wrong name (dropped `-rc.N`)

`library-release.yml` re-derived the tag from a built zip's filename with a regex assuming a bare `X.Y.Z`:

```sh
sed -E 's/.*\/(c2pa-v[0-9]+\.[0-9]+\.[0-9]+)-.*\.zip/\1/'
```

`c2pa-v0.90.0-rc.2-<target>.zip` → `c2pa-v0.90.0`, burning the tag reserved for the post-bake final release. **Fix:** use `github.ref_name` (the exact ref that triggered the run) with a `c2pa-v*` guard — matching how `c2patool-release.yml` already resolves its tag. Never reconstruct a version from a filename.

## 2. Release pointed at `main`, not the tag's commit

Because of #1, `action-gh-release` created a *new* tag `c2pa-v0.90.0` and defaulted its commit to the default branch (`main`). Fixing the name means it attaches to the existing rc tag at the right commit; **as a safety net**, `target_commitish: ${{ github.sha }}` is now pinned so a release can never be created against the wrong commit.

## 3. Changelog cited an unrelated crate's tag

The auto-notes showed `Full Changelog: c2patool-v0.26.72...c2pa-v0.90.0`. Tags are repo-global and interleaved (`c2pa-v*`, `c2patool-v*`, `c2pa-c-ffi-v*`), and GitHub's automatic "previous tag" is the chronologically previous tag *regardless of crate*. **Fix:** compute the previous **same-crate** tag (`git/matching-refs` + `sort -V`) and pass it explicitly as `previous_tag_name` to the generate-notes API, using the result as the release body.

## Notes
- Artifacts now download to `dist/` so the generated `release-notes.md` is never uploaded as a release asset.
- `prerelease` handling is unchanged (library: always prerelease pre-1.0; c2patool: only `-rc.` tags).
- For a real (promotion) release, this sets GitHub-generated notes scoped to the previous same-crate tag. If we'd rather preserve release-plz's `CHANGELOG.md`-based body on promotion releases, that's an easy follow-up (only generate notes when the release doesn't already exist) — called out separately to keep this fix race-tolerant/idempotent.
- The erroneous `c2pa-v0.90.0` release+tag are being deleted separately; the correct `c2pa-v0.90.0-rc.2` tag remains.
- Still open (not this PR): no `c2patool-v0.28.0-rc.2` tag/release was produced for that RC build — worth investigating.

Validated with `actionlint` (new steps clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)