### PR TITLE
ci: Reinstate the `safe to test` label in version-controlled labels (backport #2422)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,6 +11,10 @@
   color: "0e8a16"
   description: "release-plz release PR; runs the full Tier 1A+1B+2 suite"
 
+- name: safe to test
+  color: "0e8a16"
+  description: "Maintainer trusts this fork PR; allow secret-dependent CI to run"
+
 - name: check-release
   color: "1d76db"
   description: "Force the full Tier 1A+1B+2 suite on this PR"


### PR DESCRIPTION
Automated backport of #2422 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.