### PR TITLE
release: prepare 0.90.0 / 0.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.89.3...c2pa-v0.90.0)
+_16 July 2026_
+
+### Changed
+
+* Transition release onto the new scheduled breaking-change release train (see [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md)). This is a version-only bump: there are no `c2pa` library code changes since 0.89.3 ([#2250](https://github.com/contentauth/c2pa-rs/pull/2250)).
+
 ## [0.89.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.89.2...c2pa-v0.89.3)
 _13 July 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.0-rc.3"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.0-rc.3"
+version = "0.90.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.0-rc.3"
+version = "0.90.0"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.0-rc.3"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.0-rc.3"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2598,7 +2598,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.0-rc.3"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.0-rc.3"
+version = "0.90.0"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.0-rc.3", default-features = false }
+c2pa = { path = "sdk", version = "0.90.0", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.90.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.89.3...c2pa-c-ffi-v0.90.0)
+_16 July 2026_
+
+### Changed
+
+* Transition release onto the new scheduled breaking-change release train (see [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md)). This is a version-only bump: there are no `c2pa-c-ffi` library code changes since 0.89.3 ([#2250](https://github.com/contentauth/c2pa-rs/pull/2250)).
+
 ## [0.88.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.87.0...c2pa-c-ffi-v0.88.0)
 _11 June 2026_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.72...c2patool-v0.27.0)
+_16 July 2026_
+
+### Changed
+
+* Transition release onto the new scheduled breaking-change release train (see [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md)). This is a version-only bump: there are no `c2patool` code changes since 0.26.72 ([#2250](https://github.com/contentauth/c2pa-rs/pull/2250)).
+
 ## [0.26.72](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.26.71...c2patool-v0.26.72)
 _13 July 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.0-rc.3"
+version = "0.27.0"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION
## Why

The `0.90.0-rc` branch was promoted (merged) into `stable` carrying the release-candidate versions `c2pa 0.90.0-rc.3` / `c2patool 0.27.0-rc.3`. The `release-plz` `release-pr` job ([failing run](https://github.com/contentauth/c2pa-rs/actions/runs/29547621229/job/87783227903)) then aborted:

```
local package `c2pa` has a greater version (0.90.0-rc.3) with respect to the
registry package (0.89.3), but the git tag c2pa-v0.90.0-rc.3 exists.
Consider running `cargo publish` manually to publish the new version of this package.
```

release-plz's guard matches a git tag against the **exact local version**. `release-rc.yml` had already created `c2pa-v0.90.0-rc.3` (a prerelease binary-build tag, deliberately never published to crates.io), so release-plz reads it as an unpublished-but-tagged release and refuses to proceed.

## What

1. **Strip the `-rc.3` prerelease suffix** to the final `0.90.0` / `0.27.0`.
   - *No tag deletion needed.* The guard now looks for `c2pa-v0.90.0` (which doesn't exist); the `-rc.N` tags no longer match the local version.
   - *Deterministic + matches the baked binaries.* Pins the release to the exact versions validated as `-rc.3`, rather than letting release-plz recompute each crate's bump independently (c2patool has no code commits since 0.26.72, so release-plz would compute at most `0.26.73` — a regression below the already-tagged `c2patool-v0.27.0-rc.3`).

2. **Add `0.90.0` / `0.27.0` changelog entries** (`CHANGELOG.md`, `c2pa_c_ffi/CHANGELOG.md`, `cli/CHANGELOG.md`).

## ⚠️ This is a version-only transition release

release-plz generates **no** changelog for this release because **nothing in the train touches the published crates**:

- `sdk/src` (c2pa): **0 files changed** since `c2pa-v0.89.3`
- `cli/` (c2patool): only the version line since `c2patool-v0.26.72`
- The commits on `stable` beyond 0.89.3 are all CI / docs / release-process / lockfile changes

The train's substantive breaking work (~1,350 lines in `sdk/src`) is still on `main`, queued for the next train — this `0.90.0` was cut before it landed ("don't hold the train"). So `0.90.0` / `0.27.0` are **code-identical** to `0.89.3` / `0.26.72`; the changelog entries are header-only (release-plz's style for a no-releasable-commits release) plus a note recording the process transition.

## ⚠️ Merging this publishes to crates.io

Merging to `stable` triggers `release.yml` → `release-plz release`, publishing `c2pa 0.90.0`, `c2pa-c-ffi 0.90.0`, and `c2patool 0.27.0`. Version numbers can never be reused — merge deliberately. (Changelog dates read `16 July 2026`; adjust if merged later.)

## Follow-up

This will recur on **every** train because promotion carries `-rc.N` into `stable`. A separate PR to `main` will make the promotion step strip the suffix automatically so this stops happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)