### PR TITLE
feat(sdk): Add jumbf_io::remove_jumbf_from_stream

### DIFF
--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -265,6 +265,26 @@ pub fn save_jumbf_to_stream(
     }
 }
 
+/// reads an asset of asset_type from input_stream, removes the manifest store and writes the
+/// result to output_stream
+///
+/// This is the stream equivalent of `remove_jumbf_from_file`, and the only form available
+/// without the `file_io` feature.
+///
+/// returns Unsupported type or errors from remove_cai_store_from_stream
+pub fn remove_jumbf_from_stream(
+    asset_type: &str,
+    input_stream: &mut dyn CAIRead,
+    output_stream: &mut dyn CAIReadWrite,
+) -> Result<()> {
+    match get_caiwriter_handler(asset_type) {
+        Some(asset_handler) => {
+            asset_handler.remove_cai_store_from_stream(input_stream, output_stream)
+        }
+        None => Err(Error::UnsupportedType),
+    }
+}
+
 /// writes the jumbf data in store_bytes into an asset in data and returns the newly created asset
 pub fn save_jumbf_to_memory(asset_type: &str, data: &[u8], store_bytes: &[u8]) -> Result<Vec<u8>> {
     let mut input_stream = Cursor::new(data);
@@ -626,6 +646,16 @@ pub mod tests {
         assert!(supported.iter().any(|s| s == "jxl"));
     }
 
+    #[test]
+    fn test_remove_jumbf_from_stream_unsupported_type() {
+        let mut input = Cursor::new(Vec::new());
+        let mut output = Cursor::new(Vec::new());
+
+        let result = remove_jumbf_from_stream("badtype", &mut input, &mut output);
+
+        assert!(matches!(result.err().unwrap(), Error::UnsupportedType));
+    }
+
     fn test_jumbf(asset_type: &str, reader: &mut dyn CAIRead) {
         let mut writer = Cursor::new(Vec::new());
         let store = create_test_store().unwrap();
@@ -638,11 +668,8 @@ pub mod tests {
 
         // test removing cai store
         writer.set_position(0);
-        let handler = get_caiwriter_handler(asset_type).unwrap();
         let mut removed = Cursor::new(Vec::new());
-        handler
-            .remove_cai_store_from_stream(&mut writer, &mut removed)
-            .unwrap();
+        remove_jumbf_from_stream(asset_type, &mut writer, &mut removed).unwrap();
         removed.set_position(0);
         let result = load_jumbf_from_stream(asset_type, &mut removed);
         if (asset_type != "wav")


### PR DESCRIPTION
Fixes #2451.

## Changes in this pull request

`jumbf_io` publishes memory, stream and file forms of load and save, but only the file form of remove:

| | memory | stream | file |
|---|---|---|---|
| load | `load_jumbf_from_memory` | `load_jumbf_from_stream` | `load_jumbf_from_file` |
| save | `save_jumbf_to_memory` | `save_jumbf_to_stream` | `save_jumbf_to_file` |
| remove | | | `remove_jumbf_from_file` |

`remove_jumbf_from_file` is gated on `file_io`, so with that feature off there is no public way to remove a manifest store at all. The capability is already there: every asset handler implements `CAIWriter::remove_cai_store_from_stream`, and the file form is a thin dispatch over the path equivalent. Only the public entry point was missing.

This adds the sibling, dispatching through `get_caiwriter_handler` exactly as `save_jumbf_to_stream` does and returning `Error::UnsupportedType` for a format with no writer:

```rust
pub fn remove_jumbf_from_stream(
    asset_type: &str,
    input_stream: &mut dyn CAIRead,
    output_stream: &mut dyn CAIReadWrite,
) -> Result<()>
```

The doc comment refers to `remove_jumbf_from_file` in backticks rather than as an intra-doc link, since that item does not exist in a build without `file_io` and the link would dangle there.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

## Tests

`test_jumbf`, the helper behind the per-format `test_streams_*` tests, already wanted this operation and had no public function to call, so it resolved the handler itself:

```rust
let handler = get_caiwriter_handler(asset_type).unwrap();
let mut removed = Cursor::new(Vec::new());
handler
    .remove_cai_store_from_stream(&mut writer, &mut removed)
    .unwrap();
```

It now calls `remove_jumbf_from_stream`, so the new function is covered for every format that helper runs: jpeg, png, webp, tiff, svg, mp3, wav, avi, mp4, heif, heic, avif, jxl and c2pa. That replaces the hand-rolled dispatch rather than adding a parallel test for it.

`test_remove_jumbf_from_stream_unsupported_type` covers the dispatch failure, which the per-format tests cannot reach.

`cargo test -p c2pa --lib jumbf_io` is green (21 tests), as are `cargo fmt` and `cargo clippy --all-targets`. `cargo check --no-default-features` passes, since being available without `file_io` is the point of the function.
