### PR TITLE
fix: relax field restriction requirements on ingredients

### DIFF
--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -1137,6 +1137,36 @@ pub mod tests {
     }
 
     #[test]
+    fn test_unknown_field_does_not_break_decoding() {
+        let ingredients = [
+            Ingredient::new("title", "image/jpeg", "instance_id", None),
+            Ingredient::new_v2("title", "image/jpeg"),
+            Ingredient::new_v3(Relationship::ParentOf),
+        ];
+
+        for ingredient in ingredients {
+            let version = ingredient.version;
+            let assertion = ingredient.to_assertion().unwrap();
+
+            let mut value: c2pa_cbor::Value = c2pa_cbor::from_slice(assertion.data()).unwrap();
+            if let c2pa_cbor::Value::Map(map) = &mut value {
+                map.insert(
+                    c2pa_cbor::Value::Text("someFutureField".to_owned()),
+                    c2pa_cbor::Value::Text("unrecognized".to_owned()),
+                );
+            } else {
+                panic!("expected a CBOR map");
+            }
+            let data = c2pa_cbor::to_vec(&value).unwrap();
+            let assertion_with_unknown_field =
+                Assertion::new(Ingredient::LABEL, Some(version), AssertionData::Cbor(data));
+
+            let decoded = Ingredient::from_assertion(&assertion_with_unknown_field).unwrap();
+            assert_eq!(decoded.version, version);
+        }
+    }
+
+    #[test]
     fn test_from_stream() {
         use std::io::Cursor;
 

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -680,75 +680,9 @@ impl AssertionBase for Ingredient {
 
         let version = assertion.get_ver();
 
-        static V1_FIELDS: [&str; 9] = [
-            "dc:title",
-            "dc:format",
-            "documentID",
-            "instanceID",
-            "relationship",
-            "c2pa_manifest",
-            "thumbnail",
-            "validationStatus",
-            "metadata",
-        ];
-
-        static V2_FIELDS: [&str; 13] = [
-            "dc:title",
-            "dc:format",
-            "relationship",
-            "documentID",
-            "instanceID",
-            "data",
-            "data_types",
-            "c2pa_manifest",
-            "thumbnail",
-            "validationStatus",
-            "description",
-            "informational_URI",
-            "metadata",
-        ];
-
-        static V3_FIELDS: [&str; 15] = [
-            "dc:title",
-            "dc:format",
-            "relationship",
-            "validationResults",
-            "instanceID",
-            "data",
-            "dataTypes",
-            "activeManifest",
-            "claimSignature",
-            "thumbnail",
-            "description",
-            "informationalURI",
-            "softBindingsMatched",
-            "softBindingAlgorithmsMatched",
-            "metadata",
-        ];
-
-        // make sure decoded matches expected fields
+        // Only the fields required by the CDDL for each version are enforced.
         let decoded = match version {
             1 => {
-                // make sure only V1 fields are present
-                if let c2pa_cbor::Value::Map(m) = &ingredient_value {
-                    if !m.keys().all(|v| match v {
-                        c2pa_cbor::Value::Text(t) => V1_FIELDS.contains(&t.as_str()),
-                        _ => false,
-                    }) {
-                        return Err(to_decoding_err(
-                            &assertion.label(),
-                            assertion.get_ver(),
-                            "invalid field found in Ingredient assertion",
-                        ));
-                    }
-                } else {
-                    return Err(to_decoding_err(
-                        &assertion.label(),
-                        assertion.get_ver(),
-                        "invalid field found in Ingredient assertion",
-                    ));
-                }
-
                 // add mandatory field
                 let title: String = map_cbor_to_type("dc:title", &ingredient_value).ok_or(
                     to_decoding_err(&assertion.label(), assertion.get_ver(), "dc:title"),
@@ -791,26 +725,6 @@ impl AssertionBase for Ingredient {
                 }
             }
             2 => {
-                // make sure only V2 fields are present
-                if let c2pa_cbor::Value::Map(m) = &ingredient_value {
-                    if !m.keys().all(|v| match v {
-                        c2pa_cbor::Value::Text(t) => V2_FIELDS.contains(&t.as_str()),
-                        _ => false,
-                    }) {
-                        return Err(to_decoding_err(
-                            &assertion.label(),
-                            assertion.get_ver(),
-                            "invalid field found in Ingredient assertion",
-                        ));
-                    }
-                } else {
-                    return Err(to_decoding_err(
-                        &assertion.label(),
-                        assertion.get_ver(),
-                        "invalid field found in Ingredient assertion",
-                    ));
-                }
-
                 // add mandatory field
                 let title: String = map_cbor_to_type("dc:title", &ingredient_value).ok_or(
                     to_decoding_err(&assertion.label(), assertion.get_ver(), "dc:title"),
@@ -862,26 +776,6 @@ impl AssertionBase for Ingredient {
                 }
             }
             3 => {
-                // make sure only V3 fields are present
-                if let c2pa_cbor::Value::Map(m) = &ingredient_value {
-                    if !m.keys().all(|v| match v {
-                        c2pa_cbor::Value::Text(t) => V3_FIELDS.contains(&t.as_str()),
-                        _ => false,
-                    }) {
-                        return Err(to_decoding_err(
-                            &assertion.label(),
-                            assertion.get_ver(),
-                            "invalid field found in Ingredient assertion",
-                        ));
-                    }
-                } else {
-                    return Err(to_decoding_err(
-                        &assertion.label(),
-                        assertion.get_ver(),
-                        "invalid field found in Ingredient assertion",
-                    ));
-                }
-
                 // add mandatory field
                 let relationship: Relationship =
                     map_cbor_to_type("relationship", &ingredient_value).ok_or(to_decoding_err(


### PR DESCRIPTION
Assertions may contain any additional unknown fields. We should not require that any unknown field must exist in the set of required and optional fields defined in the CDDL. This keeps assertions forward compatible with the spec.

> Since the addition of optional fields can be done while maintaining backwards compatibility, such fields may be added to an existing assertion’s schema without a change to the version number.

https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_versioning_2