### PR TITLE
fix: Upgrade lopdf to 0.44.0 and drop ttf-parser advisory exemption (backport #2417)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,9 +2561,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7407d2ac60a10b2084e208586cb8a556937ee52e221a1796fbd43b66cd96788"
+checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
  "aes",
  "bitflags 2.13.1",
@@ -2586,7 +2586,6 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.19",
  "time",
- "ttf-parser",
  "weezl 0.2.1",
 ]
 
@@ -4842,12 +4841,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typed-path"

--- a/deny.toml
+++ b/deny.toml
@@ -17,11 +17,6 @@ yanked = "deny"
 ignore = [
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
   "RUSTSEC-2024-0370", # proc-macro-error
-  # ttf-parser is unmaintained and reaches us only as a transitive dependency of
-  # lopdf (pdf feature). There is no fix available; we are tracking the lopdf
-  # migration off ttf-parser in https://github.com/contentauth/c2pa-rs/issues/2269
-  # (which follows https://github.com/J-F-Liu/lopdf/issues/514).
-  "RUSTSEC-2026-0192", # ttf-parser unmaintained (transitive via lopdf)
 ]
 
 [bans]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -131,7 +131,7 @@ img-parts = "0.4.0"
 iref = { version = "3.2.2", features = ["serde"] }
 jfifdump = "0.6.0"
 log = "0.4.30"
-lopdf = { version = "0.43.0", optional = true }
+lopdf = { version = "0.44.0", optional = true }
 lazy_static = "1.5.0"
 memchr = "2.8.1"
 nom = "7.1.3"


### PR DESCRIPTION
Automated backport of #2417 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.