### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
-## [0.91.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.3...c2pa-v0.91.0)
+## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.3...c2pa-v0.90.4)
 _04 August 2026_
 
 ### Added
@@ -30,6 +30,10 @@ _04 August 2026_
 * Reject timed-media BMFF Merkle maps that verify against no track (backport #2369) ([#2400](https://github.com/contentauth/c2pa-rs/pull/2400))
 * Validate c2pa.translated action for source and target languages params (backport #2378) ([#2393](https://github.com/contentauth/c2pa-rs/pull/2393))
 * Harden against integer underflow attacks in  ID3 v2.3 frame decoder (backport #2284) ([#2389](https://github.com/contentauth/c2pa-rs/pull/2389))
+
+### Other
+
+**IMPORTANT:** An experimental feature was renamed from `experimental_builder_filter` to `unstable_builder_filter`. Strictly speaking in Rust SemVer, this is a breaking change, but since it was previously expressed that experimental features were exempt from SemVer, we decided not to bump the version.
 
 ## [0.90.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.2...c2pa-v0.90.3)
 _24 July 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.91.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.3...c2pa-v0.91.0)
+_04 August 2026_
+
+### Added
+
+* New builder method to combine filtering of actions and ingredients ([#2379](https://github.com/contentauth/c2pa-rs/pull/2379)) ([#2401](https://github.com/contentauth/c2pa-rs/pull/2401))
+
+### Documented
+
+* Doc how to generate bench fixtures (backport #2366) ([#2370](https://github.com/contentauth/c2pa-rs/pull/2370))
+
+### Fixed
+
+* Make URI checks for (data)boxes when going through redactions mo… ([#2404](https://github.com/contentauth/c2pa-rs/pull/2404))
+* Remove archive assertions when constructing builder from archive (backport #2374) ([#2408](https://github.com/contentauth/c2pa-rs/pull/2408))
+* Thumbnails silently dropped when format string has uppercase mimetype (backport #2365) ([#2407](https://github.com/contentauth/c2pa-rs/pull/2407))
+* Unify partially-applied feature name change
+* Replace mp4 crate with hardened native BMFF sample reader (CAI-12277) (backport #2357) ([#2402](https://github.com/contentauth/c2pa-rs/pull/2402))
+* Reject timed-media BMFF Merkle maps that verify against no track (backport #2369) ([#2400](https://github.com/contentauth/c2pa-rs/pull/2400))
+* Validate c2pa.translated action for source and target languages params (backport #2378) ([#2393](https://github.com/contentauth/c2pa-rs/pull/2393))
+* Harden against integer underflow attacks in  ID3 v2.3 frame decoder (backport #2284) ([#2389](https://github.com/contentauth/c2pa-rs/pull/2389))
+
 ## [0.90.3](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.2...c2pa-v0.90.3)
 _24 July 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.91.0"
+version = "0.90.4"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.91.0"
+version = "0.90.4"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.91.0"
+version = "0.90.4"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.91.0"
+version = "0.90.4"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2598,7 +2598,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.91.0"
+version = "0.90.4"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.3"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -613,7 +613,7 @@ dependencies = [
  "reqwest",
  "riff",
  "rsa",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde-transcode",
  "serde-wasm-bindgen",
@@ -628,7 +628,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "ureq",
  "url",
  "uuid",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.3"
+version = "0.91.0"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.3"
+version = "0.91.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.3"
+version = "0.27.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -699,7 +699,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "treeline",
  "url",
  "wasi 0.14.7+wasi-0.2.4",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -952,15 +952,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1202,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -1329,13 +1320,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1402,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1496,11 +1487,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1517,11 +1507,11 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.3"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "c2pa",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_json",
 ]
 
@@ -1955,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2034,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -2348,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "iref"
@@ -2423,9 +2413,9 @@ checksum = "68cf72bc7b75b6615ffd06bfe6840f3c57e7e4ea615558a2a452f458ebf5551e"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2449,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2608,7 +2598,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.3"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2621,7 +2611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -2795,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty-collections"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d127e00b37b19c36c28ac00e874240a61faeea14c7b759b1d9c77efa048322a"
+checksum = "988fb92b275335f315a9bddf7a8881a02c79c6084e9a626f656f12c50776a045"
 dependencies = [
  "serde",
 ]
@@ -3891,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3969,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3982,14 +3972,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4103,13 +4093,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4170,7 +4160,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4565,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4647,13 +4637,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4707,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -4740,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.3"
+version = "0.91.0"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.3", default-features = false }
+c2pa = { path = "sdk", version = "0.91.0", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.91.0"
+version = "0.90.4"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.91.0", default-features = false }
+c2pa = { path = "sdk", version = "0.90.4", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.91.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.91.0)
+## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.90.4)
 _04 August 2026_
 
 ### Fixed

--- a/c2pa_c_ffi/CHANGELOG.md
+++ b/c2pa_c_ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.91.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.91.0)
+_04 August 2026_
+
+### Fixed
+
+* Emscripten build which lost its header (backport #2395) ([#2396](https://github.com/contentauth/c2pa-rs/pull/2396))
+
 ## [0.90.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.89.3...c2pa-c-ffi-v0.90.0)
 _16 July 2026_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.4](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.3...c2patool-v0.27.4)
+_04 August 2026_
+
 ## [0.27.3](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.2...c2patool-v0.27.3)
 _24 July 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.3"
+version = "0.27.4"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.3 -> 0.90.4 (⚠ API breaking changes - see changelog for why this wasn't a version bump)
* `c2pa-c-ffi`: 0.90.3 -> 0.90.4
* `c2patool`: 0.27.3 -> 0.27.4

### ⚠ `c2pa` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/feature_missing.ron

Failed in:
  feature experimental_builder_filter in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  Builder::filter_actions, previously in file /tmp/.tmpEFRQl8/c2pa/src/builder.rs:990
  Builder::filter_ingredients, previously in file /tmp/.tmpEFRQl8/c2pa/src/builder.rs:1088
  Ingredient::effective_id, previously in file /tmp/.tmpEFRQl8/c2pa/src/ingredient.rs:276
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.3...c2pa-v0.90.4)

_04 August 2026_

### Added

* New builder method to combine filtering of actions and ingredients ([#2379](https://github.com/contentauth/c2pa-rs/pull/2379)) ([#2401](https://github.com/contentauth/c2pa-rs/pull/2401))

### Documented

* Doc how to generate bench fixtures (backport #2366) ([#2370](https://github.com/contentauth/c2pa-rs/pull/2370))

### Fixed

* Make URI checks for (data)boxes when going through redactions mo… ([#2404](https://github.com/contentauth/c2pa-rs/pull/2404))
* Remove archive assertions when constructing builder from archive (backport #2374) ([#2408](https://github.com/contentauth/c2pa-rs/pull/2408))
* Thumbnails silently dropped when format string has uppercase mimetype (backport #2365) ([#2407](https://github.com/contentauth/c2pa-rs/pull/2407))
* Unify partially-applied feature name change
* Replace mp4 crate with hardened native BMFF sample reader (CAI-12277) (backport #2357) ([#2402](https://github.com/contentauth/c2pa-rs/pull/2402))
* Reject timed-media BMFF Merkle maps that verify against no track (backport #2369) ([#2400](https://github.com/contentauth/c2pa-rs/pull/2400))
* Validate c2pa.translated action for source and target languages params (backport #2378) ([#2393](https://github.com/contentauth/c2pa-rs/pull/2393))
* Harden against integer underflow attacks in  ID3 v2.3 frame decoder (backport #2284) ([#2389](https://github.com/contentauth/c2pa-rs/pull/2389))

### Other

**IMPORTANT:** An experimental feature was renamed from `experimental_builder_filter` to `unstable_builder_filter`. Strictly speaking in Rust SemVer, this is a breaking change, but since it was previously expressed that experimental features were exempt from SemVer, we decided not to bump the version.
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.91.0](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.91.0)

_04 August 2026_

### Fixed

* Emscripten build which lost its header (backport #2395) ([#2396](https://github.com/contentauth/c2pa-rs/pull/2396))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.4](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.3...c2patool-v0.27.4)

_04 August 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).