### PR TITLE
fix!: Remove generic XML support from SVG handler

### DIFF
--- a/sdk/src/asset_handlers/svg_io.rs
+++ b/sdk/src/asset_handlers/svg_io.rs
@@ -46,16 +46,7 @@ use crate::{
     },
 };
 
-static SUPPORTED_TYPES: [&str; 8] = [
-    "svg",
-    "application/svg+xml",
-    "xhtml",
-    "xml",
-    "application/xhtml+xml",
-    "application/xml",
-    "image/svg+xml",
-    "text/xml",
-];
+static SUPPORTED_TYPES: [&str; 3] = ["svg", "application/svg+xml", "image/svg+xml"];
 
 const SVG: &str = "svg";
 const METADATA: &str = "metadata";


### PR DESCRIPTION
## Changes in this pull request
XML and other structured text types are now covered by their own specific manifest placement rules per the C2PA spec.  Remove the generic handling we had for those.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
