### PR TITLE
fix: chain resources in `Builder::add_ingredient_from_stream` (backport #2432)

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -1288,6 +1288,7 @@ impl Builder {
 
         #[allow(unused_mut)]
         let mut ingredient: Ingredient = Ingredient::from_json(&ingredient_json.into())?;
+        ingredient.chain_resolver_to(&mut self.resources);
 
         if format == "c2pa" || format == "application/c2pa" {
             let parent_ingredient = self.add_ingredient_from_archive(stream)?;


### PR DESCRIPTION
Automated backport of #2432 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.