### PR TITLE
ci: auto-merge backport PRs once CI passes and approved

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997 # v3
         with:
           github_token: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -49,3 +50,20 @@ jobs:
             Upstream-first: this change already merged to `main`. If the
             cherry-pick did not apply cleanly, adapt it so it compiles and
             passes tests on this branch.
+
+      # Arm GitHub's native auto-merge on each backport PR that was opened. The
+      # actual merge only fires once the target branch's protection rules are
+      # satisfied -- i.e. CI is green and at least one approving review is in --
+      # so those requirements must be configured as branch protection on the
+      # release-line branches (CI passing + 1 required approval). Requires
+      # "Allow auto-merge" to be enabled in the repository settings.
+      - name: Enable auto-merge on backport PRs
+        if: steps.backport.outputs.created_pull_numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CREATED_PRS: ${{ steps.backport.outputs.created_pull_numbers }}
+        run: |
+          for pr in $CREATED_PRS; do
+            echo "Enabling auto-merge (squash) on backport PR #$pr"
+            gh pr merge "$pr" --auto --squash --repo "$GITHUB_REPOSITORY"
+          done


### PR DESCRIPTION
Arms GitHub's native auto-merge on each backport PR opened by `backport.yml`, so a backport lands automatically once the release-line branch's protection rules are satisfied — **without** a maintainer manually clicking merge.

## What changed

- Gave the `korthout/backport-action` step an `id` so its `created_pull_numbers` output is readable.
- Added an **Enable auto-merge on backport PRs** step that runs `gh pr merge --auto --squash` on each created PR.

## How the gate is enforced

`--auto` only *arms* auto-merge; GitHub holds the merge until the target branch's ruleset is satisfied. The `stable` / `v0.*` **"Release lines"** ruleset now requires **1 approving review + the full Tier 1A suite + `cargo-semver-checks`**, and the repo has **Allow auto-merge** + **Allow squash merging** enabled. So a backport auto-merges only when CI is green and it has at least one approval.

## Notes

- Squash matches the repo's squash-merge workflow.
- The step is a no-op when the backport action created no PRs (`created_pull_numbers` empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)