### PR TITLE
ci: add detailed summary to backport failures

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,9 +37,10 @@ jobs:
 
       - name: Create backport PRs
         id: backport
-        uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997 # v3
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           github_token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          comment_style: summary
           # Labels look like `backport-<branch>`; the captured group is the
           # target branch name.
           label_pattern: '^backport-(?<target>.+)$'


### PR DESCRIPTION
Upgrades the `korthout/backport-action` to 4.6.0 and uses the detailed failure summary so we don't get non-actionable error messages like so:
> Git push to origin failed for stable with exitcode 1

https://github.com/contentauth/c2pa-rs/pull/2398#issuecomment-5170556653