### PR TITLE
fix: Thumbnails silently dropped when format string has uppercase mimetype (backport #2365)

### DIFF
--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -388,7 +388,9 @@ pub fn instance(label: &str) -> usize {
 /// );
 /// ```
 pub fn add_thumbnail_format(label: &str, format: &str) -> String {
-    match format {
+    // mimetypes are case-insensitive (RFC 2045 section 5.1).
+    let format = format.to_lowercase();
+    match format.as_str() {
         "image/jpeg" | "jpeg" | "jpg" => format!("{label}.jpeg"),
         "image/png" | "png" => format!("{label}.png"),
         "image/svg+xml" | "svg" => format!("{label}.svg"),
@@ -406,6 +408,26 @@ pub fn add_thumbnail_format(label: &str, format: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// MIME types are case-insensitive (RFC 2045 section 5.1),
+    /// every spelling should produces the same label.
+    #[test]
+    fn test_add_thumbnail_format_case_insensitive() {
+        // (label prefix, format, expected label)
+        let cases = [
+            (CLAIM_THUMBNAIL, "image/jpeg", JPEG_CLAIM_THUMBNAIL),
+            (CLAIM_THUMBNAIL, "IMAGE/JPEG", JPEG_CLAIM_THUMBNAIL),
+            (CLAIM_THUMBNAIL, "Image/Jpeg", JPEG_CLAIM_THUMBNAIL),
+            (CLAIM_THUMBNAIL, "JPG", JPEG_CLAIM_THUMBNAIL),
+            (INGREDIENT_THUMBNAIL, "image/png", PNG_INGREDIENT_THUMBNAIL),
+            (INGREDIENT_THUMBNAIL, "IMAGE/PNG", PNG_INGREDIENT_THUMBNAIL),
+            (CLAIM_THUMBNAIL, "IMAGE/SVG+XML", SVG_CLAIM_THUMBNAIL),
+        ];
+
+        for (label, format, expected) in cases {
+            assert_eq!(add_thumbnail_format(label, format), expected);
+        }
+    }
 
     /// Regression tests for usize underflow in `parse_label` when the input
     /// is a bare version token with no base label (e.g. "v1").

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -9033,6 +9033,47 @@ mod tests {
         assert!(reader_json.contains("thumbnail.ingredient"));
     }
 
+    /// `set_thumbnail` stores the format verbatim, bypassing `format_to_mime`.
+    #[test]
+    fn test_set_thumbnail_uppercase_mime_v1_claim() {
+        let definition = ManifestDefinition {
+            claim_version: Some(1),
+            claim_generator_info: [ClaimGeneratorInfo::default()].to_vec(),
+            format: "image/jpeg".to_string(),
+            title: Some("Test_Manifest".to_string()),
+            ..Default::default()
+        };
+
+        let mut builder = Builder {
+            definition,
+            ..Default::default()
+        };
+
+        let mut thumbnail = Cursor::new(TEST_THUMBNAIL);
+        builder
+            .set_thumbnail("IMAGE/JPEG", &mut thumbnail)
+            .expect("thumbnail should be set");
+
+        let claim = builder.to_claim().expect("claim should build");
+        let labels: Vec<String> = claim
+            .claim_assertion_store()
+            .iter()
+            .map(|a| a.label_raw())
+            .collect();
+
+        assert!(
+            labels
+                .iter()
+                .any(|l| l.contains(labels::JPEG_CLAIM_THUMBNAIL)),
+            "expected a {} assertion, got: {labels:?}",
+            labels::JPEG_CLAIM_THUMBNAIL
+        );
+        assert!(
+            !labels.iter().any(|l| l.contains("IMAGE/JPEG")),
+            "uppercase format leaked into an assertion label: {labels:?}"
+        );
+    }
+
     #[test]
     fn test_with_archive() -> Result<()> {
         let builder = Builder::default().with_definition(r#"{"title": "Test Image"}"#)?;

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -51,12 +51,14 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
 /// Convert a format to a MIME type
 /// formats can be passed in as extensions, e.g. "jpg" or "jpeg"
 /// or as MIME types, e.g. "image/jpeg"
+/// MIME types are case-insensitive (RFC 2045 section 5.1), so the format is
+/// lowercased before matching.
 pub fn format_to_mime(format: &str) -> String {
-    match extension_to_mime(format) {
-        Some(mime) => mime,
+    let format = format.to_lowercase();
+    match extension_to_mime(&format) {
+        Some(mime) => mime.to_string(),
         None => format,
     }
-    .to_string()
 }
 
 /// Converts a format to a file extension (not used anymore but maybe we want it later?)
@@ -102,4 +104,26 @@ pub fn format_from_path<P: AsRef<std::path::Path>>(path: P) -> Option<String> {
     path.as_ref().extension().map(|ext| {
         crate::utils::mime::format_to_mime(ext.to_string_lossy().to_lowercase().as_ref())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// MIME type and subtype are case-insensitive per RFC 2045 section 5.1.
+    /// An uppercase spelling must normalize to the canonical lowercase form.
+    #[test]
+    fn test_format_to_mime_uppercase() {
+        assert_eq!(format_to_mime("IMAGE/JPEG"), "image/jpeg");
+        assert_eq!(format_to_mime("Image/Png"), "image/png");
+        assert_eq!(format_to_mime("JPG"), "image/jpeg");
+        assert_eq!(format_to_mime("PNG"), "image/png");
+    }
+
+    #[test]
+    fn test_format_to_mime_lowercase_unchanged() {
+        assert_eq!(format_to_mime("image/jpeg"), "image/jpeg");
+        assert_eq!(format_to_mime("jpg"), "image/jpeg");
+        assert_eq!(format_to_mime("image/svg+xml"), "image/svg+xml");
+    }
 }

--- a/sdk/src/utils/test.rs
+++ b/sdk/src/utils/test.rs
@@ -420,6 +420,7 @@ pub fn fixture_path(file_name: &str) -> PathBuf {
 
 /// Create in-memory test streams from a fixture file
 #[allow(clippy::expect_used)]
+#[allow(clippy::panic)]
 pub fn create_test_streams(
     fixture_name: &str,
 ) -> (
@@ -469,6 +470,7 @@ pub fn create_test_streams(
 /// Create a single in-memory input stream from a fixture file.
 /// Use this for read-only tests (e.g. format detection) that don't need an output stream.
 #[allow(clippy::expect_used)]
+#[allow(clippy::panic)]
 pub fn create_test_stream(fixture_name: &str) -> (&'static str, std::io::Cursor<Vec<u8>>) {
     if let Some(fixture) = get_registry().get(fixture_name) {
         return (fixture.1, std::io::Cursor::new(fixture.0.to_vec()));

--- a/sdk/src/utils/thumbnail.rs
+++ b/sdk/src/utils/thumbnail.rs
@@ -36,9 +36,12 @@ impl ThumbnailFormat {
     /// Create a new [ThumbnailFormat] from the given format extension or mime type.
     ///
     /// If the format is unsupported, this function will return `None`.
+    /// `from_extension` lowercases internally but `from_mime_type` does not, so
+    /// normalize first to accept uppercase MIME types (RFC 2045 section 5.1).
     pub fn new(format: &str) -> Option<ThumbnailFormat> {
-        ImageFormat::from_extension(format)
-            .or_else(|| ImageFormat::from_mime_type(format))
+        let format = format.to_lowercase();
+        ImageFormat::from_extension(&format)
+            .or_else(|| ImageFormat::from_mime_type(&format))
             .and_then(|format| ThumbnailFormat::try_from(format).ok())
     }
 }
@@ -219,6 +222,8 @@ where
 #[cfg(test)]
 pub mod tests {
     #![allow(clippy::unwrap_used)]
+    #![allow(clippy::expect_used)]
+    #![allow(clippy::panic)]
 
     use image::GenericImageView;
 
@@ -432,6 +437,50 @@ pub mod tests {
         ImageReader::with_format(Cursor::new(bytes), format.into())
             .decode()
             .unwrap();
+    }
+
+    /// Formats are matched as mimetypes with case-insensitively.
+    ///
+    /// `ignore_errors` is disabled so an unresolved format surfaces as an `Err`
+    /// rather than the silent `Ok(None)` the default settings produce.
+    #[test]
+    fn test_make_thumbnail_bytes_from_stream_format_case_insensitive() {
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [builder.thumbnail]
+                    prefer_smallest_format = false
+                    ignore_errors = false
+                }
+                .to_string(),
+            )
+            .expect("settings should build");
+
+        // (format, source image, expected resolved format)
+        let cases = [
+            ("image/jpeg", TEST_JPEG, ThumbnailFormat::Jpeg),
+            ("IMAGE/JPEG", TEST_JPEG, ThumbnailFormat::Jpeg),
+            ("Image/Jpeg", TEST_JPEG, ThumbnailFormat::Jpeg),
+            ("image/png", TEST_PNG, ThumbnailFormat::Png),
+            ("IMAGE/PNG", TEST_PNG, ThumbnailFormat::Png),
+            // Extensions already resolve case-insensitively via
+            // `ImageFormat::from_extension`; pin that so it cannot regress.
+            ("jpg", TEST_JPEG, ThumbnailFormat::Jpeg),
+            ("JPG", TEST_JPEG, ThumbnailFormat::Jpeg),
+        ];
+
+        for (input, source, expected) in cases {
+            let (format, bytes) =
+                make_thumbnail_bytes_from_stream(input, Cursor::new(source), &settings)
+                    .unwrap_or_else(|err| panic!("{input} should be a supported format: {err}"))
+                    .unwrap_or_else(|| panic!("{input} should produce a thumbnail"));
+
+            assert_eq!(format, expected, "wrong format resolved for {input}");
+
+            ImageReader::with_format(Cursor::new(bytes), format.into())
+                .decode()
+                .unwrap_or_else(|err| panic!("{input} thumbnail should decode: {err}"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Automated backport of #2365 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.