### PR TITLE
fix: Gate lopdf's rayon feature by real thread availability (backport #2428)

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -131,7 +131,7 @@ img-parts = "0.4.0"
 iref = { version = "3.2.2", features = ["serde"] }
 jfifdump = "0.6.0"
 log = "0.4.30"
-lopdf = { version = "0.44.0", optional = true }
+lopdf = { version = "0.44.0", optional = true, default-features = false }
 lazy_static = "1.5.0"
 memchr = "2.8.1"
 nom = "7.1.3"
@@ -180,6 +180,10 @@ web-time = "1.1"
 x509-parser = "0.18.1"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 zip = { version = "8.6.0", default-features = false }
+
+# lopdf's rayon needs real threads: native always has them, WASM only with atomics.
+[target.'cfg(any(not(target_arch = "wasm32"), target_feature = "atomics"))'.dependencies]
+lopdf = { version = "0.44.0", optional = true }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
 reqwest = { version = "0.12.28", default-features = false, features = [


### PR DESCRIPTION
Automated backport of #2428 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.