### PR TITLE
chore: Declare issue labels used in workflows

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -50,3 +50,51 @@
 - name: task
   color: "1d76db"
   description: "General work item or chore"
+
+- name: "status: todo"
+  color: "ededed"
+  description: "Not yet started"
+
+- name: "status: wip"
+  color: "ededed"
+  description: "Work in progress"
+
+- name: "status: in progress"
+  color: "ededed"
+  description: "Actively being worked on"
+
+- name: "status: in test"
+  color: "ededed"
+  description: "Undergoing testing"
+
+- name: "status: not prioritized"
+  color: "ededed"
+  description: "Not yet prioritized for work"
+
+- name: "status: blocked"
+  color: "ededed"
+  description: "Blocked on another issue or dependency"
+
+- name: "status: api review"
+  color: "ededed"
+  description: "Awaiting API review"
+
+- name: "status: code review"
+  color: "ededed"
+  description: "Awaiting code review"
+
+- name: "status: design review"
+  color: "ededed"
+  description: "Awaiting design review"
+
+- name: "status: code complete"
+  color: "ededed"
+  description: "Code complete, pending remaining checks"
+
+- name: "status: ready"
+  color: "ededed"
+  description: "Ready to be worked on"
+
+- name: "status: done"
+  color: "ededed"
+  description: "Completed"


### PR DESCRIPTION
Declares issue labels used in workflows like `closing_issues.yml` and `reopening_issues.yml` so they don't fail.

https://github.com/contentauth/c2pa-rs/actions/workflows/closing_ticket.yml