### PR TITLE
fix: Allow dc:created and dc:modified in c2pa.metadata (CAI-13221)

### DIFF
--- a/sdk/src/assertions/metadata.rs
+++ b/sdk/src/assertions/metadata.rs
@@ -147,7 +147,7 @@ impl AssertionBase for Metadata {
 lazy_static! {
     /// The c2pa.metadata assertion shall only contain certain schemas.
     ///
-    /// See [metadata_annex - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#metadata_annex)
+    /// See [metadata_annex - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#metadata_annex)
     static ref ALLOWED_SCHEMAS: HashMap<&'static str, &'static str> = vec![
         ("xmp", "http://ns.adobe.com/xap/1.0/"),
         ("xmpMM", "http://ns.adobe.com/xap/1.0/mm/"),
@@ -176,8 +176,8 @@ lazy_static! {
 
 /// The c2pa.metadata assertion shall only contain certain fields.
 ///
-/// See [metadata_annex - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#metadata_annex)
-static ALLOWED_FIELDS: [&str; 292] = [
+/// See [metadata_annex - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#metadata_annex)
+static ALLOWED_FIELDS: [&str; 294] = [
     // xmp:
     "xmp:CreateDate",
     "xmp:CreatorTool",
@@ -261,10 +261,12 @@ static ALLOWED_FIELDS: [&str; 292] = [
     "pdf:Trapped",
     // dc:
     "dc:coverage",
+    "dc:created",
     "dc:date",
     "dc:format",
     "dc:identifier",
     "dc:language",
+    "dc:modified",
     "dc:relation",
     "dc:type",
     // Iptc4xmpExt:
@@ -544,6 +546,18 @@ pub mod tests {
         }
         "#;
 
+    // dc:created and dc:modified were added to the supported Dublin Core
+    // properties for c2pa.metadata in version 2.4 of the C2PA technical
+    // specification.
+    const DC_TIMESTAMPS: &str = r#" {
+        "@context" : {
+            "dc" : "http://purl.org/dc/elements/1.1/"
+        },
+        "dc:created": "2025-08-13T00:00:00Z",
+        "dc:modified": "2025-08-14T00:00:00Z"
+        }
+        "#;
+
     const CUSTOM_METADATA: &str = r#" {
         "@context" : {
             "bar": "http://foo.com/bar/1.0/"
@@ -655,6 +669,14 @@ pub mod tests {
         assert!(!metadata.is_valid());
         // custom metadata does not have restriction on uris
         metadata.custom_metadata_label = Some("custom.metadata".to_owned());
+        assert!(metadata.is_valid());
+    }
+
+    #[test]
+    fn test_dc_created_modified() {
+        // dc:created and dc:modified are allowed in c2pa.metadata as of version
+        // 2.4 of the C2PA technical specification (CAI-13221).
+        let metadata = Metadata::new(METADATA, DC_TIMESTAMPS).unwrap();
         assert!(metadata.is_valid());
     }
 


### PR DESCRIPTION
## Summary

Version 2.4 of the C2PA technical specification added `dc:created` and `dc:modified` to the supported Dublin Core properties for the `c2pa.metadata` assertion ([§5.3.1 change log](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html): *"dc:created and dc:modified added to supported Dublin Core properties in c2pa.metadata"*).

These fields were **not** previously allowed: `Metadata::is_valid()` enforces the `ALLOWED_FIELDS` allowlist for the `c2pa.metadata` label, and only `dc:coverage`, `dc:date`, `dc:format`, `dc:identifier`, `dc:language`, `dc:relation`, and `dc:type` were permitted in the `dc:` namespace. Any assertion carrying `dc:created`/`dc:modified` would have failed validation.

Resolves [CAI-13221](https://jira.corp.adobe.com/browse/CAI-13221).

## Changes

- Add `dc:created` and `dc:modified` to `ALLOWED_FIELDS` (and bump the array length `292` -> `294`).
- Add a `test_dc_created_modified` test verifying both fields validate under the `c2pa.metadata` label.
- Update the metadata-annex spec links from 2.3 -> 2.4.

## Notes

- No `ALLOWED_SCHEMAS` change is needed — the `dc` namespace URI was already allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)