### PR TITLE
fix: Disable `release-plz` `release_commits` until upstream is fixed (backport #2308)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -40,8 +40,8 @@ release_always = false
 # Only these commit types trigger a release PR. This keeps chore-only commits
 # (including chore cherry-picks brought over by the backport bot) from
 # generating spurious release PRs on a release-line branch.
-# See https://github.com/contentauth/c2pa-rs/issues/2229
-release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
+# TODO: Commented due to bug with release-plz, see https://github.com/contentauth/c2pa-rs/issues/2229
+# release_commits = "^(feat|fix|docs|perf|refactor|revert|test|update)[!]?[(:]"
 
 [[package]]
 name = "c2pa"


### PR DESCRIPTION
Automated backport of #2308 to `0.90.0-rc`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.