### PR TITLE
fix!: Enforce trusted-issuer allow-list for CAWG ICA credentials (CAI-11347) (backport #2209)

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -3308,14 +3308,40 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn test_c2pa_reader_from_stream_cawg() {
+        // This fixture's identity claims aggregation (ICA) credential is signed
+        // by a `did:jwk` issuer. ICA issuers are untrusted by default, so we must
+        // add that issuer to `cawg_trust.trusted_ica_issuers` for the credential
+        // to be reported as valid.
+        let builder = unsafe { c2pa_context_builder_new() };
+        let settings = unsafe { c2pa_settings_new() };
+
+        let path = CString::new("cawg_trust.trusted_ica_issuers").unwrap();
+        let value = CString::new(
+            r#"["did:jwk:eyJhbGciOiJFZERTQSIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiTXA1LTBlODNuTmdRaGRoQlc4UnNoa2p5OTBzYTFBOUpJemtJdGNEcUN1SSJ9"]"#,
+        )
+        .unwrap();
+        let result = unsafe { c2pa_settings_set_value(settings, path.as_ptr(), value.as_ptr()) };
+        assert_eq!(result, 0);
+
+        let result = unsafe { c2pa_context_builder_set_settings(builder, settings) };
+        assert_eq!(result, 0);
+
+        let context = unsafe { c2pa_context_builder_build(builder) };
+        assert!(!context.is_null());
+
+        let reader = unsafe { c2pa_reader_from_context(context) };
+        assert!(!reader.is_null());
+
         let source_image = include_bytes!(
             "../../sdk/src/identity/tests/fixtures/claim_aggregation/ica_validation/success.jpg"
         );
         let mut stream = TestStream::new(source_image.to_vec());
         let format = CString::new("image/jpeg").unwrap();
-        let reader = unsafe { c2pa_reader_from_stream(format.as_ptr(), stream.as_ptr()) };
-        assert!(!reader.is_null());
-        let json = unsafe { c2pa_reader_json(reader) };
+        let configured_reader =
+            unsafe { c2pa_reader_with_stream(reader, format.as_ptr(), stream.as_ptr()) };
+        assert!(!configured_reader.is_null());
+
+        let json = unsafe { c2pa_reader_json(configured_reader) };
         assert!(!json.is_null());
         let json_str = unsafe { CString::from_raw(json) };
         assert!(json_str.to_str().unwrap().contains("Silly Cats 929"));
@@ -3323,7 +3349,12 @@ mod tests {
             .to_str()
             .unwrap()
             .contains("cawg.ica.credential_valid"));
-        unsafe { c2pa_reader_free(reader) };
+
+        unsafe {
+            c2pa_free(settings as *mut c_void);
+            c2pa_free(context as *mut c_void);
+            c2pa_reader_free(configured_reader);
+        };
     }
 
     #[test]

--- a/docs/cawg-identity.md
+++ b/docs/cawg-identity.md
@@ -2,6 +2,33 @@
 
 The CAI Rust library includes an implementation of the [Creator Assertions Working Group (CAWG) identity assertion specification](https://cawg.io/identity/1.1-draft).
 
+## Trusting identity claims aggregation (ICA) issuers
+
+An identity claims aggregation credential is signed by an issuer identified by a DID (for example a `did:web` or `did:jwk`). A valid signature only proves that the credential was signed by whoever controls that DID — it does **not**, on its own, establish that the issuer is trustworthy. In particular, a self-issued `did:jwk` can be minted by anyone, so accepting it as trusted would let an attacker assert any identity.
+
+For this reason, the library treats ICA issuers as untrusted unless they appear on an explicit allow-list. Configure the allow-list through the `cawg_trust.trusted_ica_issuers` setting, which is a list of exact DID strings (any DID method):
+
+```json
+{
+  "cawg_trust": {
+    "trusted_ica_issuers": [
+      "did:web:issuer.example.com"
+    ]
+  }
+}
+```
+
+The DID of the credential's `issuer` (with any fragment removed) is compared, using exact string matching, against this list.
+
+* If the issuer is on the list, validation can proceed to the success code `cawg.ica.credential_valid`.
+* If the issuer is **not** on the list, the informational code `cawg.ica.untrusted_issuer` is reported for that identity assertion and `cawg.ica.credential_valid` is withheld. Treat the absence of `cawg.ica.credential_valid` as the signal that the identity was not validated.
+
+The default value is empty, meaning that **no** ICA issuer is trusted. This is a deliberate secure default; populate the list with the issuers you trust.
+
+The `cawg.ica.untrusted_issuer` result is scoped to the individual identity assertion and is recorded informationally: it does not make the enclosing manifest's `validation_state` `Invalid`, nor does it downgrade a manifest that is otherwise `Trusted` on the basis of its own C2PA signer.
+
+These settings are read from the [`Context`](https://docs.rs/c2pa/latest/c2pa/struct.Context.html) under which validation is performed. When using the explicit post-validation API, construct the validator with that context via `CawgValidator::new(&context)`.
+
 ## Known limitations
 
 The library does not currently support the following optional fields from the CAWG identity assertion:

--- a/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
+++ b/sdk/src/identity/claim_aggregation/ica_signature_verifier.rs
@@ -52,7 +52,15 @@ use crate::{
 /// [§8.1, Identity claims aggregation]: https://creator-assertions.github.io/identity/1.1-draft/#_identity_claims_aggregation
 /// [§3.3.1 Securing JSON-LD Verifiable Credentials with COSE]: https://w3c.github.io/vc-jose-cose/#securing-vcs-with-cose
 pub struct IcaSignatureVerifier<'a> {
-    // TO DO (CAI-7980): Add option to configure trusted ICA issuers.
+    /// Context under which validation is performed.
+    ///
+    /// The `cawg_trust.trusted_ica_issuers` setting on this context's
+    /// [`Settings`](crate::settings::Settings) is the exact-match allow-list of
+    /// trusted ICA issuer DIDs. During validation, the credential's `issuer`
+    /// (after stripping any fragment) is compared against that list; an issuer
+    /// that is not present is reported with `cawg.ica.untrusted_issuer` for that
+    /// identity assertion (see [`IcaSignatureVerifier::check_issuer_trust`]). An
+    /// empty list means that no issuer is trusted.
     context: &'a Context,
 }
 
@@ -81,11 +89,21 @@ impl SignatureVerifier for IcaSignatureVerifier<'_> {
 
         let mut ica_credential = self.parse_ica_vc_v2(payload_bytes, status_tracker)?;
 
-        self.check_issuer_signature(&sign1, &ica_credential)
-            .or_else(|err| {
+        let signature_ok = match self.check_issuer_signature(&sign1, &ica_credential) {
+            Ok(()) => true,
+            Err(err) => {
                 ok = false;
-                self.handle_signature_error(err, status_tracker)
-            })?;
+                self.handle_signature_error(err, status_tracker)?;
+                false
+            }
+        };
+
+        // Once we've established that the signature is valid, verify that the
+        // issuer is one we've been configured to trust. This is scoped to this
+        // identity assertion and does not affect the enclosing manifest's state.
+        if signature_ok {
+            self.check_issuer_trust(&ica_credential, status_tracker, &mut ok)?;
+        }
 
         let local_ctp = CertificateTrustPolicy::passthrough();
         let mut timestamp_tracker = StatusTracker::default();
@@ -156,12 +174,24 @@ impl SignatureVerifier for IcaSignatureVerifier<'_> {
         // TO DO (CAI-7970): Add support for VC version 1.
         let mut ica_credential = self.parse_ica_vc_v2(payload_bytes, status_tracker)?;
 
-        self.check_issuer_signature_async(&sign1, &ica_credential)
+        let signature_ok = match self
+            .check_issuer_signature_async(&sign1, &ica_credential)
             .await
-            .or_else(|err| {
+        {
+            Ok(()) => true,
+            Err(err) => {
                 ok = false;
-                self.handle_signature_error(err, status_tracker)
-            })?;
+                self.handle_signature_error(err, status_tracker)?;
+                false
+            }
+        };
+
+        // Once we've established that the signature is valid, verify that the
+        // issuer is one we've been configured to trust. This is scoped to this
+        // identity assertion and does not affect the enclosing manifest's state.
+        if signature_ok {
+            self.check_issuer_trust(&ica_credential, status_tracker, &mut ok)?;
+        }
 
         // todo: no trust list support yet for CAWG so passthrough for now
         let local_ctp = CertificateTrustPolicy::passthrough();
@@ -541,6 +571,60 @@ impl<'a> IcaSignatureVerifier<'a> {
                 public_key.verify(data, &signature).map_err(JwkError::from)
             })
             .map_err(|_e| ValidationError::SignatureMismatch)?;
+
+        Ok(())
+    }
+
+    /// Verify that the credential's issuer DID is present on the configured
+    /// list of trusted ICA issuers.
+    ///
+    /// The CAWG identity spec requires the validator to verify that the issuer's
+    /// DID can be traced to its preconfigured list of trustable entities. If the
+    /// issuer is not verifiably trusted, the validator issues the
+    /// `cawg.ica.untrusted_issuer` code (recorded informationally) and withholds
+    /// the `cawg.ica.credential_valid` success code, but MAY continue validation.
+    ///
+    /// The list of trusted issuers is the `cawg_trust.trusted_ica_issuers`
+    /// setting of the [`Context`] under which validation is performed. It is
+    /// empty by default, which means that no issuer is trusted unless explicitly
+    /// configured: a self-issued `did:jwk` (or any other DID) is not trustworthy
+    /// merely because its signature is self-consistent.
+    ///
+    /// This is scoped to the individual identity assertion. It does not render
+    /// the enclosing C2PA manifest invalid or untrusted (see
+    /// [`ValidationResults::validation_state`]).
+    ///
+    /// [`Context`]: crate::Context
+    /// [`ValidationResults::validation_state`]: crate::validation_results::ValidationResults::validation_state
+    fn check_issuer_trust(
+        &self,
+        ica_credential: &IcaCredential,
+        status_tracker: &mut StatusTracker,
+        ok: &mut bool,
+    ) -> Result<(), ValidationError<IcaValidationError>> {
+        let issuer_id = Did::new(&ica_credential.issuer)?;
+        let (primary_did, _fragment) = issuer_id.split_fragment();
+        let primary_did: &str = &primary_did;
+
+        if let Some(trusted_issuers) = &self.context.settings().cawg_trust.trusted_ica_issuers {
+            if trusted_issuers.iter().any(|t| t.as_str() == primary_did) {
+                return Ok(());
+            }
+        }
+
+        // Withhold the `cawg.ica.credential_valid` success code so the identity
+        // is not surfaced as validated...
+        *ok = false;
+
+        // ...but record the untrusted issuer only informationally. It is scoped
+        // to this identity assertion and must not, on its own, fail the enclosing
+        // manifest (see [`ValidationResults::validation_state`]).
+        log_current_item!(
+            "ICA issuer is not a trusted issuer",
+            "IcaSignatureVerifier::check_signature"
+        )
+        .validation_status("cawg.ica.untrusted_issuer")
+        .informational(status_tracker);
 
         Ok(())
     }

--- a/sdk/src/identity/identity_assertion/assertion.rs
+++ b/sdk/src/identity/identity_assertion/assertion.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
 use crate::{
+    context::Context,
     crypto::{
         cose::{parse_cose_sign1, CertificateTrustPolicy, CoseError, Verifier},
         raw_signature::RawSignatureValidationError,
@@ -43,7 +44,7 @@ use crate::{
     jumbf::labels::to_assertion_uri,
     log_current_item, log_item,
     status_tracker::StatusTracker,
-    Context, Manifest, Reader,
+    Manifest, Reader,
 };
 
 /// This struct represents the raw content of the identity assertion.
@@ -306,7 +307,7 @@ impl IdentityAssertion {
         status_tracker: &mut StatusTracker,
         context: &Context,
     ) -> Result<serde_json::Value, ValidationError<String>> {
-        let settings = Context::new().settings().clone();
+        let settings = context.settings();
         self.check_padding(status_tracker)?;
 
         self.signer_payload
@@ -411,12 +412,11 @@ impl IdentityAssertion {
                     .map_err(|e| ValidationError::UnknownSignatureType(e.to_string()))
             }?;
 
-            log_current_item!(
-                "CAWG identity_claims_aggregation signature valid",
-                "validate_partial_claim"
-            )
-            .validation_status("cawg.ica.credential_valid")
-            .success(status_tracker);
+            // NOTE: The `cawg.ica.credential_valid` success code is issued by
+            // `IcaSignatureVerifier::check_signature` itself, and only when the
+            // credential is valid and its issuer is trusted (i.e. no
+            // `cawg.ica.untrusted_issuer` notice was generated). We must not issue
+            // it again here, or an untrusted issuer would be reported as valid.
 
             serde_json::to_value(result)
                 .map_err(|e| ValidationError::UnknownSignatureType(e.to_string()))

--- a/sdk/src/identity/tests/claim_aggregation/interop.rs
+++ b/sdk/src/identity/tests/claim_aggregation/interop.rs
@@ -23,6 +23,7 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use crate::{
     identity::{
         claim_aggregation::{IcaSignatureVerifier, IdentityProvider, VerifiedIdentity},
+        tests::ica_test_context,
         IdentityAssertion, SignerPayload,
     },
     settings::Settings,
@@ -69,7 +70,7 @@ async fn adobe_connected_identities() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
     let ica = ia.validate(manifest, &mut st, &isv).await.unwrap();
 
@@ -146,7 +147,7 @@ async fn ims_multiple_manifests() {
 
     // Check the summary report for the entire manifest store.
     let mut st = StatusTracker::default();
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
     let ia_summary = IdentityAssertion::summarize_from_reader(&reader, &mut st, &isv).await;
     let ia_json = serde_json::to_string(&ia_summary).unwrap();

--- a/sdk/src/identity/tests/claim_aggregation/validation.rs
+++ b/sdk/src/identity/tests/claim_aggregation/validation.rs
@@ -24,10 +24,12 @@ use c2pa_macros::c2pa_test_async;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 use crate::{
-    context::Context,
     identity::{
         claim_aggregation::{IcaSignatureVerifier, IcaValidationError},
-        tests::fixtures::claim_aggregation::ica_credential_example,
+        tests::{
+            fixtures::claim_aggregation::ica_credential_example, ica_test_context,
+            ICA_FIXTURE_JWK_ISSUER,
+        },
         IdentityAssertion, ValidationError,
     },
     status_tracker::{LogKind, StatusTracker},
@@ -67,7 +69,7 @@ async fn success_case() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -132,7 +134,7 @@ async fn invalid_cose_sign1() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_err = ia.validate(manifest, &mut st, &isv).await.unwrap_err();
@@ -213,7 +215,7 @@ async fn invalid_cose_sign_alg() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_err = ia.validate(manifest, &mut st, &isv).await.unwrap_err();
@@ -276,7 +278,7 @@ async fn missing_cose_sign_alg() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_err = ia.validate(manifest, &mut st, &isv).await.unwrap_err();
@@ -340,7 +342,7 @@ async fn invalid_content_type() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -404,7 +406,7 @@ async fn invalid_content_type_assigned() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -467,7 +469,7 @@ async fn missing_content_type() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -542,7 +544,7 @@ async fn missing_vc() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_err = ia.validate(manifest, &mut st, &isv).await.unwrap_err();
@@ -601,7 +603,7 @@ async fn invalid_vc() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_err = ia.validate(manifest, &mut st, &isv).await.unwrap_err();
@@ -669,7 +671,7 @@ async fn invalid_issuer_did() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -735,7 +737,7 @@ async fn unsupported_did_method() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -799,7 +801,7 @@ async fn unresolvable_did() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -863,7 +865,7 @@ async fn did_doc_without_assertion_method() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -900,16 +902,125 @@ async fn did_doc_without_assertion_method() {
     assert!(log_items.next().is_none());
 }
 
-// #[test]
-// #[ignore]
-// fn did_is_untrusted() {
-//     // The validator SHALL verify that the issuer’s DID is present or can be
-//     // traced to its preconfigured list of trustable entities. If the issuer
-// is     // not verifiably trusted, the validator MUST issue the failure code
-//     // `cawg.ica.untrusted_issuer` but MAY continue validation.
+#[c2pa_test_async]
+async fn did_is_untrusted() {
+    // The validator SHALL verify that the issuer's DID is present or can be
+    // traced to its preconfigured list of trustable entities. If the issuer is
+    // not verifiably trusted, the validator MUST issue the failure code
+    // `cawg.ica.untrusted_issuer` but MAY continue validation.
 
-//     // TO DO (CAI-7980): Add option to configure trusted ICA issuers.
-// }
+    let format = "image/jpeg";
+    let test_image = include_bytes!("../fixtures/claim_aggregation/ica_validation/success.jpg");
+
+    let mut test_image = Cursor::new(test_image);
+
+    let reader = crate::identity::tests::read_manifest(format, &mut test_image).await;
+    assert_eq!(reader.validation_status(), None);
+
+    let manifest = reader.active_manifest().unwrap();
+    let mut st = StatusTracker::default();
+    let mut ia_iter = IdentityAssertion::from_manifest(manifest, &mut st);
+
+    // Should find exactly one identity assertion.
+    let ia = ia_iter.next().unwrap().unwrap();
+    assert!(ia_iter.next().is_none());
+    drop(ia_iter);
+
+    // Use a verifier that trusts NO issuers, so this credential's self-issued
+    // `did:jwk` is treated as untrusted. (This mirrors the secure production
+    // default; the allow-list must be set explicitly to empty here because the
+    // `#[cfg(test)]` default trusts the bundled fixture issuers.)
+    let context = crate::Context::new()
+        .with_settings(
+            crate::settings::Settings::default()
+                .with_value("cawg_trust.trusted_ica_issuers", Vec::<String>::new())
+                .unwrap(),
+        )
+        .unwrap();
+    let isv = IcaSignatureVerifier::new(&context);
+
+    // The credential is otherwise well-formed and its signature is valid, so
+    // validation still succeeds and returns the credential.
+    let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
+
+    let expected_identities = ica_credential_example::ica_example_identities();
+    let subject = ica_vc.credential_subjects.first();
+    assert_eq!(subject.verified_identities, expected_identities);
+
+    // Because the issuer is untrusted, the `cawg.ica.credential_valid` success
+    // code MUST NOT be issued. The only logged item is the untrusted-issuer
+    // notice, which is recorded informationally (not as a failure) because it is
+    // scoped to the identity assertion and does not fail the manifest.
+    let mut log_items = st.logged_items().iter();
+
+    let li = log_items.next().unwrap();
+
+    assert_eq!(li.kind, LogKind::Informational);
+    assert_eq!(
+        li.label,
+        "self#jumbf=/c2pa/test:urn:uuid:71b584f1-da28-4bf7-89a8-417be6bb07ac/c2pa.assertions/cawg.identity"
+    );
+    assert_eq!(li.description, "ICA issuer is not a trusted issuer");
+    assert_eq!(li.crate_name, "c2pa");
+    assert_eq!(
+        li.validation_status.as_ref().unwrap(),
+        "cawg.ica.untrusted_issuer"
+    );
+
+    assert!(log_items.next().is_none());
+}
+
+#[c2pa_test_async]
+async fn issuer_trusted_on_allow_list() {
+    // When the issuer's DID is present on the configured allow-list, no
+    // untrusted-issuer failure is generated and the credential is reported as
+    // valid.
+
+    let format = "image/jpeg";
+    let test_image = include_bytes!("../fixtures/claim_aggregation/ica_validation/success.jpg");
+
+    let mut test_image = Cursor::new(test_image);
+
+    let reader = crate::identity::tests::read_manifest(format, &mut test_image).await;
+    assert_eq!(reader.validation_status(), None);
+
+    let manifest = reader.active_manifest().unwrap();
+    let mut st = StatusTracker::default();
+    let mut ia_iter = IdentityAssertion::from_manifest(manifest, &mut st);
+
+    let ia = ia_iter.next().unwrap().unwrap();
+    assert!(ia_iter.next().is_none());
+    drop(ia_iter);
+
+    // Trust exactly the issuer that signed this fixture.
+    let context = crate::Context::new()
+        .with_settings(
+            crate::settings::Settings::default()
+                .with_value(
+                    "cawg_trust.trusted_ica_issuers",
+                    vec![ICA_FIXTURE_JWK_ISSUER.to_string()],
+                )
+                .unwrap(),
+        )
+        .unwrap();
+    let isv = IcaSignatureVerifier::new(&context);
+
+    let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
+    assert_eq!(ica_vc.issuer, ICA_FIXTURE_JWK_ISSUER);
+
+    // The only logged item is the `cawg.ica.credential_valid` success code.
+    let mut log_items = st.logged_items().iter();
+
+    let li = log_items.next().unwrap();
+
+    assert_eq!(li.kind, LogKind::Success);
+    assert_eq!(
+        li.validation_status.as_ref().unwrap(),
+        "cawg.ica.credential_valid"
+    );
+
+    assert!(log_items.next().is_none());
+}
 
 #[c2pa_test_async]
 async fn signature_mismatch() {
@@ -940,7 +1051,7 @@ async fn signature_mismatch() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1009,7 +1120,7 @@ async fn valid_time_stamp() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1097,7 +1208,7 @@ async fn invalid_time_stamp() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1167,7 +1278,7 @@ async fn valid_from_missing() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1236,7 +1347,7 @@ async fn valid_from_in_future() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1310,7 +1421,7 @@ async fn valid_from_after_time_stamp() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1407,7 +1518,7 @@ async fn valid_until_in_future() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1477,7 +1588,7 @@ async fn valid_until_in_past() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();
@@ -1566,7 +1677,7 @@ async fn signer_payload_mismatch() {
     drop(ia_iter);
 
     // And that identity assertion should be valid for this manifest.
-    let context = Context::new();
+    let context = ica_test_context();
     let isv = IcaSignatureVerifier::new(&context);
 
     let ica_vc = ia.validate(manifest, &mut st, &isv).await.unwrap();

--- a/sdk/src/identity/tests/mod.rs
+++ b/sdk/src/identity/tests/mod.rs
@@ -20,6 +20,38 @@ mod examples;
 pub(crate) mod fixtures;
 mod validation_method;
 
+/// The `did:jwk` issuer that the bundled CAWG ICA `ica_validation` fixtures are
+/// signed with.
+pub(crate) const ICA_FIXTURE_JWK_ISSUER: &str = "did:jwk:eyJhbGciOiJFZERTQSIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiTXA1LTBlODNuTmdRaGRoQlc4UnNoa2p5OTBzYTFBOUpJemtJdGNEcUN1SSJ9";
+
+/// The `did:web` issuer that the Adobe connected-identities fixtures are signed
+/// with.
+pub(crate) const ICA_FIXTURE_WEB_ISSUER: &str =
+    "did:web:connected-identities.identity-stage.adobe.com";
+
+/// A [`Context`](crate::Context) whose `cawg_trust.trusted_ica_issuers`
+/// allow-list trusts the issuers used by the bundled CAWG ICA test fixtures.
+///
+/// Tests that exercise a directly-constructed
+/// [`IcaSignatureVerifier`](crate::identity::claim_aggregation::IcaSignatureVerifier)
+/// build it from this context (`IcaSignatureVerifier::new(&ica_test_context())`)
+/// so that an otherwise-valid fixture is treated as having a trusted issuer (and
+/// therefore produces `cawg.ica.credential_valid`). To exercise the
+/// untrusted-issuer path, build a verifier from a context with a different (or
+/// empty) allow-list, such as `Context::new()`.
+pub(crate) fn ica_test_context() -> crate::Context {
+    let settings = crate::settings::Settings::default()
+        .with_value(
+            "cawg_trust.trusted_ica_issuers",
+            vec![
+                ICA_FIXTURE_JWK_ISSUER.to_string(),
+                ICA_FIXTURE_WEB_ISSUER.to_string(),
+            ],
+        )
+        .unwrap();
+    crate::Context::new().with_settings(settings).unwrap()
+}
+
 /// Read a manifest store with identity assertion decoding disabled so the raw
 /// assertion bytes are preserved for manual validation in tests.
 pub(crate) async fn read_manifest<R: std::io::Read + std::io::Seek + Send>(

--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -26,6 +26,10 @@ use crate::{
 };
 
 /// Validates a CAWG identity assertion.
+///
+/// A `CawgValidator` carries the [`Context`] that governs CAWG validation,
+/// including the `cawg_trust.trusted_ica_issuers` allow-list. Construct one with
+/// [`CawgValidator::new`] to validate under a specific [`Context`].
 pub struct CawgValidator<'a> {
     context: &'a Context,
 }
@@ -129,18 +133,14 @@ mod tests {
 
         //println!("validation results: {}", reader);
 
-        assert_eq!(
-            reader
-                .validation_results()
-                .unwrap()
-                .active_manifest()
-                .unwrap()
-                .success()
-                .last()
-                .unwrap()
-                .code(),
-            "cawg.ica.credential_valid"
-        );
+        assert!(reader
+            .validation_results()
+            .unwrap()
+            .active_manifest()
+            .unwrap()
+            .success()
+            .iter()
+            .any(|s| s.code() == "cawg.ica.credential_valid"));
     }
 
     #[c2pa_test_async]
@@ -168,6 +168,67 @@ mod tests {
                 .len(),
             1
         );
+        assert_eq!(reader.validation_state(), ValidationState::Valid);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[c2pa_test_async]
+    async fn ica_issuer_untrusted_does_not_affect_manifest_state() {
+        use crate::{Context, Settings};
+
+        let _did_server = mock_connected_identities_did();
+
+        // Build a Context that trusts NO ICA issuers (empty allow-list) and skips
+        // C2PA certificate trust checking. The empty list must reach the verifier
+        // through the Context carried by the CawgValidator.
+        let settings = Settings::new()
+            .with_value("verify.verify_trust", false)
+            .unwrap()
+            .with_value("core.decode_identity_assertions", false)
+            .unwrap()
+            .with_value("cawg_trust.trusted_ica_issuers", Vec::<String>::new())
+            .unwrap();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .into_shared();
+
+        // Both the reader and the validator share this context, so the empty
+        // allow-list reaches the verifier through the CawgValidator.
+        let validator = super::CawgValidator::new(&context);
+
+        let mut stream = Cursor::new(CONNECTED_IDENTITIES_VALID);
+        let mut reader = Reader::from_shared_context(&context)
+            .with_stream_async("image/jpeg", &mut stream)
+            .await
+            .unwrap();
+
+        reader.post_validate_async(&validator).await.unwrap();
+
+        let results = reader.validation_results().unwrap();
+        let active = results.active_manifest().unwrap();
+
+        // The credential's issuer is not on the (empty) allow-list, so an
+        // untrusted-issuer notice is recorded informationally for this identity
+        // assertion (not as a failure, so it does not affect manifest state)...
+        assert!(active
+            .informational()
+            .iter()
+            .any(|s| s.code() == "cawg.ica.untrusted_issuer"));
+        assert!(!active
+            .failure()
+            .iter()
+            .any(|s| s.code() == "cawg.ica.untrusted_issuer"));
+
+        // ...and, because the issuer is untrusted, the credential is not reported
+        // as valid.
+        assert!(!active
+            .success()
+            .iter()
+            .any(|s| s.code() == "cawg.ica.credential_valid"));
+
+        // But the untrusted ICA issuer is scoped to the identity assertion: it
+        // does NOT invalidate the enclosing C2PA manifest.
         assert_eq!(reader.validation_state(), ValidationState::Valid);
     }
 

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -85,6 +85,23 @@ pub struct Trust {
     pub trust_config: Option<String>,
     /// List of explicitly allowed certificates as a PEM bundle.
     pub allowed_list: Option<String>,
+    /// Exact-match allow-list of trusted CAWG identity claims aggregation (ICA)
+    /// issuer DIDs.
+    ///
+    /// Each entry is a full DID string (any DID method) that is compared, after
+    /// stripping any fragment, against the `issuer` of an ICA verifiable
+    /// credential. An issuer that is not present on this list is reported with
+    /// the informational code `cawg.ica.untrusted_issuer` for that identity
+    /// assertion and its `cawg.ica.credential_valid` success code is withheld.
+    ///
+    /// The default value is empty, meaning that NO ICA issuer is trusted. This
+    /// is a deliberate secure default: a self-issued `did:jwk` (or any other
+    /// issuer) is not trustworthy simply because its signature is
+    /// self-consistent. Populate this list with the DIDs of issuers you trust.
+    // TO DO (CAI-12709): This field is only meaningful for `cawg_trust`, not for
+    // the C2PA `trust`. Move it (and the other CAWG-relevant settings) to a
+    // dedicated `CawgTrust` struct so it no longer pollutes the C2PA `Trust`.
+    pub trusted_ica_issuers: Option<Vec<String>>,
 }
 
 impl Trust {
@@ -152,6 +169,13 @@ impl Default for Trust {
                 trust_anchors: None,
                 trust_config: None,
                 allowed_list: None,
+                // Trust the ICA issuer DIDs used by the bundled CAWG test
+                // fixtures so the existing ICA validation tests continue to
+                // produce `cawg.ica.credential_valid`.
+                trusted_ica_issuers: Some(vec![
+                    "did:jwk:eyJhbGciOiJFZERTQSIsImt0eSI6Ik9LUCIsImNydiI6IkVkMjU1MTkiLCJ4IjoiTXA1LTBlODNuTmdRaGRoQlc4UnNoa2p5OTBzYTFBOUpJemtJdGNEcUN1SSJ9".to_string(),
+                    "did:web:connected-identities.identity-stage.adobe.com".to_string(),
+                ]),
             };
 
             trust.trust_config = Some(
@@ -177,6 +201,7 @@ impl Default for Trust {
                 trust_anchors: None,
                 trust_config: None,
                 allowed_list: None,
+                trusted_ica_issuers: None,
             }
         }
     }

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -220,6 +220,13 @@ impl ValidationResults {
             // NOTE: Changes here may impact the impl of [`ValidationFailureSummary::fmt`].
             //       Ensure changes are reciprocated in both locations.
             //
+            // A failure to trust the issuer of a CAWG identity claims aggregation
+            // (ICA) credential is scoped to that individual identity assertion and
+            // does not affect the enclosing manifest's state. It is recorded with
+            // the informational code `cawg.ica.untrusted_issuer` (and the
+            // credential's `cawg.ica.credential_valid` success code is withheld),
+            // so it never appears among the failures examined below.
+            //
             // https://spec.c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_valid_manifest
             let is_valid = active_manifest
                 // First check if the claim is valid and the certificate hasn't expired.
@@ -256,9 +263,7 @@ impl ValidationResults {
                 && active_manifest.failure().is_empty()
                 // Finally check if the ingredients contain no failures.
                 && self.ingredient_deltas.as_ref().iter().all(|deltas| {
-                    deltas.iter().all(|idv| {
-                        idv.validation_deltas().failure().is_empty()
-                    })
+                    deltas.iter().all(|idv| idv.validation_deltas().failure().is_empty())
                 })
                 && is_valid;
 
@@ -779,6 +784,19 @@ pub mod validation_codes {
     /// Any corresponding URL should point to a C2PA claim signature box.
     pub const SIGNING_CREDENTIAL_UNTRUSTED: &str = "signingCredential.untrusted";
 
+    /// The issuer of a CAWG identity claims aggregation (ICA) credential is not
+    /// listed on the validator's configured list of trusted ICA issuers.
+    ///
+    /// This is informational and scoped to the individual CAWG identity
+    /// assertion: it does not by itself render the enclosing C2PA manifest
+    /// invalid or untrusted. The credential's `cawg.ica.credential_valid` success
+    /// code is withheld when this is reported, so consumers should treat the
+    /// absence of `cawg.ica.credential_valid` as the signal that the identity was
+    /// not validated.
+    ///
+    /// Any corresponding URL should point to a CAWG identity assertion.
+    pub const CAWG_ICA_UNTRUSTED_ISSUER: &str = "cawg.ica.untrusted_issuer";
+
     /// The signing credential is not valid for signing.
     ///
     /// Any corresponding URL should point to a C2PA claim signature box.
@@ -1104,7 +1122,8 @@ pub mod validation_codes {
             | ALGORITHM_DEPRECATED
             | TIME_OF_SIGNING_INSIDE_VALIDITY
             | INGREDIENT_PROVENANCE_UNKNOWN
-            | ASSERTION_DATAHASH_ADDITIONAL_EXCLUSIONS => LogKind::Informational,
+            | ASSERTION_DATAHASH_ADDITIONAL_EXCLUSIONS
+            | CAWG_ICA_UNTRUSTED_ISSUER => LogKind::Informational,
             _ => LogKind::Failure,
         }
     }


### PR DESCRIPTION
Automated backport of #2209 to `0.90.0-rc`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.