### PR TITLE
chore: Use org-level CRATES_IO_ORG_TOKEN for crates.io publishing

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -45,7 +45,7 @@ jobs:
           verbose: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_ORG_TOKEN }}
 
       # release-plz sometimes opens a new release branch + PR instead of
       # updating the existing one, leaving the old branch behind. Delete stale

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           verbose: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_ORG_TOKEN }}
 
       - name: Debug release-plz outputs
         env:


### PR DESCRIPTION
## Summary

Migrates the crates.io publish token from the repo-specific `CRATES_IO_SECRET` to the org-level `CRATES_IO_ORG_TOKEN`.

- `.github/workflows/release.yml` — `release-plz release` (publish) step
- `.github/workflows/release-pr.yml` — `release-plz release-pr` step

Both map the secret to `CARGO_REGISTRY_TOKEN`.

## ⚠️ Prerequisite

`CRATES_IO_ORG_TOKEN` must be defined at the org level (or on the repo) and visible to `contentauth/c2pa-rs`. If it isn't configured, `CARGO_REGISTRY_TOKEN` resolves to an empty string and publishing will fail. Please confirm the org secret exists before merging / the next release.

Note: the previous secret was named `CRATES_IO_SECRET` (not `CRATES_IO_TOKEN`); there was no `CRATES_IO_TOKEN` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)