### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.6](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.5...c2pa-v0.90.6)
+_06 August 2026_
+
+### Fixed
+
+* *(sdk)* Reject did:web documents whose id doesn't match the requested DID (backport #2411) ([#2427](https://github.com/contentauth/c2pa-rs/pull/2427))
+* Upgrade lopdf to 0.44.0 and drop ttf-parser advisory exemption (backport #2417) ([#2418](https://github.com/contentauth/c2pa-rs/pull/2418))
+
 ## [0.90.5](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.4...c2pa-v0.90.5)
 _05 August 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.5"
+version = "0.90.6"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.5"
+version = "0.90.6"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.5"
+version = "0.90.6"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.5"
+version = "0.27.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.5"
+version = "0.90.6"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2597,7 +2597,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.5"
+version = "0.90.6"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.5"
+version = "0.90.6"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.5", default-features = false }
+c2pa = { path = "sdk", version = "0.90.6", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.6](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.5...c2patool-v0.27.6)
+_06 August 2026_
+
 ## [0.27.5](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.4...c2patool-v0.27.5)
 _05 August 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.5"
+version = "0.27.6"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.5 -> 0.90.6 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.5 -> 0.90.6
* `c2patool`: 0.27.5 -> 0.27.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.6](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.5...c2pa-v0.90.6)

_06 August 2026_

### Fixed

* *(sdk)* Reject did:web documents whose id doesn't match the requested DID (backport #2411) ([#2427](https://github.com/contentauth/c2pa-rs/pull/2427))
* Upgrade lopdf to 0.44.0 and drop ttf-parser advisory exemption (backport #2417) ([#2418](https://github.com/contentauth/c2pa-rs/pull/2418))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.90.4)

_04 August 2026_

### Fixed

* Emscripten build which lost its header (backport #2395) ([#2396](https://github.com/contentauth/c2pa-rs/pull/2396))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.6](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.5...c2patool-v0.27.6)

_06 August 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).