### PR TITLE
fix: Terminate crJSON b64' byte-string values with closing quote

### DIFF
--- a/sdk/src/crjson.rs
+++ b/sdk/src/crjson.rs
@@ -54,7 +54,7 @@ struct Base64Bytes(Vec<u8>);
 
 impl Serialize for Base64Bytes {
     fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("b64'{}", base64::encode(&self.0)))
+        s.serialize_str(&format!("b64'{}'", base64::encode(&self.0)))
     }
 }
 
@@ -387,7 +387,7 @@ impl<'a> CrJsonExporter<'a> {
                         key,
                         json!({
                             "identifier": absolute_uri,
-                            "hash": format!("b64'{}", base64::encode(&assertion_ref.hash()))
+                            "hash": format!("b64'{}'", base64::encode(&assertion_ref.hash()))
                         }),
                     );
                 }
@@ -429,7 +429,7 @@ impl<'a> CrJsonExporter<'a> {
                 Ok(Some(json!({
                     "format": assertion.content_type(),
                     "identifier": absolute_uri,
-                    "hash": format!("b64'{}", base64::encode(ca.hash()))
+                    "hash": format!("b64'{}'", base64::encode(ca.hash()))
                 })))
             }
             _ => Ok(assertion.as_json_object().ok().map(fix_hash_encoding)),
@@ -678,7 +678,7 @@ fn fix_hash_encoding(value: Value) -> Value {
                                 .collect();
                             map.insert(
                                 field.to_string(),
-                                json!(format!("b64'{}", base64::encode(&bytes))),
+                                json!(format!("b64'{}'", base64::encode(&bytes))),
                             );
                         }
                     }
@@ -687,7 +687,7 @@ fn fix_hash_encoding(value: Value) -> Value {
 
             // Ensure hash-bearing objects also carry a (possibly empty) pad field.
             if map.contains_key("hash") && !map.contains_key("pad") {
-                map.insert("pad".to_string(), json!("b64'"));
+                map.insert("pad".to_string(), json!("b64''"));
             }
 
             if let Some(sig_val) = map.get("signature") {
@@ -698,7 +698,7 @@ fn fix_hash_encoding(value: Value) -> Value {
                             .filter_map(|v| v.as_u64().map(|n| n as u8))
                             .collect();
                         let decoded = decode_cawg_signature(&sig_bytes).unwrap_or_else(|_| {
-                            json!(format!("b64'{}", base64::encode(&sig_bytes)))
+                            json!(format!("b64'{}'", base64::encode(&sig_bytes)))
                         });
                         map.insert("signature".to_string(), decoded);
                     }
@@ -996,8 +996,8 @@ mod tests {
         // Verify pad2 is a b64'-prefixed string if present (pad1 does not exist in the schema)
         if let Some(pad2) = cawg_identity.get("pad2").and_then(|v| v.as_str()) {
             assert!(
-                pad2.starts_with("b64'"),
-                "pad2 must start with \"b64'\" prefix, got: {pad2:?}"
+                pad2.starts_with("b64'") && pad2.ends_with('\''),
+                "pad2 must be delimited by \"b64'\" and a closing \"'\", got: {pad2:?}"
             );
         }
 
@@ -1079,8 +1079,8 @@ mod tests {
             // Verify pad2 is a b64'-prefixed string if present (pad1 does not exist in the schema)
             if let Some(pad2) = cawg_identity.get("pad2").and_then(|v| v.as_str()) {
                 assert!(
-                    pad2.starts_with("b64'"),
-                    "pad2 must start with \"b64'\" prefix, got: {pad2:?}"
+                    pad2.starts_with("b64'") && pad2.ends_with('\''),
+                    "pad2 must be delimited by \"b64'\" and a closing \"'\", got: {pad2:?}"
                 );
             }
 

--- a/sdk/tests/crjson/hash_assertions.rs
+++ b/sdk/tests/crjson/hash_assertions.rs
@@ -45,7 +45,11 @@ fn test_hash_data_assertion_structure() -> Result<()> {
         "c2pa.hash.data.hash must start with \"b64'\" prefix, got: {hash:?}"
     );
     assert!(
-        hash.len() > "b64'".len(),
+        hash.ends_with('\''),
+        "c2pa.hash.data.hash must end with a closing \"'\", got: {hash:?}"
+    );
+    assert!(
+        hash.len() > "b64''".len(),
         "c2pa.hash.data.hash payload must not be empty"
     );
 
@@ -65,6 +69,10 @@ fn test_hash_data_assertion_structure() -> Result<()> {
         assert!(
             pad_str.starts_with("b64'"),
             "c2pa.hash.data.pad must start with \"b64'\" prefix, got: {pad_str:?}"
+        );
+        assert!(
+            pad_str.ends_with('\''),
+            "c2pa.hash.data.pad must end with a closing \"'\", got: {pad_str:?}"
         );
     }
 
@@ -154,6 +162,10 @@ fn test_action_ingredient_hash_is_base64() -> Result<()> {
             assert!(
                 hash_str.starts_with("b64'"),
                 "action[{i}] ingredient hash must start with \"b64'\" prefix, got: {hash_str:?}"
+            );
+            assert!(
+                hash_str.ends_with('\''),
+                "action[{i}] ingredient hash must end with a closing \"'\", got: {hash_str:?}"
             );
         }
     }

--- a/sdk/tests/crjson/schema_compliance.rs
+++ b/sdk/tests/crjson/schema_compliance.rs
@@ -296,12 +296,16 @@ fn test_hash_fields_are_base64_strings() -> Result<()> {
                             "'{child_path}' must be a b64'-prefixed string, not an integer array"
                         );
                         if let Some(s) = v.as_str() {
-                            // Must start with "b64'" prefix.
+                            // Must be delimited by a "b64'" prefix and a closing "'".
                             assert!(
                                 s.starts_with("b64'"),
                                 "'{child_path}' value must start with \"b64'\" prefix, got: {s:?}"
                             );
-                            let payload = &s["b64'".len()..];
+                            assert!(
+                                s.len() > "b64'".len() && s.ends_with('\''),
+                                "'{child_path}' value must end with a closing \"'\", got: {s:?}"
+                            );
+                            let payload = &s["b64'".len()..s.len() - 1];
                             // Payload must be valid base64 if non-empty.
                             if !payload.is_empty() {
                                 use std::collections::HashSet;


### PR DESCRIPTION
## Summary

Fixes [CAI-12948](https://jira.corp.adobe.com/browse/CAI-12948). Closes #2266.

crJSON byte-string values are emitted in CBOR extended diagnostic notation as `b64'<data>`, but the exporter was omitting the closing `'` delimiter that the notation requires (RFC 8949 §8). Every b64 value in the output was malformed:

```json
"pad": "b64'AAAAAAAAAAAA"
```

when it should be:

```json
"pad": "b64'AAAAAAAAAAAA'"
```

## Note

The [crJSON specification](https://spec.c2pa.org/specifications/specifications/2.4/crJSON/crjson-format.html) currently describes the examples using malformed syntax. This is considered a bug by C2PA and will be fixed in an upcoming version of the spec. This PR anticipates that fix.

## Changes

- `sdk/src/crjson.rs` — add the trailing `'` at every producer: the `Base64Bytes` serializer, assertion-reference/binary hashes, the `fix_hash_encoding` hash/pad/pad2 conversion, the CAWG signature fallback, and the empty-pad case (now `b64''`).
- Extend the crJSON tests (`hash_assertions.rs`, `schema_compliance.rs`, and the in-source CAWG tests) to assert the closing delimiter, and update the schema-compliance base64 payload check to strip it.

## Testing

- `cargo test -p c2pa --features file_io --test crjson_tests` — 29 passed
- `cargo test -p c2pa --features file_io --lib crjson` — 7 passed
- `cargo fmt -p c2pa -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)