### PR TITLE
chore: Add do-not-backport label to version-controlled labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,10 @@
   color: "5319e7"
   description: "Cherry-pick this merged main PR onto the stable release line"
 
+- name: do-not-backport
+  color: "6a737d"
+  description: "Deliberately not backported onto stable (e.g. incompatible behavior change)"
+
 - name: release-train
   color: "fbca04"
   description: "Tracking issue for an active breaking-change release train bake"


### PR DESCRIPTION
## Changes in this pull request

Registers the `do-not-backport` label in `.github/labels.yml` so the labeler workflow (`crazy-max/ghaction-github-labeler`) keeps it in sync rather than wiping the manually-created label.

The label marks merged main PRs we **deliberately** decline to backport onto `stable` — for example when a change alters the behavior of an existing API and is therefore unsafe for a patch release. It complements `backport-stable` by giving triage a positive "intentionally skipped" signal instead of leaving such PRs indistinguishable from un-triaged ones.

Color/description match the label already created on GitHub, so the sync is a no-op for the existing label. First application: #2344.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)