### PR TITLE
ci: auto-merge backport PRs once CI passes and approved (backport #2343)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997 # v3
         with:
           github_token: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -49,3 +50,20 @@ jobs:
             Upstream-first: this change already merged to `main`. If the
             cherry-pick did not apply cleanly, adapt it so it compiles and
             passes tests on this branch.
+
+      # Arm GitHub's native auto-merge on each backport PR that was opened. The
+      # actual merge only fires once the target branch's protection rules are
+      # satisfied -- i.e. CI is green and at least one approving review is in --
+      # so those requirements must be configured as branch protection on the
+      # release-line branches (CI passing + 1 required approval). Requires
+      # "Allow auto-merge" to be enabled in the repository settings.
+      - name: Enable auto-merge on backport PRs
+        if: steps.backport.outputs.created_pull_numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CREATED_PRS: ${{ steps.backport.outputs.created_pull_numbers }}
+        run: |
+          for pr in $CREATED_PRS; do
+            echo "Enabling auto-merge (squash) on backport PR #$pr"
+            gh pr merge "$pr" --auto --squash --repo "$GITHUB_REPOSITORY"
+          done


### PR DESCRIPTION
Automated backport of #2343 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.