### PR TITLE
fix: Thumbnails silently dropped when format string has uppercase mimetype (e.g. IMAGE/JPEG)

### DIFF
--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -407,40 +407,6 @@ pub fn add_thumbnail_format(label: &str, format: &str) -> String {
 mod tests {
     use super::*;
 
-    /// Repro: `add_thumbnail_format` matches the format string case-sensitively.
-    /// An uppercase mimetype falls through, producing a label
-    /// ("c2pa.thumbnail.claim/IMAGE/JPEG") instead of "c2pa.thumbnail.claim.jpeg".
-    /// Downstream label lookups then fail to find the thumbnail.
-    #[test]
-    fn test_add_thumbnail_format_uppercase_mime() {
-        assert_eq!(
-            add_thumbnail_format(CLAIM_THUMBNAIL, "IMAGE/JPEG"),
-            JPEG_CLAIM_THUMBNAIL
-        );
-
-        assert_eq!(
-            add_thumbnail_format(INGREDIENT_THUMBNAIL, "IMAGE/PNG"),
-            PNG_INGREDIENT_THUMBNAIL
-        );
-    }
-
-    /// The lowercase counterpart of [test_add_thumbnail_format_uppercase_mime].
-    /// Pins the ordinary lowercase spelling so a case-normalizing fix cannot
-    /// regress it (e.g. by normalizing to uppercase, or handling only
-    /// "IMAGE/JPEG").
-    #[test]
-    fn test_add_thumbnail_format_lowercase_mime() {
-        assert_eq!(
-            add_thumbnail_format(CLAIM_THUMBNAIL, "image/jpeg"),
-            JPEG_CLAIM_THUMBNAIL
-        );
-
-        assert_eq!(
-            add_thumbnail_format(INGREDIENT_THUMBNAIL, "image/png"),
-            PNG_INGREDIENT_THUMBNAIL
-        );
-    }
-
     /// Regression tests for usize underflow in `parse_label` when the input
     /// is a bare version token with no base label (e.g. "v1").
     ///

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -407,7 +407,7 @@ pub fn add_thumbnail_format(label: &str, format: &str) -> String {
 mod tests {
     use super::*;
 
-    /// Repro: `add_thumbnail_format` matches the format string case-sensitively,
+    /// Repro: `add_thumbnail_format` matches the format string case-sensitively.
     /// An uppercase mimetype falls through, producing a label
     /// ("c2pa.thumbnail.claim/IMAGE/JPEG") instead of "c2pa.thumbnail.claim.jpeg".
     /// Downstream label lookups then fail to find the thumbnail.
@@ -420,6 +420,23 @@ mod tests {
 
         assert_eq!(
             add_thumbnail_format(INGREDIENT_THUMBNAIL, "IMAGE/PNG"),
+            PNG_INGREDIENT_THUMBNAIL
+        );
+    }
+
+    /// The lowercase counterpart of [test_add_thumbnail_format_uppercase_mime].
+    /// Pins the ordinary lowercase spelling so a case-normalizing fix cannot
+    /// regress it (e.g. by normalizing to uppercase, or handling only
+    /// "IMAGE/JPEG").
+    #[test]
+    fn test_add_thumbnail_format_lowercase_mime() {
+        assert_eq!(
+            add_thumbnail_format(CLAIM_THUMBNAIL, "image/jpeg"),
+            JPEG_CLAIM_THUMBNAIL
+        );
+
+        assert_eq!(
+            add_thumbnail_format(INGREDIENT_THUMBNAIL, "image/png"),
             PNG_INGREDIENT_THUMBNAIL
         );
     }

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -407,6 +407,23 @@ pub fn add_thumbnail_format(label: &str, format: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Repro: `add_thumbnail_format` matches the format string case-sensitively,
+    /// An uppercase mimetype falls through, producing a label
+    /// ("c2pa.thumbnail.claim/IMAGE/JPEG") instead of "c2pa.thumbnail.claim.jpeg".
+    /// Downstream label lookups then fail to find the thumbnail.
+    #[test]
+    fn test_add_thumbnail_format_uppercase_mime() {
+        assert_eq!(
+            add_thumbnail_format(CLAIM_THUMBNAIL, "IMAGE/JPEG"),
+            JPEG_CLAIM_THUMBNAIL
+        );
+
+        assert_eq!(
+            add_thumbnail_format(INGREDIENT_THUMBNAIL, "IMAGE/PNG"),
+            PNG_INGREDIENT_THUMBNAIL
+        );
+    }
+
     /// Regression tests for usize underflow in `parse_label` when the input
     /// is a bare version token with no base label (e.g. "v1").
     ///

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -434,6 +434,33 @@ pub mod tests {
             .unwrap();
     }
 
+    /// An uppercase MIME format (e.g. "IMAGE/JPEG") yields no thumbnail.
+    /// (Because checks are case-sensitive and not normalized).
+    #[test]
+    fn test_make_thumbnail_bytes_from_stream_uppercase_mime() {
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    prefer_smallest_format = false
+                    ignore_errors = false
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        let (format, bytes) =
+            make_thumbnail_bytes_from_stream("IMAGE/JPEG", Cursor::new(TEST_JPEG), &settings)
+                .unwrap()
+                .unwrap();
+
+        assert!(matches!(format, ThumbnailFormat::Jpeg));
+
+        ImageReader::with_format(Cursor::new(bytes), format.into())
+            .decode()
+            .unwrap();
+    }
+
     #[test]
     fn test_make_thumbnail_with_prefer_smallest_format() {
         let settings = Settings::new()

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -461,6 +461,35 @@ pub mod tests {
             .unwrap();
     }
 
+    /// The lowercase counterpart of
+    /// [test_make_thumbnail_bytes_from_stream_uppercase_mime]. Pins the
+    /// ordinary lowercase spelling so a case-normalizing fix cannot regress it
+    /// (e.g. by normalizing to uppercase, or handling only "IMAGE/JPEG").
+    #[test]
+    fn test_make_thumbnail_bytes_from_stream_lowercase_mime() {
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    prefer_smallest_format = false
+                    ignore_errors = false
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        let (format, bytes) =
+            make_thumbnail_bytes_from_stream("image/jpeg", Cursor::new(TEST_JPEG), &settings)
+                .unwrap()
+                .unwrap();
+
+        assert!(matches!(format, ThumbnailFormat::Jpeg));
+
+        ImageReader::with_format(Cursor::new(bytes), format.into())
+            .decode()
+            .unwrap();
+    }
+
     #[test]
     fn test_make_thumbnail_with_prefer_smallest_format() {
         let settings = Settings::new()


### PR DESCRIPTION
## Changes in this pull request
Bug repro for `Thumbnails silently dropped when format string has uppercase mimetype (e.g. IMAGE/JPEG)`.

Bug report: https://github.com/contentauth/c2pa-rs/issues/2364.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
