### PR TITLE
fix: Remove archive assertions when constructing builder from archive (backport #2374)

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -9456,6 +9456,30 @@ mod tests {
     }
 
     #[test]
+    fn test_with_archive_drops_archive_metadata_assertion() -> Result<()> {
+        let settings = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
+        let context = Context::new().with_settings(settings)?;
+        let builder = Builder::from_context(context)
+            .with_definition(r#"{"title": "Test Archive Metadata"}"#)?;
+
+        let mut archive = Cursor::new(Vec::new());
+        builder.to_archive(&mut archive)?;
+        archive.rewind()?;
+
+        let loaded = Builder::default().with_archive(archive)?;
+        assert!(
+            !loaded
+                .definition
+                .assertions
+                .iter()
+                .any(|a| a.label == crate::assertions::labels::ARCHIVE_METADATA),
+            "archive bookkeeping assertion should not survive into the reconstructed builder"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_archive_self_signed_ed25519_signature() -> Result<()> {
         let settings = Settings::new().with_value("builder.generate_c2pa_archive", true)?;
 

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1237,6 +1237,13 @@ impl Reader {
                     builder.add_ingredient(ingredient);
                 }
                 for assertion in manifest.assertions.iter() {
+                    // Archive bookkeeping, not part of the manifest being edited.
+                    if assertion
+                        .label()
+                        .starts_with(crate::assertions::labels::ARCHIVE_METADATA)
+                    {
+                        continue;
+                    }
                     builder.add_assertion(assertion.label(), assertion.value()?)?;
                 }
             }


### PR DESCRIPTION
Automated backport of #2374 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.