### PR TITLE
feat: Add related assertions field and validation to c2pa.actions

### DIFF
--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -422,6 +422,9 @@ pub struct ActionParameters {
     /// Was this action performed multiple times.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiple_instances: Option<bool>,
+    /// Hashed JUMBF URI(s) to assertion(s) related to this action that are neither ingredients nor actions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_assertions: Option<Vec<HashedUri>>,
 
     /// Anything from the common parameters.
     #[serde(flatten)]
@@ -607,6 +610,13 @@ impl Action {
     /// See [Related actions - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_related_actions).
     pub fn related(&self) -> Option<&[Action]> {
         self.related.as_deref()
+    }
+
+    /// Returns the list of hashed URIs to assertions related to this action.
+    pub fn related_assertions(&self) -> Option<&[HashedUri]> {
+        self.parameters
+            .as_ref()
+            .and_then(|parameters| parameters.related_assertions.as_deref())
     }
 
     /// Returns the reason why this action was performed.

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2656,7 +2656,7 @@ impl Claim {
 
                         if assertion.is_none() {
                             log_item!(
-                                label.clone(),
+                                url.clone(),
                                 format!("relatedAssertions reference could not be resolved within the current manifest: {url}"),
                                 "verify_actions"
                             )
@@ -2676,7 +2676,7 @@ impl Claim {
                         let base = labels::base(&target_label);
                         if base == labels::ACTIONS || base == labels::INGREDIENT {
                             log_item!(
-                                label.clone(),
+                                url.clone(),
                                 format!("relatedAssertions must not reference an actions or ingredient assertion: {url}"),
                                 "verify_actions"
                             )

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2651,13 +2651,13 @@ impl Claim {
                         } else {
                             manifest_label_from_uri(&url).as_deref() == Some(claim.label())
                         };
-                        let assertions = if in_current_manifest {
+                        let assertion = if in_current_manifest {
                             claim.get_claim_assertion(&target_label, instance)
                         } else {
                             None
                         };
 
-                        if assertions.is_none() {
+                        if assertion.is_none() {
                             log_item!(
                                 label.clone(),
                                 format!("relatedAssertions reference could not be resolved within the current manifest: {url}"),

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2618,7 +2618,7 @@ impl Claim {
                 // 2.f if the action’s parameters field exists and contains a relatedAssertions field
                 if let Some(related_assertions) = action
                     .parameters()
-                    .and_then(|p| p.related_assertions.as_ref())
+                    .and_then(|parameters| parameters.related_assertions.as_ref())
                 {
                     // 2.f.i if the value of relatedAssertions is not an array with at least one element,
                     //       the claim shall be rejected with a failure code of assertion.action.malformed

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -4448,7 +4448,7 @@ pub mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use crate::{resource_store::UriOrResource, utils::test::create_test_claim};
+    use crate::{resource_store::UriOrResource, utils::test::create_test_claim, DigitalSourceType};
 
     #[test]
     fn test_build_claim() {
@@ -5272,6 +5272,98 @@ pub mod tests {
         assert!(
             !log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
             "c2pa.translated with both languages should not be malformed"
+        );
+    }
+
+    fn verify_related_assertions(claim: &mut Claim, related: Vec<HashedUri>) -> StatusTracker {
+        let edited = Action::new(c2pa_action::EDITED)
+            .set_parameter("relatedAssertions", related)
+            .unwrap();
+        let actions = Actions::new()
+            .add_action(
+                Action::new(c2pa_action::CREATED)
+                    .set_source_type(DigitalSourceType::AlgorithmicMedia),
+            )
+            .add_action(edited);
+        claim.add_assertion(&actions).unwrap();
+
+        let svi = StoreValidationInfo::default();
+        let settings = Settings::default();
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::ContinueWhenPossible);
+        Claim::verify_actions(claim, &svi, &mut validation_log, &settings).unwrap();
+
+        validation_log
+    }
+
+    #[test]
+    fn test_verify_related_assertions_empty_rejected() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let log = verify_related_assertions(&mut claim, vec![]);
+        assert!(
+            log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "empty relatedAssertions should be malformed"
+        );
+    }
+
+    #[test]
+    fn test_verify_related_assertions_unresolvable_rejected() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let uri = HashedUri::new(
+            to_assertion_uri(claim.label(), "com.example.missing"),
+            Some("sha256".to_string()),
+            b"hash",
+        );
+        let log = verify_related_assertions(&mut claim, vec![uri]);
+        assert!(
+            log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "unresolvable relatedAssertions reference should be malformed"
+        );
+    }
+
+    #[test]
+    fn test_verify_related_assertions_references_actions_rejected() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let uri = HashedUri::new(
+            to_assertion_uri(claim.label(), Actions::LABEL_VERSIONED),
+            Some("sha256".to_string()),
+            b"hash",
+        );
+        let log = verify_related_assertions(&mut claim, vec![uri]);
+        assert!(
+            log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "relatedAssertions referencing an actions assertion should be malformed"
+        );
+    }
+
+    #[test]
+    fn test_verify_related_assertions_references_ingredient_rejected() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let ingredient_uri = claim
+            .add_assertion(&Ingredient::new_v3(Relationship::ComponentOf))
+            .unwrap();
+        let log = verify_related_assertions(&mut claim, vec![ingredient_uri]);
+        assert!(
+            log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "relatedAssertions referencing an ingredient assertion should be malformed"
+        );
+    }
+
+    #[test]
+    fn test_verify_related_assertions_valid() {
+        use crate::assertions::UserCbor;
+
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let uri = claim
+            .add_assertion(&UserCbor::new(
+                "com.example.related",
+                c2pa_cbor::to_vec(&"related payload").unwrap(),
+            ))
+            .unwrap();
+        let log = verify_related_assertions(&mut claim, vec![uri]);
+        assert!(
+            !log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "relatedAssertions referencing an allowed assertion should not be malformed"
         );
     }
 

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2667,7 +2667,7 @@ impl Claim {
                             .failure_no_throw(
                                 validation_log,
                                 Error::ValidationRule(
-                                    "relatedAssertions reference could not be resolved within the current manifest".into(),
+                                format!("relatedAssertions reference could not be resolved within the current manifest: {url}"),
                                 ),
                             );
                         }
@@ -2687,7 +2687,7 @@ impl Claim {
                             .failure_no_throw(
                                 validation_log,
                                 Error::ValidationRule(
-                                    "relatedAssertions must not reference an actions or ingredient assertion".into(),
+                                format!("relatedAssertions must not reference an actions or ingredient assertion: {url}"),
                                 ),
                             );
                         }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2616,10 +2616,7 @@ impl Claim {
                 }
 
                 // 2.f if the action’s parameters field exists and contains a relatedAssertions field
-                if let Some(related_assertions) = action
-                    .parameters()
-                    .and_then(|parameters| parameters.related_assertions.as_ref())
-                {
+                if let Some(related_assertions) = action.related_assertions() {
                     // 2.f.i if the value of relatedAssertions is not an array with at least one element,
                     //       the claim shall be rejected with a failure code of assertion.action.malformed
                     if related_assertions.is_empty() {

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2615,6 +2615,85 @@ impl Claim {
                     }
                 }
 
+                // 2.f if the action’s parameters field exists and contains a relatedAssertions field
+                if let Some(related_assertions) = action
+                    .parameters()
+                    .and_then(|p| p.related_assertions.as_ref())
+                {
+                    // 2.f.i if the value of relatedAssertions is not an array with at least one element,
+                    //       the claim shall be rejected with a failure code of assertion.action.malformed
+                    if related_assertions.is_empty() {
+                        log_item!(
+                            label.clone(),
+                            "relatedAssertions must contain at least one entry",
+                            "verify_actions"
+                        )
+                        .validation_status(validation_status::ASSERTION_ACTION_MALFORMED)
+                        .failure_no_throw(
+                            validation_log,
+                            Error::ValidationRule(
+                                "relatedAssertions must contain at least one entry".into(),
+                            ),
+                        );
+                    }
+
+                    for related in related_assertions {
+                        let url = related.url();
+
+                        // 2.f.ii.B resolve the hashed URI to locate the referenced assertion
+                        let (target_label, instance) = Claim::assertion_label_from_link(&url);
+
+                        // 2.f.ii.C if the referenced assertion cannot be resolved, or does not
+                        //          resolve to an assertion within the current manifest, the claim
+                        //          shall be rejected with a failure code of assertion.action.malformed
+                        let in_current_manifest = if related.is_relative_url() {
+                            true
+                        } else {
+                            manifest_label_from_uri(&url).as_deref() == Some(claim.label())
+                        };
+                        let assertions = if in_current_manifest {
+                            claim.get_claim_assertion(&target_label, instance)
+                        } else {
+                            None
+                        };
+
+                        if assertions.is_none() {
+                            log_item!(
+                                label.clone(),
+                                format!("relatedAssertions reference could not be resolved within the current manifest: {url}"),
+                                "verify_actions"
+                            )
+                            .validation_status(validation_status::ASSERTION_ACTION_MALFORMED)
+                            .failure_no_throw(
+                                validation_log,
+                                Error::ValidationRule(
+                                    "relatedAssertions reference could not be resolved within the current manifest".into(),
+                                ),
+                            );
+                        }
+
+                        // 2.f.ii.D If the referenced assertion is of of type c2pa.ingredients,
+                        //          c2pa.ingredients.v2, c2pa.ingredients.v3, c2pa.actions, or
+                        //          c2pa.actions.v2, the claim shall be rejected with a failure
+                        //          code of assertion.action.malformed.
+                        let base = labels::base(&target_label);
+                        if base == labels::ACTIONS || base == labels::INGREDIENT {
+                            log_item!(
+                                label.clone(),
+                                format!("relatedAssertions must not reference an actions or ingredient assertion: {url}"),
+                                "verify_actions"
+                            )
+                            .validation_status(validation_status::ASSERTION_ACTION_MALFORMED)
+                            .failure_no_throw(
+                                validation_log,
+                                Error::ValidationRule(
+                                    "relatedAssertions must not reference an actions or ingredient assertion".into(),
+                                ),
+                            );
+                        }
+                    }
+                }
+
                 // 2.h check softwareAgent icons
                 let mut icons = Vec::new();
                 if let Some(assertions::SoftwareAgent::ClaimGeneratorInfo(cgi)) =


### PR DESCRIPTION
Adds the new 2.4 `Action::related_assertions` field and the corresponding validation for it.

- Closes #2394