### PR TITLE
fix(sdk): only emit timeStamp.trusted when a trust check ran

### DIFF
--- a/sdk/src/crypto/time_stamp/verify.rs
+++ b/sdk/src/crypto/time_stamp/verify.rs
@@ -540,15 +540,18 @@ pub fn verify_time_stamp(
                 last_err = TimeStampError::Untrusted;
                 continue;
             }
-        }
 
-        log_item!(
-            "",
-            format!("timestamp cert trusted: {}", &common_name),
-            "verify_time_stamp"
-        )
-        .validation_status(TIMESTAMP_TRUSTED)
-        .success(&mut current_validation_log);
+            // Only assert trust when a trust check actually ran. Emitting this
+            // outside the guard claims a trusted timestamp on the
+            // verify_trust == false path, where nothing was evaluated.
+            log_item!(
+                "",
+                format!("timestamp cert trusted: {}", &common_name),
+                "verify_time_stamp"
+            )
+            .validation_status(TIMESTAMP_TRUSTED)
+            .success(&mut current_validation_log);
+        }
 
         // If we find a valid value, we're done.
         validation_log.append(&current_validation_log);


### PR DESCRIPTION
Towards #2317. **Opening this as a concrete option, not to pre-empt the spec
question** @scouten-adobe raised there on 17 July — if @lrosenthol's answer
prescribes a different response for a V1 claim with no trust list, I am happy to
rework or close this.

## Changes in this pull request

`verify_time_stamp()` emitted the `timeStamp.trusted` success status at
function-body depth, outside the `if verify_trust { ... }` block. The block's
only trust-failure exits are `continue`, so when `verify_trust == false` the
whole block is skipped and control falls straight through to the success
emission. The SDK therefore asserted a trusted timestamp certificate having
performed no trust check.

`Store` derives that argument as `rc.version() != 1`
(`sdk/src/store.rs:1952`, "no trust checks for leagacy timestamps"), so the path
is reachable for any claim-v1 active manifest. For v2 claims `verify_trust` is
true and the check runs, so behaviour there is unchanged.

This moves the emission inside the guard, which is the conservative reading:
a v1 manifest gets `timeStamp.validated` and **no trust claim in either
direction**, rather than a positive claim with nothing behind it. It asserts
nothing new, so it should be compatible with whatever the spec answer turns out
to be — if the correct response is a distinct "trust not checked" status, that
is a new status code and a larger change, and I did not want to invent one.

The skip itself is left alone: declining to trust-check a legacy timestamp is a
deliberate choice and is not what this touches.

The two other call sites passing `verify_trust = false` literally
(`sdk/src/assertions/timestamp.rs:117` and
`sdk/src/crypto/time_stamp/http_request.rs:67`) run at signing time with
`CertificateTrustPolicy::passthrough()` and a `StatusTracker` that is discarded,
so they were not user-visible and are unaffected.

## Testing

`cargo test -p c2pa --lib`: 904 passed, 6 failed — and the **same 6 fail on
`main` without this change**, so there is no regression from it. Those 6 are
environmental: I built with `--no-default-features --features
rust_native_crypto,file_io,add_thumbnails,http_ureq`, which leaves out the async
HTTP resolver, so the three `did_web::resolve` tests fail with
`AsyncHttpResolverNotImplemented` and the three `identity::validator` tests that
depend on them fail in turn.

Because those CAWG tests cannot run in that configuration, they do **not**
answer the question I asked on the issue: whether
`identity/claim_aggregation/ica_signature_verifier.rs:735`, which consumes
`TIMESTAMP_TRUSTED` as a boolean, is reachable with `verify_trust == false`. If
it is, this change also removes a trust decision resting on an unchecked
timestamp — but I could not verify that and am not claiming it.

Reported by @contrario, whose control-flow trace was accurate; I confirmed it
still held on `main` and checked the surrounding call sites before changing
anything.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
