### PR TITLE
fix(sdk): Parse PEM cert chain to DER for RemoteSigner

### DIFF
--- a/sdk/src/settings/signer.rs
+++ b/sdk/src/settings/signer.rs
@@ -124,13 +124,17 @@ impl SignerSettings {
                 tsa_url,
                 referenced_assertions: _,
                 roles: _,
-            } => Ok(Box::new(RemoteSigner {
-                url,
-                alg,
-                reserve_size: 10000 + sign_cert.len(),
-                certs: vec![sign_cert.into_bytes()],
-                tsa_url,
-            })),
+            } => {
+                let certs = cert_chain_pem_to_der(sign_cert.as_bytes())?;
+                let reserve_size = 10000 + certs.iter().map(|c| c.len()).sum::<usize>();
+                Ok(Box::new(RemoteSigner {
+                    url,
+                    alg,
+                    reserve_size,
+                    certs,
+                    tsa_url,
+                }))
+            }
         }
     }
 
@@ -524,5 +528,113 @@ pub mod tests {
         assert_eq!(signer.sign(&[1, 2, 3]).unwrap(), signed_bytes);
 
         mock.assert();
+
+        // certs() must return DER-encoded certs (not raw PEM text), matching the
+        // Local variant's behavior via create_signer::from_keys.
+        let der_certs = signer.certs().unwrap();
+        assert!(!der_certs.is_empty());
+        let pem_text = String::from_utf8(sign_cert.to_vec()).unwrap();
+        let expected_der = crate::crypto::cert_chain_pem_to_der(pem_text.as_bytes()).unwrap();
+        assert_eq!(der_certs, expected_der);
+        for der in &der_certs {
+            assert_ne!(der.as_slice(), pem_text.as_bytes());
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_make_remote_signer_json_escaped_pem() {
+        use httpmock::MockServer;
+
+        use crate::create_signer;
+
+        let alg = SigningAlg::Ps384;
+        let (sign_cert, private_key) = test_signer::cert_chain_and_private_key_for_alg(alg);
+
+        let signer = create_signer::from_keys(sign_cert, private_key, alg, None).unwrap();
+        let signed_bytes = signer.sign(&[1, 2, 3]).unwrap();
+
+        let server = MockServer::start();
+        let mock = remote_signer_mock_server(&server, &signed_bytes);
+
+        // Simulate a cert chain delivered with literal "\n" escapes, as happens
+        // when a PEM cert is embedded in a JSON config value.
+        let pem_text = String::from_utf8(sign_cert.to_vec()).unwrap();
+        let escaped_pem = pem_text.replace('\n', "\\n");
+
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [signer.remote]
+                    url = (server.base_url())
+                    alg = (alg.to_string())
+                    sign_cert = (escaped_pem)
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        let signer_settings = settings.signer.expect("signer settings should be present");
+        let signer = signer_settings.c2pa_signer().unwrap();
+        assert_eq!(signer.alg(), alg);
+        assert_eq!(signer.sign(&[1, 2, 3]).unwrap(), signed_bytes);
+
+        let der_certs = signer.certs().unwrap();
+        assert!(!der_certs.is_empty());
+        let expected_der = crate::crypto::cert_chain_pem_to_der(pem_text.as_bytes()).unwrap();
+        assert_eq!(der_certs, expected_der);
+
+        mock.assert();
+    }
+
+    #[test]
+    fn test_make_remote_signer_malformed_pem_errors() {
+        let alg = SigningAlg::Ps384;
+
+        // Has BEGIN/END markers (so the parser attempts to decode a block) but
+        // the body is not valid base64, so decoding must fail with an error
+        // rather than silently producing an empty cert list.
+        let malformed_pem =
+            "-----BEGIN CERTIFICATE-----\nnot-valid-base64!!!\n-----END CERTIFICATE-----\n";
+
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [signer.remote]
+                    url = "https://example.com/sign"
+                    alg = (alg.to_string())
+                    sign_cert = (malformed_pem)
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        let signer_settings = settings.signer.expect("signer settings should be present");
+        assert!(signer_settings.c2pa_signer().is_err());
+    }
+
+    #[test]
+    fn test_make_remote_signer_no_pem_blocks_yields_empty_certs() {
+        // No BEGIN/END markers at all: the underlying parser treats this as
+        // "no blocks found" and returns an empty cert list rather than an
+        // error. This documents that behavior so a future change can't
+        // silently alter it without a failing test.
+        let alg = SigningAlg::Ps384;
+
+        let settings = Settings::new()
+            .with_toml(
+                &toml::toml! {
+                    [signer.remote]
+                    url = "https://example.com/sign"
+                    alg = (alg.to_string())
+                    sign_cert = "not a pem cert chain at all"
+                }
+                .to_string(),
+            )
+            .unwrap();
+
+        let signer_settings = settings.signer.expect("signer settings should be present");
+        let signer = signer_settings.c2pa_signer().unwrap();
+        assert_eq!(signer.certs().unwrap(), Vec::<Vec<u8>>::new());
     }
 }


### PR DESCRIPTION
## Summary

- `SignerSettings::c2pa_signer()`'s `Remote` variant was storing the raw PEM
  text bytes as a single "cert" and sizing `reserve_size` off PEM text length,
  instead of parsing the chain into individual DER-encoded certificates like
  the `Local` variant does via `create_signer::from_keys`.
- Now uses `crypto::cert_chain_pem_to_der` to parse `sign_cert` into DER certs
  (also handles JSON-escaped `\n` PEM), and computes `reserve_size` from the
  summed DER cert lengths.

## Issue

https://github.com/contentauth/c2pa-rs/issues/2074