### PR TITLE
fix: Disable `release-plz` `release_commits` until upstream is fixed

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -40,8 +40,8 @@ release_always = false
 # Only these commit types trigger a release PR. This keeps chore-only commits
 # (including chore cherry-picks brought over by the backport bot) from
 # generating spurious release PRs on a release-line branch.
-# See https://github.com/contentauth/c2pa-rs/issues/2229
-release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
+# TODO: Commented due to bug with release-plz, see https://github.com/contentauth/c2pa-rs/issues/2229
+# release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
 
 [[package]]
 name = "c2pa"


### PR DESCRIPTION
Disables `release_commits` until #2229 is fixed. Upstream `release-plz` has not yet fixed this issue.