### PR TITLE
fix: Reject BMFF Merkle map location that overflows u32 chunk index (CAI-12884)

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1505,7 +1505,14 @@ impl BmffHash {
                         // finalize leaf hashes
                         let mut leaf_hashes = Vec::new();
                         for chunk_bmff_mm in &track_to_bmff_merkle_map[&(track_id as usize)] {
-                            match chunk_hash_map.remove(&(chunk_bmff_mm.location as u32 + 1)) {
+                            // `location` is attacker-controlled (deserialized from the
+                            // file's uuid merkle box), so both the u32 conversion and the
+                            // +1 must be checked rather than wrapping/panicking.
+                            let chunk_id = u32::try_from(chunk_bmff_mm.location)
+                                .ok()
+                                .and_then(|loc| loc.checked_add(1));
+
+                            match chunk_id.and_then(|id| chunk_hash_map.remove(&id)) {
                                 Some(h) => {
                                     let h = Hasher::finalize(h);
                                     leaf_hashes.push(h);

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -1111,3 +1111,92 @@ fn track_without_chunk_offsets_is_skipped() {
 fn track_without_stsz_is_skipped() {
     assert_dropped_track_rejected(b"stsz");
 }
+
+// --- Regression: CAI-12884 / VULN-36815 -------------------------------------
+//
+// A crafted C2PA merkle `uuid` box declaring `BmffMerkleMap.location =
+// u32::MAX` drove an integer overflow panic in this crate's own
+// `verify_stream_hash_with_progress`: `chunk_bmff_mm.location as u32 + 1`
+// overflows when the (attacker-controlled, CBOR-deserialized) `location`
+// casts to `u32::MAX`. Unlike CAI-12939, this bug has nothing to do with the
+// removed `mp4` crate -- it lives entirely in `bmff_hash.rs`, in the
+// "finalize leaf hashes" step that runs after sample reading succeeds.
+
+/// Builds the same `uuid` merkle box as [`build_merkle_uuid_box`], but with a
+/// `location` value encoded as a full CBOR `u32` (major type 0, additional
+/// info 26) instead of the small-int encoding `put_uint` produces, so
+/// `location` can be set to values as large as `u32::MAX`.
+fn build_merkle_uuid_box_with_u32_location(
+    unique_id: u64,
+    local_id: u64,
+    location: u32,
+) -> Vec<u8> {
+    let mut cbor = vec![0xa3];
+    cbor.extend_from_slice(&[0x68]);
+    cbor.extend_from_slice(b"uniqueId");
+    cbor.push(unique_id as u8);
+    cbor.extend_from_slice(&[0x67]);
+    cbor.extend_from_slice(b"localId");
+    cbor.push(local_id as u8);
+    cbor.extend_from_slice(&[0x68]);
+    cbor.extend_from_slice(b"location");
+    cbor.push(0x1a);
+    cbor.extend_from_slice(&location.to_be_bytes());
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&C2PA_UUID);
+    payload.extend_from_slice(&[0u8; 4]);
+    payload.extend_from_slice(b"merkle\x00");
+    payload.extend_from_slice(&cbor);
+    build_box(b"uuid", &payload)
+}
+
+/// A `location = u32::MAX` merkle box must be rejected with an error, not
+/// panic. (Before the checked conversion, this input panicked with an
+/// integer-overflow abort at `bmff_hash.rs:1508`.)
+#[test]
+fn location_u32_max_does_not_panic() {
+    let track = TrackSpec {
+        track_id: 1,
+        stsc: vec![StscEntry {
+            first_chunk: 1,
+            samples_per_chunk: 1,
+            sample_description_index: 1,
+        }],
+        sample_sizes: SampleSizes::Variable(vec![23]),
+        use_co64: false,
+    };
+    let sample: &[u8] = b"hello world sample data";
+    let (file, roots) = build_single_track_asset(track, &[sample]);
+
+    // Replace the single, auto-generated `location = 0` uuid box with one
+    // declaring `location = u32::MAX`. The replacement box is a different
+    // length, so the single `stco` chunk offset (the only absolute file
+    // offset in the asset) needs shifting by the same delta.
+    let ftyp_len = build_box(b"ftyp", b"isom\x00\x00\x00\x00isom").len();
+    let old_uuid = build_merkle_uuid_box(0, 1, 0);
+    let bad_uuid = build_merkle_uuid_box_with_u32_location(0, 1, u32::MAX);
+    let delta = bad_uuid.len() as i64 - old_uuid.len() as i64;
+
+    let mut file = file;
+    file.splice(ftyp_len..ftyp_len + old_uuid.len(), bad_uuid);
+
+    let stco_pos = file
+        .windows(4)
+        .position(|w| w == b"stco")
+        .expect("stco box present");
+    let off_pos = stco_pos + 4 + 4 + 4; // fourcc -> version/flags -> entry_count
+    let old_off = u32::from_be_bytes(file[off_pos..off_pos + 4].try_into().unwrap());
+    let new_off = (old_off as i64 + delta) as u32;
+    file[off_pos..off_pos + 4].copy_from_slice(&new_off.to_be_bytes());
+
+    let bmff_hash = track_merkle_assertion(1, &roots);
+    let mut reader = Cursor::new(file);
+    let err = bmff_hash
+        .verify_stream_hash(&mut reader, Some("sha256"))
+        .expect_err("a location of u32::MAX must be rejected, not overflow");
+    assert!(
+        matches!(err, c2pa::Error::HashMismatch(_)),
+        "expected a clean rejection, got: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- CAI-12884 (HackerOne VULN-36815) reports a crafted MP4 whose C2PA merkle `uuid` box declares `BmffMerkleMap.location = u32::MAX`. In `BmffHash::verify_stream_hash_with_progress`'s leaf-hash finalization step, `chunk_bmff_mm.location as u32 + 1` overflows and panics ("attempt to add with overflow"), since `location` is a `usize` deserialized straight from attacker-controlled CBOR.
- Note this is **not** related to the recently-removed `mp4` crate (CAI-12277): the panic site is c2pa-rs's own code in `sdk/src/assertions/bmff_hash.rs`, in the step that runs *after* sample reading succeeds. I confirmed by reproduction that it's still live on current `main`.
- Fix: convert `location` to `u32` with a checked `try_from`, and use `checked_add(1)` for the chunk-index computation, so a malformed/out-of-range `location` is rejected with `Error::HashMismatch` instead of aborting the process.
- Added a regression test (`location_u32_max_does_not_panic`) reproducing the reporter's exact PoC value and asserting a clean rejection.

## Test plan

- [x] `cargo test -p c2pa --test bmff_timed_media_merkle` — all 23 tests pass, including the new regression test
- [x] `cargo test -p c2pa --lib --features file_io` — 941 passed
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy -p c2pa --lib --test bmff_timed_media_merkle` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)