### PR TITLE
fix: Exclude release-ceremony commits from reconciliation (backport #2321)

### DIFF
--- a/.github/workflows/reconciliation.yml
+++ b/.github/workflows/reconciliation.yml
@@ -12,6 +12,17 @@ name: Release-branch reconciliation
 # It deliberately does NOT merge a release-line branch back into `main`:
 # merging into the actively-refactored `main` is the conflict-prone direction
 # and risks resurrecting code a refactor removed.
+#
+# Release-ceremony commits are excluded. A release line carries version/
+# changelog bookkeeping commits that are native to the release process and
+# must NOT be forward-ported -- RC version bumps (release-rc.yml), the final
+# release-prep commit, etc. `main` owns its own versions (release-plz plus the
+# dev-cycle bump in release-train-cut.yml), so replaying these onto `main`
+# would only cause conflicts. They are identified structurally -- by a diff
+# confined entirely to bookkeeping paths (Cargo.toml, Cargo.lock, CHANGELOG.md)
+# -- rather than by author or commit message, both of which vary (some bumps
+# are made by github-actions[bot], some by a maintainer by hand). Any commit
+# that touches a non-bookkeeping file is real work and is still reported.
 
 on:
   schedule:
@@ -47,8 +58,30 @@ jobs:
           fi
           git fetch origin main "${{ matrix.branch }}"
           # `git cherry` marks with `+` the commits on the release branch whose
-          # change is NOT present (as an equivalent patch) on main.
-          MISSING=$(git cherry origin/main "origin/${{ matrix.branch }}" | grep '^+' || true)
+          # change is NOT present (as an equivalent patch) on main. Cherry-picks
+          # already on main are patch-equivalent and are NOT marked, so the `+`
+          # set is exactly the commits native to the release line.
+          CANDIDATES=$(git cherry origin/main "origin/${{ matrix.branch }}" | sed -n 's/^+ //p')
+
+          # Drop release-ceremony commits: those whose entire diff is confined
+          # to version/changelog bookkeeping files (see header comment). A
+          # commit touching any other path is real work and is reported.
+          MISSING=""
+          for sha in $CANDIDATES; do
+            files=$(git diff-tree --no-commit-id --name-only -r "$sha")
+            # -vE prints paths that are NOT bookkeeping; `|| true` keeps the
+            # step alive under `set -e` when grep matches nothing (all files
+            # are bookkeeping, i.e. a ceremony commit).
+            non_bookkeeping=$(printf '%s\n' "$files" \
+              | grep -vE '(^|/)Cargo\.toml$|^Cargo\.lock$|(^|/)CHANGELOG\.md$' || true)
+            if [ -n "$files" ] && [ -z "$non_bookkeeping" ]; then
+              echo "Skipping release-ceremony commit $sha (version/changelog bookkeeping only)."
+            else
+              MISSING="${MISSING}+ ${sha}"$'\n'
+            fi
+          done
+          MISSING=$(printf '%s' "$MISSING" | sed '/^$/d')
+
           {
             echo "missing<<EOF"
             echo "$MISSING"


### PR DESCRIPTION
Automated backport of #2321 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.