### PR TITLE
ci: Replace `safe to test` trust logic with GitHub native fork-approval

### DIFF
--- a/.github/workflows/check-no-patch-deps.yml
+++ b/.github/workflows/check-no-patch-deps.yml
@@ -19,16 +19,9 @@ jobs:
   check:
     name: No patch/git dependencies
 
-    # When invoked directly on a PR, run only for trusted PRs (same-repo branch,
-    # or a fork PR labeled `safe to test`/`check-release`); see tier-1a.yml for
-    # why trust keys off the PR's head repository rather than
-    # `author_association`. Invocations via `workflow_call` are not pull-request
-    # events, so the first clause lets the reusable guard always run there.
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    # Fork-PR trust is enforced by GitHub's "Fork pull request workflows from
+    # outside collaborators" Actions setting (see tier-1a.yml), not in this
+    # workflow; `workflow_call` invocations run unconditionally.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -22,15 +22,10 @@ jobs:
   semver-checks:
     name: cargo-semver-checks
 
-    # Trusted PRs only: same-repo branch, or a fork PR a maintainer has labeled
-    # `safe to test`/`check-release`. cargo-semver-checks compiles the PR's
-    # code, so untrusted forks must not run it unreviewed. We key off the PR's
-    # head repository rather than `author_association` (see tier-1a.yml).
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-      contains(github.event.pull_request.labels.*.name, 'check-release')
+    # cargo-semver-checks compiles the PR's code, so untrusted fork PRs must not
+    # run it unreviewed. That trust gate is enforced by GitHub's "Fork pull
+    # request workflows from outside collaborators" Actions setting (see
+    # tier-1a.yml) rather than in this workflow.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -7,6 +7,14 @@
 # If you change the supported platforms in this workflow, please also
 # update docs/support-tiers.md to match the changes you're making.
 
+# Fork-PR trust is handled by GitHub, not by this workflow: the repository's
+# "Fork pull request workflows from outside collaborators" Actions setting holds
+# a fork PR's workflows until a maintainer approves them, so by the time this
+# suite runs it is already authorized. Same-repo branches (which require write
+# access to push) always run. Secrets are still never exposed to fork PRs, so
+# the Codecov upload steps below additionally gate on the PR originating from
+# this repository.
+
 name: Tier 1A
 
 on:
@@ -25,7 +33,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - labeled
   push:
     branches:
       - main
@@ -34,40 +41,6 @@ on:
       - '*-rc*'
 
 jobs:
-  # Decide once whether this run is trusted, and expose the result to every
-  # other job. A run is trusted when it is not a pull request (push, schedule,
-  # or manual dispatch), when the PR branch lives in this repository, or when a
-  # maintainer has applied the `safe to test` or `check-release` label to a
-  # fork PR.
-  #
-  # We key trust off the PR's head repository rather than `author_association`
-  # because GitHub only reports `MEMBER`/`COLLABORATOR` for public org members
-  # and direct collaborators. A private org member with team-granted write
-  # access shows up as `CONTRIBUTOR` and would otherwise be denied CI even
-  # though they can push branches here. Pushing a branch to this repository
-  # already requires write access, so "the branch is in this repo" is an
-  # accurate, maintenance-free proxy for "the author is a trusted team member".
-  authorize:
-    name: Authorize CI run
-    runs-on: ubuntu-latest
-    outputs:
-      # Full trust: run the entire CI suite.
-      trusted: ${{ steps.decide.outputs.trusted }}
-
-      # Run originates from this repository (not a fork), so repository secrets
-      # (e.g. the Codecov token) are available. Fork PRs never receive secrets,
-      # even when labeled `safe to test`, so secret-dependent steps must gate on
-      # this rather than on `trusted`.
-      same-repo: ${{ steps.decide.outputs.same-repo }}
-    steps:
-      - name: Determine trust level
-        id: decide
-        run: |
-          {
-            echo "same-repo=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}"
-            echo "trusted=${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || contains(github.event.pull_request.labels.*.name, 'check-release') }}"
-          } >> "$GITHUB_OUTPUT"
-
   get-features:
     name: Get features
     runs-on: ubuntu-latest
@@ -102,8 +75,7 @@ jobs:
 
   tests-openssl:
     name: Unit tests (OpenSSL installed)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -141,7 +113,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: needs.authorize.outputs.same-repo == 'true'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -151,8 +123,7 @@ jobs:
 
   tests-rust-native-crypto:
     name: Unit tests (Rust native crypto installed)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -190,7 +161,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: needs.authorize.outputs.same-repo == 'true'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -200,8 +171,7 @@ jobs:
 
   tests-cli:
     name: Unit tests (c2patool)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -233,7 +203,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: needs.authorize.outputs.same-repo == 'true'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -243,8 +213,7 @@ jobs:
 
   tests-windows-arm-openssl:
     name: Unit tests (Windows ARM, OpenSSL)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: windows-11-arm
 
@@ -269,8 +238,7 @@ jobs:
 
   tests-windows-arm-rust-native-crypto:
     name: Unit tests (Windows ARM, Rust native crypto)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: windows-11-arm
 
@@ -295,10 +263,7 @@ jobs:
 
   docs_rs:
     name: Preflight docs.rs build
-    needs: authorize
     runs-on: ubuntu-latest
-
-    if: needs.authorize.outputs.trusted == 'true'
 
     steps:
       - name: Checkout repository
@@ -335,10 +300,8 @@ jobs:
 
   docs_stable:
     name: Doc build (stable, warnings denied)
-    needs: [authorize, get-features]
+    needs: get-features
     runs-on: ubuntu-latest
-
-    if: needs.authorize.outputs.trusted == 'true'
 
     steps:
       - name: Checkout repository
@@ -375,13 +338,11 @@ jobs:
 
   doc-tests:
     name: Doc tests (requires nightly Rust)
-    needs: [authorize, get-features]
+    needs: get-features
     # TODO: Remove this once cargo-llvm-cov can run doc tests and generate
     # coverage. (This requires a bug fix that is only available in nightly Rust.)
     # Watch https://github.com/taiki-e/cargo-llvm-cov/issues/2
     # for progress.
-
-    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -423,7 +384,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       # - name: Upload code coverage results
-      #   if: needs.authorize.outputs.same-repo == 'true'
+      #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       #   uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       #   with:
       #     token: ${{ secrets.CODECOV_TOKEN }}
@@ -432,8 +393,6 @@ jobs:
 
   cargo-check:
     name: Default features build
-    needs: authorize
-    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -454,8 +413,6 @@ jobs:
 
   cargo-lock:
     name: Cargo.lock is up to date
-    needs: authorize
-    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -473,8 +430,7 @@ jobs:
 
   tests-wasm:
     name: Unit tests (Wasm)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -512,8 +468,7 @@ jobs:
 
   tests-wasi:
     name: Unit tests (WASI)
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -561,8 +516,7 @@ jobs:
 
   clippy_check:
     name: Clippy
-    needs: [authorize, get-features]
-    if: needs.authorize.outputs.trusted == 'true'
+    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -587,8 +541,6 @@ jobs:
 
   cargo_fmt:
     name: Enforce Rust code format
-    needs: authorize
-    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 
@@ -607,8 +559,6 @@ jobs:
 
   cargo-deny:
     name: License / vulnerability audit
-    needs: authorize
-    if: needs.authorize.outputs.trusted == 'true'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -9,11 +9,12 @@
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
 #
-# On top of that scope, the suite only runs for trusted PRs (those whose branch
-# lives in this repository, plus fork PRs a maintainer has labeled `safe to
-# test`/`check-release`); see tier-1a.yml for why trust keys off the PR's head
-# repository rather than `author_association`. Both conditions are combined once
-# in the `authorize` job below into a single `run-suite` decision.
+# Fork-PR trust is handled by GitHub's "Fork pull request workflows from outside
+# collaborators" Actions setting (see tier-1a.yml), not by this workflow, so the
+# `authorize` job below only decides scope. A `labeled` event fires for every
+# label, so the scope decision also ignores label events unless the label added
+# is one that can bring a PR into scope (`release`/`check-release`); this keeps
+# an unrelated label (e.g. `backport-stable`) from restarting the suite.
 
 name: Tier 1B
 
@@ -46,7 +47,7 @@ jobs:
       - name: Determine whether to run the Tier 1B suite
         id: decide
         run: |
-          echo "run-suite=${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || contains(github.event.pull_request.labels.*.name, 'check-release')) && (github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')) }}" >> "$GITHUB_OUTPUT"
+          echo "run-suite=${{ (github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.base.ref == 'stable' || startsWith(github.event.pull_request.base.ref, 'v0.') || contains(github.event.pull_request.base.ref, '-rc') || contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'check-release')) && (github.event.action != 'labeled' || contains(fromJSON('["release", "check-release"]'), github.event.label.name)) }}" >> "$GITHUB_OUTPUT"
 
   get-features:
     name: Get features

--- a/.github/workflows/tier-2.yml
+++ b/.github/workflows/tier-2.yml
@@ -9,10 +9,11 @@
 # release-plz release PR. For a PR against `main`, add the "check-release" label
 # to run this suite on demand.
 #
-# On top of that scope, the suite only runs for trusted PRs (those whose branch
-# lives in this repository, plus fork PRs a maintainer has labeled `safe to
-# test`/`check-release`); see tier-1a.yml for why trust keys off the PR's head
-# repository rather than `author_association`.
+# Fork-PR trust is handled by GitHub's "Fork pull request workflows from outside
+# collaborators" Actions setting (see tier-1a.yml), not by this workflow, so the
+# `if:` below only decides scope, and ignores `labeled` events unless the label
+# added can bring a PR into scope (`release`/`check-release`); this keeps an
+# unrelated label (e.g. `backport-stable`) from restarting the suite.
 
 name: Tier 2
 
@@ -38,19 +39,17 @@ jobs:
   c-library-mobile-builds:
     name: C library mobile builds
 
-    # Trusted (same-repo branch, or fork PR labeled `safe to test`/
-    # `check-release`) AND in scope for the release-oriented Tier 2 suite.
+    # In scope for the release-oriented Tier 2 suite. (Fork-PR trust is enforced
+    # by GitHub's fork-approval setting; see tier-1a.yml.)
     if: >-
-      (github.event_name != 'pull_request' ||
-        github.event.pull_request.head.repo.full_name == github.repository ||
-        contains(github.event.pull_request.labels.*.name, 'safe to test') ||
-        contains(github.event.pull_request.labels.*.name, 'check-release')) &&
       (github.event_name == 'push' || github.event_name == 'schedule' ||
         github.event.pull_request.base.ref == 'stable' ||
         startsWith(github.event.pull_request.base.ref, 'v0.') ||
         contains(github.event.pull_request.base.ref, '-rc') ||
         contains(github.event.pull_request.labels.*.name, 'release') ||
-        contains(github.event.pull_request.labels.*.name, 'check-release'))
+        contains(github.event.pull_request.labels.*.name, 'check-release')) &&
+      (github.event.action != 'labeled' ||
+        contains(fromJSON('["release", "check-release"]'), github.event.label.name))
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
## Why

Two related CI annoyances:

1. **Adding any label to a PR restarts checks.** `tier-1a`/`tier-1b`/`tier-2` list `labeled` in their `pull_request` triggers, and GitHub fires `labeled` for *every* label (no way to filter by name in `on:`). An unrelated label like `backport-stable` spawns a full fresh run — for same-repo PRs that means re-running the entire required `tier-1a` suite.
2. **We hand-roll fork-PR trust in YAML** (`safe to test` / `head.repo` / `author_association` gymnastics) across five workflows — a reimplementation of a native GitHub feature.

## What this does

Deletes the custom trust logic and leans on GitHub's native gate:

- **`tier-1a.yml`** — drop `labeled` from the trigger; remove the `authorize` job and every `if: trusted` gate. Only fork-specific bit left is the Codecov upload `if:` (forks still get no secrets), inlined onto the 3 upload steps.
- **`tier-1b.yml` / `tier-2.yml`** — remove the trust clause; keep `labeled` for on-demand `release`/`check-release` scope, but add a label-name guard so only those labels re-trigger. `backport-stable` no longer restarts them.
- **`semver-checks.yml` / `check-no-patch-deps.yml`** — drop the trust `if:` (they always run on their triggers / `workflow_call`).
- Removes `safe to test` from the flow entirely. `check-release`/`release` survive purely as *scope* labels.

Required-check contexts (the `tier-1a` job names + `cargo-semver-checks`) are unchanged, so the branch rulesets need no edits. Net: **+46 / −108**.

## ⚠️ Prerequisite — do not merge before this is done

This is a **draft** because it depends on an admin settings change that **must land first**:

> **Settings → Actions → General → "Fork pull request workflows from outside collaborators" → "Require approval for all outside collaborators."**

If this YAML merges while that setting is off, fork PRs would run automatically with no trust gate (still no secrets, but untrusted code executing in CI unreviewed). Once the setting is enabled, mark this ready for review.

## Behavior after

| Scenario | Before | After |
|---|---|---|
| Same-repo PR, add `backport-stable` | full `tier-1a` re-run | no new run |
| Fork PR, opened | checks skipped until `safe to test` | checks pending until maintainer "Approve and run" |
| Add `check-release` to a main PR | runs tier-1b/2 | unchanged |
| Add unrelated label to a stable/`-rc` PR | re-runs tier-1b/2 | no re-run |

## Open question

Native approval may re-prompt on subsequent pushes from an outside collaborator, whereas `safe to test` persisted for the PR's life. Worth confirming before flipping the setting; likely a non-issue given how rarely we take fork PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)