### PR TITLE
fix: Trim whitespace padding around formats

### DIFF
--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -112,7 +112,9 @@ fn normalize_format(format: &str) -> String {
 /// used to check whether two format strings belong to the same container family without
 /// needing a separate enum: `container_from_format("dng") == container_from_format("tif")`.
 fn container_from_format(format: &str) -> Option<&'static str> {
-    CONTAINER_MAP.get(normalize_format(format).as_str()).copied()
+    CONTAINER_MAP
+        .get(normalize_format(format).as_str())
+        .copied()
 }
 
 /// Detects the [`ContainerType`] of a stream by inspecting its leading bytes.

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -34,6 +34,7 @@ use crate::{
     asset_io::{AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, HashObjectPositions},
     error::{Error, Result},
     maybe_send_sync::MaybeSend,
+    utils::mime::normalize_format,
 };
 
 // One prototype instance per handler family. All three lookup maps are derived from
@@ -98,12 +99,6 @@ lazy_static! {
 
 pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
     container_from_format(asset_type) == container_from_format("avif")
-}
-
-/// Normalizes a format string (extension or MIME type) into
-/// a canonical key (lower-case, whitespace padding trimmed).
-fn normalize_format(format: &str) -> String {
-    format.trim().to_lowercase()
 }
 
 /// Returns the container ID for a given format string (extension or MIME type), if known.

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -100,13 +100,19 @@ pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
     container_from_format(asset_type) == container_from_format("avif")
 }
 
+/// Normalizes a caller-supplied format string (extension or MIME type) into the
+/// canonical key (lower-case, whitespace padding trimmed).
+fn normalize_format(format: &str) -> String {
+    format.trim().to_lowercase()
+}
+
 /// Returns the container ID for a given format string (extension or MIME type), if known.
 ///
 /// The container ID is the first format registered by the matching I/O handler. It can be
 /// used to check whether two format strings belong to the same container family without
 /// needing a separate enum: `container_from_format("dng") == container_from_format("tif")`.
 fn container_from_format(format: &str) -> Option<&'static str> {
-    CONTAINER_MAP.get(format.to_lowercase().as_str()).copied()
+    CONTAINER_MAP.get(normalize_format(format).as_str()).copied()
 }
 
 /// Detects the [`ContainerType`] of a stream by inspecting its leading bytes.
@@ -286,19 +292,19 @@ pub(crate) fn get_assetio_handler_from_path(asset_path: &Path) -> Option<&dyn As
 }
 
 pub(crate) fn get_assetio_handler(ext: &str) -> Option<&dyn AssetIO> {
-    let ext = ext.to_lowercase();
+    let ext = normalize_format(ext);
 
     CAI_READERS.get(&ext).map(|h| h.as_ref())
 }
 
 pub(crate) fn get_cailoader_handler(asset_type: &str) -> Option<&dyn CAIReader> {
-    let asset_type = asset_type.to_lowercase();
+    let asset_type = normalize_format(asset_type);
 
     CAI_READERS.get(&asset_type).map(|h| h.get_reader())
 }
 
 pub(crate) fn get_caiwriter_handler(asset_type: &str) -> Option<&dyn CAIWriter> {
-    let asset_type = asset_type.to_lowercase();
+    let asset_type = normalize_format(asset_type);
 
     CAI_WRITERS.get(&asset_type).map(|h| h.as_ref())
 }
@@ -584,6 +590,19 @@ pub mod tests {
                 assert!(get_caiwriter_handler(tiff_type).is_none());
             }
         }
+    }
+
+    /// Padded format strings (e.g. from an FFI boundary) must resolve to the
+    /// same handler as the unpadded form for reads, writes, and container lookup.
+    #[test]
+    fn test_handlers_trim_padded_format() {
+        assert!(get_cailoader_handler("  image/jpeg  ").is_some());
+        assert!(get_caiwriter_handler("\timage/jpeg\n").is_some());
+        assert!(get_assetio_handler("  image/png  ").is_some());
+        assert_eq!(
+            container_from_format("  image/jpeg  "),
+            container_from_format("image/jpeg")
+        );
     }
 
     #[test]

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -100,8 +100,8 @@ pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
     container_from_format(asset_type) == container_from_format("avif")
 }
 
-/// Normalizes a caller-supplied format string (extension or MIME type) into the
-/// canonical key (lower-case, whitespace padding trimmed).
+/// Normalizes a format string (extension or MIME type) into
+/// a canonical key (lower-case, whitespace padding trimmed).
 fn normalize_format(format: &str) -> String {
     format.trim().to_lowercase()
 }

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -48,13 +48,19 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
     })
 }
 
+/// Normalizes a format string (extension or MIME type) into a canonical
+/// lookup key: surrounding whitespace is trimmed and the value is lowercased.
+pub(crate) fn normalize_format(format: &str) -> String {
+    format.trim().to_lowercase()
+}
+
 /// Convert a format to a MIME type
 /// formats can be passed in as extensions, e.g. "jpg" or "jpeg"
 /// or as MIME types, e.g. "image/jpeg"
 /// MIME types are case-insensitive (RFC 2045 section 5.1), so the format is
 /// trimmed to remove surrounding whitespaces and lowercased before matching.
 pub fn format_to_mime(format: &str) -> String {
-    let format = format.trim().to_lowercase();
+    let format = normalize_format(format);
     match extension_to_mime(&format) {
         Some(mime) => mime.to_string(),
         None => format,

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -52,9 +52,9 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
 /// formats can be passed in as extensions, e.g. "jpg" or "jpeg"
 /// or as MIME types, e.g. "image/jpeg"
 /// MIME types are case-insensitive (RFC 2045 section 5.1), so the format is
-/// lowercased before matching.
+/// trimmed to remove surrounding whitespaces and lowercased before matching.
 pub fn format_to_mime(format: &str) -> String {
-    let format = format.to_lowercase();
+    let format = format.trim().to_lowercase();
     match extension_to_mime(&format) {
         Some(mime) => mime.to_string(),
         None => format,
@@ -125,5 +125,13 @@ mod tests {
         assert_eq!(format_to_mime("image/jpeg"), "image/jpeg");
         assert_eq!(format_to_mime("jpg"), "image/jpeg");
         assert_eq!(format_to_mime("image/svg+xml"), "image/svg+xml");
+    }
+
+    #[test]
+    fn test_format_to_mime_trims_whitespace() {
+        assert_eq!(format_to_mime("  image/jpeg  "), "image/jpeg");
+        assert_eq!(format_to_mime("\timage/png\n"), "image/png");
+        assert_eq!(format_to_mime("  JPG  "), "image/jpeg");
+        assert_eq!(format_to_mime("  image/svg+xml  "), "image/svg+xml");
     }
 }


### PR DESCRIPTION
## Changes in this pull request
For https://github.com/contentauth/c2pa-rs/issues/2375.
This will also allow the bindings to defer this operation to the Rust native lib instead.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
