### PR TITLE
feat: new builder method to combine filtering of actions and ingredients (#2379)

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -1,0 +1,104 @@
+# Experimental features policy
+
+The Content Authenticity Initiative (CAI) SDK is an evolving project, and we welcome contributions from the wider community. From time to time, an external contributor may propose a new feature that we believe is valuable but that the CAI team is not able to commit to maintaining as part of the core SDK.
+
+Rather than reject such contributions outright, we may accept them as **experimental features**. This document describes what that designation means, the conditions a contribution must satisfy to qualify, and the support expectations that apply on both sides.
+
+This policy complements the [Deprecation policy](deprecation-policy.md) and [Support tiers](support-tiers.md). Experimental features sit outside the stability guarantees described in those documents.
+
+## What is an experimental feature?
+
+An experimental feature is functionality that has been accepted into the SDK source tree but is **not** covered by the SDK's normal stability and maintenance commitments. We accept experimental features when we judge the feature to be of value to the community but cannot commit to maintaining it ourselves.
+
+Experimental features let us give promising contributions a home and real-world exposure without expanding the surface area that the CAI team guarantees to support indefinitely. The same mechanism also serves first-party features that the CAI team maintains but is not ready to stabilize – for example, an API built for an internal need whose long-term design is still an open question.
+
+In particular, experimental features are **not** covered by the [Deprecation policy](deprecation-policy.md) or its timelines. An experimental feature can be changed or removed in any release, with no deprecation window – once it is removed, it is gone.
+
+## Conditions for acceptance
+
+To be accepted as an experimental feature, a contribution must satisfy all of the following conditions.
+
+### 1. Gated by a non-default crate feature
+
+The feature must be gated by a Rust crate feature named `unstable_<name>` (for example, `unstable_widget_export`). This feature **must not** be enabled by default and must not be pulled in by any default feature set.
+
+> [!NOTE]
+> Cargo feature names in this repository use `snake_case` (for example, `add_thumbnails`, `fetch_remote_manifests`, `rust_native_crypto`). Experimental feature flags follow the same convention: `unstable_<name>`, not `unstable-<name>`.
+>
+> The `unstable_` prefix is deliberate. [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) — which we run on every release-line PR (see the [release process](release-process.md#semver-checks)) — by default ignores features named `unstable`, `nightly`, `bench`, or `no_std`, and any feature whose name begins with `_`, `unstable-`, or `unstable_`. Naming experimental flags `unstable_<name>` therefore makes our tooling automatically treat them as exempt from breaking-change detection, so changing or removing an experimental API never forces a version bump on its own.
+
+### 2. Public API changes are gated
+
+Any changes to the public API surface must be visible **only** when the experimental feature flag is enabled. With the flag disabled, the public API must be identical to a build that does not include the feature at all (for example, by gating the affected items with `#[cfg(feature = "unstable_<name>")]`).
+
+### 3. New dependencies are optional and gated
+
+Any new crate dependencies introduced for the feature must be declared as `optional = true` and must be activated only by the experimental feature flag (via `dep:<crate>` in the feature definition). A default build must not compile or link these dependencies.
+
+### 4. No adverse impact when disabled
+
+The feature must not have an adverse effect on the performance or behavior of the SDK when the feature is disabled. A build without the feature should be indistinguishable, in performance and behavior, from one in which the feature does not exist.
+
+### 5. Listed in the registry
+
+The feature must be added to the [Registry of experimental features](#registry-of-experimental-features) section below, including:
+
+- The human-readable feature name.
+- The Cargo feature flag in `unstable_<name>` form.
+- A brief (a few sentences) description of the feature's behavior.
+- Contact information for support, including **at least one GitHub username** of a maintainer or sponsor who can answer questions about the feature.
+- A link to the feature's open discussion issue (see condition 7).
+
+### 6. Same licensing and dependency review as the rest of the SDK
+
+Experimental features are exempt from the CAI team's *maintenance* commitments, not from the project's legal and supply-chain requirements. The contributed code must be offered under the SDK's existing license terms, and any new dependency (see condition 3) is subject to the same license-compatibility and security review as any other dependency in the tree. A feature whose license or dependencies cannot be cleared is not eligible for acceptance – experimental or otherwise.
+
+### 7. Tracked by an open discussion issue
+
+Before a feature is accepted, an issue must be opened on the [`c2pa-rs` issue tracker](https://github.com/contentauth/c2pa-rs/issues) proposing it as an experimental feature. The team and community use that issue to discuss and agree to host the feature in the first place; it then stays open for the life of the feature as the standing home for design discussion, change proposals, bug reports, and any argument for promotion or removal. Each registry entry links to its feature's issue. Closing the issue signals that the feature has been promoted or removed.
+
+## Stability and support expectations
+
+By accepting a feature as experimental, the CAI team makes **no** stability guarantees about it:
+
+- **Unstable by design.** Any APIs or behaviors gated by an experimental feature flag are considered unstable and may be altered or removed at any time, in any release, without following the [Deprecation policy](deprecation-policy.md).
+- **Best-effort maintenance.** The CAI team will make a best effort to keep experimental features building and working as the primary SDK evolves, but reserves the right to disable or remove an experimental feature if it cannot be made compatible with the primary SDK code.
+- **Community-supported.** Day-to-day support for an experimental feature is primarily the responsibility of the contributor and the contacts listed in the registry, not the CAI team.
+- **Security handled by responsiveness.** A security or licensing problem reported against experimental code is handled on the same best-effort, community-supported basis. If the registered contact does not address it promptly, the CAI team will disable or remove the feature immediately rather than wait out any window – protecting the primary SDK takes precedence over preserving an experimental feature.
+
+### Exempt from breaking-change calculations
+
+Because experimental features are gated behind a non-default flag and excluded from the public API of a default build, changing or removing one is **not** considered a breaking change under the [Deprecation policy](deprecation-policy.md), and it never forces a minor/breaking (`0.x.0`) version bump.
+
+The `unstable_` flag prefix makes this automatic: [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) ignores `unstable_`-prefixed features by default, so a change confined to an experimental feature is never flagged as a break. Experimental APIs are therefore free to change at will – including breaking changes, at any time, in any release – **provided that the change does not affect any API in the public/stable surface** (a default build, or any non-experimental feature). See [Semver checks](release-process.md#semver-checks) in the release process.
+
+This does **not** mean experimental changes are invisible to consumers. A change to an experimental feature may still ride an ordinary patch (`0.x.y`) release, and it is recorded in a dedicated **Experimental** section of the changelog so that anyone who has opted into an `unstable_` feature has a clear, human-readable signal of what changed. What the exemption removes is the *semver guarantee* (and the minor/breaking bump), not the paper trail. To get this routing, mark such commits with the `experimental` scope – for example `feat(experimental): add widget export` or `fix(experimental): correct frame ordering` – and never use the breaking (`!`) marker on them, since experimental APIs are outside semver by definition. See [Version numbering](release-process.md#version-numbering-across-a-train) and the commit-scope rules in the release process.
+
+## Build and CI expectations
+
+Experimental features are held to the SDK's quality bar **at contribution time** – they must build cleanly and pass `cargo +nightly fmt`, `clippy`, and their own tests when accepted – but keeping them green over time is best-effort and primarily the contact's responsibility, not the CAI team's.
+
+To make that split concrete:
+
+- **Not part of the merge gate.** A dedicated, **non-blocking** workflow ([`experimental-features.yml`](../.github/workflows/experimental-features.yml)) builds, lints, and tests the SDK with every `unstable_` feature enabled, on pull requests and on a daily schedule. It is advisory only – it is deliberately not a required status check, so a failure there never blocks a merge.
+- **Broken features get disabled, not fixed on demand.** When an experimental feature stops building or passing – for example after a Rust toolchain update or a refactor of the primary SDK – the CAI team will notify the registered contact. If it is not repaired promptly, the feature is disabled (removed from the build, and ultimately from the tree) rather than holding up the SDK. This keeps one unmaintained feature from blocking everyone.
+- **Excluded from the required build/test/lint suites.** The required [Tier 1A](../.github/workflows/tier-1a.yml), [Tier 1B](../.github/workflows/tier-1b.yml), and [Tier 2](../.github/workflows/tier-2.yml) suites – along with the [beta preflight](../.github/workflows/beta-preflight.yml) and the [cross-repo canary](../.github/workflows/canary-extracted-crates.yml) – build the non-experimental feature set only, so experimental breakage cannot fail the ordinary compile, test, or lint gates. (They compute the feature list from `cargo metadata` and filter out `unstable_`-prefixed features; Tier 2 builds no `unstable_` features to begin with.) The one deliberate exception is the Tier 1A `docs.rs` preflight: experimental APIs *are* intentionally published to docs.rs (clearly marked experimental), so that job mirrors the real docs.rs build and does compile them.
+
+## Promotion or removal
+
+An experimental feature is not expected to remain experimental forever. Over time, an experimental feature may be:
+
+- **Promoted** to a fully supported feature if it proves valuable and the CAI team is able to take on its maintenance. At that point it becomes subject to the normal stability and deprecation guarantees.
+- **Removed** if it falls out of maintenance, loses its last responsive contact, cannot be kept compatible with the primary SDK, or is no longer of sufficient value to justify its presence in the tree.
+
+### Handing off or losing a contact
+
+A registered contact is the feature's lifeline. Contacts are kept current by pull request: a contact who can no longer support a feature should hand it off by updating the registry to name a replacement. If a feature is left with **no responsive contact** – nobody who answers questions or repairs breakage – it becomes an immediate candidate for removal under the rule above; the CAI team is not obligated to adopt an orphaned experimental feature.
+
+## Registry of experimental features
+
+The following table lists the experimental features currently present in the SDK. See [Conditions for acceptance](#conditions-for-acceptance) for what each entry must include.
+
+| Feature | Cargo flag | Description | Contact | Discussion |
+| -- | -- | -- | -- | -- |
+| Builder action/ingredient filtering | `unstable_builder_filter` | Adds `Builder::filter_actions`, `Builder::filter_ingredients`, `Builder::filter_actions_and_ingredients`, and `Ingredient::effective_id` for filtering the actions and ingredients written into a manifest. Maintained by the Adobe CAI team to serve an internal need; kept experimental because the long-term viability of the API design is not yet settled. | Adobe CAI team ([@contentauth](https://github.com/contentauth)) | [#2368](https://github.com/contentauth/c2pa-rs/issues/2368) |

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -969,7 +969,9 @@ impl Builder {
     ///
     /// This does not touch ingredients. Call [`Builder::filter_ingredients`]
     /// (`filter_ingredients(|_| false)` to drop all orphans) afterwards if you also want to drop
-    /// ingredients now orphaned by the removed actions.
+    /// ingredients now orphaned by the removed actions. If you want to rescue an ingredient (and
+    /// keep the action referencing it, even when `keep` alone would drop it), use
+    /// [`Builder::filter_actions_and_ingredients`] instead.
     ///
     /// # Arguments
     /// * `keep` - A predicate; the action is retained when it returns true.
@@ -1067,7 +1069,10 @@ impl Builder {
     /// of interest, so retain the whole ingredient (and its nested chain)"; the closure may inspect
     /// the ingredient's [`manifest_data`](Ingredient::manifest_data) to decide. Prune all orphans
     /// with `filter_ingredients(|_| false)`. Call [`Builder::filter_actions`] first if you are also
-    /// removing actions: the keep-set is computed from whatever actions currently remain.
+    /// removing actions: the keep-set is computed from whatever actions currently remain. If a
+    /// rescued ingredient's action was already removed by a prior `filter_actions` call, that
+    /// action stays removed — use [`Builder::filter_actions_and_ingredients`] instead if you need
+    /// the rescue decision to also keep the referencing action.
     ///
     /// # Arguments
     /// * `rescue` - A predicate that can rescue an otherwise-orphaned ingredient by returning true.
@@ -1118,23 +1123,7 @@ impl Builder {
         for pos in actions_positions {
             let actions: Actions = self.definition.assertions[pos].to_assertion()?;
             for action in &actions.actions {
-                // Symbolic references: ingredientIds / org.cai.ingredientIds / instanceId /
-                // deprecated instance_id. Relationship-agnostic: any referenced ingredient is
-                // kept whatever its relationship (e.g. `c2pa.edited` -> `inputTo`).
-                for id in action.ingredient_ids() {
-                    keep_set.insert(id);
-                }
-                // Positional `parameters.ingredients` HashedUri references -> ingredients[N].
-                if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
-                    for uri in uris {
-                        if let Some(label) = assertion_label_from_uri(&uri.url()) {
-                            let (_, idx) = parse_positional_label(&label);
-                            if let Some(id) = pre_filter_ids.get(idx) {
-                                keep_set.insert(id.clone());
-                            }
-                        }
-                    }
-                }
+                keep_set.extend(action_ingredient_ref_ids(action, &pre_filter_ids));
             }
             decoded.push((pos, actions));
         }
@@ -1167,6 +1156,81 @@ impl Builder {
         }
 
         Ok(self)
+    }
+
+    /// Retains actions and ingredients together in one call.
+    ///
+    /// Calling [`Builder::filter_actions`] then [`Builder::filter_ingredients`] separately is
+    /// order-dependent: the action filter can drop an action (e.g. `c2pa.edited`) before its
+    /// ingredient gets a chance to be rescued, orphaning the link. This method removes that
+    /// ordering concern by deciding rescues up front, so a rescued ingredient's action is force-
+    /// kept too.
+    ///
+    /// An action is kept if `keep_action` returns true, it is the inception action
+    /// (`c2pa.created`/`c2pa.opened`), or it references an ingredient `rescue_ingredient` would
+    /// keep. An ingredient is kept if it is referenced by a surviving action, it is a
+    /// [`Relationship::ParentOf`] ingredient, or `rescue_ingredient` returns true for it.
+    /// `rescue_ingredient` is called exactly once per ingredient.
+    ///
+    /// # Arguments
+    /// * `keep_action` - A predicate; the action is retained when it returns true.
+    /// * `rescue_ingredient` - A predicate that can rescue an otherwise-orphaned ingredient (and
+    ///   the action referencing it) by returning true.
+    /// # Returns
+    /// * A mutable reference to the [`Builder`].
+    /// # Errors
+    /// * Returns an [`Error`] if an assertion cannot be decoded or rebuilt, or if action retention
+    ///   would leave an actions assertion with no actions.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This method is available only with the `unstable_builder_filter`
+    /// feature enabled. It is exempt from this crate's usual semantic-versioning stability
+    /// guarantees and may change in a backward-incompatible way, or be removed entirely, in any
+    /// release.
+    ///
+    /// </div>
+    #[cfg(feature = "unstable_builder_filter")]
+    pub fn filter_actions_and_ingredients<FA, FI>(
+        &mut self,
+        mut keep_action: FA,
+        mut rescue_ingredient: FI,
+    ) -> Result<&mut Self>
+    where
+        FA: FnMut(&Action) -> bool,
+        FI: FnMut(&Ingredient) -> bool,
+    {
+        // Single pass over ingredients: snapshot positional order (`pre_filter_ids`) and evaluate
+        // `rescue_ingredient` up front, exactly once per ingredient (`rescued_ids`), so an action
+        // referencing a to-be-rescued ingredient can be protected before any action is dropped.
+        let mut pre_filter_ids: Vec<String> = Vec::with_capacity(self.definition.ingredients.len());
+        let mut rescued_by_index: Vec<bool> = Vec::with_capacity(self.definition.ingredients.len());
+        let mut rescued_ids: HashSet<String> = HashSet::new();
+        for ing in &self.definition.ingredients {
+            let id = ing.effective_id_internal();
+            let rescued = rescue_ingredient(ing);
+            if rescued {
+                rescued_ids.insert(id.clone());
+            }
+            rescued_by_index.push(rescued);
+            pre_filter_ids.push(id);
+        }
+
+        self.filter_actions(|a| {
+            keep_action(a)
+                || action_ingredient_ref_ids(a, &pre_filter_ids)
+                    .iter()
+                    .any(|id| rescued_ids.contains(id))
+        })?;
+
+        // `filter_actions` never touches `self.definition.ingredients`, so this still iterates in
+        // the same positional order as the snapshot above.
+        let mut next_index = 0usize;
+        self.filter_ingredients(|_ing| {
+            let rescued = rescued_by_index[next_index];
+            next_index += 1;
+            rescued
+        })
     }
 
     /// Request a trusted timestamp for manifests with the given label.
@@ -3598,6 +3662,25 @@ enum UriRewrite {
     Stale,
     /// Repointed to the ingredient's new index.
     Rewritten(HashedUri),
+}
+
+/// Ingredient ids that `action` references, both symbolically (`ingredientIds` /
+/// `org.cai.ingredientIds` / `instanceId` / deprecated `instance_id`) and positionally
+/// (`parameters.ingredients` `HashedUri`s resolved against `pre_filter_ids`).
+#[cfg(feature = "unstable_builder_filter")]
+fn action_ingredient_ref_ids(action: &Action, pre_filter_ids: &[String]) -> Vec<String> {
+    let mut ids = action.ingredient_ids();
+    if let Some(uris) = action.parameters().and_then(|p| p.ingredients.as_ref()) {
+        for uri in uris {
+            if let Some(label) = assertion_label_from_uri(&uri.url()) {
+                let (_, idx) = parse_positional_label(&label);
+                if let Some(id) = pre_filter_ids.get(idx) {
+                    ids.push(id.clone());
+                }
+            }
+        }
+    }
+    ids
 }
 
 /// Rewrites a single `HashedUri` whose URL ends in a positional ingredient label so it points at
@@ -10595,6 +10678,95 @@ mod tests {
                 .unwrap();
             dropped.filter_ingredients(|_| false).unwrap();
             assert!(dropped.definition.ingredients.is_empty());
+        }
+
+        // a two-step filter_actions then filter_ingredients call can drop a
+        // `c2pa.edited` action whose `inputTo` ingredient would otherwise have been rescued,
+        // orphaning the link. `filter_actions_and_ingredients` closes that gap by rescuing
+        // the action too.
+        #[test]
+        fn filter_actions_and_ingredients_rescues_edited_action_for_kept_ingredient() {
+            let def = json!({
+                "ingredients": [
+                    { "title": "edit", "format": "image/jpeg", "relationship": "inputTo", "label": "ing_edit", "instance_id": "id_edit" },
+                ],
+                "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.edited", "parameters": { "ingredientIds": ["ing_edit"] } },
+                ]}}]
+            });
+
+            // The action predicate alone would drop `c2pa.edited`, but the ingredient predicate
+            // rescues its `inputTo` ingredient. The action must survive too, or the surviving
+            // ingredient would be orphaned.
+            let mut b = removal_builder(def);
+            b.filter_actions_and_ingredients(
+                |a| a.action() != "c2pa.edited",
+                |ing| ing.label() == Some("ing_edit"),
+            )
+            .unwrap();
+
+            assert_eq!(b.definition.ingredients.len(), 1);
+            assert_eq!(
+                b.definition.ingredients[0].relationship(),
+                &Relationship::InputTo
+            );
+            assert!(builder_actions(&b)
+                .actions
+                .iter()
+                .any(|a| a.action() == "c2pa.edited"));
+        }
+
+        // Contrast case: neither the action predicate nor the ingredient predicate keeps
+        // anything, so both the action and its ingredient are pruned as before.
+        #[test]
+        fn filter_actions_and_ingredients_drops_unreferenced_and_unrescued() {
+            let def = json!({
+                "ingredients": [
+                    { "title": "edit", "format": "image/jpeg", "relationship": "inputTo", "label": "ing_edit", "instance_id": "id_edit" },
+                ],
+                "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                    created_action(),
+                    { "action": "c2pa.edited", "parameters": { "ingredientIds": ["ing_edit"] } },
+                ]}}]
+            });
+
+            let mut b = removal_builder(def);
+            b.filter_actions_and_ingredients(|a| a.action() != "c2pa.edited", |_| false)
+                .unwrap();
+
+            assert!(b.definition.ingredients.is_empty());
+            assert!(!builder_actions(&b)
+                .actions
+                .iter()
+                .any(|a| a.action() == "c2pa.edited"));
+        }
+
+        // Two ingredients with neither a `label` nor an `instance_id` both fall back to the same
+        // `effective_id_internal() == "None"`. Rescue decisions must be tracked positionally, not
+        // by that id, or rescuing one would incorrectly rescue the other too.
+        #[test]
+        fn filter_actions_and_ingredients_no_id_collision() {
+            let def = json!({
+                "ingredients": [
+                    { "title": "no_id_1", "format": "image/jpeg", "relationship": "componentOf" },
+                    { "title": "no_id_2", "format": "image/jpeg", "relationship": "componentOf" },
+                ],
+                "assertions": [{ "label": "c2pa.actions.v2", "data": { "actions": [
+                    created_action(),
+                ]}}]
+            });
+            let mut b = removal_builder(def);
+            b.filter_actions_and_ingredients(|_| true, |ing| ing.title() == Some("no_id_1"))
+                .unwrap();
+
+            let titles: Vec<_> = b
+                .definition
+                .ingredients
+                .iter()
+                .map(|i| i.title().unwrap().to_string())
+                .collect();
+            assert_eq!(titles, vec!["no_id_1"]);
         }
 
         // a parentOf ingredient at a non-zero index survives and its opened link re-indexes.


### PR DESCRIPTION

## Changes in this pull request

* feat: new builder method to combine filtering of actions and ingredients

Filter functions should not remove edited actions that point to kept ingredients. We need `c2pa.edited` actions to survive when they point at an ingredient we want to keep, even if the caller's action-level predicate wouldn't otherwise keep that action.

- Fix comments
- Cross-link filter_actions/filter_ingredients docs to the new combined method, and explain the call-order gap it closes.
- Combine two separate iterations over definition.ingredients into one pass computing pre_filter_ids and rescued_ids together.
- Change filter_actions_and_ingredients to rescue based on index rather than effective_id, as ingredients may have neither instance_id or label.

* docs: Update experimental features for new function

(cherry picked from commit 12f9ac6b6661871c03e16756310af09511d56e26)

