### PR TITLE
fix(sdk): Disable HTTP redirects in default resolver (CAI-12574)

### DIFF
--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -460,9 +460,14 @@ impl Context {
                             .set_allowed_hosts(self.settings.core.allowed_network_hosts.clone());
                         Arc::new(resolver)
                     } else {
-                        // For backwards compatibility, we enable redirects in the default case.
-                        // Source: https://github.com/contentauth/c2pa-rs/pull/1907
-                        Arc::new(SyncGenericResolver::with_redirects().unwrap_or_default())
+                        // Even with no allowed-host list configured, the default resolver must not
+                        // follow HTTP redirects. `SyncGenericResolver::new` disables them
+                        // (`max_redirects(0)`), which prevents an attacker-controlled remote
+                        // manifest URL from bouncing the SDK to an internal or cloud-metadata
+                        // endpoint via a 3xx response (SSRF – CAI-12574). Redirect following was
+                        // previously enabled here for backwards compatibility (PR #1907); it is
+                        // now disabled because the SDK cannot inspect intermediate redirect hops.
+                        Arc::new(SyncGenericResolver::new())
                     }
                 })
                 .clone(),
@@ -484,9 +489,14 @@ impl Context {
                             .set_allowed_hosts(self.settings.core.allowed_network_hosts.clone());
                         Arc::new(resolver)
                     } else {
-                        // For backwards compatibility, we enable redirects in the default case.
-                        // Source: https://github.com/contentauth/c2pa-rs/pull/1907
-                        Arc::new(AsyncGenericResolver::with_redirects().unwrap_or_default())
+                        // Even with no allowed-host list configured, the default resolver must not
+                        // follow HTTP redirects. `AsyncGenericResolver::new` disables them
+                        // (`redirect::Policy::none()`), which prevents an attacker-controlled
+                        // remote manifest URL from bouncing the SDK to an internal or cloud-metadata
+                        // endpoint via a 3xx response (SSRF – CAI-12574). Redirect following was
+                        // previously enabled here for backwards compatibility (PR #1907); it is
+                        // now disabled because the SDK cannot inspect intermediate redirect hops.
+                        Arc::new(AsyncGenericResolver::new())
                     }
                 })
                 .clone(),
@@ -1070,6 +1080,87 @@ mod tests {
     fn test_default_async_resolver() {
         let context = Context::new();
         let _resolver = context.resolver_async();
+    }
+
+    // The default resolver (no `allowed_network_hosts` configured) must not follow HTTP
+    // redirects. A malicious remote manifest URL could otherwise return a 302 pointing at an
+    // internal or cloud-metadata endpoint, resulting in SSRF (CAI-12574).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_default_sync_resolver_does_not_follow_redirects() {
+        use std::io::Read;
+
+        use http::Request;
+        use httpmock::MockServer;
+
+        use crate::http::SyncHttpResolver;
+
+        let server = MockServer::start();
+        let redirect = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/redirect");
+            then.status(302)
+                .header("Location", "http://169.254.169.254/latest/meta-data/");
+        });
+        let canary = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/canary");
+            then.status(200).body([1, 2, 3]);
+        });
+
+        let context = Context::new();
+        let resolver = context.resolver();
+
+        let request = Request::get(format!("{}/redirect", server.base_url()))
+            .body(vec![])
+            .unwrap();
+
+        let response = resolver.http_resolve(request).unwrap();
+
+        // The resolver returns the 302 itself rather than following it.
+        assert_eq!(response.status(), 302);
+        let mut body = Vec::new();
+        response.into_body().read_to_end(&mut body).unwrap();
+
+        redirect.assert_calls(1);
+        canary.assert_calls(0);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_default_async_resolver_does_not_follow_redirects() {
+        use std::io::Read;
+
+        use http::Request;
+        use httpmock::MockServer;
+
+        use crate::http::AsyncHttpResolver;
+
+        let server = MockServer::start();
+        let redirect = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/redirect");
+            then.status(302)
+                .header("Location", "http://169.254.169.254/latest/meta-data/");
+        });
+        let canary = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/canary");
+            then.status(200).body([1, 2, 3]);
+        });
+
+        let context = Context::new();
+        let resolver = context.resolver_async();
+
+        let request = Request::get(format!("{}/redirect", server.base_url()))
+            .body(vec![])
+            .unwrap();
+
+        let response = resolver.http_resolve_async(request).await.unwrap();
+
+        // The resolver returns the 302 itself rather than following it.
+        assert_eq!(response.status(), 302);
+        let mut body = Vec::new();
+        response.into_body().read_to_end(&mut body).unwrap();
+
+        redirect.assert_calls(1);
+        canary.assert_calls(0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the SSRF-via-HTTP-redirect bypass reported in CAI-12574 (HackerOne #3784091).

The default HTTP resolver path — used when `allowed_network_hosts` is **not** configured (the default) — built its client with `with_redirects()`, which follows 3xx responses internally with no host validation. Opening a malicious asset with an attacker-controlled remote-manifest URL (e.g. `dcterms:provenance` XMP) triggers an outbound request; the attacker's server responds `302 → http://169.254.169.254/latest/meta-data/` and the SDK follows it, yielding SSRF to internal / cloud-metadata endpoints.

The earlier `max_redirects(0)` hardening only covered the `RestrictedResolver`-wrapped path taken when `allowed_network_hosts` **is** set, so the default configuration bypassed it entirely.

## Change

- `sdk/src/context.rs` `resolver()` / `resolver_async()`: the default (no-allowlist) branch now uses `SyncGenericResolver::new()` / `AsyncGenericResolver::new()`, which disable redirects (`max_redirects(0)` / `redirect::Policy::none()`). Redirect-following is now off in **every** configuration.

Because ureq/reqwest follow redirects internally, `RestrictedResolver` cannot inspect intermediate hops — "validate each redirect target" is not achievable without re-implementing redirect-following. Disabling redirects by default is the approach agreed in the ticket discussion.

## Context

- The prior remediation (PR #2402) was **documentation-only** and changed no code, which is why the default path kept following redirects.
- Redirect-following was originally enabled in this path for backwards compatibility (PR #1907).

## Tests

Adds sync + async regression tests that stand up an httpmock server returning `302 → http://169.254.169.254/latest/meta-data/` and assert the default resolver returns the 302 itself and never calls the redirect target.

## Follow-up

#2430 tracks a separate, pre-existing residual: in the default config an attacker can point a manifest URL **directly** at an internal/metadata IP (no redirect). That hardening has backwards-compat tradeoffs (localhost/intranet fetching) and is scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)