### PR TITLE
fix: Harden against integer overflow attacks in exclusion subsets checks in BMFF hash processing

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1198,7 +1198,17 @@ impl BmffHash {
                     }
                     // check that the subsets do not overlap
                     for i in 0..subsets.len() - 1 {
-                        if subsets[i].offset + subsets[i].length > subsets[i + 1].offset {
+                        // `offset` and `length` are attacker-controlled u64s from
+                        // CBOR; a sum that overflows u64 cannot fit the addressing
+                        // space, so treat it as malformed rather than panicking on
+                        // the add (overflow-checked builds abort otherwise).
+                        let subset_end = subsets[i]
+                            .offset
+                            .checked_add(subsets[i].length)
+                            .ok_or_else(|| {
+                                Error::C2PAValidation(ASSERTION_BMFFHASH_MALFORMED.to_string())
+                            })?;
+                        if subset_end > subsets[i + 1].offset {
                             return Err(Error::C2PAValidation(
                                 ASSERTION_BMFFHASH_MALFORMED.to_string(),
                             ));
@@ -2472,6 +2482,7 @@ fn stsc_index(track: &Mp4Track, sample_id: u32) -> crate::Result<usize> {
 
 #[cfg(test)]
 mod bmff_hash_tests {
+    #![allow(clippy::expect_used)]
     #![allow(clippy::unwrap_used)]
 
     use std::io::Cursor;
@@ -2519,6 +2530,81 @@ mod bmff_hash_tests {
             &box_info,
             &mut merkle_map,
         );
+    }
+
+    fn bmff_hash_with_subsets(subsets: Vec<SubsetMap>) -> BmffHash {
+        let mut bmff_hash = BmffHash::new("test", "sha256", None);
+        let mut exclusion = ExclusionsMap::new("/mdat".to_owned());
+        exclusion.subset = Some(subsets);
+        bmff_hash.add_exclusions(&mut vec![exclusion]);
+        bmff_hash
+    }
+
+    /// Regression: `offset` and `length` are attacker-controlled `u64`s from
+    /// CBOR. When `offset + length` overflows `u64`, `verify_self` used to panic
+    /// with "attempt to add with overflow" (process abort, exit 101) while
+    /// validating a crafted BmffHash assertion — no valid signature required.
+    /// It must now surface a validation error instead of crashing.
+    #[test]
+    fn verify_self_rejects_subset_offset_length_overflow() {
+        let bmff_hash = bmff_hash_with_subsets(vec![
+            // offset + length overflows u64
+            SubsetMap {
+                offset: 100,
+                length: u64::MAX,
+            },
+            SubsetMap {
+                offset: 200,
+                length: 0,
+            },
+        ]);
+
+        assert!(
+            matches!(bmff_hash.verify_self(), Err(Error::C2PAValidation(_))),
+            "overflowing subset must be rejected as malformed, not panic",
+        );
+    }
+
+    /// A genuine (non-overflowing) overlap must still be rejected — the fix must
+    /// not weaken the existing overlap check.
+    #[test]
+    fn verify_self_rejects_overlapping_subsets() {
+        let bmff_hash = bmff_hash_with_subsets(vec![
+            // ends at 30, past the next subset's offset (20) → overlap
+            SubsetMap {
+                offset: 0,
+                length: 30,
+            },
+            SubsetMap {
+                offset: 20,
+                length: 5,
+            },
+        ]);
+
+        assert!(matches!(
+            bmff_hash.verify_self(),
+            Err(Error::C2PAValidation(_))
+        ));
+    }
+
+    /// Positive: valid ordered, non-overlapping subsets must still pass — the fix
+    /// must not over-reject legitimate assertions.
+    #[test]
+    fn verify_self_accepts_valid_non_overlapping_subsets() {
+        let bmff_hash = bmff_hash_with_subsets(vec![
+            SubsetMap {
+                offset: 0,
+                length: 10,
+            },
+            SubsetMap {
+                offset: 20,
+                length: 5,
+            },
+        ]);
+
+        bmff_hash
+            .verify_self()
+            .expect("valid non-overlapping subsets must pass verify_self");
     }
 
     fn make_bmff_merkle_entries(count: usize) -> Vec<BmffMerkleMap> {


### PR DESCRIPTION
## Changes in this pull request
### The vulnerability
`BmffHash::verify_self()` in `sdk/src/assertions/bmff_hash.rs` checked whether exclusion subsets overlap with an unchecked add:

```rust
if subsets[i].offset + subsets[i].length > subsets[i + 1].offset { … }
```

`SubsetMap.offset` and `SubsetMap.length` are `u64` values deserialized from **attacker-controlled CBOR** (the `BmffHash` assertion inside a C2PA manifest). When `offset + length` exceeds `u64::MAX`, the add overflows and, in overflow-checked builds, **panics with "attempt to add with overflow" (process abort, exit 101)**. Verifying any BMFF asset (MP4/MOV/HEIC/AVIF) whose manifest carries a crafted `BmffHash` assertion crashes the host application. `verify_self` is a structural assertion check reached during validation, so **no valid signature is required**.

### The fix
Replace the unchecked add with `checked_add`. A subset whose `offset + length` overflows `u64` cannot fit the addressing space, so it is inherently malformed/overlapping — return the **existing** `Error::C2PAValidation(ASSERTION_BMFFHASH_MALFORMED)` instead of panicking. 


### Tests added (`bmff_hash_tests`)
- `verify_self_rejects_subset_offset_length_overflow` — a subset with `offset + length` overflowing `u64` returns `C2PAValidation` instead of panicking. **Fails without the fix** (the test profile has overflow checks on, so the old code aborts).
- `verify_self_rejects_overlapping_subsets` — a genuine (non-overflowing) overlap is still rejected (guards against weakening the check).
- `verify_self_accepts_valid_non_overlapping_subsets` — positive test: valid ordered, non-overlapping subsets still pass (no over-rejection).

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
