### PR TITLE
feat: Add core soft binding resolution API support (Decoupled spec)

### DIFF
--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -1173,6 +1173,51 @@ pub unsafe extern "C" fn c2pa_reader_with_manifest_data_and_stream(
     box_tracked!(reader)
 }
 
+/// Resolves and validates a manifest for `stream` using a soft binding value the caller
+/// has already obtained (e.g. via a proprietary local watermark/fingerprint decoder).
+///
+/// This implements the caller-driven half of the C2PA "Decoupled" soft binding resolution
+/// flow: it looks up `alg` in the configured soft binding algorithm registry, queries its
+/// resolution API endpoint(s), and validates the best matching manifest against `stream`.
+/// This method consumes the original Reader and returns a new configured Reader. The
+/// original Reader pointer becomes invalid after this call and should not be reused.
+///
+/// # Safety
+///
+/// * `reader` must be a valid pointer to a configured C2paReader
+///   (usually with a Context).
+/// * `alg` must be a valid null-terminated string with the soft binding algorithm identifier.
+/// * `value` must be a valid pointer to the soft binding value bytes.
+/// * `value_size` must be the length of the `value` buffer.
+/// * `format` must be a valid null-terminated string with the MIME type.
+/// * `stream` must be a valid pointer to a C2paStream.
+/// * After calling this function, the `reader` pointer becomes invalid.
+///
+/// # Returns
+///
+/// A pointer to a newly configured C2paReader, or NULL on error.
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_reader_with_soft_binding(
+    reader: *mut C2paReader,
+    alg: *const c_char,
+    value: *const c_uchar,
+    value_size: usize,
+    format: *const c_char,
+    stream: *mut C2paStream,
+) -> *mut C2paReader {
+    // Take ownership of `reader` first so every early return below (ours or
+    // `with_soft_binding`'s) drops it uniformly via scope-exit `Drop`.
+    let reader = untrack_or_return_null!(reader, C2paReader);
+
+    let alg = cstr_or_return_null!(alg);
+    let value = bytes_or_return_null!(value, value_size, "value");
+    let format = cstr_or_return_null!(format);
+    let stream = deref_mut_or_return_null!(stream, C2paStream);
+
+    let reader = ok_or_return_null!(reader.with_soft_binding(&alg, value, &format, stream));
+    box_tracked!(reader)
+}
+
 /// Configures an existing reader with a fragment stream.
 ///
 /// This is used for fragmented BMFF media formats where manifests are stored
@@ -3486,6 +3531,64 @@ mod tests {
             c2pa_free(builder as *const c_void);
             c2pa_free(signer as *const c_void);
             c2pa_free(context as *const c_void);
+        }
+    }
+
+    #[test]
+    fn test_c2pa_reader_with_soft_binding_null_alg() {
+        let reader = unsafe { c2pa_reader_new() };
+        assert!(!reader.is_null());
+
+        let mut stream = TestStream::new(Vec::new());
+        let format = CString::new("image/jpeg").unwrap();
+        let value = [1u8, 2, 3];
+
+        let result = unsafe {
+            c2pa_reader_with_soft_binding(
+                reader,
+                std::ptr::null(),
+                value.as_ptr(),
+                value.len(),
+                format.as_ptr(),
+                stream.as_ptr(),
+            )
+        };
+        assert!(result.is_null());
+        let error = unsafe { c2pa_error() };
+        let error_str = unsafe { CString::from_raw(error) };
+        assert_eq!(error_str.to_str().unwrap(), "NullParameter: alg");
+    }
+
+    #[test]
+    fn test_c2pa_reader_with_soft_binding_no_registry_is_noop() {
+        let context = unsafe { c2pa_context_new() };
+        assert!(!context.is_null());
+
+        let reader = unsafe { c2pa_reader_from_context(context) };
+        assert!(!reader.is_null());
+
+        let source_image = include_bytes!(fixture_path!("CA.jpg"));
+        let mut stream = TestStream::new(source_image.to_vec());
+        let format = CString::new("image/jpeg").unwrap();
+        let alg = CString::new("com.example.watermark").unwrap();
+        let value = [1u8, 2, 3];
+
+        // No `soft_binding.algorithm_registry` configured: this should be a no-op that
+        // still returns a valid (unchanged) reader, not an error.
+        let configured_reader = unsafe {
+            c2pa_reader_with_soft_binding(
+                reader,
+                alg.as_ptr(),
+                value.as_ptr(),
+                value.len(),
+                format.as_ptr(),
+                stream.as_ptr(),
+            )
+        };
+        assert!(!configured_reader.is_null());
+
+        unsafe {
+            c2pa_free(configured_reader as *const c_void);
         }
     }
 

--- a/c2pa_c_ffi/src/error.rs
+++ b/c2pa_c_ffi/src/error.rs
@@ -114,7 +114,9 @@ impl C2paError {
             | CertificateTrustError(_)
             | InvalidCertificateError(_)
             | InvalidEcdsaSignature => Self::Signature(err_str),
-            RemoteManifestFetch(_) | RemoteManifestUrl(_) => Self::RemoteManifest(err_str),
+            RemoteManifestFetch(_) | RemoteManifestUrl(_) | SoftBindingResolutionFetch(_) => {
+                Self::RemoteManifest(err_str)
+            }
             JumbfNotFound => Self::ManifestNotFound(err_str),
             IoError(_) => Self::Io(err_str),
             JsonError(e) => Self::Json(err_str),
@@ -349,6 +351,15 @@ mod tests {
             "C2paException in c2pa-c checks for 'Remote:' prefix; got: {}",
             msg
         );
+    }
+
+    #[test]
+    fn test_soft_binding_resolution_fetch_maps_to_remote_manifest() {
+        let c2pa_err =
+            c2pa::Error::SoftBindingResolutionFetch("request to endpoint failed".to_string());
+        let c2pa_c_err = C2paError::from_c2pa_error(c2pa_err);
+        assert_eq!(c2pa_c_err.code(), 112);
+        assert!(matches!(c2pa_c_err, C2paError::RemoteManifest(_)));
     }
 
     #[test]

--- a/sdk/src/assertions/soft_binding.rs
+++ b/sdk/src/assertions/soft_binding.rs
@@ -4,7 +4,7 @@ use super::labels;
 use crate::{
     assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::region_of_interest::RegionOfInterest,
-    cbor_types::{DateT, UriT},
+    cbor_types::UriT,
     Result,
 };
 
@@ -117,174 +117,36 @@ pub struct SoftBindingTimespan {
     pub end: u64,
 }
 
-// A parsed C2PA soft binding algorithm registry.
-// Use this to parse a list of soft binding algorithms from a JSON string and
-// to build a list of soft binding algorithms.  Use this function to parse the official C2PA
-// soft binding algorithm registry from the JSON file at <https://github.com/c2pa-org/softbinding-algorithm-list/blob/main/softbinding-algorithm-list.json>
-// to build a list of soft binding algorithms.  The list can be used to validate soft binding algorithms in C2PA assertions.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(transparent)]
-#[allow(unused)]
-struct SoftBindingList(pub Vec<SoftBindingAlgorithm>);
-
-#[allow(unused)]
-impl SoftBindingList {
-    /// Parse a JSON string containing a soft binding algorithm list.
-    pub fn from_json_str(json: &str) -> Result<Self> {
-        let list: Self = serde_json::from_str(json)?;
-        list.validate()?;
-        Ok(list)
-    }
-
-    fn validate(&self) -> Result<()> {
-        for algorithm in &self.0 {
-            algorithm.validate()?;
-        }
-        Ok(())
-    }
-
-    /// Returns a list of soft binding algorithms strings from a vector of `SoftBindingAlgorithm` entries using the `alg` field.
-    pub fn algorithm_strings(&self) -> Vec<String> {
-        self.0.iter().map(|alg| alg.alg.clone()).collect()
-    }
-}
-
-// A single soft binding algorithm entry.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[allow(unused)]
-struct SoftBindingAlgorithm {
-    pub identifier: u16,
-
-    #[serde(default)]
-    pub deprecated: bool,
-
-    pub alg: String,
-
-    #[serde(rename = "type")]
-    pub alg_type: SoftBindingAlgorithmType,
-
-    #[serde(rename = "decodedMediaTypes", skip_serializing_if = "Option::is_none")]
-    pub decoded_media_types: Option<Vec<SoftBindingMediaType>>,
-
-    #[serde(rename = "encodedMediaTypes", skip_serializing_if = "Option::is_none")]
-    pub encoded_media_types: Option<Vec<String>>,
-
-    #[serde(rename = "entryMetadata")]
-    pub entry_metadata: SoftBindingEntryMetadata,
-
-    #[serde(
-        rename = "softBindingResolutionApis",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub soft_binding_resolution_apis: Option<Vec<UriT>>,
-}
-
-#[allow(unused)]
-impl SoftBindingAlgorithm {
-    fn validate(&self) -> Result<()> {
-        if self
-            .decoded_media_types
-            .as_ref()
-            .map(Vec::is_empty)
-            .unwrap_or(false)
-        {
-            return Err(crate::error::Error::ValidationRule(
-                "decodedMediaTypes must be a non-empty array when present".to_owned(),
-            ));
-        }
-
-        if self
-            .encoded_media_types
-            .as_ref()
-            .map(Vec::is_empty)
-            .unwrap_or(false)
-        {
-            return Err(crate::error::Error::ValidationRule(
-                "encodedMediaTypes must be a non-empty array when present".to_owned(),
-            ));
-        }
-
-        if self.decoded_media_types.is_none() && self.encoded_media_types.is_none() {
-            return Err(crate::error::Error::ValidationRule(
-                "soft binding algorithm entry must include decodedMediaTypes or encodedMediaTypes"
-                    .to_owned(),
-            ));
-        }
-
-        if let Some(apis) = &self.soft_binding_resolution_apis {
-            if apis.is_empty() {
-                return Err(crate::error::Error::ValidationRule(
-                    "softBindingResolutionApis must be a non-empty array when present".to_owned(),
-                ));
-            }
-            for api in apis {
-                url::Url::parse(api.as_ref()).map_err(|_| {
-                    crate::error::Error::ValidationRule(format!(
-                        "softBindingResolutionApis contains invalid URI: {}",
-                        api.as_ref()
-                    ))
-                })?;
-            }
-        }
-
-        self.entry_metadata.validate()
-    }
-}
-
-/// Metadata for a soft binding algorithm entry.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[allow(unused)]
-struct SoftBindingEntryMetadata {
-    pub description: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub categories: Option<Vec<String>>,
-
-    #[serde(rename = "dateEntered")]
-    pub date_entered: DateT,
-
-    pub contact: String,
-
-    #[serde(rename = "informationalUrl")]
-    pub informational_url: UriT,
-}
-
-impl SoftBindingEntryMetadata {
-    fn validate(&self) -> Result<()> {
-        url::Url::parse(self.informational_url.as_ref()).map_err(|_| {
-            crate::error::Error::ValidationRule(format!(
-                "entryMetadata.informationalUrl is not a valid URI: {}",
-                self.informational_url.as_ref()
-            ))
-        })?;
-        Ok(())
-    }
-}
-
-// The type of soft binding algorithm.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "lowercase")]
-#[allow(unused)]
-enum SoftBindingAlgorithmType {
-    Watermark,
-    Fingerprint,
-}
-
-// Target media types for soft binding algorithms.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "lowercase")]
-#[allow(unused)]
-enum SoftBindingMediaType {
-    Application,
-    Audio,
-    Image,
-    Model,
-    Text,
-    Video,
-}
-
 impl SoftBinding {
     pub const LABEL: &'static str = labels::SOFT_BINDING;
+
+    /// Create a new [`SoftBinding`] with the given algorithm identifier and blocks.
+    ///
+    /// `alg` should be a value from the
+    /// [C2PA soft binding algorithm list](https://github.com/c2pa-org/softbinding-algorithm-list).
+    /// Optional fields (`name`, `alg_params`) can be set directly on the returned value,
+    /// since both are public.
+    pub fn new(alg: impl Into<String>, blocks: Vec<SoftBindingBlock>) -> Self {
+        SoftBinding {
+            alg: Some(alg.into()),
+            blocks,
+            name: None,
+            alg_params: None,
+            pad: Vec::new(),
+            pad2: None,
+            url: None, // deprecated
+        }
+    }
+
+    /// Set a human-readable description of what this soft binding covers.
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = Some(name.into());
+    }
+
+    /// Set a string describing parameters of the soft binding algorithm.
+    pub fn set_alg_params(&mut self, alg_params: impl Into<String>) {
+        self.alg_params = Some(alg_params.into());
+    }
 }
 
 impl AssertionBase for SoftBinding {
@@ -347,38 +209,21 @@ pub mod tests {
     }
 
     #[test]
-    fn test_soft_binding_list_json_parse() {
-        let json = r#"[
-            {
-                "identifier": 1,
-                "alg": "com.example.watermark.alg1",
-                "type": "watermark",
-                "decodedMediaTypes": ["image"],
-                "entryMetadata": {
-                    "description": "Example watermarking algorithm",
-                    "dateEntered": "2025-01-01T00:00:00Z",
-                    "contact": "contact@example.com",
-                    "informationalUrl": "https://example.com/softbinding/alg1"
-                }
-            }
-        ]"#;
+    fn test_new() {
+        let block = SoftBindingBlock {
+            scope: SoftBindingScope::default(),
+            value: b"some value".to_vec(),
+        };
+        let soft_binding = SoftBinding::new("com.example.watermark", vec![block]);
 
-        let list = SoftBindingList::from_json_str(json).unwrap();
-        assert_eq!(list.0.len(), 1);
-        let algorithm = &list.0[0];
-        assert_eq!(algorithm.identifier, 1);
-        assert_eq!(algorithm.alg, "com.example.watermark.alg1");
-        assert!(matches!(
-            algorithm.alg_type,
-            SoftBindingAlgorithmType::Watermark
-        ));
-        assert_eq!(
-            algorithm.decoded_media_types.as_ref().unwrap(),
-            &[SoftBindingMediaType::Image]
-        );
+        assert_eq!(soft_binding.alg.as_deref(), Some("com.example.watermark"));
+        assert_eq!(soft_binding.blocks.len(), 1);
+        assert_eq!(soft_binding.name, None);
+        assert_eq!(soft_binding.alg_params, None);
 
-        // get the algorithm strings
-        let alg_strings = list.algorithm_strings();
-        assert_eq!(alg_strings, vec!["com.example.watermark.alg1"]);
+        // Round-trips through CBOR like a normal assertion.
+        let assertion = soft_binding.to_assertion().unwrap();
+        let result = SoftBinding::from_assertion(&assertion).unwrap();
+        assert_eq!(result, soft_binding);
     }
 }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -168,6 +168,9 @@ pub enum Error {
     #[error("must fetch remote manifests from url {0}")]
     RemoteManifestUrl(String),
 
+    #[error("soft binding resolution API request failed: {0}")]
+    SoftBindingResolutionFetch(String),
+
     #[error("failed to remotely sign data")]
     FailedToRemoteSign,
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -224,6 +224,10 @@ pub mod jumbf_io;
 /// The settings module provides a way to configure the C2PA SDK.
 pub mod settings;
 
+/// The `soft_binding` module supports the C2PA soft binding algorithm list registry
+/// and the [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html).
+pub mod soft_binding;
+
 /// Supports status tracking as defined in the C2PA Technical Specification.
 #[doc(hidden)]
 pub mod status_tracker;

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -461,6 +461,114 @@ impl Reader {
         Ok(self)
     }
 
+    /// Resolve and validate a manifest for `stream` using a soft binding value the caller
+    /// has already obtained (e.g. via a proprietary local watermark/fingerprint decoder, or
+    /// the caller's own call to [`crate::soft_binding::resolution_api::query_by_content`]).
+    ///
+    /// This implements the caller-driven half of the C2PA
+    /// ["Decoupled" soft binding](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html)
+    /// resolution flow: it looks up `alg` in
+    /// [`Settings.soft_binding.algorithm_registry`](crate::settings::SoftBinding::algorithm_registry),
+    /// queries each of its registered resolution API endpoints via `byBinding`, and — for
+    /// the best match found — constructs the manifest's fetch URL and hands it to the same
+    /// remote-manifest fetch path used for an XMP-embedded provenance reference. If
+    /// fetching is disabled ([`Verify::remote_manifest_fetch`](crate::settings::Verify::remote_manifest_fetch))
+    /// or unsupported (the `fetch_remote_manifests` feature is off), this surfaces as
+    /// [`Error::RemoteManifestUrl`], exactly as it would for an XMP remote manifest
+    /// reference, so the caller can fetch it out-of-band and pass the bytes to
+    /// [`with_manifest_data_and_stream`](Self::with_manifest_data_and_stream) instead.
+    ///
+    /// The SDK never uploads asset content on the caller's behalf as part of this call —
+    /// only the small, already-known `value` is sent in the query.
+    ///
+    /// # Arguments
+    /// * `alg` - The soft binding algorithm identifier (e.g. `"com.adobe.trustmark.Q"`).
+    /// * `value` - The soft binding value already extracted from the asset by the caller.
+    /// * `format` - The format of the stream.
+    /// * `stream` - The stream to verify the resolved manifest against.
+    /// # Returns
+    /// The updated [`Reader`], unchanged if `algorithm_registry` isn't configured, `alg`
+    /// isn't found in it, or no endpoint returns a match — all normal, expected outcomes.
+    /// # Errors
+    /// Returns an [`Error`] if a match is found but its manifest cannot be fetched or fails
+    /// to validate.
+    #[async_generic]
+    pub fn with_soft_binding(
+        self,
+        alg: &str,
+        value: &[u8],
+        format: &str,
+        stream: impl Read + Seek + MaybeSend,
+    ) -> Result<Self> {
+        use crate::soft_binding::{resolution_api, SoftBindingList};
+
+        let registry = match self
+            .context
+            .settings()
+            .soft_binding
+            .algorithm_registry
+            .as_deref()
+        {
+            Some(json) => SoftBindingList::from_json_str(json)?,
+            None => return Ok(self),
+        };
+
+        let Some(entry) = registry.find(alg) else {
+            return Ok(self);
+        };
+
+        let mut all_matches = Vec::new();
+        for endpoint in entry.resolution_apis() {
+            let endpoint = endpoint.as_ref();
+            let result = if _sync {
+                resolution_api::query_by_binding_get(endpoint, alg, value, None, &self.context)
+            } else {
+                resolution_api::query_by_binding_get_async(
+                    endpoint,
+                    alg,
+                    value,
+                    None,
+                    &self.context,
+                )
+                .await
+            };
+            // Best-effort: one endpoint failing shouldn't abort the others.
+            if let Ok(query_result) = result {
+                all_matches.extend(query_result.matches.into_iter().map(|m| (endpoint, m)));
+            }
+        }
+
+        let best = all_matches.into_iter().max_by(|(_, a), (_, b)| {
+            match (a.similarity_score, b.similarity_score) {
+                (Some(x), Some(y)) => x.cmp(&y),
+                (Some(_), None) => std::cmp::Ordering::Greater,
+                (None, Some(_)) => std::cmp::Ordering::Less,
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+        });
+
+        let Some((endpoint, best_match)) = best else {
+            return Ok(self);
+        };
+
+        let manifest_endpoint = best_match.endpoint.as_deref().unwrap_or(endpoint);
+        let manifest_url =
+            resolution_api::manifest_url(manifest_endpoint, &best_match.manifest_id)?;
+
+        let manifest_bytes = if _sync {
+            Store::handle_remote_manifest(manifest_url.as_str(), &self.context)?
+        } else {
+            Store::handle_remote_manifest_async(manifest_url.as_str(), &self.context).await?
+        };
+
+        if _sync {
+            self.with_manifest_data_and_stream(&manifest_bytes, format, stream)
+        } else {
+            self.with_manifest_data_and_stream_async(&manifest_bytes, format, stream)
+                .await
+        }
+    }
+
     /// Create a manifest store [`Reader`] from existing `c2pa_data` and a stream.
     /// Use this to validate a remote manifest or a sidecar manifest.
     /// # Arguments
@@ -1400,6 +1508,152 @@ pub mod tests {
         let remote_url = reader.remote_url();
         assert_eq!(remote_url, Some("https://cai-manifests.adobe.com/manifests/adobe-urn-uuid-5f37e182-3687-462e-a7fb-573462780391"));
         assert!(!reader.is_embedded());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_soft_binding_no_registry_is_noop() -> Result<()> {
+        // No `algorithm_registry` configured: `with_soft_binding` should be a no-op and
+        // must not attempt any network call.
+        let reader = Reader::default().with_soft_binding(
+            "com.example.watermark",
+            b"some watermark value",
+            "image/jpeg",
+            Cursor::new(IMAGE_WITH_MANIFEST),
+        )?;
+        assert!(reader.active_manifest().is_none());
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "fetch_remote_manifests")]
+    #[cfg(not(target_arch = "wasm32"))] // httpmock doesn't support wasm32 (issue #1378)
+    fn test_with_soft_binding_resolves_and_validates() -> Result<()> {
+        use httpmock::{Method, MockServer};
+
+        use crate::soft_binding::resolution_api::{SoftBindingMatch, SoftBindingQueryResult};
+
+        const CLOUD_ASSET: &[u8] = include_bytes!("../tests/fixtures/cloud.jpg");
+        const CLOUD_MANIFEST: &[u8] = include_bytes!("../tests/fixtures/cloud_manifest.c2pa");
+
+        let server = MockServer::start();
+
+        let query_result = SoftBindingQueryResult {
+            matches: vec![SoftBindingMatch {
+                manifest_id: "cloud_manifest".to_owned(),
+                endpoint: None,
+                similarity_score: Some(90),
+            }],
+        };
+        let by_binding_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/matches/byBinding")
+                .query_param("alg", "com.example.watermark");
+            then.status(200).json_body_obj(&query_result);
+        });
+        let manifest_mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/manifests/cloud_manifest");
+            then.status(200)
+                .header("content-type", "application/c2pa")
+                .body(CLOUD_MANIFEST);
+        });
+
+        let registry_json = serde_json::json!([{
+            "identifier": 1,
+            "alg": "com.example.watermark",
+            "type": "watermark",
+            "decodedMediaTypes": ["image"],
+            "entryMetadata": {
+                "description": "test algorithm",
+                "dateEntered": "2025-01-01T00:00:00Z",
+                "contact": "test@example.com",
+                "informationalUrl": "https://example.com"
+            },
+            "softBindingResolutionApis": [server.base_url()]
+        }])
+        .to_string();
+
+        let mut context = Context::new();
+        context.settings_mut().soft_binding.algorithm_registry = Some(registry_json);
+        // The bundled test trust list doesn't include the cert this fixture was signed
+        // with; disable trust verification the same way other tests using this fixture do.
+        context.settings_mut().verify.verify_trust = false;
+
+        let reader = Reader::from_context(context).with_soft_binding(
+            "com.example.watermark",
+            b"some watermark value",
+            "image/jpeg",
+            Cursor::new(CLOUD_ASSET),
+        )?;
+
+        assert!(reader.active_manifest().is_some());
+        by_binding_mock.assert();
+        manifest_mock.assert();
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "fetch_remote_manifests")]
+    #[cfg(not(target_arch = "wasm32"))] // httpmock doesn't support wasm32 (issue #1378)
+    fn test_with_soft_binding_fetch_disabled_returns_remote_manifest_url() -> Result<()> {
+        use httpmock::{Method, MockServer};
+
+        use crate::soft_binding::resolution_api::{SoftBindingMatch, SoftBindingQueryResult};
+
+        const CLOUD_ASSET: &[u8] = include_bytes!("../tests/fixtures/cloud.jpg");
+
+        let server = MockServer::start();
+
+        let query_result = SoftBindingQueryResult {
+            matches: vec![SoftBindingMatch {
+                manifest_id: "cloud_manifest".to_owned(),
+                endpoint: None,
+                similarity_score: Some(90),
+            }],
+        };
+        let by_binding_mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/matches/byBinding");
+            then.status(200).json_body_obj(&query_result);
+        });
+
+        let registry_json = serde_json::json!([{
+            "identifier": 1,
+            "alg": "com.example.watermark",
+            "type": "watermark",
+            "decodedMediaTypes": ["image"],
+            "entryMetadata": {
+                "description": "test algorithm",
+                "dateEntered": "2025-01-01T00:00:00Z",
+                "contact": "test@example.com",
+                "informationalUrl": "https://example.com"
+            },
+            "softBindingResolutionApis": [server.base_url()]
+        }])
+        .to_string();
+
+        let mut context = Context::new();
+        context.settings_mut().soft_binding.algorithm_registry = Some(registry_json);
+        // Fetching the resolved manifest is disabled; the query itself is still allowed.
+        context.settings_mut().verify.remote_manifest_fetch = false;
+
+        let err = Reader::from_context(context)
+            .with_soft_binding(
+                "com.example.watermark",
+                b"some watermark value",
+                "image/jpeg",
+                Cursor::new(CLOUD_ASSET),
+            )
+            .unwrap_err();
+
+        match err {
+            Error::RemoteManifestUrl(url) => {
+                assert!(url.ends_with("/manifests/cloud_manifest"));
+            }
+            other => panic!("expected Error::RemoteManifestUrl, got {other:?}"),
+        }
+        by_binding_mock.assert();
 
         Ok(())
     }

--- a/sdk/src/settings/mod.rs
+++ b/sdk/src/settings/mod.rs
@@ -470,10 +470,27 @@ impl SettingsValidate for Verify {}
 )]
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct SoftBinding {
+    /// List of soft binding algorithms to validate against. If not specified, soft binding
+    /// errors may be generated.
     pub soft_binding_algorithms: Option<Vec<String>>,
+    /// Raw JSON text of the C2PA soft binding algorithm list registry (see
+    /// <https://github.com/c2pa-org/softbinding-algorithm-list>), used to look up
+    /// [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html)
+    /// endpoints for [`Reader::with_soft_binding`](crate::Reader::with_soft_binding).
+    ///
+    /// This registry is not bundled with the SDK — populate it the same way you populate
+    /// [`Trust::trust_anchors`](crate::settings::Trust::trust_anchors).
+    pub algorithm_registry: Option<String>,
 }
 
-impl SettingsValidate for SoftBinding {}
+impl SettingsValidate for SoftBinding {
+    fn validate(&self) -> Result<()> {
+        if let Some(registry) = &self.algorithm_registry {
+            crate::soft_binding::SoftBindingList::from_json_str(registry)?;
+        }
+        Ok(())
+    }
+}
 
 /// Settings for configuring all aspects of c2pa-rs.
 ///

--- a/sdk/src/soft_binding/algorithm_list.rs
+++ b/sdk/src/soft_binding/algorithm_list.rs
@@ -1,0 +1,310 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! A parsed C2PA soft binding algorithm registry.
+//!
+//! Use this to parse a list of soft binding algorithms from a JSON string and
+//! to build a list of soft binding algorithms. Use this to parse the official
+//! C2PA soft binding algorithm registry from the JSON file at
+//! <https://github.com/c2pa-org/softbinding-algorithm-list/blob/main/softbinding-algorithm-list.json>.
+//! The list can be used to validate soft binding algorithms in C2PA
+//! assertions and to look up [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html)
+//! endpoints for a given algorithm.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    cbor_types::{DateT, UriT},
+    Result,
+};
+
+/// A parsed C2PA soft binding algorithm registry.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(transparent)]
+pub struct SoftBindingList(pub Vec<SoftBindingAlgorithm>);
+
+impl SoftBindingList {
+    /// Parse a JSON string containing a soft binding algorithm list.
+    pub fn from_json_str(json: &str) -> Result<Self> {
+        let list: Self = serde_json::from_str(json)?;
+        list.validate()?;
+        Ok(list)
+    }
+
+    fn validate(&self) -> Result<()> {
+        for algorithm in &self.0 {
+            algorithm.validate()?;
+        }
+        Ok(())
+    }
+
+    /// Returns a list of soft binding algorithms strings from a vector of `SoftBindingAlgorithm` entries using the `alg` field.
+    pub fn algorithm_strings(&self) -> Vec<String> {
+        self.0.iter().map(|alg| alg.alg.clone()).collect()
+    }
+
+    /// Returns all entries in this registry.
+    pub fn algorithms(&self) -> &[SoftBindingAlgorithm] {
+        &self.0
+    }
+
+    /// Find the registry entry for a given algorithm string (e.g. `"com.adobe.trustmark.Q"`).
+    pub fn find(&self, alg: &str) -> Option<&SoftBindingAlgorithm> {
+        self.0.iter().find(|a| a.alg == alg)
+    }
+}
+
+/// A single soft binding algorithm entry.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct SoftBindingAlgorithm {
+    pub identifier: u16,
+
+    #[serde(default)]
+    pub deprecated: bool,
+
+    pub alg: String,
+
+    #[serde(rename = "type")]
+    pub alg_type: SoftBindingAlgorithmType,
+
+    #[serde(rename = "decodedMediaTypes", skip_serializing_if = "Option::is_none")]
+    pub decoded_media_types: Option<Vec<SoftBindingMediaType>>,
+
+    #[serde(rename = "encodedMediaTypes", skip_serializing_if = "Option::is_none")]
+    pub encoded_media_types: Option<Vec<String>>,
+
+    #[serde(rename = "entryMetadata")]
+    pub entry_metadata: SoftBindingEntryMetadata,
+
+    #[serde(
+        rename = "softBindingResolutionApis",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub soft_binding_resolution_apis: Option<Vec<UriT>>,
+}
+
+impl SoftBindingAlgorithm {
+    fn validate(&self) -> Result<()> {
+        if self
+            .decoded_media_types
+            .as_ref()
+            .map(Vec::is_empty)
+            .unwrap_or(false)
+        {
+            return Err(crate::error::Error::ValidationRule(
+                "decodedMediaTypes must be a non-empty array when present".to_owned(),
+            ));
+        }
+
+        if self
+            .encoded_media_types
+            .as_ref()
+            .map(Vec::is_empty)
+            .unwrap_or(false)
+        {
+            return Err(crate::error::Error::ValidationRule(
+                "encodedMediaTypes must be a non-empty array when present".to_owned(),
+            ));
+        }
+
+        if self.decoded_media_types.is_none() && self.encoded_media_types.is_none() {
+            return Err(crate::error::Error::ValidationRule(
+                "soft binding algorithm entry must include decodedMediaTypes or encodedMediaTypes"
+                    .to_owned(),
+            ));
+        }
+
+        if let Some(apis) = &self.soft_binding_resolution_apis {
+            if apis.is_empty() {
+                return Err(crate::error::Error::ValidationRule(
+                    "softBindingResolutionApis must be a non-empty array when present".to_owned(),
+                ));
+            }
+            for api in apis {
+                url::Url::parse(api.as_ref()).map_err(|_| {
+                    crate::error::Error::ValidationRule(format!(
+                        "softBindingResolutionApis contains invalid URI: {}",
+                        api.as_ref()
+                    ))
+                })?;
+            }
+        }
+
+        self.entry_metadata.validate()
+    }
+
+    /// The algorithm identifier string (e.g. `"com.adobe.trustmark.Q"`).
+    pub fn alg(&self) -> &str {
+        &self.alg
+    }
+
+    /// Whether this algorithm entry is deprecated. Deprecated algorithms shall not be used
+    /// for creating soft bindings, and their use for resolving soft bindings is discouraged.
+    pub fn is_deprecated(&self) -> bool {
+        self.deprecated
+    }
+
+    /// The kind of soft binding (watermark or fingerprint) this algorithm implements.
+    pub fn alg_type(&self) -> &SoftBindingAlgorithmType {
+        &self.alg_type
+    }
+
+    /// The [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html)
+    /// endpoints this algorithm's registry entry advertises. Empty if none are configured.
+    pub fn resolution_apis(&self) -> &[UriT] {
+        self.soft_binding_resolution_apis.as_deref().unwrap_or(&[])
+    }
+}
+
+/// Metadata for a soft binding algorithm entry.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct SoftBindingEntryMetadata {
+    pub description: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub categories: Option<Vec<String>>,
+
+    #[serde(rename = "dateEntered")]
+    pub date_entered: DateT,
+
+    pub contact: String,
+
+    #[serde(rename = "informationalUrl")]
+    pub informational_url: UriT,
+}
+
+impl SoftBindingEntryMetadata {
+    fn validate(&self) -> Result<()> {
+        url::Url::parse(self.informational_url.as_ref()).map_err(|_| {
+            crate::error::Error::ValidationRule(format!(
+                "entryMetadata.informationalUrl is not a valid URI: {}",
+                self.informational_url.as_ref()
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+/// The type of soft binding algorithm.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SoftBindingAlgorithmType {
+    Watermark,
+    Fingerprint,
+}
+
+/// Target media types for soft binding algorithms.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SoftBindingMediaType {
+    Application,
+    Audio,
+    Image,
+    Model,
+    Text,
+    Video,
+}
+
+#[cfg(test)]
+pub mod tests {
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn test_soft_binding_list_json_parse() {
+        let json = r#"[
+            {
+                "identifier": 1,
+                "alg": "com.example.watermark.alg1",
+                "type": "watermark",
+                "decodedMediaTypes": ["image"],
+                "entryMetadata": {
+                    "description": "Example watermarking algorithm",
+                    "dateEntered": "2025-01-01T00:00:00Z",
+                    "contact": "contact@example.com",
+                    "informationalUrl": "https://example.com/softbinding/alg1"
+                }
+            }
+        ]"#;
+
+        let list = SoftBindingList::from_json_str(json).unwrap();
+        assert_eq!(list.0.len(), 1);
+        let algorithm = &list.0[0];
+        assert_eq!(algorithm.identifier, 1);
+        assert_eq!(algorithm.alg, "com.example.watermark.alg1");
+        assert!(matches!(
+            algorithm.alg_type,
+            SoftBindingAlgorithmType::Watermark
+        ));
+        assert_eq!(
+            algorithm.decoded_media_types.as_ref().unwrap(),
+            &[SoftBindingMediaType::Image]
+        );
+
+        // get the algorithm strings
+        let alg_strings = list.algorithm_strings();
+        assert_eq!(alg_strings, vec!["com.example.watermark.alg1"]);
+
+        // find the algorithm by name
+        assert!(list.find("com.example.watermark.alg1").is_some());
+        assert!(list.find("com.example.nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_resolution_apis() {
+        let json = r#"[
+            {
+                "identifier": 1,
+                "alg": "com.example.watermark.alg1",
+                "type": "watermark",
+                "decodedMediaTypes": ["image"],
+                "entryMetadata": {
+                    "description": "Example watermarking algorithm",
+                    "dateEntered": "2025-01-01T00:00:00Z",
+                    "contact": "contact@example.com",
+                    "informationalUrl": "https://example.com/softbinding/alg1"
+                },
+                "softBindingResolutionApis": ["https://example.com/resolve"]
+            }
+        ]"#;
+
+        let list = SoftBindingList::from_json_str(json).unwrap();
+        let algorithm = list.find("com.example.watermark.alg1").unwrap();
+        assert_eq!(algorithm.resolution_apis().len(), 1);
+        assert_eq!(
+            algorithm.resolution_apis()[0].as_ref(),
+            "https://example.com/resolve"
+        );
+
+        // an entry with no resolution APIs configured returns an empty slice
+        let json_no_apis = r#"[
+            {
+                "identifier": 2,
+                "alg": "com.example.watermark.alg2",
+                "type": "watermark",
+                "decodedMediaTypes": ["image"],
+                "entryMetadata": {
+                    "description": "Example watermarking algorithm",
+                    "dateEntered": "2025-01-01T00:00:00Z",
+                    "contact": "contact@example.com",
+                    "informationalUrl": "https://example.com/softbinding/alg2"
+                }
+            }
+        ]"#;
+        let list_no_apis = SoftBindingList::from_json_str(json_no_apis).unwrap();
+        let algorithm_no_apis = list_no_apis.find("com.example.watermark.alg2").unwrap();
+        assert!(algorithm_no_apis.resolution_apis().is_empty());
+    }
+}

--- a/sdk/src/soft_binding/mod.rs
+++ b/sdk/src/soft_binding/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! Support for the C2PA soft binding algorithm list registry and the
+//! [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html)
+//! ("Decoupled" soft binding).
+//!
+//! This module deliberately does not perform any local watermark/fingerprint
+//! embedding or extraction; callers are expected to obtain a soft binding
+//! `alg` and `value` themselves (e.g. via a proprietary decoder) and pass it
+//! to [`crate::Reader::with_soft_binding`].
+
+pub mod algorithm_list;
+pub mod resolution_api;
+
+pub use algorithm_list::{
+    SoftBindingAlgorithm, SoftBindingAlgorithmType, SoftBindingEntryMetadata, SoftBindingList,
+    SoftBindingMediaType,
+};
+pub use resolution_api::{SoftBindingMatch, SoftBindingQueryResult};

--- a/sdk/src/soft_binding/resolution_api.rs
+++ b/sdk/src/soft_binding/resolution_api.rs
@@ -1,0 +1,410 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! A client for the [Soft Binding Resolution API](https://spec.c2pa.org/specifications/specifications/2.2/softbinding/Decoupled.html#soft-binding-resolution-api)
+//! defined by the C2PA "Decoupled" soft binding spec.
+//!
+//! This module is a pure HTTP client wrapper with no domain-specific logic. It is built
+//! entirely on [`Context::resolver`]/[`Context::resolver_async`], so it has no bespoke
+//! authentication mechanism of its own: a caller needing to authenticate against a
+//! particular resolution API host should register a custom [`SyncHttpResolver`]/
+//! [`AsyncHttpResolver`] via [`Context::with_resolver`]/[`Context::with_resolver_async`]
+//! that attaches the required headers.
+//!
+//! [`SyncHttpResolver`]: crate::http::SyncHttpResolver
+//! [`AsyncHttpResolver`]: crate::http::AsyncHttpResolver
+//! [`Context::with_resolver`]: crate::Context::with_resolver
+//! [`Context::with_resolver_async`]: crate::Context::with_resolver_async
+
+use std::io::Read;
+
+use async_generic::async_generic;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{crypto::base64, error::Error, Context, Result};
+
+/// Maximum number of bytes read from a Soft Binding Resolution API JSON response.
+///
+/// Match-query responses are expected to be small (a short list of manifest identifiers),
+/// so this is far smaller than the cap used for fetching manifest bytes themselves.
+const MAX_QUERY_RESPONSE_SIZE: u64 = 1024 * 1024; // 1 MB
+
+/// A soft binding match returned by a Soft Binding Resolution API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SoftBindingMatch {
+    /// Unique identifier of a matched C2PA Manifest.
+    pub manifest_id: String,
+    /// Endpoint of a Soft Binding Resolution API from which the C2PA Manifest may be
+    /// obtained. If absent, the C2PA Manifest is available from the same endpoint the
+    /// query was sent to, using the `/manifests` endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// An integer score in the range (0-100) representing the strength of match, if
+    /// appropriate, where 0 is the weakest possible match and 100 is the strongest
+    /// possible match.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub similarity_score: Option<u8>,
+}
+
+/// A list of soft binding matches returned by a soft binding resolution API.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct SoftBindingQueryResult {
+    #[serde(default)]
+    pub matches: Vec<SoftBindingMatch>,
+}
+
+/// Internal struct used for constructing the query string for [`query_by_binding_get`].
+#[derive(Debug, Clone, Copy)]
+struct ByBindingQuery<'a> {
+    alg: &'a str,
+    value: &'a [u8],
+    max_results: Option<u32>,
+}
+
+fn base_url(endpoint: &str) -> Result<Url> {
+    let mut base = endpoint.to_owned();
+    if !base.ends_with('/') {
+        base.push('/');
+    }
+    Url::parse(&base).map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))
+}
+
+fn join_url(endpoint: &str, path: &str) -> Result<Url> {
+    base_url(endpoint)?
+        .join(path)
+        .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))
+}
+
+/// Construct the URL for fetching a manifest by id from a Soft Binding Resolution API,
+/// per the spec's `GET {endpoint}/manifests/{manifestId}` endpoint. `manifest_id` is
+/// percent-encoded as a path segment.
+pub(crate) fn manifest_url(endpoint: &str, manifest_id: &str) -> Result<Url> {
+    let mut url = base_url(endpoint)?;
+    url.path_segments_mut()
+        .map_err(|_| {
+            Error::SoftBindingResolutionFetch(format!("endpoint {endpoint} cannot be a base URL"))
+        })?
+        .push("manifests")
+        .push(manifest_id);
+    Ok(url)
+}
+
+#[async_generic(async_signature(
+    url: Url,
+    context: &Context,
+))]
+fn get_json<T: for<'de> Deserialize<'de>>(url: Url, context: &Context) -> Result<T> {
+    let request = http::Request::get(url.as_str())
+        .body(Vec::new())
+        .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    let response = if _sync {
+        context.resolver().http_resolve(request)
+    } else {
+        context.resolver_async().http_resolve_async(request).await
+    }
+    .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    if response.status() != 200 {
+        return Err(Error::SoftBindingResolutionFetch(format!(
+            "request to {url} failed: code: {}, status: {}",
+            response.status().as_u16(),
+            response.status().as_str()
+        )));
+    }
+
+    let mut body = Vec::new();
+    response
+        .into_body()
+        .take(MAX_QUERY_RESPONSE_SIZE)
+        .read_to_end(&mut body)
+        .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    serde_json::from_slice(&body).map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))
+}
+
+/// Given one soft binding `alg`/`value`, find zero or more manifest identifiers within a
+/// manifest repository matching the soft binding, by querying `{endpoint}/matches/byBinding`.
+///
+/// `value` is base64-encoded before being placed in the query string, per the spec's
+/// `c2pa.softBindingQuery` schema.
+#[async_generic(async_signature(
+    endpoint: &str,
+    alg: &str,
+    value: &[u8],
+    max_results: Option<u32>,
+    context: &Context,
+))]
+pub fn query_by_binding_get(
+    endpoint: &str,
+    alg: &str,
+    value: &[u8],
+    max_results: Option<u32>,
+    context: &Context,
+) -> Result<SoftBindingQueryResult> {
+    let query = ByBindingQuery {
+        alg,
+        value,
+        max_results,
+    };
+
+    let mut url = join_url(endpoint, "matches/byBinding")?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("alg", query.alg);
+        pairs.append_pair("value", &base64::encode(query.value));
+        if let Some(max_results) = query.max_results {
+            pairs.append_pair("maxResults", &max_results.to_string());
+        }
+    }
+
+    if _sync {
+        get_json(url, context)
+    } else {
+        get_json_async(url, context).await
+    }
+}
+
+/// Find zero or more C2PA Manifest identifiers within a manifest repository using an
+/// uploaded file containing a digital asset, by querying `{endpoint}/matches/byContent`.
+///
+/// This is a spec-complete, optional utility that knows the wire shape of the Soft
+/// Binding Resolution API's upload endpoint. It is never called automatically by the
+/// SDK — a caller must invoke it explicitly if they choose to accept the cost of
+/// uploading raw asset content to a third-party resolution service.
+#[allow(clippy::too_many_arguments)]
+#[async_generic(async_signature(
+    endpoint: &str,
+    content: &[u8],
+    mime_type: &str,
+    alg: Option<&str>,
+    max_results: Option<u32>,
+    hint_alg: Option<&str>,
+    hint_value: Option<&[u8]>,
+    context: &Context,
+))]
+pub fn query_by_content(
+    endpoint: &str,
+    content: &[u8],
+    mime_type: &str,
+    alg: Option<&str>,
+    max_results: Option<u32>,
+    hint_alg: Option<&str>,
+    hint_value: Option<&[u8]>,
+    context: &Context,
+) -> Result<SoftBindingQueryResult> {
+    let mut url = join_url(endpoint, "matches/byContent")?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        if let Some(alg) = alg {
+            pairs.append_pair("alg", alg);
+        }
+        if let Some(max_results) = max_results {
+            pairs.append_pair("maxResults", &max_results.to_string());
+        }
+        if let Some(hint_alg) = hint_alg {
+            pairs.append_pair("hintAlg", hint_alg);
+        }
+        if let Some(hint_value) = hint_value {
+            pairs.append_pair("hintValue", &base64::encode(hint_value));
+        }
+    }
+
+    let request = http::Request::post(url.as_str())
+        .header(http::header::CONTENT_TYPE, mime_type)
+        .body(content.to_vec())
+        .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    let response = if _sync {
+        context.resolver().http_resolve(request)
+    } else {
+        context.resolver_async().http_resolve_async(request).await
+    }
+    .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    if response.status() != 200 {
+        return Err(Error::SoftBindingResolutionFetch(format!(
+            "request to {url} failed: code: {}, status: {}",
+            response.status().as_u16(),
+            response.status().as_str()
+        )));
+    }
+
+    let mut body = Vec::new();
+    response
+        .into_body()
+        .take(MAX_QUERY_RESPONSE_SIZE)
+        .read_to_end(&mut body)
+        .map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))?;
+
+    serde_json::from_slice(&body).map_err(|e| Error::SoftBindingResolutionFetch(e.to_string()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::panic)]
+
+    use httpmock::{Method, MockServer};
+
+    use super::*;
+
+    #[test]
+    fn test_query_by_binding_get_happy_path() {
+        let server = MockServer::start();
+        let result = SoftBindingQueryResult {
+            matches: vec![SoftBindingMatch {
+                manifest_id: "some-manifest-id".to_owned(),
+                endpoint: None,
+                similarity_score: Some(75),
+            }],
+        };
+
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/matches/byBinding")
+                .query_param("alg", "com.example.watermark")
+                .query_param("value", base64::encode(b"some value"))
+                .query_param("maxResults", "5");
+            then.status(200).json_body_obj(&result);
+        });
+
+        let context = Context::new();
+        let response = query_by_binding_get(
+            &server.base_url(),
+            "com.example.watermark",
+            b"some value",
+            Some(5),
+            &context,
+        )
+        .unwrap();
+
+        assert_eq!(response, result);
+        mock.assert();
+    }
+
+    #[test]
+    fn test_query_by_binding_get_non_200() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/matches/byBinding");
+            then.status(500);
+        });
+
+        let context = Context::new();
+        let err = query_by_binding_get(
+            &server.base_url(),
+            "com.example.watermark",
+            b"some value",
+            None,
+            &context,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::SoftBindingResolutionFetch(_)));
+        mock.assert();
+    }
+
+    #[test]
+    fn test_query_by_binding_get_malformed_json() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/matches/byBinding");
+            then.status(200).body("not json");
+        });
+
+        let context = Context::new();
+        let err = query_by_binding_get(
+            &server.base_url(),
+            "com.example.watermark",
+            b"some value",
+            None,
+            &context,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, Error::SoftBindingResolutionFetch(_)));
+        mock.assert();
+    }
+
+    #[test]
+    fn test_query_by_content_sets_content_type_and_body() {
+        let server = MockServer::start();
+        let result = SoftBindingQueryResult {
+            matches: vec![SoftBindingMatch {
+                manifest_id: "some-manifest-id".to_owned(),
+                endpoint: Some("https://other.example.com".to_owned()),
+                similarity_score: None,
+            }],
+        };
+
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/matches/byContent")
+                .query_param("alg", "com.example.fingerprint")
+                .header("content-type", "image/jpeg")
+                .body("raw asset bytes");
+            then.status(200).json_body_obj(&result);
+        });
+
+        let context = Context::new();
+        let response = query_by_content(
+            &server.base_url(),
+            b"raw asset bytes",
+            "image/jpeg",
+            Some("com.example.fingerprint"),
+            None,
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+
+        assert_eq!(response, result);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_query_by_binding_get_async() {
+        let server = MockServer::start();
+        let result = SoftBindingQueryResult {
+            matches: vec![SoftBindingMatch {
+                manifest_id: "some-manifest-id".to_owned(),
+                endpoint: None,
+                similarity_score: Some(50),
+            }],
+        };
+
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/matches/byBinding");
+            then.status(200).json_body_obj(&result);
+        });
+
+        let context = Context::new();
+        let response = query_by_binding_get_async(
+            &server.base_url(),
+            "com.example.watermark",
+            b"some value",
+            None,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response, result);
+        mock.assert();
+    }
+}

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -3458,7 +3458,7 @@ impl Store {
 
     /// Handles remote manifests when file_io/fetch_remote_manifests feature is enabled
     #[async_generic]
-    fn handle_remote_manifest(ext_ref: &str, _context: &Context) -> Result<Vec<u8>> {
+    pub(crate) fn handle_remote_manifest(ext_ref: &str, _context: &Context) -> Result<Vec<u8>> {
         // verify provenance path is remote url
         if Store::is_valid_remote_url(ext_ref) {
             #[cfg(feature = "fetch_remote_manifests")]


### PR DESCRIPTION
Implements the registry, resolution query client, and a caller-driven Reader::with_soft_binding() for the C2PA "Decoupled" soft binding spec. This is an update from ok-nick/soft-binding-api branch; local watermark/fingerprint embedding and extraction are deliberately out of scope here