### PR TITLE
fix: Support additional MP3 mime_types for compatibility (backport #2320)

### DIFF
--- a/sdk/src/asset_handlers/id3_helper.rs
+++ b/sdk/src/asset_handlers/id3_helper.rs
@@ -684,7 +684,6 @@ pub(crate) mod test_helpers {
         let types = handler.supported_types();
         assert!(types.contains(&expected_ext));
         assert!(types.contains(&expected_mime));
-        assert_eq!(types.len(), 2);
     }
 
     pub(crate) fn run_embed_reference_file_path(

--- a/sdk/src/asset_handlers/mp3_io.rs
+++ b/sdk/src/asset_handlers/mp3_io.rs
@@ -24,7 +24,13 @@ use crate::{
     error::{Error, Result},
 };
 
-static SUPPORTED_TYPES: [&str; 2] = ["mp3", "audio/mpeg"];
+static SUPPORTED_TYPES: [&str; 5] = [
+    "mp3",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/x-mp3",
+    "audio/mpeg3",
+];
 
 // ── MP3-specific ID3 header reader ──────────────────────────────────────────
 


### PR DESCRIPTION
Automated backport of #2320 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.