### PR TITLE
fix: Remove archive assertions when constructing builder from archive

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -9496,6 +9496,30 @@ mod tests {
     }
 
     #[test]
+    fn test_with_archive_drops_archive_metadata_assertion() -> Result<()> {
+        let settings = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
+        let context = Context::new().with_settings(settings)?;
+        let builder = Builder::from_context(context)
+            .with_definition(r#"{"title": "Test Archive Metadata"}"#)?;
+
+        let mut archive = Cursor::new(Vec::new());
+        builder.to_archive(&mut archive)?;
+        archive.rewind()?;
+
+        let loaded = Builder::default().with_archive(archive)?;
+        assert!(
+            !loaded
+                .definition
+                .assertions
+                .iter()
+                .any(|a| a.label == crate::assertions::labels::ARCHIVE_METADATA),
+            "archive bookkeeping assertion should not survive into the reconstructed builder"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_archive_self_signed_ed25519_signature() -> Result<()> {
         let settings = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1237,6 +1237,10 @@ impl Reader {
                     builder.add_ingredient(ingredient);
                 }
                 for assertion in manifest.assertions.iter() {
+                    // Archive bookkeeping, not part of the manifest being edited.
+                    if assertion.label().starts_with(crate::assertions::labels::ARCHIVE_METADATA) {
+                        continue;
+                    }
                     builder.add_assertion(assertion.label(), assertion.value()?)?;
                 }
             }

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1238,7 +1238,10 @@ impl Reader {
                 }
                 for assertion in manifest.assertions.iter() {
                     // Archive bookkeeping, not part of the manifest being edited.
-                    if assertion.label().starts_with(crate::assertions::labels::ARCHIVE_METADATA) {
+                    if assertion
+                        .label()
+                        .starts_with(crate::assertions::labels::ARCHIVE_METADATA)
+                    {
                         continue;
                     }
                     builder.add_assertion(assertion.label(), assertion.value()?)?;


### PR DESCRIPTION
## Changes in this pull request
Remove the assertion "org.contentauth.archive.metadata" when creating a builder from an archive.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
