### PR TITLE
fix: Harden against local_id truncation issue in accessing BMFF merkle maps

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1502,9 +1502,16 @@ impl BmffHash {
                             }
                         }
 
+                        // Look up by `mm.local_id`, the key this group was actually
+                        // inserted under in `split_bmff_merkle_map` (not `track_id`,
+                        // which only coincidentally matches it).
+                        let chunk_bmff_mms = track_to_bmff_merkle_map
+                            .get(&mm.local_id)
+                            .ok_or(Error::HashMismatch("Merkle location not found".to_owned()))?;
+
                         // finalize leaf hashes
                         let mut leaf_hashes = Vec::new();
-                        for chunk_bmff_mm in &track_to_bmff_merkle_map[&(track_id as usize)] {
+                        for chunk_bmff_mm in chunk_bmff_mms {
                             // `location` is attacker-controlled (deserialized from the
                             // file's uuid merkle box), so both the u32 conversion and the
                             // +1 must be checked rather than wrapping/panicking.
@@ -1525,7 +1532,7 @@ impl BmffHash {
                             }
                         }
 
-                        for chunk_bmff_mm in &track_to_bmff_merkle_map[&(track_id as usize)] {
+                        for chunk_bmff_mm in chunk_bmff_mms {
                             if chunk_bmff_mm.location >= leaf_hashes.len() {
                                 return Err(Error::HashMismatch(
                                     "BmffMerkleMap location exceeds leaf hash count".to_string(),
@@ -3073,6 +3080,30 @@ mod bmff_hash_tests {
             matches!(err, Error::HashMismatch(_)),
             "unexpected error: {err:?}"
         );
+    }
+
+    /// A `local_id` that exceeds `u32::MAX` but truncates to a real track id
+    /// (here, track 1) must not panic. Before the fix, the group built by
+    /// `split_bmff_merkle_map` was keyed by the full `local_id`, while the
+    /// verify loop looked it back up by the real track's `u32` id widened to
+    /// `usize` - those never match once `local_id > u32::MAX`, so the
+    /// panicking `HashMap` index crashed here. The data is otherwise
+    /// legitimate (the sample truly hashes to `root`), so once the lookup
+    /// uses the same key it was inserted under, verification just succeeds.
+    ///
+    /// Gated to 64-bit targets: on a 32-bit `usize` (wasm32, wasi), a value
+    /// "exceeding `u32::MAX`" can't exist, and the shift below is a
+    /// compile-time overflow rather than a runtime scenario to test.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn timed_media_oversized_local_id_matching_real_track_does_not_panic() {
+        let (file, root) = build_timed_media(b"hello sample data", true);
+        let oversized_local_id = (1usize << 32) | 1; // truncates to the real track id, 1
+        let bmff_hash = tm_assertion(root, oversized_local_id);
+        let mut reader = Cursor::new(file);
+        bmff_hash
+            .verify_stream_hash(&mut reader, Some("sha256"))
+            .expect("oversized-but-consistent local_id should verify, not panic");
     }
 }
 


### PR DESCRIPTION
## Changes in this pull request
`BmffHash`'s timed-media Merkle verification (`sdk/src/assertions/bmff_hash.rs`) panicked on a crafted MP4 whose Merkle assertion declared a `MerkleMap.local_id` (an untrusted `usize` from the manifest) greater than `u32::MAX`. `split_bmff_merkle_map` keyed its output map by the full `local_id`, but the verify loop looked the group back up using the real track's `u32` `track_id` widened to `usize` — a value that only coincidentally equals `local_id` when the latter already fits in `u32`. Once `local_id > u32::MAX` (but truncates to a real track id), the two keys diverge and `HashMap`'s panicking `Index` (`[]`) crashed with "no entry found for key" — an unrecoverable panic from untrusted, attacker-controlled input in both debug and release builds. In scope per `SECURITY.md`'s welcome "parsing errors that cause crashes" category.

**Fix**: Look up by `mm.local_id` — the exact key it was inserted under — instead of re-deriving a value via the real track's id. This removes the only place the two identifiers were conflated, with no truncation needed anywhere. Also replaced the panicking `[]` index with `.get(...).ok_or(Error::HashMismatch(...))`, matching the non-panicking style already used for every other attacker-influenced lookup in this function (e.g. the existing `mm.local_id as u32` track lookup a few lines above).

## Tests added
- `timed_media_oversized_local_id_matching_real_track_does_not_panic` — builds a real single-track MP4 (reusing existing `build_timed_media`/`tm_assertion` test helpers) with `local_id = (1usize << 32) | 1`, which truncates to the real track id (1). 

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
