### PR TITLE
feat: add the `builder.ignore_ingredient_errors` setting

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -5931,6 +5931,28 @@ mod tests {
         assert!(m.ingredients()[0].active_manifest().is_some());
     }
 
+    #[c2pa_test_async]
+    async fn test_add_cloud_ingredient_ignore_ingredient_errors() {
+        let mut cloud_image = Cursor::new(TEST_IMAGE_CLOUD);
+
+        let settings = Settings::default()
+            .with_value("verify.remote_manifest_fetch", false)
+            .unwrap()
+            .with_value("builder.ignore_ingredient_errors", true)
+            .unwrap();
+        let context = Context::default().with_settings(settings).unwrap();
+
+        let mut builder = Builder::from_context(context);
+
+        let ingredient = builder
+            .add_ingredient_from_stream_async(parent_json(), "image/jpeg", &mut cloud_image)
+            .await
+            .unwrap();
+
+        assert_eq!(ingredient.validation_status(), None);
+        assert_eq!(ingredient.validation_results(), None);
+    }
+
     #[test]
     fn test_redaction() {
         let context = test_context();

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1485,7 +1485,12 @@ impl Ingredient {
             };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, Some(manifest_bytes), &validation_log, &context)?;
+        ingredient.update_validation_status(
+            result,
+            Some(manifest_bytes),
+            &validation_log,
+            &context,
+        )?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -660,6 +660,7 @@ impl Ingredient {
         result: Result<Store>,
         manifest_bytes: Option<Vec<u8>>,
         validation_log: &StatusTracker,
+        context: &Context,
     ) -> Result<()> {
         match result {
             Ok(store) => {
@@ -715,6 +716,11 @@ impl Ingredient {
             | Err(Error::UnsupportedType) => Ok(()), // no claims but valid file
             Err(Error::BadParam(desc)) if desc == *"unrecognized file type" => Ok(()),
             Err(Error::RemoteManifestUrl(url)) | Err(Error::RemoteManifestFetch(url)) => {
+                if context.settings().builder.ignore_ingredient_errors {
+                    debug!("ignoring ingredient error: remote manifest not fetched: {url}");
+                    return Ok(());
+                }
+
                 let status =
                     ValidationStatus::new_failure(validation_status::MANIFEST_INACCESSIBLE)
                         .set_url(url)
@@ -726,6 +732,11 @@ impl Ingredient {
                 Ok(())
             }
             Err(e) => {
+                if context.settings().builder.ignore_ingredient_errors {
+                    debug!("ignoring ingredient error: {e:?}");
+                    return Ok(());
+                }
+
                 // we can ignore the error here because it should have a log entry corresponding to it
                 debug!("ingredient {e:?}");
 
@@ -892,7 +903,7 @@ impl Ingredient {
         }
 
         // set validation status from result and log
-        self.update_validation_status(result, manifest_bytes, &validation_log)?;
+        self.update_validation_status(result, manifest_bytes, &validation_log, context)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]
@@ -982,7 +993,7 @@ impl Ingredient {
             };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, manifest_bytes, &validation_log)?;
+        ingredient.update_validation_status(result, manifest_bytes, &validation_log, context)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]
@@ -1474,7 +1485,7 @@ impl Ingredient {
             };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, Some(manifest_bytes), &validation_log)?;
+        ingredient.update_validation_status(result, Some(manifest_bytes), &validation_log, &context)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -591,6 +591,16 @@ pub struct BuilderSettings {
     ///
     /// [`TimeStamp`]: crate::assertions::TimeStamp
     pub auto_timestamp_assertion: TimeStampSettings,
+    /// Whether to ignore errors encountered while loading or validating an ingredient's
+    /// manifest (e.g. a remote manifest that couldn't be fetched, or an invalid file format).
+    ///
+    /// The default value is false.
+    ///
+    /// <div class="warning">
+    /// When enabled, an ingredient whose manifest can't be loaded or validated is returned
+    /// with no validation status or validation results set, instead of failing.
+    /// </div>
+    pub ignore_ingredient_errors: bool,
 }
 
 impl Default for BuilderSettings {
@@ -607,6 +617,7 @@ impl Default for BuilderSettings {
             prefer_box_hash: false,
             generate_c2pa_archive: Some(true),
             auto_timestamp_assertion: TimeStampSettings::default(),
+            ignore_ingredient_errors: false,
         }
     }
 }


### PR DESCRIPTION
Adds a `builder.ignore_ingredient_errors` setting to ignore parsing/remote manifest fetch/etc. errors and adding the ingredient anyways.

This was split from #2176 and is a result of #2327.