### PR TITLE
ci: pin `cargo-udeps` and update nightly toolchain

### DIFF
--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
         with:
-          toolchain: nightly-2025-12-06
+          toolchain: nightly-2026-07-12
           # Pinning to specific nightly build for now. More recent versions
           # introduce a lifetime check that creates a whole slew of build
           # errors.
@@ -235,7 +235,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
 
       - name: Install cargo-udeps
-        run: cargo binstall --no-confirm cargo-udeps
+        run: cargo binstall --no-confirm cargo-udeps@0.1.61
 
       # Experimental (`unstable_`) features are excluded (see get-features); an
       # unstable-only optional dependency stays unactivated and so is never


### PR DESCRIPTION
Pins `cargo-udeps` and updates the nightly toolchain so that it can be properly built from source.

There was an issue where, when failing to from the pre-built `cargo-udeps` from GitHub, it tried building from source, but nightly was out of date. See details here: https://github.com/contentauth/c2pa-rs/actions/runs/30837003564/job/91764612907?pr=2396