### PR TITLE
ci: Reinstate the `safe to test` label in version-controlled labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,6 +11,10 @@
   color: "0e8a16"
   description: "release-plz release PR; runs the full Tier 1A+1B+2 suite"
 
+- name: safe to test
+  color: "0e8a16"
+  description: "Maintainer trusts this fork PR; allow secret-dependent CI to run"
+
 - name: check-release
   color: "1d76db"
   description: "Force the full Tier 1A+1B+2 suite on this PR"


### PR DESCRIPTION
## Problem

The `safe to test` label is the trust gate that lets maintainers allow secret-dependent CI to run on fork PRs. It is referenced by name in five workflows:

- `.github/workflows/tier-1a.yml`
- `.github/workflows/tier-1b.yml`
- `.github/workflows/tier-2.yml`
- `.github/workflows/semver-checks.yml`
- `.github/workflows/check-no-patch-deps.yml`

However, it was only ever created by hand in the GitHub UI and was never declared in `.github/labels.yml`. It has since been deleted, so maintainers can no longer apply it to greenlight a contributor's PR.

## Fix

Declare `safe to test` in `.github/labels.yml` (verified the exact name — lowercase with spaces — against the `contains(github.event.pull_request.labels.*.name, 'safe to test')` checks in the workflows). Once merged to `main`, the **Sync labels** workflow recreates it and keeps it version-controlled going forward.

The `skip_delete: true` setting means the labeler only creates/updates labels, so this is safe for existing labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)