### PR TITLE
fix: Replace mp4 crate with hardened native BMFF sample reader (CAI-12277) (backport #2357)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,6 @@ dependencies = [
  "lopdf",
  "memchr",
  "mockall",
- "mp4",
  "nom 7.1.3",
  "non-empty-string",
  "nonempty-collections",
@@ -2737,20 +2736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mp4"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef834d5ed55e494a2ae350220314dc4aacd1c43a9498b00e320e0ea352a5c3"
-dependencies = [
- "byteorder",
- "bytes",
- "num-rational",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,7 +2907,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -134,7 +134,6 @@ log = "0.4.30"
 lopdf = { version = "0.43.0", optional = true }
 lazy_static = "1.5.0"
 memchr = "2.8.1"
-mp4 = "0.14.0"
 nom = "7.1.3"
 non-empty-string = { version = "0.2.6", features = ["serde"] }
 nonempty-collections = { version = "1.3.0", features = ["serde"] }

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -18,7 +18,6 @@ use std::{
     ops::Deref,
 };
 
-use mp4::*;
 use serde::{
     de::{SeqAccess, Visitor},
     ser::SerializeSeq,
@@ -61,7 +60,8 @@ use crate::{
     assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::labels,
     asset_handlers::bmff_io::{
-        bmff_to_jumbf_exclusions, read_bmff_c2pa_boxes, BoxInfoLite, C2PABmffBoxes,
+        bmff_to_jumbf_exclusions, read_bmff_c2pa_boxes, BmffSampleReader, BoxInfoLite,
+        C2PABmffBoxes,
     },
     asset_io::CAIRead,
     cbor_types::UriT,
@@ -749,7 +749,10 @@ impl BmffHash {
     }
 
     // get regions to hash based on the list of top level boxes in file order
-    pub fn box_list_to_user_exclusions(&self, _box_paths: &[String]) -> Result<Vec<UserHashInfo>> {
+    pub fn box_list_to_user_exclusions(
+        &self,
+        _box_paths: &[String],
+    ) -> crate::Result<Vec<UserHashInfo>> {
         let uhis = Vec::new();
 
         Ok(uhis)
@@ -1400,10 +1403,13 @@ impl BmffHash {
                 let track_to_bmff_merkle_map = self.split_bmff_merkle_map(bmff_merkle.clone())?;
 
                 reader.rewind()?;
-                let buf_reader = BufReader::new(reader);
-                let mut mp4 = mp4::Mp4Reader::read_header(buf_reader, size)
+                // Buffer the reader so the many small header/table reads during
+                // parsing (and the per-sample reads below) don't each hit the
+                // underlying stream, matching the previous reader's behavior.
+                let mut buf_reader = BufReader::new(reader);
+                let media = BmffSampleReader::from_stream(&mut buf_reader)
                     .map_err(|_e| Error::InvalidAsset("Could not parse BMFF".to_string()))?;
-                let track_count = mp4.tracks().len();
+                let track_count = media.tracks().len();
 
                 for mm in mm_vec {
                     let alg = match &mm.alg {
@@ -1415,18 +1421,10 @@ impl BmffHash {
 
                     if track_count > 0 {
                         // timed media case
-                        let track = {
-                            // clone so we can borrow later
-                            let tt = mp4.tracks().get(&(mm.local_id as u32)).ok_or(
-                                Error::HashMismatch("Merkle location not found".to_owned()),
-                            )?;
-
-                            Mp4Track {
-                                trak: tt.trak.clone(),
-                                trafs: tt.trafs.clone(),
-                                default_sample_duration: tt.default_sample_duration,
-                            }
-                        };
+                        let track = media
+                            .tracks()
+                            .get(&(mm.local_id as u32))
+                            .ok_or(Error::HashMismatch("Merkle location not found".to_owned()))?;
 
                         let sample_cnt = track.sample_count();
                         if sample_cnt == 0 {
@@ -1440,11 +1438,11 @@ impl BmffHash {
                         // create sample to chunk mapping
                         // create the Merkle tree per samples in a chunk
                         let mut chunk_hash_map: HashMap<u32, Hasher> = HashMap::new();
-                        let stsc = &track.trak.mdia.minf.stbl.stsc;
+                        let stsc = track.stsc_runs();
                         for sample_id in 1..=sample_cnt {
-                            let stsc_idx = stsc_index(&track, sample_id)?;
+                            let stsc_idx = track.stsc_index(sample_id)?;
 
-                            let stsc_entry = &stsc.entries[stsc_idx];
+                            let stsc_entry = &stsc[stsc_idx];
 
                             let first_chunk = stsc_entry.first_chunk;
                             let first_sample = stsc_entry.first_sample;
@@ -1476,7 +1474,7 @@ impl BmffHash {
                                 e.insert(hasher_enum);
                             }
 
-                            match mp4.read_sample(track_id, sample_id) {
+                            match media.read_sample(&mut buf_reader, track_id, sample_id) {
                                 Ok(Some(sample)) => {
                                     let h = chunk_hash_map.get_mut(&chunk_id).ok_or(
                                         Error::HashMismatch(
@@ -1484,7 +1482,7 @@ impl BmffHash {
                                         ),
                                     )?;
                                     // add sample data to hash
-                                    h.update(&sample.bytes);
+                                    h.update(&sample);
                                 }
                                 // The sample's tables place it outside the asset:
                                 // a genuine Merkle location miss.
@@ -2484,22 +2482,6 @@ impl AssertionBase for BmffHash {
     }
 }
 
-fn stsc_index(track: &Mp4Track, sample_id: u32) -> crate::Result<usize> {
-    if track.trak.mdia.minf.stbl.stsc.entries.is_empty() {
-        return Err(Error::InvalidAsset("BMFF has no stsc entries".to_string()));
-    }
-    for (i, entry) in track.trak.mdia.minf.stbl.stsc.entries.iter().enumerate() {
-        if sample_id < entry.first_sample {
-            return if i == 0 {
-                Err(Error::InvalidAsset("BMFF no sample not found".to_string()))
-            } else {
-                Ok(i - 1)
-            };
-        }
-    }
-    Ok(track.trak.mdia.minf.stbl.stsc.entries.len() - 1)
-}
-
 #[cfg(test)]
 mod bmff_hash_tests {
     #![allow(clippy::expect_used)]
@@ -2901,6 +2883,188 @@ mod bmff_hash_tests {
         assert!(
             matches!(result, Err(Error::InvalidAsset(_))),
             "expected Err(InvalidAsset) for oversized variable_block_sizes in create_merkle_tree"
+        );
+    }
+
+    // --- Lib-level coverage for the timed-media, track-based Merkle verify path.
+    //
+    // The integration suite in sdk/tests/bmff_timed_media_merkle.rs exercises
+    // this end-to-end, but CI measures coverage with `cargo llvm-cov --lib`, so
+    // these in-crate tests are what register the verify path. They drive
+    // `verify_stream_hash` through the native sample reader with a compact
+    // hand-built single-track, single-sample asset.
+
+    fn tm_box(fourcc: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let s = (8 + payload.len()) as u32;
+        [&s.to_be_bytes()[..], fourcc.as_slice(), payload].concat()
+    }
+
+    fn tm_fullbox(fourcc: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        // version 0, flags 0.
+        let s = (12 + payload.len()) as u32;
+        [&s.to_be_bytes()[..], fourcc.as_slice(), &[0u8; 4], payload].concat()
+    }
+
+    /// Builds a minimal single-track, single-sample timed-media MP4 and returns
+    /// it with the SHA-256 root over the sample. With `with_track == false` the
+    /// moov has no trak, exercising the no-tracks rejection.
+    fn build_timed_media(sample: &[u8], with_track: bool) -> (Vec<u8>, Vec<u8>) {
+        let ftyp = tm_box(b"ftyp", b"isom\x00\x00\x00\x00isom");
+
+        // C2PA merkle uuid box: uuid(16) + version/flags(4) + "merkle\0" + CBOR
+        // { uniqueId: 0, localId: 1, location: 0 }.
+        const C2PA_UUID: [u8; 16] = [
+            0xd8, 0xfe, 0xc3, 0xd6, 0x1b, 0x0e, 0x48, 0x3c, 0x92, 0x97, 0x58, 0x28, 0x87, 0x7e,
+            0xc4, 0x81,
+        ];
+        let cbor: Vec<u8> = vec![
+            0xa3, 0x68, b'u', b'n', b'i', b'q', b'u', b'e', b'I', b'd', 0x00, 0x67, b'l', b'o',
+            b'c', b'a', b'l', b'I', b'd', 0x01, 0x68, b'l', b'o', b'c', b'a', b't', b'i', b'o',
+            b'n', 0x00,
+        ];
+        let mut up = Vec::new();
+        up.extend_from_slice(&C2PA_UUID);
+        up.extend_from_slice(&[0u8; 4]);
+        up.extend_from_slice(b"merkle\x00");
+        up.extend_from_slice(&cbor);
+        let uuid = tm_box(b"uuid", &up);
+
+        let build_moov = |stco_offset: u32| -> Vec<u8> {
+            let sample_entry = tm_box(b"c2pv", &[0u8; 8]);
+            let mut stsd_p = 1u32.to_be_bytes().to_vec();
+            stsd_p.extend_from_slice(&sample_entry);
+            let stsd = tm_fullbox(b"stsd", &stsd_p);
+
+            let mut stts_p = 1u32.to_be_bytes().to_vec();
+            stts_p.extend_from_slice(&1u32.to_be_bytes());
+            stts_p.extend_from_slice(&1000u32.to_be_bytes());
+            let stts = tm_fullbox(b"stts", &stts_p);
+
+            let mut stsc_p = 1u32.to_be_bytes().to_vec();
+            stsc_p.extend_from_slice(&1u32.to_be_bytes()); // first_chunk
+            stsc_p.extend_from_slice(&1u32.to_be_bytes()); // samples_per_chunk
+            stsc_p.extend_from_slice(&1u32.to_be_bytes()); // sample_description_index
+            let stsc = tm_fullbox(b"stsc", &stsc_p);
+
+            let mut stsz_p = 0u32.to_be_bytes().to_vec(); // sample_size 0 => per-sample table
+            stsz_p.extend_from_slice(&1u32.to_be_bytes()); // sample_count
+            stsz_p.extend_from_slice(&(sample.len() as u32).to_be_bytes());
+            let stsz = tm_fullbox(b"stsz", &stsz_p);
+
+            let mut stco_p = 1u32.to_be_bytes().to_vec();
+            stco_p.extend_from_slice(&stco_offset.to_be_bytes());
+            let stco = tm_fullbox(b"stco", &stco_p);
+
+            let stbl = tm_box(b"stbl", &[stsd, stts, stsc, stsz, stco].concat());
+            let vmhd = tm_fullbox(b"vmhd", &[0u8; 8]);
+            let url = tm_fullbox(b"url ", &[]);
+            let mut dref_p = 1u32.to_be_bytes().to_vec();
+            dref_p.extend_from_slice(&url);
+            let dref = tm_fullbox(b"dref", &dref_p);
+            let dinf = tm_box(b"dinf", &dref);
+            let minf = tm_box(b"minf", &[vmhd, dinf, stbl].concat());
+
+            let mut mdhd_p = vec![0u8; 8];
+            mdhd_p.extend_from_slice(&1000u32.to_be_bytes());
+            mdhd_p.extend_from_slice(&0u32.to_be_bytes());
+            mdhd_p.extend_from_slice(&0x55c4u16.to_be_bytes());
+            mdhd_p.extend_from_slice(&0u16.to_be_bytes());
+            let mdhd = tm_fullbox(b"mdhd", &mdhd_p);
+
+            let mut hdlr_p = vec![0u8; 4];
+            hdlr_p.extend_from_slice(b"vide");
+            hdlr_p.extend_from_slice(&[0u8; 13]);
+            let hdlr = tm_fullbox(b"hdlr", &hdlr_p);
+
+            let mdia = tm_box(b"mdia", &[mdhd, hdlr, minf].concat());
+
+            let mut tkhd_p = vec![0u8; 8];
+            tkhd_p.extend_from_slice(&1u32.to_be_bytes()); // track_id
+            tkhd_p.extend_from_slice(&[0u8; 60]);
+            let tkhd = tm_fullbox(b"tkhd", &tkhd_p);
+
+            let mvhd = tm_fullbox(b"mvhd", &[0u8; 96]);
+            if with_track {
+                let trak = tm_box(b"trak", &[tkhd, mdia].concat());
+                tm_box(b"moov", &[mvhd, trak].concat())
+            } else {
+                tm_box(b"moov", &mvhd)
+            }
+        };
+
+        // Two-pass: learn moov length (stco width is fixed), then set the real
+        // sample offset.
+        let moov_len = build_moov(0).len();
+        let sample_offset = (ftyp.len() + uuid.len() + moov_len + 8) as u32;
+        let moov = build_moov(sample_offset);
+
+        let mut file = Vec::new();
+        file.extend_from_slice(&ftyp);
+        file.extend_from_slice(&uuid);
+        file.extend_from_slice(&moov);
+        file.extend_from_slice(&tm_box(b"mdat", sample));
+
+        let root = {
+            let mut h = Sha256::new();
+            h.update(sample);
+            h.finalize().to_vec()
+        };
+        (file, root)
+    }
+
+    fn tm_assertion(root: Vec<u8>, local_id: usize) -> BmffHash {
+        let mut bmff_hash = BmffHash::new("test", "sha256", None);
+        bmff_hash.add_exclusions(&mut vec![ExclusionsMap::new("/uuid".to_owned())]);
+        bmff_hash.set_merkle(vec![MerkleMap {
+            unique_id: 0,
+            local_id,
+            count: 1,
+            alg: Some("sha256".into()),
+            init_hash: None,
+            hashes: VecByteBuf(vec![ByteBuf::from(root)]),
+            fixed_block_size: None,
+            variable_block_sizes: None,
+        }]);
+        bmff_hash
+    }
+
+    #[test]
+    fn timed_media_track_merkle_verifies() {
+        let (file, root) = build_timed_media(b"hello sample data", true);
+        let bmff_hash = tm_assertion(root, 1);
+        let mut reader = Cursor::new(file);
+        bmff_hash
+            .verify_stream_hash(&mut reader, Some("sha256"))
+            .expect("valid timed-media asset should verify");
+    }
+
+    #[test]
+    fn timed_media_no_tracks_rejected() {
+        let (file, root) = build_timed_media(b"hello sample data", false);
+        let bmff_hash = tm_assertion(root, 1);
+        let mut reader = Cursor::new(file);
+        let err = bmff_hash
+            .verify_stream_hash(&mut reader, Some("sha256"))
+            .expect_err("a Merkle map with no readable track must not pass");
+        assert!(
+            matches!(err, Error::HashMismatch(ref m) if m == "BMFF has no tracks for timed-media Merkle verification"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn timed_media_hash_mismatch_rejected() {
+        let (mut file, root) = build_timed_media(b"hello sample data", true);
+        // Tamper the last sample byte after computing the root.
+        *file.last_mut().unwrap() ^= 0xff;
+        let bmff_hash = tm_assertion(root, 1);
+        let mut reader = Cursor::new(file);
+        let err = bmff_hash
+            .verify_stream_hash(&mut reader, Some("sha256"))
+            .expect_err("a tampered sample must not verify");
+        assert!(
+            matches!(err, Error::HashMismatch(_)),
+            "unexpected error: {err:?}"
         );
     }
 }

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -2834,6 +2834,530 @@ pub enum BmffError {
     InvalidFileSignature { reason: String },
 }
 
+// ---------------------------------------------------------------------------
+// Native BMFF sample reader.
+//
+// This is a small, hardened reimplementation of the narrow slice of the `mp4`
+// crate that `BmffHash` verification relies on for the timed-media, track-based
+// Merkle path: enumerate a file's tracks and read the bytes of an individual
+// sample. It parses only the sample-table boxes needed to map a sample id to a
+// byte range (`stsc`, `stco`/`co64`, `stsz`) plus `tkhd` for the track id, and
+// every offset/size computation is checked so a crafted asset yields an
+// `InvalidAsset` error rather than a panic. It intentionally does not touch the
+// `emsg`, `stts`, `ctts`, or `stsd` boxes, which is where the `mp4` crate's
+// panics lived.
+// ---------------------------------------------------------------------------
+
+/// One `stsc` run, with the 1-based `first_sample` derived at parse time (it is
+/// not stored on disk).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct StscRun {
+    pub first_chunk: u32,
+    pub samples_per_chunk: u32,
+    pub first_sample: u32,
+}
+
+/// The parsed sample tables for a single track, sufficient to locate and read
+/// any sample's bytes.
+#[derive(Debug)]
+pub(crate) struct SampleTrack {
+    track_id: u32,
+    stsc: Vec<StscRun>,
+    chunk_offsets: Vec<u64>,
+    // `stsz.sample_size`: when non-zero every sample has this fixed size and
+    // `sample_sizes` is empty; when zero, `sample_sizes` holds one entry per
+    // sample.
+    fixed_sample_size: u32,
+    sample_sizes: Vec<u32>,
+    sample_count: u32,
+}
+
+impl SampleTrack {
+    pub(crate) fn track_id(&self) -> u32 {
+        self.track_id
+    }
+
+    pub(crate) fn sample_count(&self) -> u32 {
+        self.sample_count
+    }
+
+    pub(crate) fn stsc_runs(&self) -> &[StscRun] {
+        &self.stsc
+    }
+
+    /// Returns the index of the `stsc` run governing `sample_id` (the last run
+    /// whose `first_sample <= sample_id`). Mirrors the historical behavior of
+    /// the `mp4` crate's `stsc_index`.
+    pub(crate) fn stsc_index(&self, sample_id: u32) -> Result<usize> {
+        if self.stsc.is_empty() {
+            return Err(Error::InvalidAsset("BMFF has no stsc entries".to_string()));
+        }
+
+        // The runs are ordered by `first_sample`, so the governing run is the
+        // last one whose `first_sample <= sample_id`. Tracking the running match
+        // (rather than indexing `i - 1`/`len - 1`) keeps this free of any
+        // subtraction that could underflow.
+        let mut governing = None;
+        for (i, run) in self.stsc.iter().enumerate() {
+            if run.first_sample <= sample_id {
+                governing = Some(i);
+            } else {
+                break;
+            }
+        }
+
+        governing
+            .ok_or_else(|| Error::InvalidAsset("BMFF sample precedes first stsc entry".to_string()))
+    }
+
+    /// Returns the size in bytes of `sample_id` (1-based).
+    fn sample_size(&self, sample_id: u32) -> Result<u32> {
+        if self.fixed_sample_size > 0 {
+            return Ok(self.fixed_sample_size);
+        }
+
+        let index = (sample_id as usize)
+            .checked_sub(1)
+            .ok_or_else(|| Error::InvalidAsset("BMFF sample id must be non-zero".to_string()))?;
+
+        self.sample_sizes
+            .get(index)
+            .copied()
+            .ok_or_else(|| Error::InvalidAsset("BMFF stsz entry not found".to_string()))
+    }
+
+    /// Reads the bytes of `sample_id` (1-based) from `reader`. Returns
+    /// `Ok(None)` when the sample or its chunk is not present in the sample
+    /// tables (matching the `mp4` crate, which the caller treats as a Merkle
+    /// location miss); returns `Err(InvalidAsset)` for malformed tables or a
+    /// sample that would read past the end of the stream.
+    fn read_sample<R: Read + Seek + ?Sized>(
+        &self,
+        reader: &mut R,
+        sample_id: u32,
+        stream_len: u64,
+    ) -> Result<Option<Vec<u8>>> {
+        if sample_id == 0 || sample_id > self.sample_count {
+            return Ok(None);
+        }
+
+        let run = &self.stsc[self.stsc_index(sample_id)?];
+
+        if run.samples_per_chunk == 0 {
+            return Err(Error::InvalidAsset(
+                "stsc samples_per_chunk must be non-zero".to_string(),
+            ));
+        }
+
+        // chunk_id (1-based) = (sample_id - first_sample) / samples_per_chunk + first_chunk.
+        let chunk_id = sample_id
+            .checked_sub(run.first_sample)
+            .map(|n| n / run.samples_per_chunk)
+            .and_then(|n| n.checked_add(run.first_chunk))
+            .ok_or_else(|| Error::InvalidAsset("BMFF stsc chunk_id overflow".to_string()))?;
+
+        let chunk_index = match (chunk_id as usize).checked_sub(1) {
+            Some(i) => i,
+            None => {
+                return Err(Error::InvalidAsset(
+                    "BMFF stsc chunk_id is zero".to_string(),
+                ))
+            }
+        };
+
+        let chunk_offset = match self.chunk_offsets.get(chunk_index) {
+            Some(o) => *o,
+            None => return Ok(None),
+        };
+
+        // Sum the sizes of the samples preceding this one within its chunk.
+        let first_sample_in_chunk = sample_id
+            - sample_id
+                .checked_sub(run.first_sample)
+                .ok_or_else(|| Error::InvalidAsset("BMFF stsc underflow".to_string()))?
+                % run.samples_per_chunk;
+
+        // Offset of this sample within its chunk = total size of the samples
+        // preceding it. For fixed-size samples that is a single product; only the
+        // variable-size case needs to walk the entries (and the stsz box size
+        // bounds that walk). This keeps read_sample O(1) for the common
+        // fixed-size case instead of O(samples-per-chunk), which would make the
+        // caller's per-sample loop quadratic over a single-chunk track.
+        let preceding_samples = sample_id - first_sample_in_chunk;
+        let mut intra_chunk_offset = (preceding_samples as u64)
+            .checked_mul(self.fixed_sample_size as u64)
+            .ok_or_else(|| Error::InvalidAsset("BMFF intra-chunk offset overflow".to_string()))?;
+
+        if self.fixed_sample_size == 0 {
+            for i in first_sample_in_chunk..sample_id {
+                intra_chunk_offset = intra_chunk_offset
+                    .checked_add(self.sample_size(i)? as u64)
+                    .ok_or_else(|| {
+                        Error::InvalidAsset("BMFF intra-chunk offset overflow".to_string())
+                    })?;
+            }
+        }
+
+        let sample_size = self.sample_size(sample_id)?;
+        let offset = chunk_offset
+            .checked_add(intra_chunk_offset)
+            .ok_or_else(|| Error::InvalidAsset("BMFF sample offset overflow".to_string()))?;
+
+        // Bound the read against the stream before allocating, so a crafted size
+        // cannot drive an unbounded allocation (memory amplification).
+        let end = offset
+            .checked_add(sample_size as u64)
+            .ok_or_else(|| Error::InvalidAsset("BMFF sample end overflow".to_string()))?;
+
+        if end > stream_len {
+            return Err(Error::InvalidAsset(
+                "BMFF sample extends beyond end of stream".to_string(),
+            ));
+        }
+
+        reader.seek(SeekFrom::Start(offset))?;
+        let mut buf = vec![0u8; sample_size as usize];
+        reader.read_exact(&mut buf)?;
+
+        Ok(Some(buf))
+    }
+}
+
+/// A parsed BMFF file exposing its tracks' sample tables, and the ability to
+/// read individual samples. Replaces the `mp4` crate for the timed-media
+/// Merkle-verification path.
+#[derive(Debug)]
+pub(crate) struct BmffSampleReader {
+    tracks: HashMap<u32, SampleTrack>,
+    stream_len: u64,
+}
+
+impl BmffSampleReader {
+    /// Parses `reader`, extracting the sample tables of every track under
+    /// `moov`. Does not retain the reader; sample bytes are read on demand via
+    /// [`BmffSampleReader::read_sample`] using a caller-supplied reader.
+    pub(crate) fn from_stream<R: Read + Seek + ?Sized>(reader: &mut R) -> Result<Self> {
+        let stream_len = stream_len(reader)?;
+
+        let mut tracks = HashMap::new();
+
+        if let Some((moov_start, moov_end)) = find_box(reader, 0, stream_len, BoxType::MoovBox)? {
+            let mut pos = moov_start;
+            while pos < moov_end {
+                let (name, content_start, box_end) = read_child(reader, pos, moov_end)?;
+                if name == BoxType::TrakBox {
+                    if let Some(track) = parse_trak(reader, content_start, box_end)? {
+                        // A track cannot contain more samples than the stream has
+                        // bytes. This bounds the `stsz` sample_count (which the
+                        // fixed-size branch does not otherwise cap) so a crafted
+                        // value cannot drive an enormous sample-iteration loop.
+                        if track.sample_count as u64 > stream_len {
+                            return Err(Error::InvalidAsset(
+                                "BMFF stsz sample count exceeds stream length".to_string(),
+                            ));
+                        }
+
+                        tracks.insert(track.track_id, track);
+                    }
+                }
+                pos = box_end;
+            }
+        }
+
+        Ok(Self { tracks, stream_len })
+    }
+
+    pub(crate) fn tracks(&self) -> &HashMap<u32, SampleTrack> {
+        &self.tracks
+    }
+
+    /// Reads sample `sample_id` (1-based) of `track_id` from `reader`. `reader`
+    /// must be the same stream the tables were parsed from.
+    pub(crate) fn read_sample<R: Read + Seek + ?Sized>(
+        &self,
+        reader: &mut R,
+        track_id: u32,
+        sample_id: u32,
+    ) -> Result<Option<Vec<u8>>> {
+        match self.tracks.get(&track_id) {
+            Some(track) => track.read_sample(reader, sample_id, self.stream_len),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Reads the box header at `pos` and returns `(name, content_start, box_end)`,
+/// validating that the box lies within `[pos, end)` and is at least header-sized.
+fn read_child<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    pos: u64,
+    end: u64,
+) -> Result<(BoxType, u64, u64)> {
+    reader.seek(SeekFrom::Start(pos))?;
+    let header = BoxHeaderLite::read(reader)?;
+    let content_start = reader.stream_position()?;
+
+    let box_end = pos
+        .checked_add(header.size)
+        .ok_or_else(|| Error::InvalidAsset("BMFF box size overflow".to_string()))?;
+
+    if box_end > end || box_end < content_start {
+        return Err(Error::InvalidAsset(
+            "BMFF box size out of bounds".to_string(),
+        ));
+    }
+
+    Ok((header.name, content_start, box_end))
+}
+
+/// Scans the children in `[start, end)` for the first box of `target`, returning
+/// its `(content_start, box_end)`.
+fn find_box<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    start: u64,
+    end: u64,
+    target: BoxType,
+) -> Result<Option<(u64, u64)>> {
+    let mut pos = start;
+    while pos < end {
+        let (name, content_start, box_end) = read_child(reader, pos, end)?;
+        if name == target {
+            return Ok(Some((content_start, box_end)));
+        }
+        pos = box_end;
+    }
+    Ok(None)
+}
+
+/// Parses a `trak` box (children in `[start, end)`) into a [`SampleTrack`].
+///
+/// The `Ok(None)` vs `Err` distinction is deliberate: `Ok(None)` means this trak
+/// is not a readable sample track (a required box such as `tkhd`/`mdia`/`minf`/
+/// `stbl`/`stsc`/`stsz` or a chunk-offset table is simply absent), so it is
+/// skipped rather than failing the whole parse — real files carry hint/metadata
+/// tracks without full sample tables. A box that is *present but malformed*
+/// yields `Err` from the corresponding `parse_*` helper. A caller that needs a
+/// specific track therefore sees a missing one as "not found" (its `local_id`
+/// won't be in the map) and a corrupt one as a hard error.
+fn parse_trak<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    start: u64,
+    end: u64,
+) -> Result<Option<SampleTrack>> {
+    let (tkhd_start, tkhd_end) = match find_box(reader, start, end, BoxType::TkhdBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    let track_id = parse_tkhd_track_id(reader, tkhd_start, tkhd_end)?;
+
+    // Descend moov/trak/mdia/minf/stbl.
+    let (mdia_start, mdia_end) = match find_box(reader, start, end, BoxType::MdiaBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    let (minf_start, minf_end) = match find_box(reader, mdia_start, mdia_end, BoxType::MinfBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    let (stbl_start, stbl_end) = match find_box(reader, minf_start, minf_end, BoxType::StblBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    let (stsc_start, stsc_end) = match find_box(reader, stbl_start, stbl_end, BoxType::StscBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    let stsc = parse_stsc(reader, stsc_start, stsc_end)?;
+
+    let chunk_offsets =
+        if let Some((s, e)) = find_box(reader, stbl_start, stbl_end, BoxType::StcoBox)? {
+            parse_stco(reader, s, e)?
+        } else if let Some((s, e)) = find_box(reader, stbl_start, stbl_end, BoxType::Co64Box)? {
+            parse_co64(reader, s, e)?
+        } else {
+            return Ok(None);
+        };
+
+    let (stsz_start, stsz_end) = match find_box(reader, stbl_start, stbl_end, BoxType::StszBox)? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    let (fixed_sample_size, sample_sizes, sample_count) = parse_stsz(reader, stsz_start, stsz_end)?;
+
+    Ok(Some(SampleTrack {
+        track_id,
+        stsc,
+        chunk_offsets,
+        fixed_sample_size,
+        sample_sizes,
+        sample_count,
+    }))
+}
+
+/// Reads the `track_id` field of a `tkhd` box (its content spans
+/// `[start, end)`), honoring the version-dependent field layout.
+fn parse_tkhd_track_id<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    start: u64,
+    end: u64,
+) -> Result<u32> {
+    reader.seek(SeekFrom::Start(start))?;
+    let (version, _flags) = read_box_header_ext(reader)?;
+
+    // Skip creation_time + modification_time: 8 bytes for v0, 16 for v1.
+    let skip = if version == 1 { 16u64 } else { 8u64 };
+    let track_id_pos = reader
+        .stream_position()?
+        .checked_add(skip)
+        .ok_or_else(|| Error::InvalidAsset("BMFF tkhd overflow".to_string()))?;
+
+    if track_id_pos.checked_add(4).map(|p| p > end).unwrap_or(true) {
+        return Err(Error::InvalidAsset("BMFF tkhd too small".to_string()));
+    }
+
+    reader.seek(SeekFrom::Start(track_id_pos))?;
+    Ok(reader.read_u32::<BigEndian>()?)
+}
+
+/// Rejects a declared entry count whose `entry_size`-byte entries, starting at
+/// `entries_start`, would read past `end` (guards against memory-amplification),
+/// returning the count as a `usize` when it fits.
+fn bounded_entry_count(
+    declared: u32,
+    entries_start: u64,
+    end: u64,
+    entry_size: u64,
+) -> Result<usize> {
+    // Callers pass a fixed, non-zero entry size, but guard the division anyway so
+    // this helper can never divide by zero.
+    if entry_size == 0 {
+        return Err(Error::InvalidAsset(
+            "BMFF sample-table entry size must be non-zero".to_string(),
+        ));
+    }
+
+    let available = end.saturating_sub(entries_start);
+    let max_entries = available / entry_size;
+
+    if declared as u64 > max_entries {
+        return Err(Error::InvalidAsset(
+            "BMFF sample-table entry count exceeds box size".to_string(),
+        ));
+    }
+
+    Ok(declared as usize)
+}
+
+fn parse_stsc<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    start: u64,
+    end: u64,
+) -> Result<Vec<StscRun>> {
+    reader.seek(SeekFrom::Start(start))?;
+    let (_version, _flags) = read_box_header_ext(reader)?;
+    let entry_count = reader.read_u32::<BigEndian>()?;
+
+    // Each stsc entry is 12 bytes: first_chunk, samples_per_chunk, sample_description_index.
+    let count = bounded_entry_count(entry_count, reader.stream_position()?, end, 12)?;
+
+    let mut raw = Vec::with_capacity(count);
+    for _ in 0..count {
+        let first_chunk = reader.read_u32::<BigEndian>()?;
+        let samples_per_chunk = reader.read_u32::<BigEndian>()?;
+        let _sample_description_index = reader.read_u32::<BigEndian>()?;
+        raw.push((first_chunk, samples_per_chunk));
+    }
+
+    // Derive the 1-based first_sample for each run: run i covers
+    // (next.first_chunk - this.first_chunk) * this.samples_per_chunk samples.
+    let mut runs = Vec::with_capacity(raw.len());
+    let mut first_sample: u32 = 1;
+    for i in 0..raw.len() {
+        let (first_chunk, samples_per_chunk) = raw[i];
+        runs.push(StscRun {
+            first_chunk,
+            samples_per_chunk,
+            first_sample,
+        });
+
+        if i + 1 < raw.len() {
+            let next_first_chunk = raw[i + 1].0;
+            first_sample = next_first_chunk
+                .checked_sub(first_chunk)
+                .and_then(|n| n.checked_mul(samples_per_chunk))
+                .and_then(|n| n.checked_add(first_sample))
+                .ok_or_else(|| {
+                    Error::InvalidAsset("BMFF stsc first_sample overflow".to_string())
+                })?;
+        }
+    }
+
+    Ok(runs)
+}
+
+fn parse_stco<R: Read + Seek + ?Sized>(reader: &mut R, start: u64, end: u64) -> Result<Vec<u64>> {
+    reader.seek(SeekFrom::Start(start))?;
+    let (_version, _flags) = read_box_header_ext(reader)?;
+    let entry_count = reader.read_u32::<BigEndian>()?;
+    let count = bounded_entry_count(entry_count, reader.stream_position()?, end, 4)?;
+
+    let mut offsets = Vec::with_capacity(count);
+    for _ in 0..count {
+        offsets.push(reader.read_u32::<BigEndian>()? as u64);
+    }
+    Ok(offsets)
+}
+
+fn parse_co64<R: Read + Seek + ?Sized>(reader: &mut R, start: u64, end: u64) -> Result<Vec<u64>> {
+    reader.seek(SeekFrom::Start(start))?;
+    let (_version, _flags) = read_box_header_ext(reader)?;
+    let entry_count = reader.read_u32::<BigEndian>()?;
+    let count = bounded_entry_count(entry_count, reader.stream_position()?, end, 8)?;
+
+    let mut offsets = Vec::with_capacity(count);
+    for _ in 0..count {
+        offsets.push(reader.read_u64::<BigEndian>()?);
+    }
+    Ok(offsets)
+}
+
+/// Returns `(fixed_sample_size, sample_sizes, sample_count)`.
+fn parse_stsz<R: Read + Seek + ?Sized>(
+    reader: &mut R,
+    start: u64,
+    end: u64,
+) -> Result<(u32, Vec<u32>, u32)> {
+    reader.seek(SeekFrom::Start(start))?;
+    let (_version, _flags) = read_box_header_ext(reader)?;
+    let sample_size = reader.read_u32::<BigEndian>()?;
+    let sample_count = reader.read_u32::<BigEndian>()?;
+
+    if sample_size > 0 {
+        // Fixed size: no per-sample table follows.
+        return Ok((sample_size, Vec::new(), sample_count));
+    }
+
+    // Variable sizes: `sample_count` u32 entries follow the two u32 header fields.
+    let entries_start = start
+        .checked_add(4 + 4 + 4)
+        .ok_or_else(|| Error::InvalidAsset("BMFF stsz overflow".to_string()))?;
+    let available = end.saturating_sub(entries_start);
+
+    if sample_count as u64 > available / 4 {
+        return Err(Error::InvalidAsset(
+            "BMFF stsz sample count exceeds box size".to_string(),
+        ));
+    }
+
+    let mut sizes = Vec::with_capacity(sample_count as usize);
+    for _ in 0..sample_count {
+        sizes.push(reader.read_u32::<BigEndian>()?);
+    }
+
+    Ok((0, sizes, sample_count))
+}
+
 #[cfg(test)]
 pub mod tests {
     #![allow(clippy::expect_used)]
@@ -3203,5 +3727,298 @@ pub mod tests {
         let mut cursor = Cursor::new(Vec::<u8>::new());
         let big_neg: i64 = (i32::MIN as i64) - 1;
         adjust_known_offsets(&mut cursor, &arena, &map, big_neg).unwrap();
+    }
+
+    /// The native sample reader must parse our real MP4/MOV fixtures (which carry
+    /// full sample tables, multiple tracks, and codec sample entries) and read a
+    /// sample, so the parser's strict bounds don't reject legitimate assets.
+    #[test]
+    fn native_reader_parses_real_assets() {
+        for name in ["video1.mp4", "c.mov", "BigBuckBunny_320x180.mp4"] {
+            let bytes = std::fs::read(fixture_path(name))
+                .unwrap_or_else(|e| panic!("cannot read fixture {name}: {e}"));
+            let mut reader = Cursor::new(bytes);
+
+            let media = BmffSampleReader::from_stream(&mut reader)
+                .unwrap_or_else(|e| panic!("native reader failed to parse {name}: {e}"));
+            assert!(
+                !media.tracks().is_empty(),
+                "{name} should expose at least one track"
+            );
+
+            // Read sample 1 of the first track that has samples; it must succeed
+            // and return non-empty bytes.
+            let mut read_any = false;
+            for (track_id, track) in media.tracks() {
+                if track.sample_count() > 0 {
+                    let sample = media
+                        .read_sample(&mut reader, *track_id, 1)
+                        .unwrap_or_else(|e| panic!("{name} read_sample failed: {e}"))
+                        .unwrap_or_else(|| panic!("{name} track {track_id} sample 1 missing"));
+                    assert!(!sample.is_empty(), "{name} sample 1 should be non-empty");
+                    read_any = true;
+                    break;
+                }
+            }
+            assert!(read_any, "{name} should have a track with samples");
+        }
+    }
+
+    /// A zero entry size must not divide-by-zero; it is rejected instead.
+    #[test]
+    fn bounded_entry_count_rejects_zero_entry_size() {
+        assert!(bounded_entry_count(1, 0, 100, 0).is_err());
+    }
+
+    // --- Direct SampleTrack unit tests -------------------------------------
+    //
+    // These exercise the offset/size arithmetic and its defensive guards
+    // directly, including branches that the public verify path cannot reach
+    // (e.g. a degenerate `stsc` that the parser's `first_sample` derivation
+    // never actually produces).
+
+    fn one_run_track(
+        first_chunk: u32,
+        samples_per_chunk: u32,
+        chunk_offsets: Vec<u64>,
+        fixed_sample_size: u32,
+        sample_sizes: Vec<u32>,
+        sample_count: u32,
+    ) -> SampleTrack {
+        SampleTrack {
+            track_id: 1,
+            stsc: vec![StscRun {
+                first_chunk,
+                samples_per_chunk,
+                first_sample: 1,
+            }],
+            chunk_offsets,
+            fixed_sample_size,
+            sample_sizes,
+            sample_count,
+        }
+    }
+
+    #[test]
+    fn read_sample_out_of_range_is_none() {
+        let track = one_run_track(1, 1, vec![0], 4, vec![], 2);
+        let mut reader = Cursor::new(vec![0u8; 64]);
+        // sample_id 0 and sample_id > sample_count both yield Ok(None).
+        assert!(track.read_sample(&mut reader, 0, 64).unwrap().is_none());
+        assert!(track.read_sample(&mut reader, 3, 64).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_sample_zero_samples_per_chunk_errs() {
+        let track = one_run_track(1, 0, vec![0], 4, vec![], 1);
+        let mut reader = Cursor::new(vec![0u8; 64]);
+        assert!(track.read_sample(&mut reader, 1, 64).is_err());
+    }
+
+    #[test]
+    fn read_sample_zero_first_chunk_errs() {
+        // first_chunk 0 makes chunk_id 0, which has no valid 0-based index.
+        let track = one_run_track(0, 1, vec![0], 4, vec![], 1);
+        let mut reader = Cursor::new(vec![0u8; 64]);
+        let err = track.read_sample(&mut reader, 1, 64).unwrap_err();
+        assert!(matches!(err, Error::InvalidAsset(ref m) if m.contains("chunk_id is zero")));
+    }
+
+    #[test]
+    fn read_sample_missing_chunk_offset_is_none() {
+        // stsc references chunk 1 but the offset table is empty.
+        let track = one_run_track(1, 1, vec![], 4, vec![], 1);
+        let mut reader = Cursor::new(vec![0u8; 64]);
+        assert!(track.read_sample(&mut reader, 1, 64).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_sample_beyond_eof_errs() {
+        // Fixed size 4, chunk offset 60, stream len 62 -> read of [60,64) exceeds.
+        let track = one_run_track(1, 1, vec![60], 4, vec![], 1);
+        let mut reader = Cursor::new(vec![0u8; 62]);
+        let err = track.read_sample(&mut reader, 1, 62).unwrap_err();
+        assert!(matches!(err, Error::InvalidAsset(ref m) if m.contains("beyond end of stream")));
+    }
+
+    #[test]
+    fn read_sample_fixed_size_reads_correct_bytes() {
+        // Two 4-byte samples in one chunk at offset 8; sample 2 is bytes [12,16).
+        let mut data = vec![0u8; 8];
+        data.extend_from_slice(b"AAAABBBB");
+        let track = one_run_track(1, 2, vec![8], 4, vec![], 2);
+        let mut reader = Cursor::new(data);
+        assert_eq!(
+            track.read_sample(&mut reader, 1, 16).unwrap().unwrap(),
+            b"AAAA"
+        );
+        assert_eq!(
+            track.read_sample(&mut reader, 2, 16).unwrap().unwrap(),
+            b"BBBB"
+        );
+    }
+
+    #[test]
+    fn read_sample_variable_size_reads_correct_bytes() {
+        // Variable sizes [3, 5] in one chunk at offset 4; sample 2 is bytes [7,12).
+        let mut data = vec![0u8; 4];
+        data.extend_from_slice(b"aaabbbbb");
+        let track = one_run_track(1, 2, vec![4], 0, vec![3, 5], 2);
+        let mut reader = Cursor::new(data);
+        assert_eq!(
+            track.read_sample(&mut reader, 1, 12).unwrap().unwrap(),
+            b"aaa"
+        );
+        assert_eq!(
+            track.read_sample(&mut reader, 2, 12).unwrap().unwrap(),
+            b"bbbbb"
+        );
+    }
+
+    #[test]
+    fn stsc_index_empty_errs() {
+        let track = SampleTrack {
+            track_id: 1,
+            stsc: vec![],
+            chunk_offsets: vec![],
+            fixed_sample_size: 4,
+            sample_sizes: vec![],
+            sample_count: 0,
+        };
+        let err = track.stsc_index(1).unwrap_err();
+        assert!(matches!(err, Error::InvalidAsset(ref m) if m == "BMFF has no stsc entries"));
+    }
+
+    #[test]
+    fn stsc_index_precedes_first_entry_errs() {
+        // A degenerate run whose first_sample is greater than the queried id.
+        let track = SampleTrack {
+            track_id: 1,
+            stsc: vec![StscRun {
+                first_chunk: 1,
+                samples_per_chunk: 1,
+                first_sample: 5,
+            }],
+            chunk_offsets: vec![0],
+            fixed_sample_size: 4,
+            sample_sizes: vec![],
+            sample_count: 10,
+        };
+        let err = track.stsc_index(2).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidAsset(ref m) if m.contains("precedes first stsc entry"))
+        );
+    }
+
+    #[test]
+    fn stsc_index_selects_governing_run() {
+        let track = SampleTrack {
+            track_id: 1,
+            stsc: vec![
+                StscRun {
+                    first_chunk: 1,
+                    samples_per_chunk: 2,
+                    first_sample: 1,
+                },
+                StscRun {
+                    first_chunk: 3,
+                    samples_per_chunk: 1,
+                    first_sample: 5,
+                },
+            ],
+            chunk_offsets: vec![0, 0, 0],
+            fixed_sample_size: 4,
+            sample_sizes: vec![],
+            sample_count: 10,
+        };
+        assert_eq!(track.stsc_index(1).unwrap(), 0);
+        assert_eq!(track.stsc_index(4).unwrap(), 0);
+        assert_eq!(track.stsc_index(5).unwrap(), 1);
+        assert_eq!(track.stsc_index(9).unwrap(), 1);
+    }
+
+    #[test]
+    fn sample_size_variable_out_of_range_errs() {
+        let track = one_run_track(1, 1, vec![0], 0, vec![4], 1);
+        // sample_id 2 has no stsz entry.
+        assert!(track.sample_size(2).is_err());
+        // sample_id 0 underflows the 1-based index.
+        assert!(track.sample_size(0).is_err());
+    }
+
+    #[test]
+    fn parse_tkhd_track_id_version_1() {
+        // FullBox header (version 1), then 16 bytes of times, then track_id.
+        let mut b = vec![1u8, 0, 0, 0]; // version=1, flags=0
+        b.extend_from_slice(&[0u8; 16]); // creation+modification (64-bit each)
+        b.extend_from_slice(&42u32.to_be_bytes()); // track_id
+        let mut reader = Cursor::new(b);
+        let id = parse_tkhd_track_id(&mut reader, 0, 24).unwrap();
+        assert_eq!(id, 42);
+    }
+
+    #[test]
+    fn parse_tkhd_track_id_too_small_errs() {
+        let mut b = vec![0u8, 0, 0, 0]; // version=0, flags=0
+        b.extend_from_slice(&[0u8; 4]); // truncated before track_id
+        let mut reader = Cursor::new(b);
+        assert!(parse_tkhd_track_id(&mut reader, 0, 8).is_err());
+    }
+
+    #[test]
+    fn read_sample_end_overflow_errs() {
+        // A chunk offset at u64::MAX makes offset + size overflow.
+        let track = one_run_track(1, 1, vec![u64::MAX], 4, vec![], 1);
+        let mut reader = Cursor::new(vec![0u8; 16]);
+        let err = track.read_sample(&mut reader, 1, 16).unwrap_err();
+        assert!(matches!(err, Error::InvalidAsset(ref m) if m.contains("overflow")));
+    }
+
+    #[test]
+    fn read_sample_offset_overflow_errs() {
+        // chunk_offset near u64::MAX plus a preceding variable sample overflows
+        // the intra-chunk addition into the base offset.
+        let track = one_run_track(1, 2, vec![u64::MAX], 0, vec![1, 1], 2);
+        let mut reader = Cursor::new(vec![0u8; 16]);
+        let err = track.read_sample(&mut reader, 2, 16).unwrap_err();
+        assert!(matches!(err, Error::InvalidAsset(ref m) if m.contains("overflow")));
+    }
+
+    #[test]
+    fn parse_stsz_variable_count_exceeds_box_errs() {
+        // version/flags(4) + sample_size=0(4) + sample_count=1000(4); box ends
+        // right after the header, so 1000 entries cannot fit.
+        let mut b = vec![0u8; 4];
+        b.extend_from_slice(&0u32.to_be_bytes()); // sample_size = 0 (variable)
+        b.extend_from_slice(&1000u32.to_be_bytes()); // sample_count
+        let end = b.len() as u64;
+        let mut reader = Cursor::new(b);
+        assert!(parse_stsz(&mut reader, 0, end).is_err());
+    }
+
+    #[test]
+    fn read_child_rejects_box_extending_past_parent() {
+        // A box header claiming size 1000 inside a 20-byte parent range.
+        let mut b = 1000u32.to_be_bytes().to_vec();
+        b.extend_from_slice(b"free");
+        b.extend_from_slice(&[0u8; 12]);
+        let mut reader = Cursor::new(b);
+        assert!(read_child(&mut reader, 0, 20).is_err());
+    }
+
+    #[test]
+    fn from_stream_without_moov_has_no_tracks() {
+        // Just an ftyp box, no moov: parses to an empty track set.
+        let ftyp = {
+            let payload = b"isom\x00\x00\x00\x00isom";
+            let size = (8 + payload.len()) as u32;
+            let mut v = size.to_be_bytes().to_vec();
+            v.extend_from_slice(b"ftyp");
+            v.extend_from_slice(payload);
+            v
+        };
+        let mut reader = Cursor::new(ftyp);
+        let media = BmffSampleReader::from_stream(&mut reader).unwrap();
+        assert!(media.tracks().is_empty());
     }
 }

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -882,3 +882,232 @@ fn valid_sha512_verifies() {
         .verify_stream_hash(&mut reader, Some("sha512"))
         .expect("sha512 timed-media asset should verify");
 }
+
+// --- Regression: CAI-12277 / VULN-35208 -----------------------------------
+//
+// A crafted MP4 with a malformed `emsg` box (a scheme_id_uri string with no
+// null terminator inside the box) drove an integer underflow panic in the old
+// third-party `mp4` crate's EmsgBox::read_box. The native reader never parses
+// `emsg`, so the same input must now fail cleanly instead of panicking.
+
+/// Builds the emsg-underflow MP4 from the ticket's proof-of-concept: an `emsg`
+/// box whose 38-byte scheme_id_uri runs to the following box header, followed by
+/// a C2PA merkle `uuid` box and a minimal `moov`.
+fn build_emsg_crash_mp4() -> Vec<u8> {
+    let mut f = Vec::new();
+    f.extend_from_slice(&build_box(b"ftyp", b"isom\x00\x00\x00\x00isom"));
+
+    // emsg: declared size 50, body = version/flags (4) + 38 bytes of 0x41 with
+    // no null terminator inside the box.
+    let mut emsg = Vec::new();
+    emsg.extend_from_slice(&50u32.to_be_bytes());
+    emsg.extend_from_slice(b"emsg");
+    emsg.push(0);
+    emsg.extend_from_slice(&[0u8; 3]);
+    emsg.extend_from_slice(&[0x41u8; 38]);
+    f.extend_from_slice(&emsg);
+
+    // C2PA merkle uuid box (localId 1, location 0).
+    f.extend_from_slice(&build_merkle_uuid_box(0, 1, 0));
+
+    // Minimal moov with one track and an empty stbl.
+    let mvhd = build_fullbox(b"mvhd", 0, 0, &[0u8; 96]);
+    let mut tkhd_p = vec![0u8; 8];
+    tkhd_p.extend_from_slice(&1u32.to_be_bytes());
+    tkhd_p.extend_from_slice(&[0u8; 76]);
+    let tkhd = build_fullbox(b"tkhd", 0, 1, &tkhd_p);
+    let stsd = build_fullbox(b"stsd", 0, 0, &0u32.to_be_bytes());
+    let stts = build_fullbox(b"stts", 0, 0, &0u32.to_be_bytes());
+    let stsc = build_fullbox(b"stsc", 0, 0, &0u32.to_be_bytes());
+    let stsz = build_fullbox(b"stsz", 0, 0, &[0u8; 8]);
+    let stco = build_fullbox(b"stco", 0, 0, &0u32.to_be_bytes());
+    let stbl = build_box(b"stbl", &[stsd, stts, stsc, stsz, stco].concat());
+    let minf = build_box(b"minf", &stbl);
+    let mdia = build_box(b"mdia", &minf);
+    let trak = build_box(b"trak", &[tkhd, mdia].concat());
+    let moov = build_box(b"moov", &[mvhd, trak].concat());
+    f.extend_from_slice(&moov);
+
+    f.extend_from_slice(&build_box(b"mdat", &[0u8; 8]));
+    f
+}
+
+/// The crafted `emsg` asset must return an error, not panic. (Before the native
+/// reader, this input panicked with an integer underflow / capacity overflow.)
+#[test]
+fn crafted_emsg_does_not_panic() {
+    let mut bmff_hash = BmffHash::new("test", "sha256", None);
+    bmff_hash.add_exclusions(&mut vec![ExclusionsMap::new("/uuid".to_owned())]);
+    bmff_hash.set_merkle(vec![MerkleMap {
+        unique_id: 0,
+        local_id: 1,
+        count: 1,
+        alg: Some("sha256".into()),
+        init_hash: None,
+        hashes: VecByteBuf(vec![ByteBuf::from(vec![0u8; 32])]),
+        fixed_block_size: None,
+        variable_block_sizes: None,
+    }]);
+
+    let mut reader = Cursor::new(build_emsg_crash_mp4());
+    // Must not panic; the malformed asset is rejected with an error.
+    let result = bmff_hash.verify_stream_hash(&mut reader, Some("sha256"));
+    assert!(result.is_err(), "crafted emsg asset should be rejected");
+}
+
+/// A sample whose declared (fixed) size runs past the end of the stream must be
+/// rejected before allocating, guarding against memory-amplification.
+#[test]
+fn oversized_sample_is_rejected() {
+    let track = TrackSpec {
+        track_id: 1,
+        stsc: vec![StscEntry {
+            first_chunk: 1,
+            samples_per_chunk: 1,
+            sample_description_index: 1,
+        }],
+        // Fixed sample size far larger than the file.
+        sample_sizes: SampleSizes::Fixed(0xffff_ff00),
+        use_co64: false,
+    };
+    let (file, roots) = build_single_track_asset(track, &[b"tiny"]);
+    let bmff_hash = track_merkle_assertion(1, &roots);
+    let mut reader = Cursor::new(file);
+    let err = bmff_hash
+        .verify_stream_hash(&mut reader, Some("sha256"))
+        .unwrap_err();
+    // Rejected cleanly (no OOM / panic).
+    assert!(
+        matches!(
+            err,
+            c2pa::Error::InvalidAsset(_) | c2pa::Error::HashMismatch(_)
+        ),
+        "expected a clean rejection, got: {err:?}"
+    );
+}
+
+/// An `stco` box declaring far more entries than its size can hold must be
+/// rejected at parse time, not drive a huge allocation.
+#[test]
+fn oversized_stco_entry_count_is_rejected() {
+    let track = TrackSpec {
+        track_id: 1,
+        stsc: vec![StscEntry {
+            first_chunk: 1,
+            samples_per_chunk: 1,
+            sample_description_index: 1,
+        }],
+        sample_sizes: SampleSizes::Variable(vec![4]),
+        use_co64: false,
+    };
+    let (mut file, roots) = build_single_track_asset(track, &[b"data"]);
+
+    // Overwrite the stco entry_count with a huge value.
+    let pos = file
+        .windows(4)
+        .position(|w| w == b"stco")
+        .expect("stco box present");
+    let ec = pos + 4 + 4; // past fourcc + version/flags
+    file[ec..ec + 4].copy_from_slice(&0xffff_ffffu32.to_be_bytes());
+
+    let bmff_hash = track_merkle_assertion(1, &roots);
+    let mut reader = Cursor::new(file);
+    let err = bmff_hash
+        .verify_stream_hash(&mut reader, Some("sha256"))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            c2pa::Error::InvalidAsset(_) | c2pa::Error::HashMismatch(_)
+        ),
+        "expected a clean rejection, got: {err:?}"
+    );
+}
+
+/// A fixed-size `stsz` declaring more samples than the stream has bytes must be
+/// rejected at parse time, so a crafted `sample_count` cannot drive an enormous
+/// sample-iteration loop (the fixed-size branch doesn't otherwise bound it).
+#[test]
+fn oversized_stsz_sample_count_is_rejected() {
+    let track = TrackSpec {
+        track_id: 1,
+        stsc: vec![StscEntry {
+            first_chunk: 1,
+            samples_per_chunk: 1,
+            sample_description_index: 1,
+        }],
+        sample_sizes: SampleSizes::Fixed(4),
+        use_co64: false,
+    };
+    let (mut file, roots) = build_single_track_asset(track, &[b"data"]);
+
+    // Overwrite the stsz sample_count (second u32 of the fixed-size stsz body)
+    // with a value far larger than the file.
+    let pos = file
+        .windows(4)
+        .position(|w| w == b"stsz")
+        .expect("stsz box present");
+    // fourcc -> version/flags(4) -> sample_size(4) -> sample_count(4)
+    let sc = pos + 4 + 4 + 4;
+    file[sc..sc + 4].copy_from_slice(&0xffff_ffffu32.to_be_bytes());
+
+    let bmff_hash = track_merkle_assertion(1, &roots);
+    let mut reader = Cursor::new(file);
+    let err = bmff_hash
+        .verify_stream_hash(&mut reader, Some("sha256"))
+        .expect_err("an oversized stsz sample_count must be rejected");
+    // Rejected during parse ("Could not parse BMFF" wraps the reader error).
+    assert!(
+        matches!(err, c2pa::Error::InvalidAsset(_)),
+        "expected a clean parse rejection, got: {err:?}"
+    );
+}
+
+/// A track missing a required sample-table box is skipped (`parse_trak` returns
+/// `Ok(None)`), so it is not added to the track set. With the only track
+/// dropped, a referencing Merkle map has no track to verify against. Renaming a
+/// box's fourcc makes `find_box` miss it while leaving the byte layout intact.
+fn assert_dropped_track_rejected(fourcc: &[u8; 4]) {
+    let track = TrackSpec {
+        track_id: 1,
+        stsc: vec![StscEntry {
+            first_chunk: 1,
+            samples_per_chunk: 1,
+            sample_description_index: 1,
+        }],
+        sample_sizes: SampleSizes::Variable(vec![4]),
+        use_co64: false,
+    };
+    let (mut file, roots) = build_single_track_asset(track, &[b"data"]);
+
+    let pos = file
+        .windows(4)
+        .position(|w| w == fourcc)
+        .unwrap_or_else(|| panic!("{} box present", String::from_utf8_lossy(fourcc)));
+    file[pos..pos + 4].copy_from_slice(b"xxxx");
+
+    let bmff_hash = track_merkle_assertion(1, &roots);
+    let mut reader = Cursor::new(file);
+    let err = bmff_hash
+        .verify_stream_hash(&mut reader, Some("sha256"))
+        .expect_err("a dropped track must not verify");
+    assert!(
+        matches!(err, c2pa::Error::HashMismatch(ref m) if m == "BMFF has no tracks for timed-media Merkle verification"),
+        "expected the no-tracks rejection, got: {err:?}"
+    );
+}
+
+#[test]
+fn track_without_mdia_is_skipped() {
+    assert_dropped_track_rejected(b"mdia");
+}
+
+#[test]
+fn track_without_chunk_offsets_is_skipped() {
+    assert_dropped_track_rejected(b"stco");
+}
+
+#[test]
+fn track_without_stsz_is_skipped() {
+    assert_dropped_track_rejected(b"stsz");
+}


### PR DESCRIPTION
Manual backport of #2357 to `stable`.

The automated backport failed to cherry-pick cleanly. This PR resolves the conflicts by hand.

## Ordering note
This backport depends on #2369 (backported in #2400), which must land on `stable` first. #2357's test suite asserts that no-track / dropped-track Merkle maps are *rejected* — that rejection logic lives in #2369. With #2369 present, the upstream lineage (#2356 → #2369 → #2357) is restored and only one trivial conflict remained.

## Conflicts resolved
- **`sdk/src/utils/ephemeral_cert.rs`** — the only manual conflict. #2357 adds a `#[cfg(any(target_os = "linux", target_os = "macos"))]` guard to a *test-local* `der_to_pem` helper that only exists in `main`'s module structure. On `stable`, `der_to_pem` is a module-level `pub fn` used unconditionally by `ephemeral_signer.rs`, so the guard doesn't apply. Resolved by taking `stable`'s side (dropped the unrelated change).

## Verification
- `mp4` removed from both `sdk/Cargo.toml` and `Cargo.lock`
- BMFF Merkle integration suite (`bmff_timed_media_merkle`): 22 passed, 0 failed
- In-crate `bmff` unit tests: 61 passed, 0 failed
- `cargo +nightly fmt --all -- --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)