### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.1...c2pa-v0.90.2)
+_23 July 2026_
+
+### Fixed
+
+* Reject loopback and DNS-rebinding hosts in did:web resolution (CAI-10364) (backport #2349) ([#2353](https://github.com/contentauth/c2pa-rs/pull/2353))
+* Harden against memory amplification attacks in copy of strip, tile and big table of TIFF file (backport #2282) ([#2348](https://github.com/contentauth/c2pa-rs/pull/2348))
+
 ## [0.90.1](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.0...c2pa-v0.90.1)
 _21 July 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.1"
+version = "0.90.2"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.1"
+version = "0.90.2"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.1"
+version = "0.90.2"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -866,7 +866,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.1"
+version = "0.90.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2609,7 +2609,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.1"
+version = "0.90.2"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -3712,7 +3712,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3922,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4114,7 +4114,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4435,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4556,7 +4556,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.1"
+version = "0.90.2"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.1", default-features = false }
+c2pa = { path = "sdk", version = "0.90.2", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.1...c2patool-v0.27.2)
+_23 July 2026_
+
 ## [0.27.1](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.0...c2patool-v0.27.1)
 _21 July 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.1"
+version = "0.27.2"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.1 -> 0.90.2 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.1 -> 0.90.2
* `c2patool`: 0.27.1 -> 0.27.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.1...c2pa-v0.90.2)

_23 July 2026_

### Fixed

* Reject loopback and DNS-rebinding hosts in did:web resolution (CAI-10364) (backport #2349) ([#2353](https://github.com/contentauth/c2pa-rs/pull/2353))
* Harden against memory amplification attacks in copy of strip, tile and big table of TIFF file (backport #2282) ([#2348](https://github.com/contentauth/c2pa-rs/pull/2348))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.89.3...c2pa-c-ffi-v0.90.0)

_16 July 2026_

### Changed

* Transition release onto the new scheduled breaking-change release train (see [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md)). This is a version-only bump: there are no `c2pa-c-ffi` library code changes since 0.89.3 ([#2250](https://github.com/contentauth/c2pa-rs/pull/2250)).
</blockquote>

## `c2patool`

<blockquote>

## [0.27.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.1...c2patool-v0.27.2)

_23 July 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).