### PR TITLE
chore: Add do-not-backport label to version-controlled labels (backport #2405)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,10 @@
   color: "5319e7"
   description: "Cherry-pick this merged main PR onto the stable release line"
 
+- name: do-not-backport
+  color: "6a737d"
+  description: "Deliberately not backported onto stable (e.g. incompatible behavior change)"
+
 - name: release-train
   color: "fbca04"
   description: "Tracking issue for an active breaking-change release train bake"


### PR DESCRIPTION
Automated backport of #2405 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.