### PR TITLE
fix: Treat an unreachable ingredient manifest as absent when building a claim

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -9392,17 +9392,11 @@ mod tests {
         assert!(reader_json.contains("thumbnail.ingredient"));
     }
 
-    // An ingredient that references a manifest whose bytes are unavailable (e.g. a cloud-only
-    // manifest that was never fetched, or an ingredient reloaded without its resource store) must
-    // be treated as if it had no manifest, rather than failing archiving/signing with a
-    // "resource not found" error. `manifest_data_ref()` returns the dangling reference while
-    // `manifest_data()` already returns `None`.
-    #[test]
-    fn test_to_archive_tolerates_unreachable_ingredient_manifest() {
-        let mut builder = Builder::default()
-            .with_definition(simple_manifest_json())
-            .unwrap();
-
+    // Build an ingredient whose `manifest_data` reference points at bytes that are not present in
+    // any resource store: the dangling-reference scenario (a cloud-only manifest that was never
+    // fetched, or an ingredient reloaded without its resource store). `manifest_data_ref()` returns
+    // the dangling reference while `manifest_data()` already returns `None`.
+    fn unreachable_manifest_ingredient() -> Ingredient {
         let mut ingredient = Ingredient::new_v2("cloud-parent", "image/jpeg");
         ingredient.set_relationship(Relationship::ParentOf);
         ingredient.set_active_manifest("urn:c2pa:cloud-manifest");
@@ -9411,13 +9405,86 @@ mod tests {
             .unwrap();
         assert!(ingredient.manifest_data_ref().is_some());
         assert!(ingredient.manifest_data().is_none());
-        builder.add_ingredient(ingredient);
+        ingredient
+    }
+
+    // An ingredient that references a manifest whose bytes are unavailable must be treated as if it
+    // had no manifest, rather than failing archiving with a "resource not found" error.
+    #[test]
+    fn test_to_archive_tolerates_unreachable_ingredient_manifest() {
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
+        builder.add_ingredient(unreachable_manifest_ingredient());
 
         // Previously failed with Error::ResourceNotFound; the unreachable manifest is now dropped.
         let mut archive = Cursor::new(Vec::new());
         builder
             .to_archive(&mut archive)
             .expect("archive should tolerate an unreachable ingredient manifest");
+    }
+
+    // e2e: round-trip a builder that carries an unreachable ingredient manifest through an archive,
+    // then sign the reloaded builder. Signing must succeed, treating the dangling manifest as absent.
+    #[test]
+    fn test_sign_reloaded_archive_tolerates_unreachable_ingredient_manifest() {
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
+        builder.add_ingredient(unreachable_manifest_ingredient());
+
+        let mut archive = Cursor::new(Vec::new());
+        builder.to_archive(&mut archive).unwrap();
+        archive.rewind().unwrap();
+
+        let mut restored = Builder::default().with_archive(&mut archive).unwrap();
+
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        restored
+            .sign(
+                signer.as_ref(),
+                "image/jpeg",
+                &mut Cursor::new(TEST_IMAGE),
+                &mut dest,
+            )
+            .expect(
+                "signing a reloaded archive should tolerate an unreachable ingredient manifest",
+            );
+    }
+
+    // e2e: add a builder archive that carries an unreachable ingredient manifest as an ingredient of
+    // a new builder, then sign. Signing must succeed, treating the dangling manifest as absent.
+    #[test]
+    fn test_sign_with_added_archive_ingredient_tolerates_unreachable_ingredient_manifest() {
+        let mut source_builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
+        source_builder.add_ingredient(unreachable_manifest_ingredient());
+
+        let mut archive = Cursor::new(Vec::new());
+        source_builder.to_archive(&mut archive).unwrap();
+        archive.rewind().unwrap();
+
+        let mut signing_builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
+        signing_builder
+            .add_ingredient_from_archive(&mut archive)
+            .unwrap();
+
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut dest = Cursor::new(Vec::new());
+        signing_builder
+            .sign(
+                signer.as_ref(),
+                "image/jpeg",
+                &mut Cursor::new(TEST_IMAGE),
+                &mut dest,
+            )
+            .expect(
+                "signing with an added archive ingredient should tolerate an unreachable manifest",
+            );
     }
 
     /// `set_thumbnail` stores the format verbatim, bypassing `format_to_mime`.

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -9392,6 +9392,34 @@ mod tests {
         assert!(reader_json.contains("thumbnail.ingredient"));
     }
 
+    // An ingredient that references a manifest whose bytes are unavailable (e.g. a cloud-only
+    // manifest that was never fetched, or an ingredient reloaded without its resource store) must
+    // be treated as if it had no manifest, rather than failing archiving/signing with a
+    // "resource not found" error. `manifest_data_ref()` returns the dangling reference while
+    // `manifest_data()` already returns `None`.
+    #[test]
+    fn test_to_archive_tolerates_unreachable_ingredient_manifest() {
+        let mut builder = Builder::default()
+            .with_definition(simple_manifest_json())
+            .unwrap();
+
+        let mut ingredient = Ingredient::new_v2("cloud-parent", "image/jpeg");
+        ingredient.set_relationship(Relationship::ParentOf);
+        ingredient.set_active_manifest("urn:c2pa:cloud-manifest");
+        ingredient
+            .set_manifest_data_ref(ResourceRef::new("application/c2pa", "cloud_manifest.c2pa"))
+            .unwrap();
+        assert!(ingredient.manifest_data_ref().is_some());
+        assert!(ingredient.manifest_data().is_none());
+        builder.add_ingredient(ingredient);
+
+        // Previously failed with Error::ResourceNotFound; the unreachable manifest is now dropped.
+        let mut archive = Cursor::new(Vec::new());
+        builder
+            .to_archive(&mut archive)
+            .expect("archive should tolerate an unreachable ingredient manifest");
+    }
+
     /// `set_thumbnail` stores the format verbatim, bypassing `format_to_mime`.
     #[test]
     fn test_set_thumbnail_uppercase_mime_v1_claim() {

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1155,12 +1155,24 @@ impl Ingredient {
             .collect();
 
         // add the ingredient manifest_data to the claim
-        // this is how any existing claims are added to the new store
-        let (active_manifest, claim_signature) = match self.manifest_data_ref() {
-            Some(resource_ref) => {
-                // get the c2pa manifest bytes
-                let manifest_data = get_resource(&resource_ref.identifier)?;
-
+        // this is how any existing claims are added to the new store.
+        //
+        // A `manifest_data` reference whose bytes cannot be resolved (e.g. a cloud/remote manifest
+        // that was never fetched, or an ingredient reloaded without its resource store) is treated
+        // as if the ingredient had no manifest, mirroring `Ingredient::manifest_data`, rather than
+        // failing claim generation.
+        let manifest_data = self.manifest_data_ref().and_then(|resource_ref| {
+            get_resource(&resource_ref.identifier)
+                .inspect_err(|_| {
+                    debug!(
+                        "ingredient '{}' references a manifest whose bytes are unavailable; treating it as having no manifest",
+                        self.instance_id()
+                    );
+                })
+                .ok()
+        });
+        let (active_manifest, claim_signature) = match manifest_data {
+            Some(manifest_data) => {
                 // have Store check and load ingredients and add them to a claim
                 let ingredient_store =
                     Store::load_ingredient_to_claim(claim, &manifest_data, redactions, context)?;

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -1159,18 +1159,23 @@ impl Ingredient {
         //
         // A `manifest_data` reference whose bytes cannot be resolved (e.g. a cloud/remote manifest
         // that was never fetched, or an ingredient reloaded without its resource store) is treated
-        // as if the ingredient had no manifest, mirroring `Ingredient::manifest_data`, rather than
-        // failing claim generation.
-        let manifest_data = self.manifest_data_ref().and_then(|resource_ref| {
-            get_resource(&resource_ref.identifier)
-                .inspect_err(|_| {
+        // as if the ingredient had no manifest, like in `Ingredient::manifest_data`, rather than
+        // failing claim generation. Only "not found" errors are absorbed this way; any other error
+        // (e.g. from a resource resolver) still propagates.
+        let manifest_data = match self.manifest_data_ref() {
+            Some(resource_ref) => match get_resource(&resource_ref.identifier) {
+                Ok(manifest_data) => Some(manifest_data),
+                Err(Error::NotFound | Error::ResourceNotFound(_)) => {
                     debug!(
                         "ingredient '{}' references a manifest whose bytes are unavailable; treating it as having no manifest",
                         self.instance_id()
                     );
-                })
-                .ok()
-        });
+                    None
+                }
+                Err(e) => return Err(e),
+            },
+            None => None,
+        };
         let (active_manifest, claim_signature) = match manifest_data {
             Some(manifest_data) => {
                 // have Store check and load ingredients and add them to a claim


### PR DESCRIPTION
## Changes in this pull request

`Ingredient::add_to_claim` loads the bytes behind an ingredient's `manifest_data` reference with `?`, so a reference whose bytes cannot be resolved fails claim generation — `Builder::to_archive` (and signing) returns `Error::ResourceNotFound`. This happens for a legitimately unreachable manifest, e.g.:

- a cloud/remote manifest that was never fetched (offline), or
- an ingredient that was serialized to JSON — which `#[serde(skip)]`s its resource store — and later reloaded, leaving `manifest_data_ref()` set but the bytes gone.

`Ingredient::manifest_data()` already treats this case gracefully (returns `None`). This makes `add_to_claim` consistent: if the referenced bytes cannot be loaded, it logs at `debug` and treats the ingredient as having no manifest (the existing `None` arm) instead of erroring.

### Checklist

- [x] Added a test (`builder::tests::test_to_archive_tolerates_unreachable_ingredient_manifest`) reproducing the dangling-reference scenario.
- [x] `cargo +nightly fmt --all -- --check` clean; clippy clean on the changed crate.
- [x] `ingredient::` (18) and `builder::tests` (92) suites pass — no regressions from the behavior change.
