### PR TITLE
fix: Terminate crJSON b64' byte-string values with closing quote (backport #2333)

### DIFF
--- a/sdk/src/crjson.rs
+++ b/sdk/src/crjson.rs
@@ -54,7 +54,7 @@ struct Base64Bytes(Vec<u8>);
 
 impl Serialize for Base64Bytes {
     fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("b64'{}", base64::encode(&self.0)))
+        s.serialize_str(&format!("b64'{}'", base64::encode(&self.0)))
     }
 }
 
@@ -387,7 +387,7 @@ impl<'a> CrJsonExporter<'a> {
                         key,
                         json!({
                             "identifier": absolute_uri,
-                            "hash": format!("b64'{}", base64::encode(&assertion_ref.hash()))
+                            "hash": format!("b64'{}'", base64::encode(&assertion_ref.hash()))
                         }),
                     );
                 }
@@ -429,7 +429,7 @@ impl<'a> CrJsonExporter<'a> {
                 Ok(Some(json!({
                     "format": assertion.content_type(),
                     "identifier": absolute_uri,
-                    "hash": format!("b64'{}", base64::encode(ca.hash()))
+                    "hash": format!("b64'{}'", base64::encode(ca.hash()))
                 })))
             }
             _ => Ok(assertion.as_json_object().ok().map(fix_hash_encoding)),
@@ -678,7 +678,7 @@ fn fix_hash_encoding(value: Value) -> Value {
                                 .collect();
                             map.insert(
                                 field.to_string(),
-                                json!(format!("b64'{}", base64::encode(&bytes))),
+                                json!(format!("b64'{}'", base64::encode(&bytes))),
                             );
                         }
                     }
@@ -687,7 +687,7 @@ fn fix_hash_encoding(value: Value) -> Value {
 
             // Ensure hash-bearing objects also carry a (possibly empty) pad field.
             if map.contains_key("hash") && !map.contains_key("pad") {
-                map.insert("pad".to_string(), json!("b64'"));
+                map.insert("pad".to_string(), json!("b64''"));
             }
 
             if let Some(sig_val) = map.get("signature") {
@@ -698,7 +698,7 @@ fn fix_hash_encoding(value: Value) -> Value {
                             .filter_map(|v| v.as_u64().map(|n| n as u8))
                             .collect();
                         let decoded = decode_cawg_signature(&sig_bytes).unwrap_or_else(|_| {
-                            json!(format!("b64'{}", base64::encode(&sig_bytes)))
+                            json!(format!("b64'{}'", base64::encode(&sig_bytes)))
                         });
                         map.insert("signature".to_string(), decoded);
                     }
@@ -996,8 +996,8 @@ mod tests {
         // Verify pad2 is a b64'-prefixed string if present (pad1 does not exist in the schema)
         if let Some(pad2) = cawg_identity.get("pad2").and_then(|v| v.as_str()) {
             assert!(
-                pad2.starts_with("b64'"),
-                "pad2 must start with \"b64'\" prefix, got: {pad2:?}"
+                pad2.starts_with("b64'") && pad2.ends_with('\''),
+                "pad2 must be delimited by \"b64'\" and a closing \"'\", got: {pad2:?}"
             );
         }
 
@@ -1079,8 +1079,8 @@ mod tests {
             // Verify pad2 is a b64'-prefixed string if present (pad1 does not exist in the schema)
             if let Some(pad2) = cawg_identity.get("pad2").and_then(|v| v.as_str()) {
                 assert!(
-                    pad2.starts_with("b64'"),
-                    "pad2 must start with \"b64'\" prefix, got: {pad2:?}"
+                    pad2.starts_with("b64'") && pad2.ends_with('\''),
+                    "pad2 must be delimited by \"b64'\" and a closing \"'\", got: {pad2:?}"
                 );
             }
 

--- a/sdk/tests/crjson/hash_assertions.rs
+++ b/sdk/tests/crjson/hash_assertions.rs
@@ -45,7 +45,11 @@ fn test_hash_data_assertion_structure() -> Result<()> {
         "c2pa.hash.data.hash must start with \"b64'\" prefix, got: {hash:?}"
     );
     assert!(
-        hash.len() > "b64'".len(),
+        hash.ends_with('\''),
+        "c2pa.hash.data.hash must end with a closing \"'\", got: {hash:?}"
+    );
+    assert!(
+        hash.len() > "b64''".len(),
         "c2pa.hash.data.hash payload must not be empty"
     );
 
@@ -65,6 +69,10 @@ fn test_hash_data_assertion_structure() -> Result<()> {
         assert!(
             pad_str.starts_with("b64'"),
             "c2pa.hash.data.pad must start with \"b64'\" prefix, got: {pad_str:?}"
+        );
+        assert!(
+            pad_str.ends_with('\''),
+            "c2pa.hash.data.pad must end with a closing \"'\", got: {pad_str:?}"
         );
     }
 
@@ -154,6 +162,10 @@ fn test_action_ingredient_hash_is_base64() -> Result<()> {
             assert!(
                 hash_str.starts_with("b64'"),
                 "action[{i}] ingredient hash must start with \"b64'\" prefix, got: {hash_str:?}"
+            );
+            assert!(
+                hash_str.ends_with('\''),
+                "action[{i}] ingredient hash must end with a closing \"'\", got: {hash_str:?}"
             );
         }
     }

--- a/sdk/tests/crjson/schema_compliance.rs
+++ b/sdk/tests/crjson/schema_compliance.rs
@@ -296,12 +296,16 @@ fn test_hash_fields_are_base64_strings() -> Result<()> {
                             "'{child_path}' must be a b64'-prefixed string, not an integer array"
                         );
                         if let Some(s) = v.as_str() {
-                            // Must start with "b64'" prefix.
+                            // Must be delimited by a "b64'" prefix and a closing "'".
                             assert!(
                                 s.starts_with("b64'"),
                                 "'{child_path}' value must start with \"b64'\" prefix, got: {s:?}"
                             );
-                            let payload = &s["b64'".len()..];
+                            assert!(
+                                s.len() > "b64'".len() && s.ends_with('\''),
+                                "'{child_path}' value must end with a closing \"'\", got: {s:?}"
+                            );
+                            let payload = &s["b64'".len()..s.len() - 1];
                             // Payload must be valid base64 if non-empty.
                             if !payload.is_empty() {
                                 use std::collections::HashSet;


### PR DESCRIPTION
Automated backport of #2333 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.