### PR TITLE
ci: Automate train promotion so `-rc.N` is stripped before reaching stable

### DIFF
--- a/.github/scripts/normalize_promotion_changelog.py
+++ b/.github/scripts/normalize_promotion_changelog.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Normalize the newest changelog section to a train's forced final version.
+
+During promotion (see .github/workflows/release-promote.yml) we let release-plz
+generate the changelog while the crate versions are temporarily reset to the
+last published release, then force the crate versions to the train's chosen
+final numbers. release-plz cannot know the train's forced-minor / lockstep
+versioning policy, so the changelog header it wrote may not match the forced
+version:
+
+  * A crate with real commits gets a section headed with release-plz's *computed*
+    version (e.g. `c2patool 0.26.73`) -- we rewrite the header to the forced
+    final version (e.g. `0.27.0`).
+  * A crate with no releasable commits of its own gets no new section at all --
+    we insert a header-only section for the final version (matching how
+    release-plz renders a no-change release, e.g. the existing c2patool 0.26.72
+    entry).
+  * If release-plz already wrote the final version, we leave it alone.
+
+Whether release-plz added a section is detected by comparing the current top
+version against the top version captured *before* release-plz ran (`pretop`),
+which is robust even when a crate's changelog is already behind its published
+version (e.g. c2pa-c-ffi, whose no-change releases get no changelog entry).
+
+Each CLI argument is `CHANGELOG_PATH:CRATE:PREV_VERSION:FINAL_VERSION:PRETOP`,
+where PREV_VERSION is the last published version (the compare-link baseline),
+CRATE is the crates.io / git-tag crate name (e.g. `c2pa-c-ffi`), and PRETOP is
+the newest section's version before release-plz ran.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import sys
+
+REPO = "https://github.com/contentauth/c2pa-rs"
+HEADER_RE = re.compile(r"^## \[([^\]]+)\]")
+
+
+def compare_link(crate: str, prev: str, new: str) -> str:
+    return f"{REPO}/compare/{crate}-v{prev}...{crate}-v{new}"
+
+
+def header_line(crate: str, prev: str, final: str) -> str:
+    return f"## [{final}]({compare_link(crate, prev, final)})"
+
+
+def normalize(path: str, crate: str, prev: str, final: str, pretop: str) -> None:
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    # Locate "## [Unreleased]" and the first concrete version header after it.
+    unreleased = next(
+        (i for i, ln in enumerate(lines) if ln.strip().startswith("## [Unreleased]")),
+        None,
+    )
+    if unreleased is None:
+        raise SystemExit(f"{path}: no '## [Unreleased]' marker found")
+
+    top = None
+    top_ver = None
+    for i in range(unreleased + 1, len(lines)):
+        m = HEADER_RE.match(lines[i])
+        if m:
+            top, top_ver = i, m.group(1)
+            break
+    if top is None:
+        raise SystemExit(f"{path}: no version section found after '## [Unreleased]'")
+
+    if top_ver == final:
+        print(f"{path}: newest section already {final}; no change.")
+        return
+
+    if top_ver == pretop:
+        # release-plz added nothing new for this crate -> insert a header-only
+        # entry (baselined at the last published release, PREV).
+        today = datetime.datetime.now(datetime.timezone.utc).strftime("_%d %B %Y_")
+        lines[top:top] = [header_line(crate, prev, final), today, ""]
+        print(f"{path}: inserted header-only {final} section.")
+    else:
+        # release-plz wrote a new section at its computed version -> retitle it
+        # to the forced final version, keeping the body it generated.
+        lines[top] = header_line(crate, prev, final)
+        print(f"{path}: retitled {top_ver} section to {final}.")
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str]) -> None:
+    if not argv:
+        raise SystemExit(
+            "usage: normalize_promotion_changelog.py PATH:CRATE:PREV:FINAL:PRETOP ..."
+        )
+    for spec in argv:
+        parts = spec.split(":")
+        if len(parts) != 5:
+            raise SystemExit(f"bad spec '{spec}'; expected PATH:CRATE:PREV:FINAL:PRETOP")
+        normalize(*parts)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,228 @@
+name: Promote release candidate
+
+# Promotes a baked release-candidate branch (`0.N.0-rc`) onto the `stable`
+# release line -- the deliberate, manual final step of a breaking train's bake
+# (see docs/release-process.md, "Track 2 -- The breaking train").
+#
+# WHY THIS EXISTS
+#
+# Promotion used to be a hand-run `git merge` of the RC branch into `stable`.
+# That merge carried the candidate's *prerelease* version (`0.N.0-rc.M`) onto
+# `stable`, and release-plz then aborted its `release-pr` run with:
+#
+#     local package `c2pa` has a greater version (0.90.0-rc.3) with respect to
+#     the registry package (0.89.3), but the git tag c2pa-v0.90.0-rc.3 exists.
+#
+# release-plz's guard matches a git tag against the EXACT local version, and
+# `release-rc.yml` had already created `c2pa-v0.90.0-rc.3` for the prerelease
+# binaries. So the RC tag looked to release-plz like a botched publish, and the
+# release line was stuck every train.
+#
+# Stripping `-rc.N` to the final `0.N.0` BEFORE it reaches `stable` avoids the
+# collision entirely -- release-plz then looks for `c2pa-v0.N.0`, which does not
+# exist -- WITHOUT deleting any RC tags.
+#
+# WHAT IT DOES
+#
+#   1. Snapshots the outgoing `stable` as a `v0.<old>` branch, so the retiring
+#      line stays available for backports.
+#   2. Cuts a promotion branch from the RC branch and strips `-rc.N` -> final
+#      versions (`cargo set-version`, which also fixes intra-workspace deps).
+#   3. Generates the final-version changelog with release-plz (see the changelog
+#      step for how it works around release-plz's quirks).
+#   4. Opens a PR from the promotion branch into `stable`, labeled `release`.
+#
+# Merging that PR is what publishes: the push to `stable` triggers release.yml
+# (`release-plz release`), which publishes the crates, creates the real
+# `c2pa-v0.N.0` / `c2patool-v0.M.0` tags, and drives the binary builds. Because
+# the promotion PR already carries BOTH the final versions and the changelog,
+# publishing is a reviewed, deliberate PR merge -- not a side effect of a raw
+# branch merge, and the in-repo changelog is never skipped.
+#
+# The `release` label matters twice: it exempts the PR from the upstream-first
+# check (the version bump legitimately originates on the release line), and it
+# is the label release-plz already recognizes for release PRs.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    name: Promote release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to run outside a release-candidate branch
+        run: |
+          # An RC branch is named `<version>-rc` (no numeric suffix). Guard
+          # against dispatching against main / stable / a v0.x line.
+          case "${{ github.ref_name }}" in
+            *-rc) echo "Promoting RC branch ${{ github.ref_name }}." ;;
+            *)
+              echo "::error::release-promote must be dispatched on a *-rc branch, not '${{ github.ref_name }}'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout RC branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      # `cargo set-version` (cargo-edit) keeps intra-workspace dependency
+      # requirements in sync when it bumps a crate (e.g. c2patool's dep on c2pa).
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-edit
+          version: "0.13.6"
+
+      # Pin to the same release-plz the release workflows use, so the changelog
+      # this produces matches what release.yml would have written.
+      - name: Install release-plz
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: release-plz@0.3.158
+
+      - name: Compute promotion versions
+        id: ver
+        run: |
+          set -euo pipefail
+          meta() { cargo metadata --format-version=1 --no-deps | jq -r ".packages[]|select(.name==\"$1\")|.version"; }
+
+          # Current (candidate) versions on the RC branch, e.g. 0.90.0-rc.3.
+          RC_C2PA=$(meta c2pa); RC_TOOL=$(meta c2patool)
+
+          # Final release versions: strip the `-rc.N` prerelease suffix.
+          base() { echo "${1%-rc.*}"; }
+          FIN_C2PA=$(base "$RC_C2PA"); FIN_TOOL=$(base "$RC_TOOL")
+          case "$FIN_C2PA" in *-rc*|*-dev*) echo "::error::c2pa version '$RC_C2PA' did not reduce to a clean release version (got '$FIN_C2PA')."; exit 1;; esac
+
+          # The outgoing `stable` versions == what is on crates.io (stable tracks
+          # the latest published release). We need these both to name the
+          # snapshot branch and as the baseline for changelog generation below.
+          git fetch origin stable
+          OLD_C2PA=$(git show origin/stable:Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)
+          OLD_TOOL=$(git show origin/stable:cli/Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)
+          OLD_LINE="v$(echo "$OLD_C2PA" | cut -d. -f1,2)"   # e.g. 0.89.3 -> v0.89
+
+          {
+            echo "rc_c2pa=$RC_C2PA"
+            echo "fin_c2pa=$FIN_C2PA"
+            echo "fin_tool=$FIN_TOOL"
+            echo "old_c2pa=$OLD_C2PA"
+            echo "old_tool=$OLD_TOOL"
+            echo "old_line=$OLD_LINE"
+            echo "promote_branch=promote/${FIN_C2PA}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Promoting ${{ github.ref_name }} ($RC_C2PA) -> stable as c2pa $FIN_C2PA / c2patool $FIN_TOOL."
+          echo "Outgoing stable line $OLD_LINE (c2pa $OLD_C2PA / c2patool $OLD_TOOL)."
+
+      - name: Snapshot outgoing stable line
+        run: |
+          set -euo pipefail
+          LINE="${{ steps.ver.outputs.old_line }}"
+          if git ls-remote --exit-code --heads origin "$LINE" >/dev/null 2>&1; then
+            echo "Snapshot branch $LINE already exists; leaving it as-is."
+          else
+            # Point the retiring line at the current tip of stable so critical
+            # backports to the old release can still target it.
+            git push origin "refs/remotes/origin/stable:refs/heads/$LINE"
+            echo "Created snapshot branch $LINE from stable."
+          fi
+
+      - name: Strip -rc suffix to final versions
+        run: |
+          set -euo pipefail
+          # `-p c2pa` also moves c2pa-c-ffi, which shares the workspace version.
+          cargo set-version -p c2pa "${{ steps.ver.outputs.fin_c2pa }}"
+          cargo set-version -p c2patool "${{ steps.ver.outputs.fin_tool }}"
+
+      - name: Generate final-version changelog
+        run: |
+          set -euo pipefail
+          # release-plz will not write a changelog for a version that is already
+          # manually set ahead of the registry ("the local package has already a
+          # different version ... will not update it"), and it baselines the
+          # changelog against the highest matching git tag -- which would be a
+          # prerelease build tag (`c2pa-v0.N.0-rc.M`), truncating the range to
+          # just the bake bugfixes. Work around both, non-destructively:
+          #
+          #   a) Delete the `-rc.N` tags from THIS ephemeral checkout only. They
+          #      are never pushed, so the remote tags (and their binary GitHub
+          #      releases) are untouched. release-plz then baselines against the
+          #      last real release tag and covers the whole train.
+          #   b) Put the versions back to the last published release so
+          #      release-plz will run, generate the changelog, and compute a
+          #      bump; then restore the final (forced) versions afterward.
+          git tag -l '*-rc.*' | xargs -r git tag -d
+
+          # Record each changelog's current top version so we can later tell
+          # whether release-plz added a new section (robust even when a crate's
+          # changelog is behind its published version, e.g. c2pa-c-ffi).
+          pretop() { grep -oE '^## \[[^]]+\]' "$1" | sed -n '2s/^## \[\(.*\)\]$/\1/p'; }
+          PRE_C2PA=$(pretop CHANGELOG.md)
+          PRE_FFI=$(pretop c2pa_c_ffi/CHANGELOG.md)
+          PRE_TOOL=$(pretop cli/CHANGELOG.md)
+
+          cargo set-version -p c2pa "${{ steps.ver.outputs.old_c2pa }}"
+          cargo set-version -p c2patool "${{ steps.ver.outputs.old_tool }}"
+
+          release-plz update --repo-url "https://github.com/${GITHUB_REPOSITORY}"
+
+          # Restore the forced final versions (release-plz's computed numbers do
+          # not know the train's forced-minor / lockstep policy).
+          cargo set-version -p c2pa "${{ steps.ver.outputs.fin_c2pa }}"
+          cargo set-version -p c2patool "${{ steps.ver.outputs.fin_tool }}"
+
+          # Normalize each published crate's newest changelog section so its
+          # header version matches the forced final version (rewriting the
+          # header release-plz just wrote, or inserting a header-only section if
+          # release-plz found nothing releasable for that crate).
+          python3 .github/scripts/normalize_promotion_changelog.py \
+            "CHANGELOG.md:c2pa:${{ steps.ver.outputs.old_c2pa }}:${{ steps.ver.outputs.fin_c2pa }}:${PRE_C2PA}" \
+            "c2pa_c_ffi/CHANGELOG.md:c2pa-c-ffi:${{ steps.ver.outputs.old_c2pa }}:${{ steps.ver.outputs.fin_c2pa }}:${PRE_FFI}" \
+            "cli/CHANGELOG.md:c2patool:${{ steps.ver.outputs.old_tool }}:${{ steps.ver.outputs.fin_tool }}:${PRE_TOOL}"
+
+      - name: Open promotion pull request
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ steps.ver.outputs.promote_branch }}"
+          FIN_C2PA="${{ steps.ver.outputs.fin_c2pa }}"
+          FIN_TOOL="${{ steps.ver.outputs.fin_tool }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore: promote ${{ github.ref_name }} to c2pa ${FIN_C2PA} / c2patool ${FIN_TOOL}"
+          git push -f origin "$BRANCH"
+
+          gh pr create \
+            --base stable \
+            --head "$BRANCH" \
+            --label release \
+            --title "chore: release c2pa ${FIN_C2PA} / c2patool ${FIN_TOOL}" \
+            --body "$(cat <<EOF
+          Promotion of release-candidate branch \`${{ github.ref_name }}\` (candidate \`${{ steps.ver.outputs.rc_c2pa }}\`) onto \`stable\`.
+
+          - Versions stripped to the final **c2pa ${FIN_C2PA}** / **c2patool ${FIN_TOOL}** (c2pa-c-ffi shares the c2pa version).
+          - Changelog generated by release-plz for this release.
+          - Outgoing \`stable\` snapshotted as \`${{ steps.ver.outputs.old_line }}\` for backports.
+
+          **Merging this PR publishes to crates.io** (via \`release.yml\`) and creates the \`c2pa-v${FIN_C2PA}\` / \`c2patool-v${FIN_TOOL}\` tags, which drive the binary builds.
+
+          Before merging, please review the generated changelog sections -- release-plz cannot know the train's forced-minor / lockstep versioning, so a crate with no commits of its own (often \`c2patool\`) gets a header-only entry that you may want to annotate.
+          EOF
+          )"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -57,7 +57,7 @@ Breaking changes and larger refactors are batched onto a scheduled train:
 
 1. On the scheduled date, a release-candidate branch `0.(x+1).0-rc` is cut from `main`, and its first build `0.(x+1).0-rc.1` is cut immediately (versions set, tagged, prerelease binaries built). **RC branches are not published to crates.io** (their name keeps them off every crates.io publish trigger), but each build **does** get a prerelease GitHub release with binaries so downstream consumers that depend on pre-built binaries can validate during the bake. See [RC builds](#release-candidate-builds).
 2. **Bake period: minimum 3 business days.** Only bug fixes are accepted during the bake, and they follow upstream-first (fix on `main`, cherry-pick to the candidate). After fixes land, cut a fresh build (`-rc.2`, `-rc.3`, …) so downstream has updated binaries to test. Hold longer than 3 business days if needed to validate across the downstream projects we maintain.
-3. **Promote** (a deliberate, manual step): first snapshot the outgoing `stable` as `v0.<old>` so the retiring line is available for backports, then merge the candidate into `stable`. `release-plz` then opens the `0.(x+1).0` version/changelog PR on `stable`; merging it publishes the breaking release.
+3. **Promote** (a deliberate, manual trigger): run the [release-promote](#release-promotion) workflow (`workflow_dispatch` on the `0.(x+1).0-rc` branch). It snapshots the outgoing `stable` as `v0.<old>` (so the retiring line stays available for backports), **strips the candidate's `-rc.N` suffix to the final `0.(x+1).0`**, generates the changelog, and opens a release PR into `stable`. Merging that PR publishes the breaking release. Stripping the suffix before it reaches `stable` is deliberate: a raw merge of the candidate would carry a `0.(x+1).0-rc.N` version onto `stable`, where `release-plz` refuses to proceed because a prerelease build tag (`c2pa-v0.(x+1).0-rc.N`) already exists for that version (see [release promotion](#release-promotion)).
 
 ### Cadence: scheduled, but not forced
 
@@ -181,6 +181,19 @@ As a backstop to the proactive check above, a scheduled job, [`reconciliation.ym
 
 The first build (`-rc.1`) is cut automatically when the train is cut. A maintainer re-runs this workflow (via `workflow_dispatch` on the RC branch) to cut a fresh build after bugfixes have been cherry-picked onto the branch during the bake. Tags are pushed with a PAT (`RELEASE_PLZ_TOKEN`) so the tag-driven binary workflows actually run — pushes made with the default `GITHUB_TOKEN` do not cascade into other workflows.
 
+### Release promotion
+
+[`release-promote.yml`](../.github/workflows/release-promote.yml) performs the deliberate, manual promotion of a baked candidate branch (`0.N.0-rc`) onto `stable` (`workflow_dispatch` on the RC branch). It:
+
+1. Snapshots the outgoing `stable` as a `v0.<old>` branch, so the retiring line stays available for backports.
+2. Strips the candidate's `-rc.N` suffix to the final `0.N.0` (via `cargo set-version`, so intra-workspace deps stay in sync) on a `promote/…` branch cut from the RC branch.
+3. Generates the final-version changelog with `release-plz`.
+4. Opens a PR from the `promote/…` branch into `stable`, labeled `release`. Merging it triggers [`release.yml`](#release-plz), which publishes and creates the real `c2pa-v0.N.0` / `c2patool-v0.M.0` tags.
+
+**Why the suffix is stripped before `stable` sees it.** `release-rc.yml` tags each candidate build `c2pa-v0.N.0-rc.M` for the prerelease binaries. `release-plz` treats a git tag as evidence that a version was released, so if a raw `git merge` of the candidate carried `0.N.0-rc.M` onto `stable`, `release-plz release-pr` would abort: *"local package `c2pa` has a greater version (0.N.0-rc.M) with respect to the registry package, but the git tag `c2pa-v0.N.0-rc.M` exists."* Promoting to the final `0.N.0` sidesteps this entirely -- `release-plz` then looks for `c2pa-v0.N.0`, which does not exist -- **without deleting any RC tags** (which must survive, as they own the prerelease binary releases).
+
+**Why the changelog needs post-processing.** `release-plz` will not touch a version that is already manually set ahead of the registry, and it baselines the changelog against the highest matching git tag -- which would be a `-rc.N` build tag. The workflow works around both non-destructively: it deletes the `-rc.N` tags from its *ephemeral* checkout only (never pushed; the remote tags and their binary releases are untouched), temporarily resets the crate versions to the last published release so `release-plz` generates a full-train changelog, then restores the forced final versions. Because `release-plz` computes each crate's bump from its own commits -- and cannot know the train's forced-minor, lockstep-across-crates policy -- [`normalize_promotion_changelog.py`](../.github/scripts/normalize_promotion_changelog.py) then retitles each crate's newest changelog section to the forced final version (or inserts a header-only section for a crate with no commits of its own, e.g. `c2patool`). Review these sections in the promotion PR before merging.
+
 ### Cross-repo canary
 
 [`canary-extracted-crates.yml`](../.github/workflows/canary-extracted-crates.yml) builds `c2pa-rs` `main` against the `main` of each extracted crate via a throwaway `[patch]`, and files an issue on failure. The `[patch]` exists only inside the runner; the patch-dependency guard guarantees it can never reach a release.
@@ -265,6 +278,7 @@ Branch-name patterns (`v0.*`, `*-rc*`) can be covered with a single ruleset each
 Some release automation pushes directly to protected branches and so must be on the ruleset **bypass list** — grant this to the identity behind `RELEASE_PLZ_TOKEN`:
 
 * [`release-train-cut.yml`](#release-train-cut) commits the next-dev-cycle bump straight to `main`, and [`release-rc.yml`](#release-candidate-builds) commits `-rc.N` version bumps straight to the RC branch. Both bypass the pull-request rule by design (they are mechanical version bumps, not reviewed changes).
+* [`release-promote.yml`](#release-promotion) creates the `v0.<old>` snapshot branch (a `v0.*` protected pattern) when promoting a train. It does **not** push to `stable` directly -- the promotion lands via a reviewed release PR -- but creating the snapshot branch requires bypass of the `v0.*` ruleset.
 
 ## One-time setup
 


### PR DESCRIPTION
## Problem

Promoting a baked release-candidate branch was a hand-run `git merge` of `0.N.0-rc` into `stable`. That merge carried the candidate's **prerelease** version (`0.N.0-rc.M`) onto `stable`, and `release-plz release-pr` then aborted — as it just did for the 0.90.0 train ([run](https://github.com/contentauth/c2pa-rs/actions/runs/29547621229/job/87783227903)):

```
local package `c2pa` has a greater version (0.90.0-rc.3) with respect to the
registry package (0.89.3), but the git tag c2pa-v0.90.0-rc.3 exists.
```

release-plz's guard matches a git tag against the **exact local version**, and `release-rc.yml` had already created `c2pa-v0.90.0-rc.3` for the prerelease binaries. So the RC tag looked like a botched publish, and the release line was stuck. This recurs **every train** — and the fix must not delete the RC tags (they own the prerelease binary releases).

## Fix

New **`release-promote.yml`** (`workflow_dispatch` on the RC branch) automates the promotion the docs previously described as a manual step:

1. **Snapshots** the outgoing `stable` as `v0.<old>` (retiring line, for backports).
2. **Strips `-rc.N` → final `0.N.0`** on a `promote/…` branch *before* it reaches `stable`. release-plz then looks for `c2pa-v0.N.0` (doesn't exist) — no collision, **no RC tags deleted**.
3. **Generates the changelog** with release-plz (see below).
4. **Opens a release PR** into `stable`, labeled `release`. Merging it publishes — so publishing stays a deliberate, reviewed merge and the in-repo changelog is never skipped (the failure mode we hit on #2313).

### Changelog handling (the part most worth reviewing)

release-plz fights us two ways here, both handled **non-destructively**:

- It **won't touch a version already set ahead of the registry** → the workflow temporarily resets versions to the last published release, lets release-plz generate, then restores the forced final versions.
- It **baselines the changelog against the highest matching tag** (a `-rc.N` build tag) → the workflow deletes `-rc.N` tags from its *ephemeral checkout only* (never pushed; remote tags untouched) so the baseline is the last real release.

release-plz computes each crate's bump from its own commits and **can't know the train's forced-minor, lockstep-across-crates policy** (e.g. c2patool with no commits of its own would compute `0.26.73`, not `0.27.0`). So `normalize_promotion_changelog.py` retitles each crate's newest section to the forced final version, or inserts a header-only section for a crate with no commits of its own. Tested against all three cases (retitle / insert / already-final), including the c2pa-c-ffi case where the changelog trails its published version.

## Notes

- Draft — the changelog dance is the fiddly part; would appreciate a close look there. An alternative I considered was moving the RC binary tags out of the `{crate}-v*` namespace release-plz keys on; happy to discuss if you'd prefer that direction.
- Docs updated (`docs/release-process.md`): promotion step, a new **Release promotion** automation subsection, and the branch-protection bypass list.
- Requires the `RELEASE_PLZ_TOKEN` identity to be able to create `v0.*` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)