### PR TITLE
chore(sdk): Mark CLAIM_REVIEW deprecated

### DIFF
--- a/sdk/src/assertion.rs
+++ b/sdk/src/assertion.rs
@@ -25,7 +25,7 @@ use crate::{
 
 /// Check to see if this a label whose string can vary, if so return the root of the label and version if available
 fn get_mutable_label(var_label: &str) -> (String, Option<usize>) {
-    if var_label.starts_with(labels::SCHEMA_ORG) {
+    if var_label.starts_with(labels::SCHEMA_ORG_INTERNAL) {
         (var_label.to_string(), None)
     } else {
         // is it a type of thumbnail

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -176,7 +176,7 @@ pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 /// Label prefix for a Creative Work assertion. Deprecated in C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
-    note = "This attribute is deprecated from c2pa spec version 2.0"
+    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-12-01."
 )]
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -162,7 +162,13 @@ pub const IPTC_PHOTO_METADATA: &str = "stds.iptc.photo-metadata";
 ///
 /// See [Use of Schema.org - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_use_of_schema_org).
 #[doc(hidden)]
+#[deprecated(
+    since = "0.91.0",
+    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-11-09."
+)]
 pub const SCHEMA_ORG: &str = "schema.org";
+
+pub(crate) const SCHEMA_ORG_INTERNAL: &str = "schema.org";
 
 /// Label prefix for a Claim Review assertion. Deprecated since C2PA 2.0 spec.
 #[deprecated(

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -167,9 +167,11 @@ pub const SCHEMA_ORG: &str = "schema.org";
 /// Label prefix for a claim review assertion.
 ///
 /// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
+#[deprecated(note = "This attribute is deprecated from c2pa spec version 2.0")]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
 /// Label prefix for a creative work assertion. Deprecated in c2pa 2.0 spec.
+#[deprecated(note = "This attribute is deprecated from c2pa spec version 2.0")]
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 
 /// Label prefix for a timestamp assertion.

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -169,7 +169,7 @@ pub const SCHEMA_ORG: &str = "schema.org";
 /// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
 #[deprecated(
     since = "0.91.0",
-    note = "This attribute is deprecated from c2pa spec version 2.0"
+    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-12-14."
 )]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -167,11 +167,17 @@ pub const SCHEMA_ORG: &str = "schema.org";
 /// Label prefix for a claim review assertion.
 ///
 /// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
-#[deprecated(since = "0.91.0", note = "This attribute is deprecated from c2pa spec version 2.0")]
+#[deprecated(
+    since = "0.91.0",
+    note = "This attribute is deprecated from c2pa spec version 2.0"
+)]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
 /// Label prefix for a creative work assertion. Deprecated in c2pa 2.0 spec.
-#[deprecated(since = "0.91.0", note = "This attribute is deprecated from c2pa spec version 2.0")]
+#[deprecated(
+    since = "0.91.0",
+    note = "This attribute is deprecated from c2pa spec version 2.0"
+)]
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 
 /// Label prefix for a timestamp assertion.

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -173,7 +173,7 @@ pub const SCHEMA_ORG: &str = "schema.org";
 )]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
-/// Label prefix for a creative work assertion. Deprecated in c2pa 2.0 spec.
+/// Label prefix for a Creative Work assertion. Deprecated in C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
     note = "This attribute is deprecated from c2pa spec version 2.0"

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -164,9 +164,7 @@ pub const IPTC_PHOTO_METADATA: &str = "stds.iptc.photo-metadata";
 #[doc(hidden)]
 pub const SCHEMA_ORG: &str = "schema.org";
 
-/// Label prefix for a claim review assertion.
-///
-/// Label prefix for a claim review assertion. Deprecated since C2PA 2.0 spec.
+/// Label prefix for a Claim Review assertion. Deprecated since C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
     note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-11-09."

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -167,11 +167,11 @@ pub const SCHEMA_ORG: &str = "schema.org";
 /// Label prefix for a claim review assertion.
 ///
 /// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
-#[deprecated(note = "This attribute is deprecated from c2pa spec version 2.0")]
+#[deprecated(since = "0.91.0", note = "This attribute is deprecated from c2pa spec version 2.0")]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
 /// Label prefix for a creative work assertion. Deprecated in c2pa 2.0 spec.
-#[deprecated(note = "This attribute is deprecated from c2pa spec version 2.0")]
+#[deprecated(since = "0.91.0", note = "This attribute is deprecated from c2pa spec version 2.0")]
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 
 /// Label prefix for a timestamp assertion.

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -166,10 +166,10 @@ pub const SCHEMA_ORG: &str = "schema.org";
 
 /// Label prefix for a claim review assertion.
 ///
-/// See [Claim review - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_claim_review).
+/// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
-/// Label prefix for a creative work assertion.  Deprecated.
+/// Label prefix for a creative work assertion. Deprecated in c2pa 2.0 spec.
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 
 /// Label prefix for a timestamp assertion.

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -166,7 +166,7 @@ pub const SCHEMA_ORG: &str = "schema.org";
 
 /// Label prefix for a claim review assertion.
 ///
-/// Label prefix for a creative review assertion. Deprecated in c2pa 2.0 spec.
+/// Label prefix for a claim review assertion. Deprecated since C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
     note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-12-14."

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -169,14 +169,14 @@ pub const SCHEMA_ORG: &str = "schema.org";
 /// Label prefix for a claim review assertion. Deprecated since C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
-    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-12-14."
+    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-11-09."
 )]
 pub const CLAIM_REVIEW: &str = "stds.schema-org.ClaimReview";
 
 /// Label prefix for a Creative Work assertion. Deprecated in C2PA 2.0 spec.
 #[deprecated(
     since = "0.91.0",
-    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-12-01."
+    note = "This attribute is deprecated from C2PA spec version 2.0. Will be deleted on or after 2026-11-09."
 )]
 pub const CREATIVE_WORK: &str = "stds.schema-org.CreativeWork";
 

--- a/sdk/src/assertions/schema_org.rs
+++ b/sdk/src/assertions/schema_org.rs
@@ -126,7 +126,7 @@ impl Default for SchemaDotOrg {
 impl AssertionJson for SchemaDotOrg {}
 
 impl AssertionBase for SchemaDotOrg {
-    const LABEL: &'static str = labels::SCHEMA_ORG;
+    const LABEL: &'static str = labels::SCHEMA_ORG_INTERNAL;
     const VERSION: Option<usize> = Some(ASSERTION_CREATION_VERSION);
 
     fn to_assertion(&self) -> Result<Assertion> {

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -7036,7 +7036,7 @@ pub mod tests {
         // Check that both redactions are present
         let redacted_claim = new_claim.claim_ingredient(pc.label()).unwrap();
         assert!(redacted_claim
-            .get_assertion(labels::SCHEMA_ORG, 0)
+            .get_assertion(labels::SCHEMA_ORG_INTERNAL, 0)
             .is_none());
 
         assert!(redacted_claim

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6470,7 +6470,7 @@ pub mod tests {
         claim.add_claim_generator_info(cgi);
 
         // created redacted uri
-        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG);
+        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG_INTERNAL);
 
         let (manifest_bytes, _) = Store::load_jumbf_from_stream(
             format,
@@ -6636,7 +6636,7 @@ pub mod tests {
         // make sure the redaction stuck
         let redacted_claim = resolved_store.get_claim(pc.label()).unwrap();
         assert!(redacted_claim
-            .get_assertion(labels::SCHEMA_ORG, 0)
+            .get_assertion(labels::SCHEMA_ORG_INTERNAL, 0)
             .is_none());
     }
 
@@ -6689,7 +6689,7 @@ pub mod tests {
         claim.add_claim_generator_info(cgi);
 
         // created redacted uri
-        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG);
+        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG_INTERNAL);
 
         let (manifest_bytes, _) = Store::load_jumbf_from_stream(
             format,
@@ -6791,7 +6791,7 @@ pub mod tests {
         // the confict_store is adjusted to remove the conflicting claim
         let not_redacted_claim = new_claim.claim_ingredient(pc.label()).unwrap();
         assert!(not_redacted_claim
-            .get_assertion(labels::SCHEMA_ORG, 0)
+            .get_assertion(labels::SCHEMA_ORG_INTERNAL, 0)
             .is_some());
 
         // load ingredient with redaction
@@ -6805,7 +6805,7 @@ pub mod tests {
         // the confict_store is adjusted to remove the conflicting claim
         let redacted_claim = new_claim.claim_ingredient(pc.label()).unwrap();
         assert!(redacted_claim
-            .get_assertion(labels::SCHEMA_ORG, 0)
+            .get_assertion(labels::SCHEMA_ORG_INTERNAL, 0)
             .is_none());
     }
 
@@ -6856,7 +6856,7 @@ pub mod tests {
         claim.add_claim_generator_info(cgi.clone());
 
         // created redacted uri
-        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG);
+        let redacted_uri = to_assertion_uri(pc.label(), labels::SCHEMA_ORG_INTERNAL);
 
         output_stream.rewind().unwrap();
         let ingredient_vec = load_jumbf_from_stream(format, &mut output_stream).unwrap();
@@ -8453,7 +8453,7 @@ pub mod tests {
         store.commit_claim(claim).unwrap();
 
         // Do we generate JUMBF?
-        let signer = test_cawg_signer(SigningAlg::Ps256, &[labels::SCHEMA_ORG]).unwrap();
+        let signer = test_cawg_signer(SigningAlg::Ps256, &[labels::SCHEMA_ORG_INTERNAL]).unwrap();
 
         store
             .save_to_bmff_fragmented(


### PR DESCRIPTION
`stds.schema-org` was deprecated in c2pa spec 2.0 version. Mark all members of `stds.schema-org` as deprecated.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
