### PR TITLE
fix: Gate lopdf's rayon feature by real thread availability

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -122,7 +122,7 @@ img-parts = "0.4.0"
 iref = { version = "3.2.2", features = ["serde"] }
 jfifdump = "0.6.0"
 log = "0.4.30"
-lopdf = { version = "0.44.0", optional = true }
+lopdf = { version = "0.44.0", optional = true, default-features = false }
 lazy_static = "1.5.0"
 memchr = "2.8.1"
 nom = "7.1.3"
@@ -160,6 +160,10 @@ web-time = "1.1"
 x509-parser = "0.18.1"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 zip = { version = "8.6.0", default-features = false }
+
+# lopdf's rayon needs real threads: native always has them, WASM only with atomics.
+[target.'cfg(any(not(target_arch = "wasm32"), target_feature = "atomics"))'.dependencies]
+lopdf = { version = "0.44.0", optional = true }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
 reqwest = { version = "0.12.28", default-features = false, features = [


### PR DESCRIPTION
## Changes in this pull request

Enabling `pdf` (`dep:lopdf`) unconditionally pulls in lopdf's default features, which include `rayon`. On targets without real OS thread support (e.g. single-threaded WASM/Emscripten builds with no pthread support), rayon's global thread pool construction calls `std::thread::spawn` and panics when spawn fails - there's no graceful degradation.

lopdf already ships a serial fallback for both of its rayon call sites (`object_stream.rs`, `reader.rs`), gated behind `#[cfg(not(feature = "rayon"))]`. There was previously no way for a consumer to reach that path, since `c2pa`'s `lopdf` dependency didn't set `default-features = false`, so `rayon` came along for free with `pdf` regardless of target.

## Fix

`lopdf` now opts out of its default features and is re-declared with its defaults restored only under:

```toml
[target.'cfg(any(not(target_arch = "wasm32"), target_feature = "atomics"))'.dependencies]
```

- Native builds: always have real threads, so this is always true - identical behaviour to before.
- WASM builds compiled with atomics (threaded WASM, e.g. -C target-feature=+atomics): also true - identical behaviour to before.
- Single-threaded WASM (the case that was panicking): false, so lopdf falls back to its existing serial parsing path instead of touching rayon at all.

This restores today's behaviour everywhere it currently works and changes behaviour only for the one target family where it was actually broken. 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
