### PR TITLE
ci: Trust same-repo PR branches instead of author_association

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,15 +20,16 @@ env:
 jobs:
   build:
     name: Build benchmarks
+
+    # Only same-repo PR branches are trusted to run benchmarks; the benchmark
+    # job needs AWS/S3 and Codspeed secrets, which are never available to
+    # fork-originated PR runs, so there is deliberately no label escape hatch
+    # here. We key off the PR's head repository rather than `author_association`
+    # (see tier-1a.yml) so private org members with write access are not
+    # excluded.
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-        (github.event.pull_request.author_association == 'COLLABORATOR' ||
-        github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.user.login == 'dependabot[bot]' ||
-        contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-        contains(github.event.pull_request.labels.*.name, 'check-release') ||
-        contains(github.event.pull_request.labels.*.name, 'benchmark')))
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-no-patch-deps.yml
+++ b/.github/workflows/check-no-patch-deps.yml
@@ -18,6 +18,17 @@ on:
 jobs:
   check:
     name: No patch/git dependencies
+
+    # When invoked directly on a PR, run only for trusted PRs (same-repo branch,
+    # or a fork PR labeled `safe to test`/`check-release`); see tier-1a.yml for
+    # why trust keys off the PR's head repository rather than
+    # `author_association`. Invocations via `workflow_call` are not pull-request
+    # events, so the first clause lets the reusable guard always run there.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+      contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -21,6 +21,16 @@ permissions:
 jobs:
   semver-checks:
     name: cargo-semver-checks
+
+    # Trusted PRs only: same-repo branch, or a fork PR a maintainer has labeled
+    # `safe to test`/`check-release`. cargo-semver-checks compiles the PR's
+    # code, so untrusted forks must not run it unreviewed. We key off the PR's
+    # head repository rather than `author_association` (see tier-1a.yml).
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+      contains(github.event.pull_request.labels.*.name, 'check-release')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -34,6 +34,40 @@ on:
       - '*-rc*'
 
 jobs:
+  # Decide once whether this run is trusted, and expose the result to every
+  # other job. A run is trusted when it is not a pull request (push, schedule,
+  # or manual dispatch), when the PR branch lives in this repository, or when a
+  # maintainer has applied the `safe to test` or `check-release` label to a
+  # fork PR.
+  #
+  # We key trust off the PR's head repository rather than `author_association`
+  # because GitHub only reports `MEMBER`/`COLLABORATOR` for public org members
+  # and direct collaborators. A private org member with team-granted write
+  # access shows up as `CONTRIBUTOR` and would otherwise be denied CI even
+  # though they can push branches here. Pushing a branch to this repository
+  # already requires write access, so "the branch is in this repo" is an
+  # accurate, maintenance-free proxy for "the author is a trusted team member".
+  authorize:
+    name: Authorize CI run
+    runs-on: ubuntu-latest
+    outputs:
+      # Full trust: run the entire CI suite.
+      trusted: ${{ steps.decide.outputs.trusted }}
+
+      # Run originates from this repository (not a fork), so repository secrets
+      # (e.g. the Codecov token) are available. Fork PRs never receive secrets,
+      # even when labeled `safe to test`, so secret-dependent steps must gate on
+      # this rather than on `trusted`.
+      same-repo: ${{ steps.decide.outputs.same-repo }}
+    steps:
+      - name: Determine trust level
+        id: decide
+        run: |
+          {
+            echo "same-repo=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}"
+            echo "trusted=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || contains(github.event.pull_request.labels.*.name, 'check-release') }}"
+          } >> "$GITHUB_OUTPUT"
+
   get-features:
     name: Get features
     runs-on: ubuntu-latest
@@ -61,14 +95,8 @@ jobs:
 
   tests-openssl:
     name: Unit tests (OpenSSL installed)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -106,11 +134,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: |
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.author_association == 'COLLABORATOR' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.user.login == 'dependabot[bot]'
+        if: needs.authorize.outputs.same-repo == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -120,14 +144,8 @@ jobs:
 
   tests-rust-native-crypto:
     name: Unit tests (Rust native crypto installed)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -165,11 +183,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: |
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.author_association == 'COLLABORATOR' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.user.login == 'dependabot[bot]'
+        if: needs.authorize.outputs.same-repo == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -179,14 +193,8 @@ jobs:
 
   tests-cli:
     name: Unit tests (c2patool)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -218,11 +226,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: |
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.author_association == 'COLLABORATOR' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.user.login == 'dependabot[bot]'
+        if: needs.authorize.outputs.same-repo == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -232,14 +236,8 @@ jobs:
 
   tests-windows-arm-openssl:
     name: Unit tests (Windows ARM, OpenSSL)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: windows-11-arm
 
@@ -264,14 +262,8 @@ jobs:
 
   tests-windows-arm-rust-native-crypto:
     name: Unit tests (Windows ARM, Rust native crypto)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: windows-11-arm
 
@@ -296,15 +288,10 @@ jobs:
 
   docs_rs:
     name: Preflight docs.rs build
+    needs: authorize
     runs-on: ubuntu-latest
 
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: needs.authorize.outputs.trusted == 'true'
 
     steps:
       - name: Checkout repository
@@ -341,15 +328,10 @@ jobs:
 
   docs_stable:
     name: Doc build (stable, warnings denied)
+    needs: authorize
     runs-on: ubuntu-latest
 
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: needs.authorize.outputs.trusted == 'true'
 
     steps:
       - name: Checkout repository
@@ -384,19 +366,13 @@ jobs:
 
   doc-tests:
     name: Doc tests (requires nightly Rust)
-    needs: get-features
+    needs: [authorize, get-features]
     # TODO: Remove this once cargo-llvm-cov can run doc tests and generate
     # coverage. (This requires a bug fix that is only available in nightly Rust.)
     # Watch https://github.com/taiki-e/cargo-llvm-cov/issues/2
     # for progress.
 
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -438,11 +414,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       # - name: Upload code coverage results
-      #   if: |
-      #     github.event_name != 'pull_request' ||
-      #     github.event.pull_request.author_association == 'COLLABORATOR' ||
-      #     github.event.pull_request.author_association == 'MEMBER' ||
-      #     github.event.pull_request.user.login == 'dependabot[bot]'
+      #   if: needs.authorize.outputs.same-repo == 'true'
       #   uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       #   with:
       #     token: ${{ secrets.CODECOV_TOKEN }}
@@ -451,13 +423,8 @@ jobs:
 
   cargo-check:
     name: Default features build
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -478,13 +445,8 @@ jobs:
 
   cargo-lock:
     name: Cargo.lock is up to date
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -502,14 +464,8 @@ jobs:
 
   tests-wasm:
     name: Unit tests (Wasm)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -547,14 +503,8 @@ jobs:
 
   tests-wasi:
     name: Unit tests (WASI)
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -602,14 +552,8 @@ jobs:
 
   clippy_check:
     name: Clippy
-    needs: get-features
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -634,13 +578,8 @@ jobs:
 
   cargo_fmt:
     name: Enforce Rust code format
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -659,13 +598,8 @@ jobs:
 
   cargo-deny:
     name: License / vulnerability audit
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -8,6 +8,12 @@
 # release-candidate (`*-rc*`) branch -- this includes backport PRs and the
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
+#
+# On top of that scope, the suite only runs for trusted PRs (those whose branch
+# lives in this repository, plus fork PRs a maintainer has labeled `safe to
+# test`/`check-release`); see tier-1a.yml for why trust keys off the PR's head
+# repository rather than `author_association`. Both conditions are combined once
+# in the `authorize` job below into a single `run-suite` decision.
 
 name: Tier 1B
 
@@ -31,10 +37,22 @@ on:
       - '*-rc*'
 
 jobs:
+  authorize:
+    name: Authorize CI run
+    runs-on: ubuntu-latest
+    outputs:
+      run-suite: ${{ steps.decide.outputs.run-suite }}
+    steps:
+      - name: Determine whether to run the Tier 1B suite
+        id: decide
+        run: |
+          echo "run-suite=${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || contains(github.event.pull_request.labels.*.name, 'check-release')) && (github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')) }}" >> "$GITHUB_OUTPUT"
+
   get-features:
     name: Get features
+    needs: authorize
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    if: needs.authorize.outputs.run-suite == 'true'
     outputs:
       rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
       openssl-features: ${{ steps.get-features.outputs.openssl-features }}
@@ -59,8 +77,8 @@ jobs:
 
   tests-openssl:
     name: Unit tests (with OpenSSL installed)
-    needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.run-suite == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -90,8 +108,8 @@ jobs:
 
   tests-rust-native-crypto:
     name: Unit tests (with Rust native crypto installed)
-    needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.run-suite == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -121,8 +139,8 @@ jobs:
 
   tests-cross:
     name: Unit tests
-    needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.run-suite == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -158,8 +176,8 @@ jobs:
 
   test-direct-minimal-versions:
     name: Unit tests with minimum versions of direct dependencies
-    needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.run-suite == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -187,8 +205,8 @@ jobs:
 
   unused_deps:
     name: Check for unused dependencies
-    needs: get-features
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+    needs: [authorize, get-features]
+    if: needs.authorize.outputs.run-suite == 'true'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -8,6 +8,11 @@
 # release-candidate (`*-rc*`) branch -- this includes backport PRs and the
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
+#
+# On top of that scope, the suite only runs for trusted PRs (those whose branch
+# lives in this repository, plus fork PRs a maintainer has labeled `safe to
+# test`/`check-release`); see tier-1a.yml for why trust keys off the PR's head
+# repository rather than `author_association`.
 
 name: Tier 2
 
@@ -32,7 +37,20 @@ on:
 jobs:
   c-library-mobile-builds:
     name: C library mobile builds
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')
+
+    # Trusted (same-repo branch, or fork PR labeled `safe to test`/
+    # `check-release`) AND in scope for the release-oriented Tier 2 suite.
+    if: >-
+      (github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        contains(github.event.pull_request.labels.*.name, 'safe to test') ||
+        contains(github.event.pull_request.labels.*.name, 'check-release')) &&
+      (github.event_name == 'push' || github.event_name == 'schedule' ||
+        github.event.pull_request.base.ref == 'stable' ||
+        startsWith(github.event.pull_request.base.ref, 'v0.') ||
+        contains(github.event.pull_request.base.ref, '-rc') ||
+        contains(github.event.pull_request.labels.*.name, 'release') ||
+        contains(github.event.pull_request.labels.*.name, 'check-release'))
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
## Problem

The CI trust gate in `tier-1a.yml` (and the AND-clause in `benchmarks.yml`) accepted only `author_association == 'MEMBER' || 'COLLABORATOR'` (plus dependabot and the `safe to test` / `check-release` labels).

GitHub only reports:
- **`MEMBER`** for **public** org members, and
- **`COLLABORATOR`** for **direct** repo collaborators.

A team member whose org membership is **private** and whose write access comes via a **team** is reported as **`CONTRIBUTOR`**. Their PRs had the *entire* CI suite skipped despite having write access — e.g. #2347 (@mpgopala), and the same would hit @ok-nick.

## Fix

Key trust off the **PR's head repository** instead of `author_association`. Pushing a branch to this repo already requires write access, so *"the branch lives in this repo"* is an accurate, maintenance-free proxy for *"the author is a trusted team member"* — and it works regardless of org-membership visibility. Fork PRs keep the `safe to test` / `check-release` label escape hatch.

### Changes
| File | Change |
|------|--------|
| `tier-1a.yml` | New `authorize` job outputs `trusted` (run the suite) and `same-repo` (repo secrets available, e.g. Codecov). Every gated job keys off it — replaces ~18 copies of the old 6-line condition. |
| `tier-1b.yml` | New `authorize` job combines trust with the existing release-line scope into one `run-suite` decision. |
| `tier-2.yml` | Trust folded into the existing inline scope condition (single job). |
| `benchmarks.yml` | Drop the now-redundant `author_association` inner clause; the `head.repo == repository` AND already gates it (benchmarks need AWS/S3/Codspeed secrets forks never receive). |
| `semver-checks.yml` | Gate on the same-repo rule (compiles PR code). |
| `check-no-patch-deps.yml` | Gate on the same-repo rule; `workflow_call` path is unaffected (non-PR event). |

### Deliberately unchanged
- **`upstream-first-check.yml`** — designed to *never skip* so its required check is always conclusive; runs only git/shell, no PR code execution.
- **`pr_title.yml`** — must run on fork PRs to give contributors title feedback; executes no repo code.
- **`backport.yml`** — `pull_request_target`, merged-only maintainer automation.
- **`beta-preflight.yml`** — not PR-triggered (dispatch/push only); its `author_association` reference is already commented out.

## Behavior after this change
- Same-repo PR (any team member, public or private membership) → full CI runs. ✅ (fixes #2347)
- Fork PR → gated; maintainer adds `safe to test` to run.
- `push` / `schedule` / `workflow_dispatch` → unchanged (always trusted).
- Codecov upload still gated on `same-repo` only (no label hatch), since fork PRs never receive secrets.

## Validation
`actionlint` passes with no new findings (only pre-existing shellcheck style warnings in untouched `get-features`/benchmark scripts). The `needs` graph and all `${{ }}` expressions validate.

> [!NOTE]
> Opened as a **draft**. To unblock #2347 immediately without waiting on this, a maintainer can add the `safe to test` label there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)