### PR TITLE
feat(sdk): Read support for c2md (JUMBF data) manifests (backport #2380)

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -268,6 +268,11 @@ pub struct Claim {
     // root of CAI store
     update_manifest: bool,
 
+    // true if this claim was read from a `c2md`-tagged superbox (C2PA spec
+    // 11.2.2) rather than an ordinary `c2ma` standard manifest. Preserved so
+    // the original tag survives round-trips (e.g. ingredient copies).
+    is_c2md: bool,
+
     // true if manifest is or will be stored compressed
     compressed: bool,
 
@@ -452,6 +457,7 @@ impl Claim {
             instance_id: "".to_string(),
 
             update_manifest: false,
+            is_c2md: false,
             compressed: false,
             data_boxes: Vec::new(),
             metadata: None,
@@ -552,6 +558,7 @@ impl Claim {
             instance_id: "".to_string(),
 
             update_manifest: false,
+            is_c2md: false,
             compressed: false,
             data_boxes: Vec::new(),
             metadata: None,
@@ -665,6 +672,7 @@ impl Claim {
             Ok(Claim {
                 remote_manifest: RemoteManifest::NoRemote,
                 update_manifest: false,
+                is_c2md: false,
                 compressed: false,
                 title,
                 format: Some(format),
@@ -774,6 +782,7 @@ impl Claim {
             Ok(Claim {
                 remote_manifest: RemoteManifest::NoRemote,
                 update_manifest: false,
+                is_c2md: false,
                 compressed: false,
                 title,
                 format: None,
@@ -1150,6 +1159,12 @@ impl Claim {
         self.update_manifest
     }
 
+    /// True if this claim was read from a `c2md`-tagged superbox (C2PA spec
+    /// 11.2.2) rather than an ordinary `c2ma` standard manifest.
+    pub fn is_c2md(&self) -> bool {
+        self.is_c2md
+    }
+
     // get version of the Claim
     pub fn version(&self) -> usize {
         self.claim_version
@@ -1196,6 +1211,10 @@ impl Claim {
 
     pub(crate) fn set_update_manifest(&mut self, is_update_manifest: bool) {
         self.update_manifest = is_update_manifest;
+    }
+
+    pub(crate) fn set_is_c2md(&mut self, is_c2md: bool) {
+        self.is_c2md = is_c2md;
     }
 
     /// Adds an action to the claim.

--- a/sdk/src/jumbf/boxes.rs
+++ b/sdk/src/jumbf/boxes.rs
@@ -846,6 +846,7 @@ impl JUMBFUUIDContentBox {
 //---------------
 pub const CAI_BLOCK_UUID: &str = "6332706100110010800000AA00389B71"; // c2pa
 pub const CAI_MANIFEST_UUID: &str = "63326D6100110010800000AA00389B71"; // c2ma
+pub const CAI_MANIFEST_C2MD_UUID: &str = "63326D6400110010800000AA00389B71"; // c2md
 pub const CAI_COMPRESSED_MANIFEST_UUID: &str = "6332636D00110010800000AA00389B71"; // c2cm
 pub const CAI_UPDATE_MANIFEST_UUID: &str = "6332756D00110010800000AA00389B71"; // c2um
 pub const CAI_ASSERTION_STORE_UUID: &str = "6332617300110010800000AA00389B71"; // c2as
@@ -1438,6 +1439,10 @@ impl Default for CAIVerifiableCredentialStore {
 pub enum ManifestType {
     Manifest,
     UpdateManifest,
+    // A standard manifest read from a `c2md`-tagged superbox (C2PA spec
+    // 11.2.2). Consumers must accept these, but generators must not create
+    // them, so this variant is only ever produced by the read path.
+    C2md,
 }
 
 // ANCHOR CAI Store
@@ -1458,6 +1463,7 @@ impl BMFFBox for CAIManifest {
         match self.manifest_type {
             ManifestType::Manifest => CAI_MANIFEST_UUID,
             ManifestType::UpdateManifest => CAI_UPDATE_MANIFEST_UUID,
+            ManifestType::C2md => CAI_MANIFEST_C2MD_UUID,
         }
     }
 
@@ -1511,6 +1517,7 @@ impl CAIManifest {
         let id = match manifest_type {
             ManifestType::Manifest => Some(CAI_MANIFEST_UUID),
             ManifestType::UpdateManifest => Some(CAI_UPDATE_MANIFEST_UUID),
+            ManifestType::C2md => Some(CAI_MANIFEST_C2MD_UUID),
         };
 
         let sbox = JUMBFSuperBox::new(box_label, id);
@@ -1546,19 +1553,19 @@ impl CAIManifest {
             BoxReader::read_super_box(&mut stream)?
         };
 
-        if store_box.desc_box.box_uuid() == CAI_UPDATE_MANIFEST_UUID {
-            Ok(CAIManifest {
-                compressed_store,
-                manifest_type: ManifestType::UpdateManifest,
-                store: store_box,
-            })
+        let manifest_type = if store_box.desc_box.box_uuid() == CAI_UPDATE_MANIFEST_UUID {
+            ManifestType::UpdateManifest
+        } else if store_box.desc_box.box_uuid() == CAI_MANIFEST_C2MD_UUID {
+            ManifestType::C2md
         } else {
-            Ok(CAIManifest {
-                compressed_store,
-                manifest_type: ManifestType::Manifest,
-                store: store_box,
-            })
-        }
+            ManifestType::Manifest
+        };
+
+        Ok(CAIManifest {
+            compressed_store,
+            manifest_type,
+            store: store_box,
+        })
     }
 
     /// add a box (of various types) *WITHOUT* taking ownership of the box

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1049,6 +1049,8 @@ impl Store {
 
         let manifest_type = if claim.update_manifest() {
             ManifestType::UpdateManifest
+        } else if claim.is_c2md() {
+            ManifestType::C2md
         } else {
             ManifestType::Manifest
         };
@@ -1264,9 +1266,12 @@ impl Store {
             let cai_store_box = store_box.super_box();
             let cai_store_desc_box = cai_store_box.desc_box();
 
-            // ignore unknown boxes per the spec
+            // ignore unknown boxes per the spec. A c2md manifest is a standard
+            // manifest that consumers shall accept (C2PA spec 11.2.2), so it is
+            // read the same as a c2ma manifest.
             if cai_store_desc_box.uuid() != CAI_UPDATE_MANIFEST_UUID
                 && cai_store_desc_box.uuid() != CAI_MANIFEST_UUID
+                && cai_store_desc_box.uuid() != CAI_MANIFEST_C2MD_UUID
             {
                 continue;
             }
@@ -1319,6 +1324,7 @@ impl Store {
             }
 
             let is_update_manifest = cai_store_desc_box.uuid() == CAI_UPDATE_MANIFEST_UUID;
+            let is_c2md = cai_store_desc_box.uuid() == CAI_MANIFEST_C2MD_UUID;
 
             // get map of boxes in this manifest
             let manifest_boxes = Store::manifest_map(cai_store_box)?;
@@ -1447,6 +1453,7 @@ impl Store {
 
             // set the  type of manifest
             claim.set_update_manifest(is_update_manifest);
+            claim.set_is_c2md(is_c2md);
 
             // set order to process JUMBF boxes
             claim.set_box_order(box_order);
@@ -5768,6 +5775,88 @@ pub mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_jumbf_reads_c2md_standard_manifest() {
+        use crate::{
+            jumbf::boxes::{CAI_MANIFEST_C2MD_UUID, CAI_MANIFEST_UUID},
+            utils::test::create_test_store,
+        };
+
+        // Per C2PA spec 11.2.2, a manifest using the c2md JUMBF type UUID is a
+        // standard manifest that consumers shall accept. Build a normal (c2ma)
+        // manifest, rewrite its superbox type UUID to c2md, and confirm the
+        // store still reads the manifest instead of silently skipping it.
+        let store = create_test_store().unwrap();
+        let jumbf = store.to_jumbf_internal(0).unwrap();
+
+        // Flip the manifest superbox type UUID from c2ma to c2md in place.
+        let c2ma = hex::decode(CAI_MANIFEST_UUID).unwrap();
+        let c2md = hex::decode(CAI_MANIFEST_C2MD_UUID).unwrap();
+        let pos = jumbf
+            .windows(c2ma.len())
+            .position(|w| w == c2ma.as_slice())
+            .expect("manifest c2ma UUID present");
+        let mut patched = jumbf.clone();
+        patched[pos..pos + c2md.len()].copy_from_slice(&c2md);
+
+        let mut log = StatusTracker::default();
+        let restored = Store::from_jumbf(&patched, &mut log).expect("c2md manifest should be read");
+        assert_eq!(
+            restored.claims().len(),
+            store.claims().len(),
+            "c2md manifest should be read as a standard manifest"
+        );
+    }
+
+    #[test]
+    fn test_c2md_manifest_preserved_on_round_trip() {
+        use crate::{
+            jumbf::boxes::{CAI_MANIFEST_C2MD_UUID, CAI_MANIFEST_UUID},
+            utils::test::create_test_store,
+        };
+
+        // A c2md manifest must keep its c2md tag if the store is
+        // re-serialized (e.g. when it is copied as part of adding an update
+        // manifest or embedding it as an ingredient's manifest store) -
+        // claim generators must not synthesize new c2ma/c2um boxes for data
+        // that was never theirs to retag.
+        let store = create_test_store().unwrap();
+        let jumbf = store.to_jumbf_internal(0).unwrap();
+
+        let c2ma = hex::decode(CAI_MANIFEST_UUID).unwrap();
+        let c2md = hex::decode(CAI_MANIFEST_C2MD_UUID).unwrap();
+        let pos = jumbf
+            .windows(c2ma.len())
+            .position(|w| w == c2ma.as_slice())
+            .expect("manifest c2ma UUID present");
+        let mut patched = jumbf.clone();
+        patched[pos..pos + c2md.len()].copy_from_slice(&c2md);
+
+        let mut log = StatusTracker::default();
+        let restored = Store::from_jumbf(&patched, &mut log).expect("c2md manifest should be read");
+
+        // Re-serialize the store that was read from a c2md-tagged manifest.
+        let round_tripped = restored.to_jumbf_internal(0).unwrap();
+
+        let c2md_count = round_tripped
+            .windows(c2md.len())
+            .filter(|w| *w == c2md.as_slice())
+            .count();
+        let c2ma_count = round_tripped
+            .windows(c2ma.len())
+            .filter(|w| *w == c2ma.as_slice())
+            .count();
+
+        assert_eq!(
+            c2md_count, 1,
+            "c2md tag should survive re-serialization of the store"
+        );
+        assert_eq!(
+            c2ma_count, 0,
+            "a c2md manifest must not be rewritten as c2ma on round-trip"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated backport of #2380 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.