### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.2...c2pa-v0.90.3)
+_24 July 2026_
+
+### Fixed
+
+* Harden against integer overflow attacks in exclusion subsets checks in BMFF hash processing (backport #2359) ([#2360](https://github.com/contentauth/c2pa-rs/pull/2360))
+
 ## [0.90.2](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.1...c2pa-v0.90.2)
 _23 July 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.2"
+version = "0.90.3"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.2"
+version = "0.90.3"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.2"
+version = "0.90.3"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.2"
+version = "0.27.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.2"
+version = "0.90.3"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2609,7 +2609,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.2"
+version = "0.90.3"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.2"
+version = "0.90.3"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.2", default-features = false }
+c2pa = { path = "sdk", version = "0.90.3", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.2...c2patool-v0.27.3)
+_24 July 2026_
+
 ## [0.27.2](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.1...c2patool-v0.27.2)
 _23 July 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.2"
+version = "0.27.3"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.2 -> 0.90.3 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.2 -> 0.90.3
* `c2patool`: 0.27.2 -> 0.27.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.2...c2pa-v0.90.3)

_24 July 2026_

### Fixed

* Harden against integer overflow attacks in exclusion subsets checks in BMFF hash processing (backport #2359) ([#2360](https://github.com/contentauth/c2pa-rs/pull/2360))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.89.3...c2pa-c-ffi-v0.90.0)

_16 July 2026_

### Changed

* Transition release onto the new scheduled breaking-change release train (see [release process](https://github.com/contentauth/c2pa-rs/blob/main/docs/release-process.md)). This is a version-only bump: there are no `c2pa-c-ffi` library code changes since 0.89.3 ([#2250](https://github.com/contentauth/c2pa-rs/pull/2250)).
</blockquote>

## `c2patool`

<blockquote>

## [0.27.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.2...c2patool-v0.27.3)

_24 July 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).