### PR TITLE
feat: Add `try_*` APIs for `with_archive` on Builder, `with_stream`, `with_manifest_data_and_stream`, `with_fragment` on Reader to propagate errors

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -66,15 +66,16 @@ unsafe fn is_safe_buffer_size(size: usize, ptr: *const c_uchar) -> bool {
 /// Runs a fallible, value-consuming operation on the value
 /// behind an untracked pointer.
 ///
-/// * On success the result is tracked in a fresh allocation and its pointer is
-///   returned; the input allocation is freed and its pointer is consumed.
-/// * On error the input value is restored into its allocation and re-tracked, the
-///   error is recorded, and null is returned; the caller keeps the input pointer.
-/// * If `op` panics the value is dropped once and the input allocation is freed,
-///   so the unwind leaks nothing.
+/// - On success the result is tracked in a fresh allocation and its pointer is
+///   returned. The input allocation is freed and its pointer is consumed. The caller
+///   does not keep the pointer in this case.
+/// - On error the input value is restored into its allocation and re-tracked, the
+///   error is recorded, and null is returned. The caller keeps the input pointer.
+/// - If `op` function panics the value is dropped and the input allocation is freed,
+///   so the unwind doesn't leak.
 ///
-/// So a null return means the input was not consumed (caller must free it) and a
-/// non-null return is a new handle whose old pointer is gone.
+/// So: A null return means the input was not consumed (caller must free it),
+/// and a non-null return is a new handle whose old pointer is gone.
 ///
 /// # Safety
 /// `ptr` must be non-null, point to an initialized `T`, and be untracked at the
@@ -85,8 +86,8 @@ where
     CimplError: From<E>,
     F: FnOnce(T) -> std::result::Result<T, Box<(T, E)>>,
 {
-    // Owns a (vacated) FFI allocation after the value is read out.
-    // Its own Drop frees that allocation, so a panic in the `op` function leaks nothing.
+    // Owns a (vacated) FFI allocation slot.
+    // Its own Drop frees that allocation, so a panic in the `op` function doesn't leak.
     struct AllocationGuard<T>(*mut ManuallyDrop<T>);
     impl<T> Drop for AllocationGuard<T> {
         fn drop(&mut self) {
@@ -105,7 +106,8 @@ where
         }
         Err(boxed) => {
             let (orig, e) = *boxed;
-            // Restore the original value and re-track it; caller keeps the pointer.
+            // Restore the original value and re-track it:
+            // caller gets its pointer back to keep it.
             std::mem::forget(guard);
             std::ptr::write(ptr, orig);
             crate::track_box(ptr);

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -14,6 +14,7 @@
 use std::{
     os::raw::{c_char, c_int, c_uchar, c_void},
     sync::Arc,
+    mem::ManuallyDrop,
 };
 
 // C has no namespace so we prefix things with C2PA to make them unique (as namespace)
@@ -62,8 +63,8 @@ unsafe fn is_safe_buffer_size(size: usize, ptr: *const c_uchar) -> bool {
     true
 }
 
-/// Runs a fallible, value-consuming operation on the value behind an untracked
-/// pointer.
+/// Runs a fallible, value-consuming operation on the value
+/// behind an untracked pointer.
 ///
 /// * On success the result is tracked in a fresh allocation and its pointer is
 ///   returned; the input allocation is freed and its pointer is consumed.
@@ -84,9 +85,7 @@ where
     CimplError: From<E>,
     F: FnOnce(T) -> std::result::Result<T, (T, E)>,
 {
-    use std::mem::ManuallyDrop;
-
-    // Owns a vacated FFI allocation after the value is read out.
+    // Owns a (vacated) FFI allocation after the value is read out.
     // Its own Drop frees that allocation, so a panic in the `op` function leaks nothing.
     struct AllocationGuard<T>(*mut ManuallyDrop<T>);
     impl<T> Drop for AllocationGuard<T> {

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -83,7 +83,7 @@ unsafe fn reconfigure_or_restore<T, E, F>(ptr: *mut T, op: F) -> *mut T
 where
     T: 'static + crate::maybe_send_sync::MaybeSend,
     CimplError: From<E>,
-    F: FnOnce(T) -> std::result::Result<T, (T, E)>,
+    F: FnOnce(T) -> std::result::Result<T, Box<(T, E)>>,
 {
     // Owns a (vacated) FFI allocation after the value is read out.
     // Its own Drop frees that allocation, so a panic in the `op` function leaks nothing.
@@ -103,7 +103,8 @@ where
             crate::track_box(Box::into_raw(Box::new(new_val)))
             // `guard` frees the vacated allocation here.
         }
-        Err((orig, e)) => {
+        Err(boxed) => {
+            let (orig, e) = *boxed;
             // Restore the original value and re-track it; caller keeps the pointer.
             std::mem::forget(guard);
             std::ptr::write(ptr, orig);

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -62,6 +62,59 @@ unsafe fn is_safe_buffer_size(size: usize, ptr: *const c_uchar) -> bool {
     true
 }
 
+/// Runs a fallible, value-consuming operation on the value behind an untracked
+/// pointer.
+///
+/// * On success the result is tracked in a fresh allocation and its pointer is
+///   returned; the input allocation is freed and its pointer is consumed.
+/// * On error the input value is restored into its allocation and re-tracked, the
+///   error is recorded, and null is returned; the caller keeps the input pointer.
+/// * If `op` panics the value is dropped once and the input allocation is freed,
+///   so the unwind leaks nothing.
+///
+/// So a null return means the input was not consumed (caller must free it) and a
+/// non-null return is a new handle whose old pointer is gone.
+///
+/// # Safety
+/// `ptr` must be non-null, point to an initialized `T`, and be untracked at the
+/// moment of the call.
+unsafe fn reconfigure_or_restore<T, E, F>(ptr: *mut T, op: F) -> *mut T
+where
+    T: 'static + crate::maybe_send_sync::MaybeSend,
+    CimplError: From<E>,
+    F: FnOnce(T) -> std::result::Result<T, (T, E)>,
+{
+    use std::mem::ManuallyDrop;
+
+    // Owns a vacated FFI allocation after the value is read out.
+    // Its own Drop frees that allocation, so a panic in the `op` function leaks nothing.
+    struct AllocationGuard<T>(*mut ManuallyDrop<T>);
+    impl<T> Drop for AllocationGuard<T> {
+        fn drop(&mut self) {
+            unsafe { drop(Box::from_raw(self.0)) };
+        }
+    }
+
+    // Move the value out, leaving the allocation intact for restore-on-error.
+    let owned = std::ptr::read(ptr);
+    let guard = AllocationGuard(ptr as *mut ManuallyDrop<T>);
+    match op(owned) {
+        Ok(new_val) => {
+            // Track the new value before freeing the old, so addresses can't collide.
+            crate::track_box(Box::into_raw(Box::new(new_val)))
+            // `guard` frees the vacated allocation here.
+        }
+        Err((orig, e)) => {
+            // Restore the original value and re-track it; caller keeps the pointer.
+            std::mem::forget(guard);
+            std::ptr::write(ptr, orig);
+            crate::track_box(ptr);
+            CimplError::from(e).set_last();
+            std::ptr::null_mut()
+        }
+    }
+}
+
 // Work around limitations in cbindgen.
 mod cbindgen_fix {
     #[repr(C)]
@@ -1104,15 +1157,21 @@ pub unsafe extern "C" fn c2pa_reader_from_stream(
 
 /// Configures an existing reader with a stream.
 ///
-/// This method consumes the original reader and returns a new configured reader.
-/// The original reader pointer becomes invalid after this call.
+/// On success this method consumes the original reader and returns a new
+/// configured reader.
 ///
 /// # Safety
 ///
 /// * `reader` must be a valid pointer to a C2paReader.
 /// * `format` must be a valid null-terminated string with the MIME type.
 /// * `stream` must be a valid pointer to a C2paStream.
-/// * After calling this function, the `reader` pointer is INVALID.
+///
+/// # Ownership
+///
+/// * On success (non-NULL return), the `reader` pointer is consumed and becomes
+///   invalid. Do not use or free it, use the returned pointer instead.
+/// * On error (NULL return), the `reader` pointer is NOT consumed and remains
+///   valid and owned by the caller, who must free it with `c2pa_reader_free`.
 ///
 /// # Returns
 ///
@@ -1129,16 +1188,13 @@ pub unsafe extern "C" fn c2pa_reader_with_stream(
 
     // Now safe to take ownership - all validations passed
     untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_stream(&format, stream));
-    box_tracked!(reader)
+    reconfigure_or_restore(reader, |r| r.try_with_stream(&format, stream))
 }
 
 /// Configures an existing passed in Reader with manifest data and a stream.
 /// This covers the case when a Reader needs to be able to re-read signed
-/// manifest bytes. This method consumes the original Reader and returns a
-/// new configured Reader. The original Reader pointer becomes invalid after
-/// this call and should not be reused.
+/// manifest bytes. On success this method consumes the original Reader and
+/// returns a new configured Reader.
 ///
 /// # Safety
 ///
@@ -1148,7 +1204,13 @@ pub unsafe extern "C" fn c2pa_reader_with_stream(
 /// * `stream` must be a valid pointer to a C2paStream.
 /// * `manifest_data` must be a valid pointer to manifest bytes.
 /// * `manifest_size` must be the length of the manifest_data buffer.
-/// * After calling this function, the `reader` pointer becomes invalid.
+///
+/// # Ownership
+///
+/// * On success (non-NULL return), the `reader` pointer is consumed and becomes
+///   invalid. Do not use or free it, use the returned pointer instead.
+/// * On error (NULL return), the `reader` pointer is NOT consumed and remains
+///   valid and owned by the caller, who must free it with `c2pa_reader_free`.
 ///
 /// # Returns
 ///
@@ -1167,21 +1229,16 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
 
     // Take ownership of the Reader (needs to remove it from tracking to take it)
     untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_manifest_data_and_stream(
-        manifest_bytes,
-        &format,
-        stream
-    ));
-    // New reader, will be tracked now too
-    box_tracked!(reader)
+    reconfigure_or_restore(reader, |r| {
+        r.try_with_manifest_data_and_stream(manifest_bytes, &format, stream)
+    })
 }
 
 /// Configures an existing reader with a fragment stream.
 ///
 /// This is used for fragmented BMFF media formats where manifests are stored
-/// in separate fragments. This method consumes the original reader and returns
-/// a new configured reader. The original reader pointer becomes invalid after this call.
+/// in separate fragments. On success this method consumes the original reader and
+/// returns a new configured reader.
 ///
 /// # Safety
 ///
@@ -1189,7 +1246,13 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
 /// * `format` must be a valid null-terminated string with the MIME type.
 /// * `stream` must be a valid pointer to a C2paStream (the main asset stream).
 /// * `fragment` must be a valid pointer to a C2paStream (the fragment stream).
-/// * After calling this function, the `reader` pointer is INVALID.
+///
+/// # Ownership
+///
+/// * On success (non-NULL return), the `reader` pointer is consumed and becomes
+///   invalid. Do not use or free it, use the returned pointer instead.
+/// * On error (NULL return), the `reader` pointer is NOT consumed and remains
+///   valid and owned by the caller, who must free it with `c2pa_reader_free`.
 ///
 /// # Returns
 ///
@@ -1200,7 +1263,12 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
 /// ```c
 /// C2paReader* reader = c2pa_reader_from_context(ctx);
 /// C2paReader* new_reader = c2pa_reader_with_fragment(reader, "video/mp4", main_stream, fragment_stream);
-/// // reader is now invalid, use new_reader
+/// if (new_reader == NULL) {
+///     // error: reader is still valid and owned by the caller
+///     c2pa_reader_free(reader);
+/// } else {
+///     // success: reader was consumed, use new_reader
+/// }
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_reader_with_fragment(
@@ -1216,9 +1284,7 @@ pub unsafe extern "C" fn c2pa_reader_with_fragment(
 
     // Now safe to take ownership - all validations passed
     untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_fragment(&format, stream, fragment));
-    box_tracked!(reader)
+    reconfigure_or_restore(reader, |r| r.try_with_fragment(&format, stream, fragment))
 }
 
 /// Creates a new C2paReader from a shared Context.
@@ -1595,14 +1661,20 @@ pub unsafe extern "C" fn c2pa_builder_with_definition(
 
 /// Configures an existing builder with an archive stream.
 ///
-/// This consumes the original builder and returns a new configured builder.
-/// The original builder pointer becomes invalid after this call.
+/// On success this consumes the original builder and returns a new configured
+/// builder.
 ///
 /// # Safety
 ///
 /// * `builder` must be a valid pointer to a C2paBuilder.
 /// * `stream` must be a valid pointer to a C2paStream.
-/// * After calling this function, the `builder` pointer is INVALID.
+///
+/// # Ownership
+///
+/// * On success (non-NULL return), the `builder` pointer is consumed and becomes
+///   INVALID — do not use or free it; use the returned pointer instead.
+/// * On error (NULL return), the `builder` pointer is NOT consumed and remains
+///   valid and owned by the caller, who must free it with `c2pa_builder_free`.
 ///
 /// # Returns
 ///
@@ -1613,7 +1685,12 @@ pub unsafe extern "C" fn c2pa_builder_with_definition(
 /// ```c
 /// C2paBuilder* builder = c2pa_builder_from_context(ctx);
 /// C2paBuilder* new_builder = c2pa_builder_with_archive(builder, archive_stream);
-/// // builder is now invalid, use new_builder
+/// if (new_builder == NULL) {
+///     // error: builder is still valid and owned by the caller
+///     c2pa_builder_free(builder);
+/// } else {
+///     // success: builder was consumed, use new_builder
+/// }
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_builder_with_archive(
@@ -1625,9 +1702,7 @@ pub unsafe extern "C" fn c2pa_builder_with_archive(
 
     // Now safe to take ownership - stream is valid
     untrack_or_return_null!(builder, C2paBuilder);
-    let builder = Box::from_raw(builder);
-    let result = (*builder).with_archive(stream);
-    box_tracked!(ok_or_return_null!(result))
+    reconfigure_or_restore(builder, |b| b.try_with_archive(stream))
 }
 
 /// Sets the builder intent on the Builder.
@@ -4335,18 +4410,14 @@ verify_after_sign = true
         let archive_bytes = include_bytes!(fixture_path!("C.jpg"));
         let mut archive_stream = TestStream::new(archive_bytes.to_vec());
 
-        // Add archive to builder (this consumes the builder and returns a new one)
+        // A plain JPEG is not a valid archive, so the operation fails.
         let new_builder = unsafe { c2pa_builder_with_archive(builder, archive_stream.as_ptr()) };
+        assert!(new_builder.is_null(), "Expected failure for a non-archive");
 
-        // Verify consumed builder is no longer tracked
+        // Builder is still tracked because the operation failed
+        // after the transfer point but the input was restored to the caller.
         let free_result = unsafe { c2pa_free(builder as *const c_void) };
-        assert_eq!(free_result, -1);
-
-        if !new_builder.is_null() {
-            unsafe {
-                c2pa_free(new_builder as *mut c_void);
-            }
-        }
+        assert_eq!(free_result, 0);
     }
 
     #[test]
@@ -4385,7 +4456,7 @@ verify_after_sign = true
         let mut fragment_stream = TestStream::new(fragment_bytes.to_vec());
         let mut main_stream = TestStream::new(source_image.to_vec());
 
-        // Add fragment to reader (this consumes the reader and returns a new one)
+        // A plain JPEG is not a valid fragmented-BMFF asset, so this fails.
         let new_reader = unsafe {
             c2pa_reader_with_fragment(
                 reader,
@@ -4394,16 +4465,12 @@ verify_after_sign = true
                 fragment_stream.as_ptr(),
             )
         };
+        assert!(new_reader.is_null(), "Expected failure for a non-fragment asset");
 
-        // Verify consumed reader is no longer tracked
+        // Reader is still tracked because the operation failed after the transfer,
+        // but the input was restored to the caller.
         let free_result = unsafe { c2pa_free(reader as *const c_void) };
-        assert_eq!(free_result, -1);
-
-        if !new_reader.is_null() {
-            unsafe {
-                c2pa_free(new_reader as *mut c_void);
-            }
-        }
+        assert_eq!(free_result, 0);
     }
 
     #[test]
@@ -4437,6 +4504,106 @@ verify_after_sign = true
         // Reader is still tracked because validation failed before consumption
         let free_result = unsafe { c2pa_free(reader as *const c_void) };
         assert_eq!(free_result, 0);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_c2pa_reader_with_fragment_op_failure_reader_still_usable() {
+        // A plain JPEG is not a valid fragmented-BMFF asset, so with_fragment
+        // fails inside the SDK after the ownership transfer point.
+        // The reader must be handed back intact:
+        // still tracked, freeable, and re-usable.
+        let source_image = include_bytes!(fixture_path!("C.jpg"));
+        let mut stream = TestStream::new(source_image.to_vec());
+        let format = CString::new("image/jpeg").unwrap();
+
+        let reader = unsafe { c2pa_reader_from_stream(format.as_ptr(), stream.as_ptr()) };
+        assert!(!reader.is_null());
+
+        let mut fragment_stream = TestStream::new(source_image.to_vec());
+        let mut main_stream = TestStream::new(source_image.to_vec());
+        let new_reader = unsafe {
+            c2pa_reader_with_fragment(
+                reader,
+                format.as_ptr(),
+                main_stream.as_ptr(),
+                fragment_stream.as_ptr(),
+            )
+        };
+        assert!(new_reader.is_null(), "Expected failure for a non-fragment asset");
+
+        // The reader was restored to its original address and is still tracked
+        let mut fragment_stream2 = TestStream::new(source_image.to_vec());
+        let mut main_stream2 = TestStream::new(source_image.to_vec());
+        let new_reader2 = unsafe {
+            c2pa_reader_with_fragment(
+                reader,
+                format.as_ptr(),
+                main_stream2.as_ptr(),
+                fragment_stream2.as_ptr(),
+            )
+        };
+        assert!(new_reader2.is_null(), "Second call should also fail cleanly");
+
+        // Still owned by the caller after two failed calls: free succeeds once.
+        assert_eq!(unsafe { c2pa_free(reader as *const c_void) }, 0);
+        // Freeing again is a no-op error (already freed / untracked), not a crash.
+        assert_eq!(unsafe { c2pa_free(reader as *const c_void) }, -1);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_c2pa_reader_with_stream_success_consumes_old_handle() {
+        // On success the input reader is consumed and a new, distinct handle is returned.
+        // The old pointer must no longer be tracked (and must not alias the new one).
+        let context = unsafe { c2pa_context_new() };
+        assert!(!context.is_null());
+        let reader = unsafe { c2pa_reader_from_context(context) };
+        assert!(!reader.is_null());
+
+        let source_image = include_bytes!(fixture_path!("adobe-20220124-E-clm-CAICAI.jpg"));
+        let mut stream = TestStream::new(source_image.to_vec());
+        let format = CString::new("image/jpeg").unwrap();
+
+        let configured = unsafe { c2pa_reader_with_stream(reader, format.as_ptr(), stream.as_ptr()) };
+        assert!(!configured.is_null(), "Configuring a valid asset should succeed");
+
+        // New handle is distinct from the consumed handle.
+        assert_ne!(configured as *const c_void, reader as *const c_void);
+        // The old input pointer is consumed.
+        assert_eq!(unsafe { c2pa_free(reader as *const c_void) }, -1);
+        // The new handle is live and freeable.
+        assert_eq!(unsafe { c2pa_free(configured as *const c_void) }, 0);
+
+        unsafe {
+            c2pa_free(context as *const c_void);
+        }
+    }
+
+    #[test]
+    fn test_reconfigure_or_restore_op_panic_frees_husk_once() {
+        // If `op` panics, the value is dropped exactly once.
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+        struct Counted(#[allow(dead_code)] u32);
+        impl Drop for Counted {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let ptr = crate::track_box(Box::into_raw(Box::new(Counted(1))));
+        crate::untrack_pointer::<Counted>(ptr).unwrap();
+
+        let caught = catch_unwind(AssertUnwindSafe(|| unsafe {
+            reconfigure_or_restore::<Counted, Error, _>(ptr, |_v| panic!("boom"))
+        }));
+        assert!(caught.is_err(), "panic should propagate");
+        assert_eq!(DROPS.load(Ordering::SeqCst), 1, "value dropped exactly once");
+        // The allocation was freed, so the pointer is no longer tracked.
+        assert_eq!(unsafe { c2pa_free(ptr as *const c_void) }, -1);
     }
 
     // ========== High-Value Coverage Tests ==========

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -1086,8 +1086,7 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
             && !insert_to_first_page
             || (new_tiff_tags
                 .iter()
-                .find(|t| t.entry_tag == C2PA_TAG)
-                .is_some()
+                .any(|t| t.entry_tag == C2PA_TAG)
                 && insert_to_first_page)
             || new_tiff_tags.iter().any(|t| t.entry_tag != C2PA_TAG)
             || remove_tiff_tags

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1252,7 +1252,7 @@ impl Builder {
     /// # }
     /// ```
     pub fn with_archive(self, stream: impl Read + Seek + Send) -> Result<Self> {
-        self.try_with_archive(stream).map_err(|(_, e)| e)
+        self.try_with_archive(stream).map_err(|b| b.1)
     }
 
     /// Like [`with_archive`](Self::with_archive), but on error returns the input
@@ -1264,7 +1264,7 @@ impl Builder {
     pub fn try_with_archive(
         self,
         stream: impl Read + Seek + Send,
-    ) -> std::result::Result<Self, (Self, Error)> {
+    ) -> std::result::Result<Self, Box<(Self, Error)>> {
         let mut stream = stream;
         let result = Self::old_from_archive(&mut stream).or_else(|_| {
             // if the old method fails, try the new method
@@ -1287,7 +1287,7 @@ impl Builder {
         });
         match result {
             Ok(builder) => Ok(builder),
-            Err(e) => Err((self, e)),
+            Err(e) => Err(Box::new((self, e))),
         }
     }
 

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1252,8 +1252,21 @@ impl Builder {
     /// # }
     /// ```
     pub fn with_archive(self, stream: impl Read + Seek + Send) -> Result<Self> {
+        self.try_with_archive(stream).map_err(|(_, e)| e)
+    }
+
+    /// Like [`with_archive`](Self::with_archive), but on error returns the input
+    /// [`Builder`] back to the caller together with the [`Error`].
+    ///
+    /// # Returns
+    /// `Ok(builder)` with the archive applied, or `Err((builder, error))` with the
+    /// original, unmodified [`Builder`] handed back.
+    pub fn try_with_archive(
+        self,
+        stream: impl Read + Seek + Send,
+    ) -> std::result::Result<Self, (Self, Error)> {
         let mut stream = stream;
-        Self::old_from_archive(&mut stream).or_else(|_| {
+        let result = Self::old_from_archive(&mut stream).or_else(|_| {
             // if the old method fails, try the new method
             // Archives contain unsigned working stores (signed with BoxHash placeholder)
 
@@ -1271,7 +1284,11 @@ impl Builder {
             let mut reader = Reader::from_shared_context(&self.context);
             reader.with_store(store, &mut validation_log)?;
             reader.into_builder()
-        })
+        });
+        match result {
+            Ok(builder) => Ok(builder),
+            Err(e) => Err((self, e)),
+        }
     }
 
     /// Create a [`Builder`] from an archive stream using thread-local settings.

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1266,6 +1266,8 @@ impl Builder {
         stream: impl Read + Seek + Send,
     ) -> std::result::Result<Self, Box<(Self, Error)>> {
         let mut stream = stream;
+        // On success this creates a rebuilt Builder (not the input `self`).
+        // On a failure, `self` is handed back as-is in the `Err` below.
         let result = Self::old_from_archive(&mut stream).or_else(|_| {
             // if the old method fails, try the new method
             // Archives contain unsigned working stores (signed with BoxHash placeholder)

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -219,31 +219,68 @@ impl Reader {
     /// The updated [`Reader`] with the added manifest store.
     #[async_generic]
     pub fn with_stream(
+        self,
+        format: &str,
+        stream: impl Read + Seek + MaybeSend,
+    ) -> Result<Self> {
+        if _sync {
+            self.try_with_stream(format, stream)
+        } else {
+            self.try_with_stream_async(format, stream).await
+        }
+        .map_err(|(_, e)| e)
+    }
+
+    /// Like [`with_stream`](Self::with_stream), but on error returns the input
+    /// [`Reader`] back to the caller together with the [`Error`].
+    ///
+    /// # Arguments
+    /// * `format` - The MIME type or file extension of the stream (see [`with_stream`](Self::with_stream)).
+    /// * `stream` - The stream to read from.
+    /// # Returns
+    /// `Ok(reader)` with the updated [`Reader`], or `Err((reader, error))` with the
+    /// original, unmodified [`Reader`] handed back.
+    #[async_generic]
+    pub fn try_with_stream(
         mut self,
         format: &str,
         mut stream: impl Read + Seek + MaybeSend,
-    ) -> Result<Self> {
+    ) -> std::result::Result<Self, (Self, Error)> {
         let mut validation_log = StatusTracker::default();
-        stream.rewind()?; // Ensure stream is at the start
+        // Ensure stream is at the start.
+        if let Err(e) = stream.rewind() {
+            return Err((self, e.into()));
+        }
 
         // Prefer the caller's format hint when it identifies the same container as the
         // stream bytes (e.g. "dng" stays "dng" rather than being widened to "image/tiff").
         let format_owned = jumbf_io::format_from_stream(format, &mut stream);
         let format = format_owned.as_str();
 
-        self.context.check_progress(ProgressPhase::Reading, 1, 1)?;
+        if let Err(e) = self.context.check_progress(ProgressPhase::Reading, 1, 1) {
+            return Err((self, e));
+        }
 
-        let store = if _sync {
+        let store_result = if _sync {
             Store::from_stream(format, stream, &mut validation_log, &self.context)
         } else {
             Store::from_stream_async(format, stream, &mut validation_log, &self.context).await
-        }?;
+        };
+        let store = match store_result {
+            Ok(store) => store,
+            Err(e) => return Err((self, e)),
+        };
 
-        if _sync {
-            self.with_store(store, &mut validation_log)
+        let with_store_result = if _sync {
+            self.with_store(store, &mut validation_log).map(|_| ())
         } else {
-            self.with_store_async(store, &mut validation_log).await
-        }?;
+            self.with_store_async(store, &mut validation_log)
+                .await
+                .map(|_| ())
+        };
+        if let Err(e) = with_store_result {
+            return Err((self, e));
+        }
         Ok(self)
     }
 
@@ -428,14 +465,37 @@ impl Reader {
     /// You must check validation status for non-severe errors.
     #[async_generic]
     pub fn with_manifest_data_and_stream(
-        mut self,
+        self,
         c2pa_data: &[u8],
         format: &str,
         stream: impl Read + Seek + MaybeSend,
     ) -> Result<Self> {
+        if _sync {
+            self.try_with_manifest_data_and_stream(c2pa_data, format, stream)
+        } else {
+            self.try_with_manifest_data_and_stream_async(c2pa_data, format, stream)
+                .await
+        }
+        .map_err(|(_, e)| e)
+    }
+
+    /// Like [`with_manifest_data_and_stream`](Self::with_manifest_data_and_stream),
+    /// but on error returns the input [`Reader`] back to the caller together with
+    /// the [`Error`].
+    ///
+    /// # Returns
+    /// `Ok(reader)` with the updated [`Reader`], or `Err((reader, error))` with the
+    /// original, unmodified [`Reader`] handed back.
+    #[async_generic]
+    pub fn try_with_manifest_data_and_stream(
+        mut self,
+        c2pa_data: &[u8],
+        format: &str,
+        stream: impl Read + Seek + MaybeSend,
+    ) -> std::result::Result<Self, (Self, Error)> {
         let mut validation_log = StatusTracker::default();
 
-        let store = if _sync {
+        let store_result = if _sync {
             Store::from_manifest_data_and_stream(
                 c2pa_data,
                 format,
@@ -452,12 +512,22 @@ impl Reader {
                 &self.context,
             )
             .await
-        }?;
-        if _sync {
-            self.with_store(store, &mut validation_log)
+        };
+        let store = match store_result {
+            Ok(store) => store,
+            Err(e) => return Err((self, e)),
+        };
+
+        let with_store_result = if _sync {
+            self.with_store(store, &mut validation_log).map(|_| ())
         } else {
-            self.with_store_async(store, &mut validation_log).await
-        }?;
+            self.with_store_async(store, &mut validation_log)
+                .await
+                .map(|_| ())
+        };
+        if let Err(e) = with_store_result {
+            return Err((self, e));
+        }
         Ok(self)
     }
 
@@ -506,14 +576,35 @@ impl Reader {
     /// You must check validation status for non-severe errors.
     #[async_generic]
     pub fn with_fragment(
+        self,
+        format: &str,
+        stream: impl Read + Seek + MaybeSend,
+        fragment: impl Read + Seek + MaybeSend,
+    ) -> Result<Self> {
+        if _sync {
+            self.try_with_fragment(format, stream, fragment)
+        } else {
+            self.try_with_fragment_async(format, stream, fragment).await
+        }
+        .map_err(|(_, e)| e)
+    }
+
+    /// Like [`with_fragment`](Self::with_fragment), but on error returns the input
+    /// [`Reader`] back to the caller together with the [`Error`].
+    ///
+    /// # Returns
+    /// `Ok(reader)` with the updated [`Reader`], or `Err((reader, error))` with the
+    /// original, unmodified [`Reader`] handed back.
+    #[async_generic]
+    pub fn try_with_fragment(
         mut self,
         format: &str,
         mut stream: impl Read + Seek + MaybeSend,
         mut fragment: impl Read + Seek + MaybeSend,
-    ) -> Result<Self> {
+    ) -> std::result::Result<Self, (Self, Error)> {
         let mut validation_log = StatusTracker::default();
 
-        let store = if _sync {
+        let store_result = if _sync {
             Store::load_fragment_from_stream(
                 format,
                 &mut stream,
@@ -530,13 +621,22 @@ impl Reader {
                 &self.context,
             )
             .await
-        }?;
+        };
+        let store = match store_result {
+            Ok(store) => store,
+            Err(e) => return Err((self, e)),
+        };
 
-        if _sync {
-            self.with_store(store, &mut validation_log)
+        let with_store_result = if _sync {
+            self.with_store(store, &mut validation_log).map(|_| ())
         } else {
-            self.with_store_async(store, &mut validation_log).await
-        }?;
+            self.with_store_async(store, &mut validation_log)
+                .await
+                .map(|_| ())
+        };
+        if let Err(e) = with_store_result {
+            return Err((self, e));
+        }
         Ok(self)
     }
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -228,7 +228,7 @@ impl Reader {
         } else {
             self.try_with_stream_async(format, stream).await
         }
-        .map_err(|(_, e)| e)
+        .map_err(|b| b.1)
     }
 
     /// Like [`with_stream`](Self::with_stream), but on error returns the input
@@ -245,11 +245,11 @@ impl Reader {
         mut self,
         format: &str,
         mut stream: impl Read + Seek + MaybeSend,
-    ) -> std::result::Result<Self, (Self, Error)> {
+    ) -> std::result::Result<Self, Box<(Self, Error)>> {
         let mut validation_log = StatusTracker::default();
         // Ensure stream is at the start.
         if let Err(e) = stream.rewind() {
-            return Err((self, e.into()));
+            return Err(Box::new((self, e.into())));
         }
 
         // Prefer the caller's format hint when it identifies the same container as the
@@ -258,7 +258,7 @@ impl Reader {
         let format = format_owned.as_str();
 
         if let Err(e) = self.context.check_progress(ProgressPhase::Reading, 1, 1) {
-            return Err((self, e));
+            return Err(Box::new((self, e)));
         }
 
         let store_result = if _sync {
@@ -268,7 +268,7 @@ impl Reader {
         };
         let store = match store_result {
             Ok(store) => store,
-            Err(e) => return Err((self, e)),
+            Err(e) => return Err(Box::new((self, e))),
         };
 
         let with_store_result = if _sync {
@@ -279,7 +279,7 @@ impl Reader {
                 .map(|_| ())
         };
         if let Err(e) = with_store_result {
-            return Err((self, e));
+            return Err(Box::new((self, e)));
         }
         Ok(self)
     }
@@ -476,7 +476,7 @@ impl Reader {
             self.try_with_manifest_data_and_stream_async(c2pa_data, format, stream)
                 .await
         }
-        .map_err(|(_, e)| e)
+        .map_err(|b| b.1)
     }
 
     /// Like [`with_manifest_data_and_stream`](Self::with_manifest_data_and_stream),
@@ -492,7 +492,7 @@ impl Reader {
         c2pa_data: &[u8],
         format: &str,
         stream: impl Read + Seek + MaybeSend,
-    ) -> std::result::Result<Self, (Self, Error)> {
+    ) -> std::result::Result<Self, Box<(Self, Error)>> {
         let mut validation_log = StatusTracker::default();
 
         let store_result = if _sync {
@@ -515,7 +515,7 @@ impl Reader {
         };
         let store = match store_result {
             Ok(store) => store,
-            Err(e) => return Err((self, e)),
+            Err(e) => return Err(Box::new((self, e))),
         };
 
         let with_store_result = if _sync {
@@ -526,7 +526,7 @@ impl Reader {
                 .map(|_| ())
         };
         if let Err(e) = with_store_result {
-            return Err((self, e));
+            return Err(Box::new((self, e)));
         }
         Ok(self)
     }
@@ -586,7 +586,7 @@ impl Reader {
         } else {
             self.try_with_fragment_async(format, stream, fragment).await
         }
-        .map_err(|(_, e)| e)
+        .map_err(|b| b.1)
     }
 
     /// Like [`with_fragment`](Self::with_fragment), but on error returns the input
@@ -601,7 +601,7 @@ impl Reader {
         format: &str,
         mut stream: impl Read + Seek + MaybeSend,
         mut fragment: impl Read + Seek + MaybeSend,
-    ) -> std::result::Result<Self, (Self, Error)> {
+    ) -> std::result::Result<Self, Box<(Self, Error)>> {
         let mut validation_log = StatusTracker::default();
 
         let store_result = if _sync {
@@ -624,7 +624,7 @@ impl Reader {
         };
         let store = match store_result {
             Ok(store) => store,
-            Err(e) => return Err((self, e)),
+            Err(e) => return Err(Box::new((self, e))),
         };
 
         let with_store_result = if _sync {
@@ -635,7 +635,7 @@ impl Reader {
                 .map(|_| ())
         };
         if let Err(e) = with_store_result {
-            return Err((self, e));
+            return Err(Box::new((self, e)));
         }
         Ok(self)
     }


### PR DESCRIPTION
## Changes in this pull request

For some bindings using the C FFI, on error cases, it can be ambiguous to determine if a pointer passed in is still own by the caller or if the function took ownership. 

This PR suggests a change to propagate errors differently in the C FFI:
- Introduce try_* APIs: `try_with_archive` on Builder, `try_with_stream`, `try_with_manifest_data_and_stream`, `try_with_fragment` on Reader. Those APIs return Self and a potential error (if any) as result. The pick of those 4 APIs is not random, because it is those which can be ambiguous, as the C FFI can fail in the function body in a way that a caller can not easily determine the pointer ownership because of our own pointer tracking. The goal is to make the contract here clearer/more deterministic so a caller can rely more on return values (and has less errors cases to check).
- Use those APIs in the C FFI to handle errors: `reconfigure_or_restore` either replaces a pointer, or restores the original one so the caller can free it. 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
