### PR TITLE
fix: Builder.save_to_stream was not adding timestamp assertions CAI-21732

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -3198,8 +3198,8 @@ impl Builder {
     /// This provides a simpler alternative to [`sign()`](Self::sign) when you want to use
     /// the context's configured signer rather than providing an explicit signer.
     ///
-    /// **Note**: This method is only available for synchronous signing. For async signing,
-    /// use [`sign_async()`](Self::sign_async) with an explicit async signer.
+    /// **Note**: An async signer must be set explicitly with [`Context::with_async_signer()`],
+    /// since async signers cannot currently be created automatically from settings.
     ///
     /// # Arguments
     /// * `format` - The format of the stream.
@@ -3240,6 +3240,7 @@ impl Builder {
     /// # Ok(())
     /// # }
     /// ```
+    #[async_generic()]
     pub fn save_to_stream<R, W>(
         &mut self,
         format: &str,
@@ -3250,30 +3251,16 @@ impl Builder {
         R: Read + Seek + Send,
         W: Write + Read + Seek + Send,
     {
-        let format = format_to_mime(format);
-        self.definition.format.clone_from(&format);
-        if let Some(instance_id) = XmpInfo::from_source(source, &format).instance_id {
-            self.definition.instance_id = instance_id;
+        // Clone the Arc (cheap) so the signer borrowed from it doesn't keep
+        // `self` immutably borrowed while `sign`/`sign_async` need `&mut self`.
+        let ctx = Arc::clone(&self.context);
+        if _sync {
+            let signer = ctx.signer()?;
+            self.sign(signer, format, source, dest)
+        } else {
+            let signer = ctx.async_signer()?;
+            self.sign_async(signer, format, source, dest).await
         }
-        source.rewind()?;
-
-        #[cfg(feature = "file_io")]
-        self.apply_resource_base_path();
-
-        self.maybe_add_parent(&format, source)?;
-
-        // generate thumbnail if we don't already have one
-        #[cfg(feature = "add_thumbnails")]
-        self.maybe_add_thumbnail(&format, source)?;
-
-        // convert the manifest to a store
-        let mut store = self.to_store()?;
-
-        // Get signer from context
-        let signer = self.context.signer()?;
-
-        // sign and write our store to to the output image file
-        store.save_to_stream(&format, source, dest, signer, &self.context)
     }
 
     #[cfg(feature = "file_io")]

--- a/sdk/tests/timestamp_assertion.rs
+++ b/sdk/tests/timestamp_assertion.rs
@@ -25,7 +25,7 @@ const TEST_IMAGE: &[u8] = include_bytes!("fixtures/no_manifest.jpg");
 const FORMAT: &str = "image/jpeg";
 
 // Basic wrapper around a Signer to include a time authority URL.
-struct WrappedTsaSigner(Box<dyn Signer>);
+struct WrappedTsaSigner(Box<dyn Signer + Send + Sync>);
 
 impl Signer for WrappedTsaSigner {
     fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
@@ -239,6 +239,61 @@ fn timestamp_assertion_explicit_builder() {
         .unwrap();
     assert!(timestamp_assertion
         .get_timestamp(child_manifest_label)
+        .is_some());
+}
+
+// Sign a manifest with a child ingredient using an explicit signer, then use `save_to_stream`
+// (which resolves the signer from the context instead of taking one explicitly) to sign the
+// parent manifest and confirm the timestamp assertion is still added.
+#[test]
+fn timestamp_assertion_save_to_stream() {
+    let settings = test_settings();
+    let context = Context::new().with_settings(settings).unwrap();
+
+    let mut child_image = Cursor::new(Vec::new());
+
+    let mut builder = Builder::from_context(context);
+    builder
+        .sign(
+            &WrappedTsaSigner(Box::new(common::test_signer())),
+            FORMAT,
+            &mut Cursor::new(TEST_IMAGE),
+            &mut child_image,
+        )
+        .unwrap();
+
+    child_image.rewind().unwrap();
+    let reader = Reader::default()
+        .with_stream(FORMAT, &mut child_image)
+        .unwrap();
+    let child_manifest_label = reader.active_label().unwrap().to_owned();
+    child_image.rewind().unwrap();
+
+    let parent_context = Context::new()
+        .with_settings(test_settings())
+        .unwrap()
+        .with_signer(WrappedTsaSigner(Box::new(common::test_signer())));
+
+    let mut builder = Builder::from_context(parent_context);
+    builder.set_intent(BuilderIntent::Update);
+    builder.add_timestamp(child_manifest_label.as_str());
+
+    let mut parent_image = Cursor::new(Vec::new());
+    builder
+        .save_to_stream(FORMAT, &mut child_image, &mut parent_image)
+        .unwrap();
+
+    parent_image.rewind().unwrap();
+
+    let reader = Reader::default().with_stream(FORMAT, parent_image).unwrap();
+    let timestamp_assertion: TimeStamp = reader
+        .active_manifest()
+        .unwrap()
+        .find_assertion(assertions::labels::TIMESTAMP)
+        .unwrap();
+
+    assert!(timestamp_assertion
+        .get_timestamp(&child_manifest_label)
         .is_some());
 }
 


### PR DESCRIPTION
Updated so that save_to_stream just gets the signer from the context and calls sign, so they are now identical.

This also fixes save_to_file but does not change sign_data_hashed embeddable or sign_embeddable

those methods have never done all the things that sign does - like adding thumbnails

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
