### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.8](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.7...c2pa-v0.90.8)
+_07 August 2026_
+
+### Fixed
+
+* Ensure inception action is only auto-added once (backport #2438) ([#2444](https://github.com/contentauth/c2pa-rs/pull/2444))
+* Chain resources in `Builder::add_ingredient_from_stream` (backport #2432) ([#2442](https://github.com/contentauth/c2pa-rs/pull/2442))
+
 ## [0.90.7](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.6...c2pa-v0.90.7)
 _07 August 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.7"
+version = "0.90.8"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.7"
+version = "0.90.8"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.7"
+version = "0.90.8"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.7"
+version = "0.27.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.7"
+version = "0.90.8"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -1571,9 +1571,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -2597,7 +2597,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.7"
+version = "0.90.8"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -3564,9 +3564,9 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rasn"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88235e585f2f3fc26ad809c79a84dd77e6a7203eb7d12e5bcaab89fc036d3d90"
+checksum = "0d1b71dd951343df0fe30b11bca09518f3aba8e5bd0ece4564adbc2dabd875fa"
 dependencies = [
  "bitvec",
  "bitvec-nom2",
@@ -3587,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-cms"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37feeda266abb6b1a2dbc2cdf7158b3769ae62222fbab5f350010d62ec82e35b"
+checksum = "7b4abf4c2fe5537b99e2bf3099a7ad26e40bd9cf51bc003600ed58dbbff69a1c"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
+checksum = "979eafa601d351f7f6490f1d2f4decc168e8e51cb6517c6c6ff80111951129d5"
 dependencies = [
  "proc-macro2",
  "rasn-derive-impl",
@@ -3608,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-derive-impl"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f121c276d3f2fba8caabc870288de3f81abdb0bb94d5510651e58e1e00a7b9e7"
+checksum = "eee3136c97d6f2553c0d9f84d2c2555bb87ae9b365c5c9274e8bc5c366174431"
 dependencies = [
  "either",
  "itertools 0.13.0",
@@ -3622,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-ocsp"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecdca1d20c3d6eb377a652e21c0f06ca96b76cbacbb22a4aba1cf76714c8d42"
+checksum = "f8bf6709bc94437d12614fd2d34463c3478d981bf913286812cc50bb093bc657"
 dependencies = [
  "rasn",
  "rasn-pkix",
@@ -3632,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "rasn-pkix"
-version = "0.28.13"
+version = "0.28.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8a385ace6c844d2389fdfe8c82637dd742d7b997a6fb5826dbb97f4539057e"
+checksum = "c029da7ed3b94dd93b75299431984081c1eaf88ce79771c21b056f0ebf6fb964"
 dependencies = [
  "rasn",
 ]
@@ -5589,9 +5589,9 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.7"
+version = "0.90.8"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.7", default-features = false }
+c2pa = { path = "sdk", version = "0.90.8", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.8](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.7...c2patool-v0.27.8)
+_07 August 2026_
+
 ## [0.27.7](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.6...c2patool-v0.27.7)
 _07 August 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.7"
+version = "0.27.8"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.7 -> 0.90.8 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.7 -> 0.90.8
* `c2patool`: 0.27.7 -> 0.27.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.8](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.7...c2pa-v0.90.8)

_07 August 2026_

### Fixed

* Ensure inception action is only auto-added once (backport #2438) ([#2444](https://github.com/contentauth/c2pa-rs/pull/2444))
* Chain resources in `Builder::add_ingredient_from_stream` (backport #2432) ([#2442](https://github.com/contentauth/c2pa-rs/pull/2442))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.90.4)

_04 August 2026_

### Fixed

* Emscripten build which lost its header (backport #2395) ([#2396](https://github.com/contentauth/c2pa-rs/pull/2396))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.8](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.7...c2patool-v0.27.8)

_07 August 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).