### PR TITLE
fix: Repair broken intra-doc link in Settings doc comment (backport #2331)

### DIFF
--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -441,8 +441,12 @@ impl SettingsValidate for Verify {}
 
 /// Settings for configuring all aspects of c2pa-rs.
 ///
-/// [Settings::default] will be set thread-locally by default. Any settings set via
-/// [Settings::from_toml] or [Settings::from_file] will also be thread-local.
+/// [`Settings::default`] is used as the thread-local configuration by default.
+/// Use [`Settings::new`] together with builder-style methods such as
+/// [`with_toml`] to construct a configuration without modifying thread-local
+/// state.
+///
+/// [`with_toml`]: Settings::with_toml
 #[cfg_attr(
     feature = "json_schema",
     derive(schemars::JsonSchema),


### PR DESCRIPTION
Automated backport of #2331 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.