### PR TITLE
feat(sdk): add Builder action/ingredient removal API (backport #2281)

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -767,43 +767,64 @@ impl Action {
         Ok(self)
     }
 
-    /// Extracts ingredient IDs from the action
-    /// There are many deprecated ways to specify ingredient IDs
-    /// priority: parameters.ingredientIds, parameters.org.cai.ingredientIds, parameters.instanceId, instanceId.
-    /// This is used to map actions to their associated ingredients.
-    /// We don't want any of these fields in the final CBOR, so we remove them after extracting.
-    pub(crate) fn extract_ingredient_ids(&mut self) -> Option<Vec<String>> {
-        let ingredient_ids = self.remove_parameter(INGREDIENT_IDS);
-        let cai_ingredient_ids = self.remove_parameter("org.cai.ingredientIds");
-        let param_instance_id = self.remove_parameter("instanceId");
-        #[allow(deprecated)]
-        let instance_id = self.instance_id.take();
-        let mut ids: Vec<String> = Vec::new();
-
-        let mut convert_ids = |val: Option<c2pa_cbor::Value>| {
-            if let Some(val) = val {
-                match val {
-                    c2pa_cbor::Value::Array(arr) => {
-                        for v in arr {
-                            if let c2pa_cbor::Value::Text(s) = v {
-                                ids.push(s);
-                            }
-                        }
-                    }
-                    c2pa_cbor::Value::Text(s) => ids.push(s),
-                    _ => {}
-                }
+    /// Reads the ingredient IDs an action references, without mutating the action.
+    ///
+    /// There are many deprecated ways to specify ingredient IDs; this checks every linking
+    /// mechanism in priority order: `parameters.ingredientIds`, `parameters.org.cai.ingredientIds`,
+    /// `parameters.instanceId`, then the deprecated `instanceId` field (only when none of the
+    /// parameters are present). Used to map actions to their associated ingredients.
+    ///
+    /// This is the read-only counterpart of [`Self::extract_ingredient_ids`], which additionally
+    /// removes the parameters it reads. Use this when the action must stay intact (e.g. computing
+    /// which ingredients are referenced during a prune).
+    pub(crate) fn ingredient_ids(&self) -> Vec<String> {
+        let convert = |val: Option<c2pa_cbor::Value>| -> Vec<String> {
+            match val {
+                Some(c2pa_cbor::Value::Array(arr)) => arr
+                    .into_iter()
+                    .filter_map(|v| match v {
+                        c2pa_cbor::Value::Text(s) => Some(s),
+                        _ => None,
+                    })
+                    .collect(),
+                Some(c2pa_cbor::Value::Text(s)) => vec![s],
+                _ => vec![],
             }
         };
 
-        convert_ids(ingredient_ids);
-        convert_ids(cai_ingredient_ids);
-        convert_ids(param_instance_id);
+        let mut ids = Vec::new();
+        ids.extend(convert(self.get_parameter(INGREDIENT_IDS)));
+        ids.extend(convert(self.get_parameter("org.cai.ingredientIds")));
+        ids.extend(convert(self.get_parameter("instanceId")));
+        if ids.is_empty() {
+            #[allow(deprecated)]
+            if let Some(id) = self.instance_id.as_deref() {
+                ids.push(id.to_owned());
+            }
+        }
+        ids
+    }
 
-        if !ids.is_empty() {
-            Some(ids)
+    /// Extracts ingredient IDs from the action, removing the parameters it reads.
+    ///
+    /// Reads the same links as [`Self::ingredient_ids`], then removes the temporary
+    /// `ingredientIds` / `org.cai.ingredientIds` / `instanceId` parameters and the deprecated
+    /// `instanceId` field, because we don't want any of them in the final CBOR.
+    pub(crate) fn extract_ingredient_ids(&mut self) -> Option<Vec<String>> {
+        let ids = self.ingredient_ids();
+
+        self.remove_parameter(INGREDIENT_IDS);
+        self.remove_parameter("org.cai.ingredientIds");
+        self.remove_parameter("instanceId");
+        #[allow(deprecated)]
+        {
+            self.instance_id = None;
+        }
+
+        if ids.is_empty() {
+            None
         } else {
-            instance_id.map(|s| vec![s])
+            Some(ids)
         }
     }
 }

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -44,7 +44,10 @@ use crate::{
     crypto::cose,
     error::{Error, Result},
     hash_utils::hash_by_alg,
-    jumbf::labels::manifest_label_from_uri,
+    jumbf::labels::{
+        assertion_label_from_uri, label_segment_from_uri, manifest_label_from_uri,
+        parse_positional_label,
+    },
     jumbf_io,
     maybe_send_sync::MaybeSend,
     resource_store::{ResourceRef, ResourceResolver, ResourceStore},
@@ -902,6 +905,201 @@ impl Builder {
         Ok(self)
     }
 
+    /// Retains only the actions for which `keep` returns true, across every actions assertion.
+    ///
+    /// `keep` is applied to each action in each `c2pa.actions*` assertion. A manifest may carry
+    /// more than one (a created-list actions assertion, which holds the inception action, plus a
+    /// gathered-list actions assertion of user actions), and all are filtered. When anything is
+    /// removed from an assertion, its `allActionsIncluded` is set to `false`. An actions assertion
+    /// left with no actions is dropped entirely.
+    ///
+    /// The inception action (`c2pa.created`/`c2pa.opened`) is always kept regardless of `keep`, and
+    /// is moved to index 0 of its assertion if needed, so a manifest that already carries an
+    /// inception stays valid per the C2PA spec. This only ever affects the created-list actions
+    /// assertion; a gathered-list assertion has no inception action to keep.
+    ///
+    /// This does not touch ingredients. Call [`Builder::filter_ingredients`]
+    /// (`filter_ingredients(|_| false)` to drop all orphans) afterwards if you also want to drop
+    /// ingredients now orphaned by the removed actions.
+    ///
+    /// # Arguments
+    /// * `keep` - A predicate; the action is retained when it returns true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`]. A no-op if there is no actions assertion.
+    /// # Errors
+    /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
+    pub fn filter_actions<F>(&mut self, mut keep: F) -> Result<&mut Self>
+    where
+        F: FnMut(&Action) -> bool,
+    {
+        // Every actions assertion (created-list and gathered-list), in positional order.
+        let positions: Vec<usize> = self
+            .definition
+            .assertions
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.label().starts_with(Actions::LABEL))
+            .map(|(i, _)| i)
+            .collect();
+
+        let mut emptied: Vec<usize> = Vec::new();
+        for pos in positions {
+            // Decode a working copy; all fallible work happens before any mutation of `self`.
+            let mut actions: Actions = self.definition.assertions[pos].to_assertion()?;
+            let original_len = actions.actions.len();
+
+            // Force-keep the inception action regardless of the predicate. Only the created-list
+            // assertion contains one, so this never affects a gathered-list assertion.
+            actions.actions.retain(|a| {
+                keep(a) || a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
+            });
+
+            if actions.actions.is_empty() {
+                // A c2pa.actions assertion must have a non-empty actions array. Only a gathered
+                // assertion can reach empty (the created one keeps its inception); drop it rather
+                // than erroring, mirroring how an empty actions assertion is otherwise omitted.
+                emptied.push(pos);
+                continue;
+            }
+
+            // Keep the surviving inception at index 0 of its assertion. A no-op for valid input
+            // where it is already first.
+            if let Some(idx) = actions.actions.iter().position(|a| {
+                a.action() == c2pa_action::CREATED || a.action() == c2pa_action::OPENED
+            }) {
+                if idx != 0 {
+                    let inception = actions.actions.remove(idx);
+                    actions.actions.insert(0, inception);
+                }
+            }
+
+            if actions.actions.len() < original_len {
+                // `allActionsIncluded` is a v2 actions-assertion field; the SDK always writes the
+                // latest assertion version, so this is always safe when anything was removed.
+                actions.all_actions_included = Some(false);
+            }
+
+            // Replace the data in place: preserves the entry's label, `created` flag, and kind,
+            // and never leaves the Builder without its assertion on error.
+            self.definition.assertions[pos].data =
+                AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
+        }
+
+        // Remove emptied assertions from the back so earlier indices stay valid.
+        for pos in emptied.into_iter().rev() {
+            self.definition.assertions.remove(pos);
+        }
+
+        Ok(self)
+    }
+
+    /// Retains ingredients, then rewrites positional ingredient references so linked actions
+    /// stay valid.
+    ///
+    /// An ingredient is kept if any of the following hold:
+    /// - it is referenced by a current action (via `parameters.ingredients` URLs or the
+    ///   `ingredientIds`/`instanceId` parameters) in any actions assertion,
+    /// - it is a [`Relationship::ParentOf`] ingredient (lineage for `c2pa.opened`), or
+    /// - `rescue` returns true for it.
+    ///
+    /// `rescue` therefore only ever rescues an otherwise-orphaned ingredient; it can never drop a
+    /// referenced or lineage ingredient (that would break spec validation). Use `rescue` for
+    /// provenance-aware policy, e.g. "this ingredient's embedded manifest chain contains a signal
+    /// of interest, so retain the whole ingredient (and its nested chain)"; the closure may inspect
+    /// the ingredient's [`manifest_data`](Ingredient::manifest_data) to decide. Prune all orphans
+    /// with `filter_ingredients(|_| false)`. Call [`Builder::filter_actions`] first if you are also
+    /// removing actions: the keep-set is computed from whatever actions currently remain.
+    ///
+    /// # Arguments
+    /// * `rescue` - A predicate that can rescue an otherwise-orphaned ingredient by returning true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`].
+    /// # Errors
+    /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt.
+    pub fn filter_ingredients<F>(&mut self, mut rescue: F) -> Result<&mut Self>
+    where
+        F: FnMut(&Ingredient) -> bool,
+    {
+        // Snapshot ingredient ids in positional order BEFORE pruning so the positional `__N`
+        // references can be remapped afterwards. The id is label-or-instance_id, matching how
+        // `to_claim` keys ingredients (builder.rs `ingredient_map`) and how `ingredientIds`
+        // parameters resolve.
+        let pre_filter_ids: Vec<String> = self
+            .definition
+            .ingredients
+            .iter()
+            .map(Ingredient::effective_id)
+            .collect();
+
+        // Every actions assertion (created-list and gathered-list): references can live in any of
+        // them, and each must have its positional URLs rewritten after the prune.
+        let actions_positions: Vec<usize> = self
+            .definition
+            .assertions
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.label().starts_with(Actions::LABEL))
+            .map(|(i, _)| i)
+            .collect();
+
+        // Decode each actions assertion (WITHOUT mutating self) and union the referenced-ingredient
+        // keep-set across all of them.
+        let mut keep_set: HashSet<String> = HashSet::new();
+        let mut decoded: Vec<(usize, Actions)> = Vec::with_capacity(actions_positions.len());
+        for pos in actions_positions {
+            let actions: Actions = self.definition.assertions[pos].to_assertion()?;
+            for action in &actions.actions {
+                // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
+                // deprecated instance_id. Relationship-agnostic: any referenced ingredient is
+                // kept whatever its relationship (e.g. `c2pa.edited` -> `inputTo`).
+                for id in action.ingredient_ids() {
+                    keep_set.insert(id);
+                }
+                // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
+                if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
+                    for uri in uris {
+                        if let Some(label) = assertion_label_from_uri(&uri.url()) {
+                            let (_, idx) = parse_positional_label(&label);
+                            if let Some(id) = pre_filter_ids.get(idx) {
+                                keep_set.insert(id.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            decoded.push((pos, actions));
+        }
+
+        // Prune: keep referenced, `parentOf`, or caller-rescued ingredients; drop the rest.
+        self.definition.ingredients.retain(|ing| {
+            keep_set.contains(&ing.effective_id())
+                || matches!(ing.relationship(), &Relationship::ParentOf)
+                || rescue(ing)
+        });
+
+        // Rewrite each actions assertion's positional `__N` references to the ingredients' new
+        // positions, then replace its data in place. Encoding runs before the mutation, so an
+        // error leaves the Builder intact.
+        let new_ids: Vec<String> = self
+            .definition
+            .ingredients
+            .iter()
+            .map(Ingredient::effective_id)
+            .collect();
+        let id_to_new_idx: HashMap<&str, usize> = new_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.as_str(), i))
+            .collect();
+        for (pos, mut actions) in decoded {
+            rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx)?;
+            self.definition.assertions[pos].data =
+                AssertionData::Cbor(c2pa_cbor::value::to_value(&actions)?);
+        }
+
+        Ok(self)
+    }
+
     /// Request a trusted timestamp for manifests with the given label.
     ///
     /// This only records the label on the builder. During signing, any matching manifest(s) will
@@ -1393,11 +1591,7 @@ impl Builder {
 
         for ingredient in &definition.ingredients {
             // use the label if it exists and is not empty, otherwise use the instance_id
-            let id = ingredient
-                .label()
-                .filter(|label| !label.is_empty())
-                .map(|label| label.to_string())
-                .unwrap_or_else(|| ingredient.instance_id().to_string());
+            let id = ingredient.effective_id();
 
             // add it to the claim
             let uri = ingredient.add_to_claim(
@@ -3328,6 +3522,94 @@ impl std::fmt::Display for Builder {
         let output = serde_json::to_string_pretty(&json).map_err(|_| std::fmt::Error)?;
         f.write_str(&output)
     }
+}
+
+/// Outcome of rewriting one positional ingredient reference after pruning.
+enum UriRewrite {
+    /// Already points at the correct index (or is not a tracked positional ref); leave as-is.
+    Unchanged,
+    /// The referenced ingredient was pruned, so the reference now dangles.
+    Stale,
+    /// Repointed to the ingredient's new index.
+    Rewritten(HashedUri),
+}
+
+/// Rewrites a single `HashedUri` whose URL ends in a positional ingredient label so it points at
+/// the ingredient's new position after pruning.
+fn rewrite_one_ingredient_uri(
+    hu: &HashedUri,
+    pre_filter_ids: &[String],
+    id_to_new_idx: &HashMap<&str, usize>,
+) -> UriRewrite {
+    let url = hu.url();
+    let label = label_segment_from_uri(&url);
+    let label_start = url.len() - label.len();
+    let (base, old_idx) = parse_positional_label(label);
+    // An out-of-range index is not a positional ingredient ref we track; leave it untouched
+    // rather than guessing (`get` bounds-checks, so this never panics on malformed input).
+    let Some(instance_id) = pre_filter_ids.get(old_idx) else {
+        return UriRewrite::Unchanged;
+    };
+    let Some(&new_idx) = id_to_new_idx.get(instance_id.as_str()) else {
+        return UriRewrite::Stale;
+    };
+    if new_idx == old_idx {
+        return UriRewrite::Unchanged;
+    }
+    let new_url = format!(
+        "{}{}",
+        &url[..label_start],
+        Claim::label_with_instance(base, new_idx)
+    );
+    UriRewrite::Rewritten(HashedUri::new(new_url, hu.alg(), &hu.hash()))
+}
+
+/// Rewrites `parameters.ingredients[].url` on every action so positional labels
+/// (`c2pa.ingredient.v3__N`) point at the new positions of the surviving ingredients.
+///
+/// Required after any ingredient is pruned: `to_claim` re-emits the surviving ingredients
+/// positionally at sign time, so any stale `__N` reference would otherwise dangle.
+fn rewrite_action_ingredient_urls(
+    actions: &mut Actions,
+    pre_filter_ids: &[String],
+    id_to_new_idx: &HashMap<&str, usize>,
+) -> Result<()> {
+    let mut rewritten = Vec::with_capacity(actions.actions.len());
+    for action in actions.actions.drain(..) {
+        let Some(ingredient_uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) else {
+            rewritten.push(action);
+            continue;
+        };
+
+        let mut changed = false;
+        let mut remapped_uris: Vec<HashedUri> = Vec::with_capacity(ingredient_uris.len());
+        for uri in ingredient_uris {
+            match rewrite_one_ingredient_uri(uri, pre_filter_ids, id_to_new_idx) {
+                UriRewrite::Rewritten(new) => {
+                    changed = true;
+                    remapped_uris.push(new);
+                }
+                UriRewrite::Stale => {
+                    log::warn!(
+                        "action '{}' has stale ingredient ref '{}'",
+                        action.action(),
+                        label_segment_from_uri(&uri.url()),
+                    );
+                    remapped_uris.push(uri.clone());
+                }
+                UriRewrite::Unchanged => remapped_uris.push(uri.clone()),
+            }
+        }
+
+        if changed {
+            // Propagate rather than swallow: a failed remap would silently dangle references.
+            rewritten.push(action.set_parameter("ingredients", remapped_uris)?);
+        } else {
+            rewritten.push(action);
+        }
+    }
+    actions.actions = rewritten;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -8776,12 +9058,7 @@ mod tests {
         )?;
 
         let mut ingredient_archive = Cursor::new(Vec::new());
-        let ingredient_id = {
-            let ing = &builder.definition.ingredients[0];
-            ing.label()
-                .map(String::from)
-                .unwrap_or_else(|| ing.instance_id().to_string())
-        };
+        let ingredient_id = builder.definition.ingredients[0].effective_id();
         builder.write_ingredient_archive(&ingredient_id, &mut ingredient_archive)?;
 
         let archive_bytes = ingredient_archive.into_inner();
@@ -9673,5 +9950,804 @@ mod tests {
 
         let future = builder.sign_async(&signer, "image/jpeg", &mut src, &mut dst);
         assert_send(future);
+    }
+
+    /// Create a `Builder` (with test context) from a JSON manifest definition.
+    fn removal_builder(def: serde_json::Value) -> Builder {
+        Builder::from_context(test_context())
+            .with_definition(def.to_string())
+            .expect("with_definition")
+    }
+
+    /// Extract the first `Actions` assertion off a builder.
+    fn builder_actions(b: &Builder) -> Actions {
+        b.definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .expect("actions assertion present")
+            .to_assertion()
+            .expect("actions assertion decodes")
+    }
+
+    /// Extract every `Actions` assertion off a builder, in positional order.
+    fn builder_all_actions(b: &Builder) -> Vec<Actions> {
+        b.definition
+            .assertions
+            .iter()
+            .filter(|a| a.label().starts_with(Actions::LABEL))
+            .map(|a| a.to_assertion().expect("actions assertion decodes"))
+            .collect()
+    }
+
+    /// The url of an action's first positional ingredient reference, if any.
+    fn first_ing_url(a: &Action) -> Option<String> {
+        a.parameters()
+            .and_then(|p| p.ingredients.as_ref())
+            .and_then(|v| v.first())
+            .map(|u| u.url())
+    }
+
+    /// A componentOf ingredient (label == instance_id) referenced by positional URL tests.
+    fn positional_ingredient(label: &str) -> serde_json::Value {
+        json!({
+            "title": label,
+            "format": "image/jpeg",
+            "relationship": "componentOf",
+            "label": label,
+            "instance_id": label,
+        })
+    }
+
+    /// A `c2pa.placed` action referencing a single positional ingredient label.
+    fn positional_placed(idx: usize) -> serde_json::Value {
+        let label = Claim::label_with_instance("c2pa.ingredient.v3", idx);
+        json!({
+            "action": "c2pa.placed",
+            "parameters": {
+                "ingredients": [{
+                    "url": format!("self#jumbf=c2pa.assertions/{label}"),
+                    "alg": "sha256",
+                    "hash": [1, 2, 3, 4],
+                }]
+            }
+        })
+    }
+
+    fn created_action() -> serde_json::Value {
+        json!({
+            "action": "c2pa.created",
+            "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty",
+        })
+    }
+
+    fn sign_and_read(mut b: Builder) -> Vec<crate::validation_status::ValidationStatus> {
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE),
+            &mut dest,
+        )
+        .expect("sign");
+        dest.rewind().unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .expect("read");
+        assert!(reader.active_manifest().is_some());
+        reader
+            .validation_status()
+            .map(|s| s.to_vec())
+            .unwrap_or_default()
+    }
+
+    fn assert_no_action_failures(status: Vec<crate::validation_status::ValidationStatus>) {
+        for s in &status {
+            assert_ne!(
+                s.code(),
+                "assertion.action.malformed",
+                "action malformed: {s:?}"
+            );
+            assert_ne!(
+                s.code(),
+                "assertion.action.ingredientMismatch",
+                "action ingredient mismatch: {s:?}"
+            );
+        }
+    }
+
+    // the inception action is force-kept even when the predicate would drop it, and moved to index 0.
+    #[test]
+    fn filter_actions_force_keeps_inception() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.color_adjustments" },
+                created_action(),
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        // Predicate drops everything, but c2pa.created is force-kept and moved to index 0.
+        b.filter_actions(|_| false).unwrap();
+        let actions = builder_actions(&b);
+        assert_eq!(actions.actions.len(), 1);
+        assert_eq!(actions.actions[0].action(), c2pa_action::CREATED);
+        assert_eq!(actions.all_actions_included, Some(false));
+    }
+
+    // targeted middle action is removed; surviving order/count preserved.
+    #[test]
+    fn filter_actions_removes_middle_keeps_order() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+                { "action": "c2pa.cropped" },
+            ]}}]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let actions = builder_actions(&b);
+        assert_eq!(actions.actions.len(), 2);
+        assert_eq!(actions.actions[0].action(), c2pa_action::CREATED);
+        assert_eq!(actions.actions[1].action(), "c2pa.cropped");
+        assert_eq!(actions.all_actions_included, Some(false));
+    }
+
+    // filtering every action out drops the emptied assertion (no error); other assertions remain.
+    #[test]
+    fn filter_actions_empty_drops_assertion() {
+        let mut b = removal_builder(json!({
+            "assertions": [
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                    { "action": "c2pa.cropped" },
+                ]}},
+                { "label": "org.test.assertion", "data": "x" },
+            ]
+        }));
+        b.filter_actions(|_| false).unwrap();
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .all(|a| !a.label().starts_with(Actions::LABEL)));
+        // Non-actions assertions are untouched.
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .any(|a| a.label() == "org.test.assertion"));
+    }
+
+    // no-op when there is no actions assertion.
+    #[test]
+    fn filter_actions_noop_without_actions() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "org.test.assertion", "data": "x" }]
+        }));
+        b.filter_actions(|_| false).unwrap();
+        assert!(b
+            .definition
+            .assertions
+            .iter()
+            .all(|a| !a.label().starts_with(Actions::LABEL)));
+    }
+
+    // the v1 `c2pa.actions` label is preserved on rebuild.
+    #[test]
+    fn filter_actions_preserves_v1_label() {
+        let mut b = removal_builder(json!({
+            "assertions": [{ "label": "c2pa.actions", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+            ]}}]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let label = b
+            .definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .unwrap()
+            .label()
+            .to_string();
+        assert_eq!(label, "c2pa.actions");
+    }
+
+    // the created/gathered flag on the actions assertion survives the in-place rebuild.
+    #[test]
+    fn filter_actions_preserves_created_flag() {
+        let mut b = removal_builder(json!({
+            "assertions": [{
+                "label": "c2pa.actions.v2",
+                "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.color_adjustments" },
+                ]},
+                "created": true
+            }]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let def = b
+            .definition
+            .assertions
+            .iter()
+            .find(|a| a.label().starts_with(Actions::LABEL))
+            .unwrap();
+        assert!(def.created(), "created flag must survive the rebuild");
+    }
+
+    // filter_actions applies to EVERY actions assertion (created-list and gathered-list).
+    #[test]
+    fn filter_actions_spans_all_assertions() {
+        let mut b = removal_builder(json!({
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.color_adjustments" },
+                ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                    { "action": "c2pa.cropped" },
+                ]}},
+            ]
+        }));
+        // Drop color_adjustments from BOTH the created and the gathered actions assertion.
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let all = builder_all_actions(&b);
+        assert_eq!(all.len(), 2);
+        // created-list keeps the inception action.
+        assert_eq!(
+            all[0]
+                .actions
+                .iter()
+                .map(|a| a.action())
+                .collect::<Vec<_>>(),
+            vec![c2pa_action::CREATED]
+        );
+        // gathered-list keeps cropped.
+        assert_eq!(
+            all[1]
+                .actions
+                .iter()
+                .map(|a| a.action())
+                .collect::<Vec<_>>(),
+            vec!["c2pa.cropped"]
+        );
+    }
+
+    // filtering a gathered actions assertion to empty drops only it; the created one stays.
+    #[test]
+    fn filter_actions_drops_only_emptied_gathered_assertion() {
+        let mut b = removal_builder(json!({
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [ created_action() ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.color_adjustments" },
+                ]}},
+            ]
+        }));
+        b.filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        let all = builder_all_actions(&b);
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].actions[0].action(), c2pa_action::CREATED);
+    }
+
+    // an ingredient referenced only by a removed action is pruned.
+    #[test]
+    fn filter_ingredients_prunes_orphan_after_action_removal() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "keep", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_keep", "instance_id": "id_keep" },
+                { "title": "drop", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_drop", "instance_id": "id_drop" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_keep"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_drop"] } },
+            ]}}]
+        }));
+        b.filter_actions(|a| {
+            !a.get_parameter::<Vec<String>>("ingredientIds")
+                .map(|ids| ids.iter().any(|i| i == "ing_drop"))
+                .unwrap_or(false)
+        })
+        .unwrap();
+        b.filter_ingredients(|_| false).unwrap();
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing_keep"]);
+    }
+
+    // a parentOf ingredient is kept even when no surviving action references it.
+    #[test]
+    fn filter_ingredients_keeps_parent_of() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "parent", "format": "image/jpeg", "relationship": "parentOf", "label": "ing_parent", "instance_id": "id_parent" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+        }));
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].label(), Some("ing_parent"));
+    }
+
+    // an ingredient reference keeps it whether the ingredient carries a label only, an
+    // instance_id only, or both (label is the effective id when present).
+    #[test]
+    fn filter_ingredients_matches_label_or_instance_id() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                // label only
+                { "title": "a", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_label" },
+                // instance_id only (no label)
+                { "title": "b", "format": "image/jpeg", "relationship": "componentOf", "instance_id": "id_only" },
+                // both present: label prevails as the effective id
+                { "title": "c", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_both", "instance_id": "id_both" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_label"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["id_only"] } },
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_both"] } },
+            ]}}]
+        }));
+        // Nothing is rescued by the predicate; all three survive purely via their references.
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 3);
+    }
+
+    // when an ingredient has both a label and an instance_id, the label is its effective id, so a
+    // reference by instance_id alone does not keep it (mirrors how ingredientIds resolve).
+    #[test]
+    fn filter_ingredients_label_prevails_over_instance_id() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "c", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_both", "instance_id": "id_both" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["id_both"] } },
+            ]}}]
+        }));
+        b.filter_ingredients(|_| false).unwrap();
+        // Referenced only by its instance_id, but the label is the effective id, so it is orphaned.
+        assert!(b.definition.ingredients.is_empty());
+    }
+
+    // an action that references its ingredient only via the deprecated top-level `instanceId`
+    // field still keeps that ingredient (exercises the Action::ingredient_ids fallback path).
+    #[test]
+    fn filter_ingredients_deprecated_instance_id_reference() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "d", "format": "image/jpeg", "relationship": "componentOf", "instance_id": "dep_id" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                // `instanceId` at the action top level maps to the deprecated `Action::instance_id`
+                // field, not a parameter.
+                { "action": "c2pa.placed", "instanceId": "dep_id" },
+            ]}}]
+        }));
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].instance_id(), "dep_id");
+    }
+
+    // rewrite_action_ingredient_urls (and rewrite_one_ingredient_uri) directly: a positional ref
+    // whose ingredient was pruned degrades to a logged Stale ref kept as-is, an out-of-range ref
+    // is left Unchanged, and a valid shift is Rewritten. Driven directly because filter_ingredients
+    // never prunes an ingredient that a surviving action still references.
+    #[test]
+    fn rewrite_action_ingredient_urls_stale_shift_and_out_of_range() {
+        use std::collections::HashMap;
+        let mut actions: Actions = serde_json::from_value(json!({ "actions": [
+            { "action": "c2pa.placed", "parameters": { "ingredients": [
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3", "alg": "sha256", "hash": [1] },
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [2] },
+                { "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__9", "alg": "sha256", "hash": [3] },
+            ]}},
+        ]}))
+        .unwrap();
+
+        // Pre-prune order was [id0, id1]; id0 was pruned, id1 survives at new index 0.
+        let pre_filter_ids = vec!["id0".to_string(), "id1".to_string()];
+        let mut id_to_new_idx: HashMap<&str, usize> = HashMap::new();
+        id_to_new_idx.insert("id1", 0);
+
+        rewrite_action_ingredient_urls(&mut actions, &pre_filter_ids, &id_to_new_idx).unwrap();
+
+        let urls: Vec<String> = actions.actions[0]
+            .parameters()
+            .unwrap()
+            .ingredients
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|u| u.url())
+            .collect();
+        // idx0 -> id0 pruned: Stale, left as-is.
+        assert!(urls[0].ends_with("c2pa.ingredient.v3"));
+        // __1 -> id1 moved to index 0: Rewritten to the base label.
+        assert!(urls[1].ends_with("c2pa.ingredient.v3"));
+        // __9 out of range: Unchanged.
+        assert!(urls[2].ends_with("c2pa.ingredient.v3__9"));
+    }
+
+    // the keep-set spans EVERY actions assertion: an ingredient referenced only from the
+    // gathered-list actions assertion must survive an orphan prune.
+    #[test]
+    fn filter_ingredients_keep_set_spans_all_assertions() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                { "title": "g", "format": "image/jpeg", "relationship": "componentOf", "label": "ing_gathered", "instance_id": "ing_gathered" },
+            ],
+            "assertions": [
+                { "label": "c2pa.actions.v2", "created": true, "data": { "actions": [ created_action() ]}},
+                { "label": "c2pa.actions.v2", "data": { "actions": [
+                    { "action": "c2pa.placed", "parameters": { "ingredientIds": ["ing_gathered"] } },
+                ]}},
+            ]
+        }));
+        // The ingredient is referenced only by the gathered assertion; it must not be pruned.
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(b.definition.ingredients[0].label(), Some("ing_gathered"));
+    }
+
+    // remove the middle ingredient (via its action); __2 collapses to __1, __1 -> base.
+    #[test]
+    fn filter_ingredients_reindex_middle_hole() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("ing0"),
+                positional_ingredient("ing1"),
+                positional_ingredient("ing2"),
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                positional_placed(0),
+                positional_placed(1),
+                positional_placed(2),
+            ]}}]
+        }));
+        // Remove the action referencing ingredient[1] (__1), orphaning it.
+        b.filter_actions(|a| !first_ing_url(a).is_some_and(|u| u.ends_with("__1")))
+            .unwrap();
+        b.filter_ingredients(|_| false).unwrap();
+
+        // ingredient[1] gone; ingredient[2] shifted to index 1.
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing0", "ing2"]);
+
+        let urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3"))); // idx0 base
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3__1"))); // was __2 -> __1
+        assert!(!urls.iter().any(|u| u.ends_with("__2")));
+    }
+
+    // multiple / non-contiguous removals leave no dangling or colliding __N.
+    #[test]
+    fn filter_ingredients_reindex_noncontiguous() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("ing0"),
+                positional_ingredient("ing1"),
+                positional_ingredient("ing2"),
+                positional_ingredient("ing3"),
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                positional_placed(0),
+                positional_placed(1),
+                positional_placed(2),
+                positional_placed(3),
+            ]}}]
+        }));
+        // Remove the actions referencing ingredients at index 0 (base) and 2 (__2).
+        b.filter_actions(|a| {
+            !first_ing_url(a)
+                .is_some_and(|u| u.ends_with("c2pa.ingredient.v3") || u.ends_with("__2"))
+        })
+        .unwrap();
+        b.filter_ingredients(|_| false).unwrap();
+
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["ing1", "ing3"]); // idx1 -> 0, idx3 -> 1
+
+        let urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3"))); // ing1 -> idx0
+        assert!(urls.iter().any(|u| u.ends_with("c2pa.ingredient.v3__1"))); // ing3 -> idx1
+        assert!(!urls
+            .iter()
+            .any(|u| u.ends_with("__2") || u.ends_with("__3")));
+    }
+
+    // `c2pa.edited` + `inputTo` ingredient survives while its action survives; pruned when removed.
+    #[test]
+    fn filter_ingredients_edited_input_to() {
+        let def = json!({
+            "ingredients": [
+                { "title": "edit", "format": "image/jpeg", "relationship": "inputTo", "label": "ing_edit", "instance_id": "id_edit" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.edited", "parameters": { "ingredientIds": ["ing_edit"] } },
+            ]}}]
+        });
+
+        // edited survives -> inputTo ingredient kept, relationship unchanged.
+        let mut kept = removal_builder(def.clone());
+        kept.filter_ingredients(|_| false).unwrap();
+        assert_eq!(kept.definition.ingredients.len(), 1);
+        assert_eq!(
+            kept.definition.ingredients[0].relationship(),
+            &Relationship::InputTo
+        );
+
+        // edited removed -> inputTo ingredient pruned.
+        let mut dropped = removal_builder(def);
+        dropped
+            .filter_actions(|a| a.action() != "c2pa.edited")
+            .unwrap();
+        dropped.filter_ingredients(|_| false).unwrap();
+        assert!(dropped.definition.ingredients.is_empty());
+    }
+
+    // a parentOf ingredient at a non-zero index survives and its opened link re-indexes.
+    #[test]
+    fn filter_ingredients_parent_of_nonzero_index() {
+        let mut b = removal_builder(json!({
+            "ingredients": [
+                positional_ingredient("comp"),
+                { "title": "parent", "format": "image/jpeg", "relationship": "parentOf", "label": "parent", "instance_id": "parent" },
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                { "action": "c2pa.opened", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1",
+                    "alg": "sha256", "hash": [9, 9]
+                }]}},
+                positional_placed(0),
+            ]}}]
+        }));
+        // Remove the placed action (ref __0), orphaning the componentOf ingredient at index 0.
+        b.filter_actions(|a| !first_ing_url(a).is_some_and(|u| u.ends_with("c2pa.ingredient.v3")))
+            .unwrap();
+        b.filter_ingredients(|_| false).unwrap();
+
+        // Only the parentOf ingredient remains, now at index 0.
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert_eq!(
+            b.definition.ingredients[0].relationship(),
+            &Relationship::ParentOf
+        );
+        // opened's __1 reference re-indexed to the base label (idx 0).
+        let opened_url = builder_actions(&b)
+            .actions
+            .iter()
+            .find(|a| a.action() == c2pa_action::OPENED)
+            .and_then(first_ing_url)
+            .unwrap();
+        assert!(opened_url.ends_with("c2pa.ingredient.v3"));
+    }
+
+    // a diamond ingredient shared by two actions re-indexes consistently and is kept
+    // while at least one referencing action survives.
+    #[test]
+    fn filter_ingredients_diamond_shared() {
+        let base_def = json!({
+            "ingredients": [
+                positional_ingredient("orphan"), // idx0, referenced by nothing
+                positional_ingredient("shared"), // idx1, referenced by two actions
+            ],
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.edited", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [1] }]}},
+                { "action": "c2pa.placed", "parameters": { "ingredients": [{
+                    "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3__1", "alg": "sha256", "hash": [1] }]}},
+            ]}}]
+        });
+
+        // Prune the orphan at idx0 -> shared moves to idx0; both actions must remap to base.
+        let mut b = removal_builder(base_def.clone());
+        b.filter_ingredients(|_| false).unwrap();
+        let labels: Vec<_> = b
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels, vec!["shared"]); // kept exactly once
+        let ref_urls: Vec<String> = builder_actions(&b)
+            .actions
+            .iter()
+            .filter_map(first_ing_url)
+            .collect();
+        assert_eq!(ref_urls.len(), 2);
+        assert!(ref_urls.iter().all(|u| u.ends_with("c2pa.ingredient.v3")));
+
+        // Remove only one of the two referring actions -> shared still referenced, not pruned.
+        let mut b2 = removal_builder(base_def);
+        b2.filter_actions(|a| a.action() != "c2pa.placed").unwrap();
+        b2.filter_ingredients(|_| false).unwrap();
+        let labels2: Vec<_> = b2
+            .definition
+            .ingredients
+            .iter()
+            .map(|i| i.label().unwrap().to_string())
+            .collect();
+        assert_eq!(labels2, vec!["shared"]);
+    }
+
+    /// Produce a signed JPEG (single `c2pa.created`) for use as a nested ingredient.
+    fn signed_created_jpeg() -> Vec<u8> {
+        let mut b = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+        }));
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE_CLEAN),
+            &mut dest,
+        )
+        .unwrap();
+        dest.into_inner()
+    }
+
+    // a kept ingredient's embedded manifest chain is untouched by top-level pruning.
+    #[test]
+    fn filter_ingredients_preserves_nested_chain() {
+        let nested = signed_created_jpeg();
+        let mut b = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.placed", "parameters": { "ingredientIds": ["nested"] } },
+            ]}}]
+        }));
+        b.add_ingredient_from_stream(
+            json!({ "title": "nested", "relationship": "componentOf", "label": "nested" })
+                .to_string(),
+            "image/jpeg",
+            &mut Cursor::new(nested),
+        )
+        .unwrap();
+
+        // The nested ingredient is referenced, so it survives an orphan prune with its chain.
+        b.filter_ingredients(|_| false).unwrap();
+        assert_eq!(b.definition.ingredients.len(), 1);
+        assert!(b.definition.ingredients[0].active_manifest().is_some());
+
+        // Sign the top-level builder and confirm the nested chain reads back intact.
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        b.sign(
+            signer.as_ref(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_IMAGE_CLEAN),
+            &mut dest,
+        )
+        .unwrap();
+        dest.rewind().unwrap();
+        let reader = Reader::default()
+            .with_stream("image/jpeg", &mut dest)
+            .unwrap();
+        let active = reader.active_manifest().unwrap();
+        let ing = &active.ingredients()[0];
+        let nested_label = ing.active_manifest().expect("nested active_manifest");
+        assert!(
+            reader.get_manifest(nested_label).is_some(),
+            "nested manifest chain must survive top-level pruning"
+        );
+    }
+
+    // a deep-nested orphan is pruned by default but rescued by a manifest_data predicate.
+    #[test]
+    fn filter_ingredients_predicate_rescues_orphan() {
+        let nested = signed_created_jpeg();
+        let make = || {
+            let mut b = removal_builder(json!({
+                "format": "image/jpeg",
+                "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [ created_action() ]}}]
+            }));
+            // Orphan ingredient: no action references it, but it carries an embedded manifest chain.
+            b.add_ingredient_from_stream(
+                json!({ "title": "orphan", "relationship": "componentOf", "label": "orphan" })
+                    .to_string(),
+                "image/jpeg",
+                &mut Cursor::new(nested.clone()),
+            )
+            .unwrap();
+            b
+        };
+
+        // Default prune drops the orphan.
+        let mut pruned = make();
+        pruned.filter_ingredients(|_| false).unwrap();
+        assert!(pruned.definition.ingredients.is_empty());
+
+        // A predicate that inspects manifest_data rescues it (whole chain rides along).
+        let mut rescued = make();
+        rescued
+            .filter_ingredients(|ing| ing.manifest_data().is_some())
+            .unwrap();
+        assert_eq!(rescued.definition.ingredients.len(), 1);
+        assert!(rescued.definition.ingredients[0]
+            .active_manifest()
+            .is_some());
+    }
+
+    // end-to-end sign + re-read produces no action/ingredient validation failures.
+    #[test]
+    fn filter_removal_end_to_end() {
+        // Case A: c2pa.created, remove a non-inception action and prune.
+        let mut created = removal_builder(json!({
+            "format": "image/jpeg",
+            "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                created_action(),
+                { "action": "c2pa.color_adjustments" },
+            ]}}]
+        }));
+        created
+            .filter_actions(|a| a.action() != "c2pa.color_adjustments")
+            .unwrap();
+        created.filter_ingredients(|_| false).unwrap();
+        assert_no_action_failures(sign_and_read(created));
+
+        // Case B: c2pa.opened + parentOf; remove the placed action and prune its ingredient.
+        let mut source = Cursor::new(TEST_IMAGE);
+        let mut opened = Builder::default().with_definition(manifest_json()).unwrap();
+        opened
+            .add_ingredient_from_stream(parent_json(), "image/jpeg", &mut source)
+            .unwrap();
+        opened
+            .resources
+            .add("thumbnail.jpg", TEST_THUMBNAIL.to_vec())
+            .unwrap();
+        opened
+            .filter_actions(|a| a.action() != "c2pa.placed")
+            .unwrap();
+        opened.filter_ingredients(|_| false).unwrap();
+        // The parentOf (CA.jpg) ingredient survives; the componentOf INGREDIENT_2 is gone.
+        assert!(opened.definition.ingredients.iter().any(|i| i.is_parent()));
+        assert!(!opened
+            .definition
+            .ingredients
+            .iter()
+            .any(|i| i.label() == Some("INGREDIENT_2")));
+        assert_no_action_failures(sign_and_read(opened));
     }
 }

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -252,6 +252,21 @@ impl Ingredient {
         self.instance_id.as_deref().unwrap_or("None") // todo: deprecate and change to Option<&str>
     }
 
+    /// Returns the id used to reference this ingredient from a claim: its [`label`](Self::label)
+    /// when present and non-empty, otherwise its [`instance_id`](Self::instance_id).
+    ///
+    /// This is how the [`Builder`](crate::Builder) keys ingredients when resolving action
+    /// `ingredientIds` and emitting positional assertion labels, so any code matching actions to
+    /// ingredients must use the same rule. It is public for exactly that reason: external code
+    /// filtering or matching actions against ingredients must not reimplement (and risk diverging
+    /// from) this rule.
+    pub fn effective_id(&self) -> String {
+        self.label()
+            .filter(|label| !label.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.instance_id().to_string())
+    }
+
     /// Returns the provenance URI if available.
     pub fn provenance(&self) -> Option<&str> {
         self.provenance.as_deref()

--- a/sdk/src/jumbf/labels.rs
+++ b/sdk/src/jumbf/labels.rs
@@ -186,6 +186,35 @@ pub(crate) fn box_name_from_uri(uri: &str) -> Option<String> {
     parts.last().map(|b| b.to_string())
 }
 
+// Returns the trailing label segment of a JUMBF URI as a slice of the input, e.g.
+// `self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2` -> `c2pa.ingredient.v3__2`.
+// When the URI has no path separator, the whole string is treated as the label.
+//
+// Sibling of `box_name_from_uri` (which returns an owned, normalized `String`) and
+// `assertion_label_from_uri` (which additionally validates the assertion structure). This variant
+// exists because it borrows a slice of the original `uri`, so callers can compute the label's byte
+// offset within `uri` and rebuild the prefix. Where only the label value is needed, prefer
+// `assertion_label_from_uri`.
+pub(crate) fn label_segment_from_uri(uri: &str) -> &str {
+    uri.rsplit('/').next().unwrap_or(uri)
+}
+
+// Splits a positional label into its base and `__N` instance index, e.g.
+// `c2pa.ingredient.v3__2` -> (`c2pa.ingredient.v3`, 2); `c2pa.ingredient.v3` -> (label, 0).
+//
+// Sibling of `parse_label`, which returns `(base, version, instance)` and strips BOTH the `.vN`
+// version and the `__N` instance off the base. This variant strips only the instance and keeps the
+// version in the returned base, so the base round-trips through `Claim::label_with_instance` to
+// rebuild the exact positional label. Prefer `parse_label` when the version is wanted separately.
+pub(crate) fn parse_positional_label(label: &str) -> (&str, usize) {
+    if let Some(pos) = label.rfind("__") {
+        if let Ok(n) = label[pos + 2..].parse::<usize>() {
+            return (&label[..pos], n);
+        }
+    }
+    (label, 0)
+}
+
 // Struct deconstructed manifest label
 #[derive(Clone, Debug)]
 pub(crate) struct ManifestParts {
@@ -518,6 +547,37 @@ pub mod tests {
         assert_eq!(
             &l6_mp.to_string(),
             "acme:urn:uuid:F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4"
+        );
+    }
+
+    #[test]
+    fn test_label_segment_from_uri() {
+        assert_eq!(
+            label_segment_from_uri("self#jumbf=c2pa.assertions/c2pa.ingredient.v3__2"),
+            "c2pa.ingredient.v3__2"
+        );
+        // No path separator: the whole string is treated as the label.
+        assert_eq!(
+            label_segment_from_uri("c2pa.ingredient.v3"),
+            "c2pa.ingredient.v3"
+        );
+    }
+
+    #[test]
+    fn test_parse_positional_label() {
+        assert_eq!(
+            parse_positional_label("c2pa.ingredient.v3__2"),
+            ("c2pa.ingredient.v3", 2)
+        );
+        // No instance suffix.
+        assert_eq!(
+            parse_positional_label("c2pa.ingredient.v3"),
+            ("c2pa.ingredient.v3", 0)
+        );
+        // A non-numeric `__` suffix is not an instance index.
+        assert_eq!(
+            parse_positional_label("c2pa.foo__bar"),
+            ("c2pa.foo__bar", 0)
         );
     }
 }


### PR DESCRIPTION
Automated backport of #2281 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.