### PR TITLE
fix: builder style c_ffi_api functions will now consistently consume the self parameter

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -727,10 +727,9 @@ pub unsafe extern "C" fn c2pa_context_builder_set_signer(
     signer_ptr: *mut C2paSigner,
 ) -> c_int {
     let builder = deref_mut_or_return_int!(builder, C2paContextBuilder);
-    // Untrack the signer before taking ownership via Box::from_raw.
+    // Untrack the signer before taking ownership.
     // This prevents double-free if C code later calls c2pa_signer_free().
-    untrack_or_return_int!(signer_ptr, C2paSigner);
-    let c2pa_signer = Box::from_raw(signer_ptr);
+    let c2pa_signer = untrack_or_return_int!(signer_ptr, C2paSigner);
     let result = builder.set_signer(c2pa_signer.signer);
     ok_or_return_int!(result);
     0
@@ -837,9 +836,8 @@ pub unsafe extern "C" fn c2pa_context_builder_set_http_resolver(
     resolver_ptr: *mut C2paHttpResolver,
 ) -> c_int {
     let builder = deref_mut_or_return_int!(builder, C2paContextBuilder);
-    untrack_or_return_int!(resolver_ptr, C2paHttpResolver);
-    let c2pa_resolver = Box::from_raw(resolver_ptr);
-    let result = builder.set_resolver(*c2pa_resolver);
+    let c2pa_resolver = untrack_or_return_int!(resolver_ptr, C2paHttpResolver);
+    let result = builder.set_resolver(c2pa_resolver);
     ok_or_return_int!(result);
     0
 }
@@ -863,9 +861,8 @@ pub unsafe extern "C" fn c2pa_context_builder_set_http_resolver(
 pub unsafe extern "C" fn c2pa_context_builder_build(
     builder: *mut C2paContextBuilder,
 ) -> *mut C2paContext {
-    untrack_or_return_null!(builder, C2paContextBuilder);
-    let context = Box::from_raw(builder);
-    box_tracked!((*context).into_shared())
+    let context = untrack_or_return_null!(builder, C2paContextBuilder);
+    box_tracked!(context.into_shared())
 }
 
 /// Creates a new immutable context with default settings.
@@ -1123,13 +1120,17 @@ pub unsafe extern "C" fn c2pa_reader_with_stream(
     format: *const c_char,
     stream: *mut C2paStream,
 ) -> *mut C2paReader {
-    // Validate inputs first, while reader is still tracked
+    // Take ownership of `reader` first: every early return below now drops it via
+    // Rust's ordinary scope-exit `Drop`, so a validation failure here invalidates
+    // `reader` exactly like a failure in `with_stream` itself would -- the caller
+    // never needs to free the passed-in reader themselves, success or failure.
+    let reader = untrack_or_return_null!(reader, C2paReader);
+
     let format = cstr_or_return_null!(format);
     let stream = deref_mut_or_return_null!(stream, C2paStream);
 
-    // Now safe to take ownership - all validations passed
-    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
-        .with_stream(&format, stream))
+    let reader = ok_or_return_null!(reader.with_stream(&format, stream));
+    box_tracked!(reader)
 }
 
 /// Configures an existing passed in Reader with manifest data and a stream.
@@ -1159,13 +1160,17 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
     manifest_data: *const c_uchar,
     manifest_size: usize,
 ) -> *mut C2paReader {
+    // Take ownership of `reader` first so every early return below (ours or
+    // `with_manifest_data_and_stream`'s) drops it uniformly via scope-exit `Drop`.
+    let reader = untrack_or_return_null!(reader, C2paReader);
+
     let format = cstr_or_return_null!(format);
     let stream = deref_mut_or_return_null!(stream, C2paStream);
     let manifest_bytes = bytes_or_return_null!(manifest_data, manifest_size, "manifest_data");
 
-    // Take ownership of the Reader (needs to remove it from tracking to take it)
-    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
-        .with_manifest_data_and_stream(manifest_bytes, &format, stream))
+    let reader =
+        ok_or_return_null!(reader.with_manifest_data_and_stream(manifest_bytes, &format, stream));
+    box_tracked!(reader)
 }
 
 /// Configures an existing reader with a fragment stream.
@@ -1200,14 +1205,16 @@ pub unsafe extern "C" fn c2pa_reader_with_fragment(
     stream: *mut C2paStream,
     fragment: *mut C2paStream,
 ) -> *mut C2paReader {
-    // Validate inputs first, while reader is still tracked
+    // Take ownership of `reader` first so every early return below (ours or
+    // `with_fragment`'s) drops it uniformly via scope-exit `Drop`.
+    let reader = untrack_or_return_null!(reader, C2paReader);
+
     let format = cstr_or_return_null!(format);
     let stream = deref_mut_or_return_null!(stream, C2paStream);
     let fragment = deref_mut_or_return_null!(fragment, C2paStream);
 
-    // Now safe to take ownership - all validations passed
-    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
-        .with_fragment(&format, stream, fragment))
+    let reader = ok_or_return_null!(reader.with_fragment(&format, stream, fragment));
+    box_tracked!(reader)
 }
 
 /// Creates a new C2paReader from a shared Context.
@@ -1572,12 +1579,14 @@ pub unsafe extern "C" fn c2pa_builder_with_definition(
     builder: *mut C2paBuilder,
     manifest_json: *const c_char,
 ) -> *mut C2paBuilder {
-    // Validate inputs first, while builder is still tracked
+    // Take ownership of `builder` first so every early return below (ours or
+    // `with_definition`'s) drops it uniformly via scope-exit `Drop`.
+    let builder = untrack_or_return_null!(builder, C2paBuilder);
+
     let manifest_json = cstr_or_return_null!(manifest_json);
 
-    // Now safe to take ownership - all validations passed
-    consume_or_return_null!(builder, C2paBuilder, |builder: C2paBuilder| builder
-        .with_definition(manifest_json))
+    let builder = ok_or_return_null!(builder.with_definition(manifest_json));
+    box_tracked!(builder)
 }
 
 /// Configures an existing builder with an archive stream.
@@ -1607,12 +1616,14 @@ pub unsafe extern "C" fn c2pa_builder_with_archive(
     builder: *mut C2paBuilder,
     stream: *mut C2paStream,
 ) -> *mut C2paBuilder {
-    // Validate stream first, while builder is still tracked
+    // Take ownership of `builder` first so every early return below (ours or
+    // `with_archive`'s) drops it uniformly via scope-exit `Drop`.
+    let builder = untrack_or_return_null!(builder, C2paBuilder);
+
     let stream = deref_mut_or_return_null!(stream, C2paStream);
 
-    // Now safe to take ownership - stream is valid
-    consume_or_return_null!(builder, C2paBuilder, |builder: C2paBuilder| builder
-        .with_archive(stream))
+    let builder = ok_or_return_null!(builder.with_archive(stream));
+    box_tracked!(builder)
 }
 
 /// Sets the builder intent on the Builder.
@@ -2634,10 +2645,8 @@ pub unsafe extern "C" fn c2pa_identity_signer_create(
     referenced_assertions: *const *const c_char,
     roles: *const *const c_char,
 ) -> *mut C2paSigner {
-    untrack_or_return_null!(c2pa_signer_ptr, C2paSigner);
-    untrack_or_return_null!(identity_signer_ptr, C2paSigner);
-    let c2pa_signer = Box::from_raw(c2pa_signer_ptr);
-    let identity_signer = Box::from_raw(identity_signer_ptr);
+    let c2pa_signer = untrack_or_return_null!(c2pa_signer_ptr, C2paSigner);
+    let identity_signer = untrack_or_return_null!(identity_signer_ptr, C2paSigner);
 
     let referenced_assertions = cstr_array_or_return_null!(referenced_assertions);
     let roles = cstr_array_or_return_null!(roles);
@@ -3377,9 +3386,10 @@ mod tests {
             unsafe { c2pa_reader_with_stream(reader, format.as_ptr(), stream.as_ptr()) };
         assert!(!configured_reader.is_null());
 
-        // Verify consumed reader is no longer tracked
-        let free_result = unsafe { c2pa_free(reader as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `reader` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         // Verify we can read the manifest
         let json = unsafe { c2pa_reader_json(configured_reader) };
@@ -3460,9 +3470,10 @@ mod tests {
             "Reader should be configured with manifest data and stream"
         );
 
-        // Verify the original reader was consumed
-        let free_result = unsafe { c2pa_free(reader as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `reader` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         // Verify we can read the manifest
         let json = unsafe { c2pa_reader_json(configured_reader) };
@@ -4018,9 +4029,10 @@ verify_after_sign = true
         let context = unsafe { c2pa_context_builder_build(builder) };
         assert!(!context.is_null());
 
-        // Verify consumed builder is no longer tracked
-        let free_result = unsafe { c2pa_free(builder as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `builder` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         unsafe {
             c2pa_free(settings as *mut c_void);
@@ -4279,9 +4291,10 @@ verify_after_sign = true
         let new_builder = unsafe { c2pa_builder_with_definition(builder, new_manifest.as_ptr()) };
         assert!(!new_builder.is_null(), "Should return new builder");
 
-        // Verify consumed builder is no longer tracked
-        let free_result = unsafe { c2pa_free(builder as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `builder` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         unsafe {
             c2pa_free(new_builder as *mut c_void);
@@ -4296,16 +4309,16 @@ verify_after_sign = true
         let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
         assert!(!builder.is_null());
 
-        // Test with null JSON: returns null, but the builder is not consumed!
+        // Test with null JSON: returns null, and the builder IS consumed -- the
+        // pointer becomes invalid on any failure, not just on success. (We don't
+        // verify this by freeing `builder` here: in a parallel test binary another
+        // thread can reallocate that exact address in the meantime, making such a
+        // check inherently unreliable.)
         let new_builder = unsafe { c2pa_builder_with_definition(builder, std::ptr::null()) };
         assert!(
             new_builder.is_null(),
             "Should return null for invalid input"
         );
-
-        // Builder is still tracked because validation failed before consumption
-        let free_result = unsafe { c2pa_free(builder as *mut c_void) };
-        assert_eq!(free_result, 0);
     }
 
     #[test]
@@ -4323,9 +4336,10 @@ verify_after_sign = true
         // Add archive to builder (this consumes the builder and returns a new one)
         let new_builder = unsafe { c2pa_builder_with_archive(builder, archive_stream.as_ptr()) };
 
-        // Verify consumed builder is no longer tracked
-        let free_result = unsafe { c2pa_free(builder as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `builder` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         if !new_builder.is_null() {
             unsafe {
@@ -4342,16 +4356,16 @@ verify_after_sign = true
         let builder = unsafe { c2pa_builder_from_json(manifest_def.as_ptr()) };
         assert!(!builder.is_null());
 
-        // Test with null stream: returns null, but the builder is NOT consumed
+        // Test with null stream: returns null, and the builder IS consumed -- the
+        // pointer becomes invalid on any failure, not just on success. (We don't
+        // verify this by freeing `builder` here: in a parallel test binary another
+        // thread can reallocate that exact address in the meantime, making such a
+        // check inherently unreliable.)
         let new_builder = unsafe { c2pa_builder_with_archive(builder, std::ptr::null_mut()) };
         assert!(
             new_builder.is_null(),
             "Should return null for invalid stream"
         );
-
-        // Builder is still tracked because validation failed before consumption
-        let free_result = unsafe { c2pa_free(builder as *mut c_void) };
-        assert_eq!(free_result, 0);
     }
 
     #[test]
@@ -4380,9 +4394,10 @@ verify_after_sign = true
             )
         };
 
-        // Verify consumed reader is no longer tracked
-        let free_result = unsafe { c2pa_free(reader as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `reader` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         if !new_reader.is_null() {
             unsafe {
@@ -4405,7 +4420,11 @@ verify_after_sign = true
         let mut fragment_stream = TestStream::new(source_image.to_vec());
         let mut main_stream = TestStream::new(source_image.to_vec());
 
-        // Test with null format: returns null, but the reader is NOT consumed
+        // Test with null format: returns null, and the reader IS consumed -- the
+        // pointer becomes invalid on any failure, not just on success. (We don't
+        // verify this by freeing `reader` here: in a parallel test binary another
+        // thread can reallocate that exact address in the meantime, making such a
+        // check inherently unreliable.)
         let new_reader = unsafe {
             c2pa_reader_with_fragment(
                 reader,
@@ -4418,10 +4437,6 @@ verify_after_sign = true
             new_reader.is_null(),
             "Should return null for invalid format"
         );
-
-        // Reader is still tracked because validation failed before consumption
-        let free_result = unsafe { c2pa_free(reader as *const c_void) };
-        assert_eq!(free_result, 0);
     }
 
     // ========== High-Value Coverage Tests ==========
@@ -5014,9 +5029,10 @@ verify_after_sign = true
         let result = unsafe { c2pa_context_builder_set_signer(builder, signer) };
         assert_eq!(result, 0);
 
-        // Verify the signer is consumed: freeing it should fail cleanly (-1)
-        let free_result = unsafe { c2pa_free(signer as *const c_void) };
-        assert_eq!(free_result, -1);
+        // Note: we don't verify that `signer` is untracked by freeing it here. In a
+        // parallel test binary, another thread can allocate a new tracked pointer at
+        // that exact (now-freed) address between this call returning and any check
+        // we'd run, making such a check inherently unreliable.
 
         let context = unsafe { c2pa_context_builder_build(builder) };
         assert!(!context.is_null());

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1128,10 +1128,8 @@ pub unsafe extern "C" fn c2pa_reader_with_stream(
     let stream = deref_mut_or_return_null!(stream, C2paStream);
 
     // Now safe to take ownership - all validations passed
-    untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_stream(&format, stream));
-    box_tracked!(reader)
+    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
+        .with_stream(&format, stream))
 }
 
 /// Configures an existing passed in Reader with manifest data and a stream.
@@ -1166,15 +1164,8 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
     let manifest_bytes = bytes_or_return_null!(manifest_data, manifest_size, "manifest_data");
 
     // Take ownership of the Reader (needs to remove it from tracking to take it)
-    untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_manifest_data_and_stream(
-        manifest_bytes,
-        &format,
-        stream
-    ));
-    // New reader, will be tracked now too
-    box_tracked!(reader)
+    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
+        .with_manifest_data_and_stream(manifest_bytes, &format, stream))
 }
 
 /// Configures an existing reader with a fragment stream.
@@ -1215,10 +1206,8 @@ pub unsafe extern "C" fn c2pa_reader_with_fragment(
     let fragment = deref_mut_or_return_null!(fragment, C2paStream);
 
     // Now safe to take ownership - all validations passed
-    untrack_or_return_null!(reader, C2paReader);
-    let reader = Box::from_raw(reader);
-    let reader = ok_or_return_null!((*reader).with_fragment(&format, stream, fragment));
-    box_tracked!(reader)
+    consume_or_return_null!(reader, C2paReader, |reader: C2paReader| reader
+        .with_fragment(&format, stream, fragment))
 }
 
 /// Creates a new C2paReader from a shared Context.
@@ -1587,10 +1576,8 @@ pub unsafe extern "C" fn c2pa_builder_with_definition(
     let manifest_json = cstr_or_return_null!(manifest_json);
 
     // Now safe to take ownership - all validations passed
-    untrack_or_return_null!(builder, C2paBuilder);
-    let builder = Box::from_raw(builder);
-    let result = (*builder).with_definition(manifest_json);
-    box_tracked!(ok_or_return_null!(result))
+    consume_or_return_null!(builder, C2paBuilder, |builder: C2paBuilder| builder
+        .with_definition(manifest_json))
 }
 
 /// Configures an existing builder with an archive stream.
@@ -1624,10 +1611,8 @@ pub unsafe extern "C" fn c2pa_builder_with_archive(
     let stream = deref_mut_or_return_null!(stream, C2paStream);
 
     // Now safe to take ownership - stream is valid
-    untrack_or_return_null!(builder, C2paBuilder);
-    let builder = Box::from_raw(builder);
-    let result = (*builder).with_archive(stream);
-    box_tracked!(ok_or_return_null!(result))
+    consume_or_return_null!(builder, C2paBuilder, |builder: C2paBuilder| builder
+        .with_archive(stream))
 }
 
 /// Sets the builder intent on the Builder.

--- a/c2pa_c_ffi/src/cimpl/macros.rs
+++ b/c2pa_c_ffi/src/cimpl/macros.rs
@@ -350,35 +350,34 @@ macro_rules! arc_tracked {
     }};
 }
 
-/// Untrack a pointer from the registry (ownership transfer from C to Rust).
+/// Untrack a pointer from the registry and take ownership of the pointee
+/// (ownership transfer from C to Rust), yielding it by value.
 ///
-/// Validates the pointer is tracked with the correct type, then removes it
-/// from the registry without running cleanup. Call this *before* `Box::from_raw()`
-/// in any FFI function that consumes a tracked pointer, so the registry doesn't
-/// hold a stale entry that would cause a double-free or false leak warning.
-///
-/// After this macro succeeds, the caller owns the allocation and must drop it
-/// (typically via `Box::from_raw()` immediately after).
+/// Validates the pointer is tracked with the correct type, removes it from the
+/// registry so it can't be double-freed or flagged as a leak, then immediately
+/// `Box::from_raw`s it and moves the value out. Because the result is an owned
+/// value rather than a pointer, any early return written *after* this macro
+/// (e.g. from validating another argument) drops it via Rust's ordinary
+/// scope-exit `Drop` — so the input is consumed the same way on every failure
+/// path, not just when the rest of the function succeeds.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// // In c2pa_context_builder_set_signer — signer is moved into the builder:
-/// untrack_or_return_int!(signer_ptr, C2paSigner);
-/// let signer = Box::from_raw(signer_ptr);
+/// let signer = untrack_or_return_int!(signer_ptr, C2paSigner);
 /// builder.set_signer(signer.signer);
 ///
 /// // In c2pa_context_builder_build — builder is consumed to produce a context:
-/// untrack_or_return_null!(builder, C2paContextBuilder);
-/// let context = Box::from_raw(builder);
-/// box_tracked!((*context).into_shared())
+/// let builder = untrack_or_return_null!(builder, C2paContextBuilder);
+/// box_tracked!(builder.into_shared())
 /// ```
 #[macro_export]
 macro_rules! untrack_or_return {
     ($ptr:expr, $type:ty, $err_val:expr) => {{
         $crate::ptr_or_return!($ptr, $err_val);
         match $crate::untrack_pointer::<$type>($ptr) {
-            Ok(()) => {}
+            Ok(()) => *Box::from_raw($ptr as *mut $type),
             Err(e) => {
                 $crate::CimplError::from(e).set_last();
                 return $err_val;
@@ -387,7 +386,7 @@ macro_rules! untrack_or_return {
     }};
 }
 
-/// Untrack a pointer from the registry, returning -1 on error.
+/// Untrack a pointer and take ownership of the pointee, returning -1 on error.
 #[macro_export]
 macro_rules! untrack_or_return_int {
     ($ptr:expr, $type:ty) => {{
@@ -395,51 +394,11 @@ macro_rules! untrack_or_return_int {
     }};
 }
 
-/// Untrack a pointer from the registry, returning NULL on error.
+/// Untrack a pointer and take ownership of the pointee, returning NULL on error.
 #[macro_export]
 macro_rules! untrack_or_return_null {
     ($ptr:expr, $type:ty) => {{
         $crate::untrack_or_return!($ptr, $type, std::ptr::null_mut())
-    }};
-}
-
-/// Used when a function accepts a tracked pointer, consumes it, and returns a new tracked pointer.
-/// Untrack a tracked pointer, take ownership, apply a fallible consuming operation,
-/// and re-track the result — or early-return with a custom error value.
-/// # Ex
-/// ```rust,ignore
-/// consume_or_return!(
-///     reader,
-///     C2paReader,
-///     |reader: C2paReader| reader.with_fragment(&format, stream, fragment),
-///     std::ptr::null_mut()
-/// )
-/// ```
-///
-/// On `Err`, the boxed value is dropped via Rust's ordinary `Drop` — the pointer
-/// was already removed from the registry by the untrack step, so no explicit free call
-/// is needed (or correct: the pointer is no longer tracked, so `cimpl_free` would just
-/// report an error) at that point.
-#[macro_export]
-macro_rules! consume_or_return {
-    ($ptr:expr, $type:ty, $op:expr, $err_val:expr) => {{
-        $crate::untrack_or_return!($ptr, $type, $err_val);
-        let boxed = Box::from_raw($ptr);
-        match ($op)(*boxed) {
-            Ok(value) => $crate::box_tracked!(value),
-            Err(e) => {
-                $crate::CimplError::from(e).set_last();
-                return $err_val;
-            }
-        }
-    }};
-}
-
-/// Same as [`consume_or_return`], returning NULL on error.
-#[macro_export]
-macro_rules! consume_or_return_null {
-    ($ptr:expr, $type:ty, $op:expr) => {{
-        $crate::consume_or_return!($ptr, $type, $op, std::ptr::null_mut())
     }};
 }
 

--- a/c2pa_c_ffi/src/cimpl/macros.rs
+++ b/c2pa_c_ffi/src/cimpl/macros.rs
@@ -406,7 +406,7 @@ macro_rules! untrack_or_return_null {
 /// Used when a function accepts a tracked pointer, consumes it, and returns a new tracked pointer.
 /// Untrack a tracked pointer, take ownership, apply a fallible consuming operation,
 /// and re-track the result — or early-return with a custom error value.
-/// # Examples
+/// # Ex
 /// ```rust,ignore
 /// consume_or_return!(
 ///     reader,

--- a/c2pa_c_ffi/src/cimpl/macros.rs
+++ b/c2pa_c_ffi/src/cimpl/macros.rs
@@ -403,6 +403,46 @@ macro_rules! untrack_or_return_null {
     }};
 }
 
+/// Used when a function accepts a tracked pointer, consumes it, and returns a new tracked pointer.
+/// Untrack a tracked pointer, take ownership, apply a fallible consuming operation,
+/// and re-track the result — or early-return with a custom error value.
+/// # Examples
+/// ```rust,ignore
+/// consume_or_return!(
+///     reader,
+///     C2paReader,
+///     |reader: C2paReader| reader.with_fragment(&format, stream, fragment),
+///     std::ptr::null_mut()
+/// )
+/// ```
+///
+/// On `Err`, the boxed value is dropped via Rust's ordinary `Drop` — the pointer
+/// was already removed from the registry by the untrack step, so no explicit free call
+/// is needed (or correct: the pointer is no longer tracked, so `cimpl_free` would just
+/// report an error) at that point.
+#[macro_export]
+macro_rules! consume_or_return {
+    ($ptr:expr, $type:ty, $op:expr, $err_val:expr) => {{
+        $crate::untrack_or_return!($ptr, $type, $err_val);
+        let boxed = Box::from_raw($ptr);
+        match ($op)(*boxed) {
+            Ok(value) => $crate::box_tracked!(value),
+            Err(e) => {
+                $crate::CimplError::from(e).set_last();
+                return $err_val;
+            }
+        }
+    }};
+}
+
+/// Same as [`consume_or_return`], returning NULL on error.
+#[macro_export]
+macro_rules! consume_or_return_null {
+    ($ptr:expr, $type:ty, $op:expr) => {{
+        $crate::consume_or_return!($ptr, $type, $op, std::ptr::null_mut())
+    }};
+}
+
 /// Maximum length for C strings when using bounded conversion (64KB)
 pub const MAX_CSTRING_LEN: usize = 1048576;
 

--- a/c2pa_c_ffi/src/cimpl/utils.rs
+++ b/c2pa_c_ffi/src/cimpl/utils.rs
@@ -253,15 +253,15 @@ pub fn validate_pointer<T: 'static>(ptr: *mut T) -> Result<(), Error> {
 ///
 /// After this call, the pointer is no longer managed by the registry. The
 /// caller owns the underlying allocation and must drop it — typically by
-/// calling `Box::from_raw()` immediately after untracking.
+/// calling `Box::from_raw()` immediately after untracking. The
+/// `untrack_or_return_*!` macros do this for you, yielding the owned value directly.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// // FFI function that consumes a signer to configure a builder:
-/// untrack_or_return_int!(signer_ptr, C2paSigner);
-/// let signer = Box::from_raw(signer_ptr);   // sole owner now
-/// builder.set_signer(signer.signer);         // inner value moved into builder
+/// let signer = untrack_or_return_int!(signer_ptr, C2paSigner); // sole owner now
+/// builder.set_signer(signer.signer);                           // inner value moved into builder
 /// // C2paSigner wrapper dropped here — no double-free risk
 /// ```
 pub fn untrack_pointer<T: 'static>(ptr: *mut T) -> Result<(), Error> {


### PR DESCRIPTION
This is for builder model methods that pass in self and return Result<Self>. 
It ensures that all steps are done correctly since this is a common model

c2pa_reader_with_stream and four similar functions (with_manifest_data_and_stream,
with_fragment, builder_with_definition, builder_with_archive) left the input pointer
tracked and reusable if a secondary argument (format, stream, fragment, manifest_json)
failed validation, but consumed it if the underlying operation failed instead

untrack_or_return!/_null!/_int! now take ownership of the pointer directly instead of
just untracking it, and are called before any other validation, so every failure path
consumes the input uniformly via ordinary scope-exit drop.

Removed ~10 test assertions that freed a just-consumed pointer and checked it was
untracked. They only verified the old inconsistent behavior, and the check is
inherently unreliable in a parallel test binary: another concurrently-running test
can allocate a new tracked pointer at that exact freed address before the check runs.