### PR TITLE
fix(sdk): Avoid u32 truncation when hashing ranges of 4 GiB or more

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -26,7 +26,15 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
 
-const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
+const MAX_HASH_BUF: u64 = 256 * 1024 * 1024; // cap memory usage to 256MB
+
+/// Size of the next chunk to read, given how much of the range is left.
+///
+/// Clamping in `u64` keeps a range of 4 GiB or more from truncating on a 32-bit target, where
+/// `usize` is 32 bits. The cap fits in every supported `usize`, so the clamped value converts.
+fn chunk_size(chunk_left: u64) -> usize {
+    usize::try_from(chunk_left.min(MAX_HASH_BUF)).unwrap_or(usize::MAX)
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// Defines a hash range to be used with `hash_stream_by_alg`
@@ -387,13 +395,13 @@ where
         }
     };
 
-    // Total callbacks = one per 256 MB chunk across all ranges (BMFF V2 single-byte offsets
-    // each contribute exactly one tick regardless of MAX_HASH_BUF).
+    // Total callbacks = one per MAX_HASH_BUF chunk across all ranges (BMFF V2 single-byte
+    // offsets each contribute exactly one tick regardless of MAX_HASH_BUF).
     let total: u32 = ranges
         .iter()
         .map(|r| {
             let len = r.end() - r.start() + 1;
-            (len as usize).div_ceil(MAX_HASH_BUF) as u32
+            u32::try_from(len.div_ceil(MAX_HASH_BUF)).unwrap_or(u32::MAX)
         })
         .sum();
     let mut step: u32 = 0;
@@ -418,7 +426,7 @@ where
             data.seek(SeekFrom::Start(*start))?;
 
             loop {
-                let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+                let mut chunk = vec![0u8; chunk_size(chunk_left)];
 
                 data.read_exact(&mut chunk)?;
 
@@ -453,7 +461,7 @@ where
             // move to start of range
             data.seek(SeekFrom::Start(*start))?;
 
-            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+            let mut chunk = vec![0u8; chunk_size(chunk_left)];
             data.read_exact(&mut chunk)?;
 
             loop {
@@ -476,7 +484,7 @@ where
                 }
 
                 // read next chunk while we wait for hash
-                let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+                let mut next_chunk = vec![0u8; chunk_size(chunk_left)];
                 data.read_exact(&mut next_chunk)?;
 
                 hasher_enum = match rx.recv() {
@@ -610,6 +618,20 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+
+    #[test]
+    fn chunk_size_does_not_truncate_on_32_bit_targets() {
+        let cap = usize::try_from(MAX_HASH_BUF).unwrap();
+
+        assert_eq!(chunk_size(0), 0);
+        assert_eq!(chunk_size(1), 1);
+        assert_eq!(chunk_size(MAX_HASH_BUF), cap);
+        assert_eq!(chunk_size(MAX_HASH_BUF + 1), cap);
+        // 4 GiB exactly. `chunk_left as usize` is 0 here on a 32-bit target, which made the read
+        // loop ask for zero bytes on every iteration and never terminate.
+        assert_eq!(chunk_size(1 << 32), cap);
+        assert_eq!(chunk_size(u64::MAX), cap);
+    }
 
     // Attacker-controlled HashRange with start+length > u64::MAX must return Err,
     // not panic, in both the exclusion and inclusion paths.


### PR DESCRIPTION
Fixes #2449.

## Changes in this pull request

Hashing a range of 4 GiB or more never terminates on a 32-bit target such as `wasm32`. `hash_stream_by_alg_with_progress`, which the public `hash_stream_by_alg` delegates to, sizes each read in `usize`:

```rust
let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
```

`usize` is 32 bits there, so `chunk_left as usize` truncates. For a range of exactly 4 GiB it is 0: the buffer is empty, `read_exact` returns immediately, `chunk_left` never decreases, and the loop spins with no I/O and no error. For other lengths above 4 GiB it picks the wrong branch of the minimum. The progress denominator truncates the same way:

```rust
(len as usize).div_ceil(MAX_HASH_BUF) as u32
```

`MAX_HASH_BUF` becomes a `u64`, which is the width both of its uses want: it is compared against `chunk_left` and divides `len`, both `u64`. Declaring it as `usize` is what forced each site to widen it and narrow the result back, and that round trip is where the truncation lived. The hashing path now has no `as` conversions left, including the unchecked `as u32` in the denominator.

The one real narrowing, from the clamped chunk length to the `usize` that sizes the buffer, is a checked `try_from` on a value that is at most `MAX_HASH_BUF`, which fits every supported `usize`:

```rust
fn chunk_size(chunk_left: u64) -> usize {
    usize::try_from(chunk_left.min(MAX_HASH_BUF)).unwrap_or(usize::MAX)
}
```

64-bit targets are unaffected: `usize` is already wide enough and the expressions evaluate identically.

The expression occurred at three call sites, so it is one helper rather than three copies. That also makes the arithmetic testable without allocating 4 GiB.

Scope: this is a 32-bit/wasm reliability fix, the same class as `test_cai_chunk_length_near_u32_max_returns_error` in `png_io`. Through the public API it needs an asset of 4 GiB or more, because the `data_len < range_end` check rejects a smaller file that declares a large range, so it is not a small-input denial of service.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

## Tests

`chunk_size_does_not_truncate_on_32_bit_targets` covers 0, 1, `MAX_HASH_BUF`, `MAX_HASH_BUF + 1`, `1 << 32` and `u64::MAX`. `cargo test -p c2pa utils::hash_utils`, `cargo fmt` and `cargo clippy --all-targets` are green.

One limit worth knowing: on a 64-bit host the old code passes this test too, because `usize` is wide enough there. It pins the contract and guards a 32-bit or wasm test run, but does not fail on x86_64 CI. Reproducing the hang needs a 32-bit target, so I ran the loop verbatim on `wasm32-wasip1` under wasmtime against a reader declaring `1 << 32` bytes: the current code never advances, this PR completes in 1024 iterations.
