### PR TITLE
fix: Harden against arbitrary file write via manifest resource path traversal in Reader::to_folder

### DIFF
--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -981,13 +981,13 @@ impl Reader {
                 ) {
                     let uri = to_assertion_uri(claim_label, &ca.label());
                     if let Some(a) = self.store.get_assertion_from_uri(&uri) {
-                        write_bytes(uri_to_path(&uri, Some(claim_label)), a.data())?;
+                        write_bytes(uri_to_path(&uri, Some(claim_label))?, a.data())?;
                     }
                 }
             }
             // Write databoxes
             for (hr, databox) in claim.databoxes() {
-                write_bytes(uri_to_path(&hr.url(), Some(claim_label)), &databox.data)?;
+                write_bytes(uri_to_path(&hr.url(), Some(claim_label))?, &databox.data)?;
             }
         }
         Ok(())
@@ -1596,6 +1596,48 @@ pub mod tests {
             );
         }
         Ok(())
+    }
+
+    /// A databox label containing path traversal (as could be read straight
+    /// from an attacker-crafted asset's JUMBF `jumd` box - see
+    /// `Store::from_jumbf_impl`, which passes that label to `Claim::put_databox`
+    /// unmodified) must not let `to_folder` write outside the output folder.
+    #[test]
+    #[cfg(feature = "file_io")]
+    fn test_to_folder_rejects_path_traversal_in_databox_label() {
+        use crate::{assertions::DataBox, claim::Claim, utils::io_utils::tempdirectory};
+
+        let malicious_databox = DataBox {
+            format: "application/octet-stream".to_string(),
+            data: b"attacker controlled bytes".to_vec(),
+            data_types: None,
+        };
+        let db_cbor = c2pa_cbor::to_vec(&malicious_databox).unwrap();
+
+        let mut claim = Claim::new("test", None, 1);
+        claim.put_databox("../../../evil", &db_cbor, None).unwrap();
+
+        let mut store = Store::new();
+        store.commit_claim(claim).unwrap();
+
+        let reader = Reader {
+            store: Arc::new(store),
+            ..Default::default()
+        };
+
+        let temp_dir = tempdirectory().unwrap();
+        let result = reader.to_folder(temp_dir.path());
+        assert!(
+            result.is_err(),
+            "a databox label containing path traversal must be rejected, not written to disk"
+        );
+
+        // Confirm nothing escaped into the output folder's parent.
+        let escaped = temp_dir.path().parent().unwrap().join("evil");
+        assert!(
+            !escaped.exists(),
+            "traversal must not create files outside the output folder"
+        );
     }
 
     #[test]

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -22,7 +22,7 @@ use std::{
 #[allow(unused)] // different code path for WASI
 use tempfile::{tempdir, Builder, NamedTempFile, SpooledTempFile, TempDir};
 
-use crate::{asset_io::rename_or_move, Error, Result};
+use crate::{asset_io::rename_or_move, utils::path_utils::sanitize_archive_path, Error, Result};
 
 // Replace data at arbitrary location and len in a file.
 // start_location is where the replacement data will start
@@ -273,13 +273,19 @@ pub(crate) fn tempdirectory() -> Result<TempDir> {
 }
 
 /// Convert a URI to a file path using PathBuf for better path handling.
+///
+/// The URI may carry a JUMBF label taken directly from an untrusted asset
+/// (see callers in `Reader::to_folder`, which writes the resulting path to
+/// disk), so the derived path is passed through `sanitize_archive_path`
+/// before being returned - this rejects `..`, absolute paths, and backslash
+/// components rather than silently stripping them.
 #[cfg(feature = "file_io")]
-pub fn uri_to_path(uri: &str, manifest_label: Option<&str>) -> PathBuf {
+pub fn uri_to_path(uri: &str, manifest_label: Option<&str>) -> Result<PathBuf> {
     let mut path_str = uri.replace(':', "_");
     if let Some(stripped) = path_str.strip_prefix("self#jumbf=") {
         path_str = stripped.to_owned();
     } else {
-        return PathBuf::from(path_str);
+        return sanitize_archive_path(&path_str).map(PathBuf::from);
     }
 
     let mut path = PathBuf::from(path_str);
@@ -292,7 +298,10 @@ pub fn uri_to_path(uri: &str, manifest_label: Option<&str>) -> PathBuf {
         path = new_path;
     }
 
-    path
+    let path_str = path.to_str().ok_or_else(|| {
+        Error::BadParam(format!("Non-UTF-8 resource path derived from URI: {uri}"))
+    })?;
+    sanitize_archive_path(path_str).map(PathBuf::from)
 }
 
 #[cfg(test)]
@@ -308,9 +317,12 @@ mod tests {
         let uri = "self#jumbf=/c2pa/urn:uuid:b3386820-9994-4b58-926f-1c47b82504c4:contentauth/c2pa.assertions/c2pa.thumbnail.claim.jpeg";
         let expected_path = "urn_uuid_b3386820-9994-4b58-926f-1c47b82504c4_contentauth/c2pa.assertions/c2pa.thumbnail.claim.jpeg";
 
-        assert_eq!(uri_to_path(uri, None), PathBuf::from(expected_path));
         assert_eq!(
-            uri_to_path(expected_path, None),
+            uri_to_path(uri, None).unwrap(),
+            PathBuf::from(expected_path)
+        );
+        assert_eq!(
+            uri_to_path(expected_path, None).unwrap(),
             PathBuf::from(expected_path)
         );
 
@@ -319,11 +331,11 @@ mod tests {
         let expected_path = format!("{manifest_label}/c2pa.assertions/c2pa.thumbnail.claim");
 
         assert_eq!(
-            uri_to_path(uri, Some(manifest_label)),
+            uri_to_path(uri, Some(manifest_label)).unwrap(),
             PathBuf::from(&expected_path)
         );
         assert_eq!(
-            uri_to_path(&expected_path, Some(manifest_label)),
+            uri_to_path(&expected_path, Some(manifest_label)).unwrap(),
             PathBuf::from(expected_path)
         );
 
@@ -333,8 +345,40 @@ mod tests {
         let expected_path_with_colon = "urn_uuid_test_label/c2pa.assertions/c2pa.thumbnail.claim";
 
         assert_eq!(
-            uri_to_path(uri, Some(manifest_label_with_colon)),
+            uri_to_path(uri, Some(manifest_label_with_colon)).unwrap(),
             PathBuf::from(expected_path_with_colon)
+        );
+    }
+
+    /// `uri_to_path` builds a path that callers (`Reader::to_folder`) write
+    /// directly to disk from a URI that may embed an untrusted JUMBF label
+    /// (an assertion or databox label read straight from an attacker-crafted
+    /// asset). It must reject traversal wherever that label can land: in the
+    /// URI's own tail, and in the `manifest_label` prefix.
+    #[cfg(feature = "file_io")]
+    #[test]
+    fn test_uri_to_path_rejects_traversal() {
+        // `..` in the databox/assertion label itself (the URI tail).
+        let uri = "self#jumbf=/c2pa/test-manifest/c2pa.databoxes/../../../evil";
+        assert!(uri_to_path(uri, None).is_err());
+
+        // `..` in the manifest_label used to prefix a bare (no `/c2pa/`) URI.
+        let uri = "self#jumbf=c2pa.databoxes/evil";
+        assert!(uri_to_path(uri, Some("../../etc")).is_err());
+
+        // A bare (no `self#jumbf=` prefix) absolute path must also be rejected -
+        // this is the early-return branch, which skips straight to
+        // `sanitize_archive_path` on the raw string.
+        assert!(uri_to_path("/etc/passwd", None).is_err());
+
+        // Backslash (Windows-style traversal), same early-return branch.
+        assert!(uri_to_path("..\\..\\evil", None).is_err());
+
+        // Legitimate labels must still work (not over-blocked).
+        let uri = "self#jumbf=/c2pa/test-manifest/c2pa.databoxes/my-databox.bin";
+        assert_eq!(
+            uri_to_path(uri, None).unwrap(),
+            PathBuf::from("test-manifest/c2pa.databoxes/my-databox.bin")
         );
     }
 

--- a/sdk/src/utils/io_utils.rs
+++ b/sdk/src/utils/io_utils.rs
@@ -278,7 +278,8 @@ pub(crate) fn tempdirectory() -> Result<TempDir> {
 /// (see callers in `Reader::to_folder`, which writes the resulting path to
 /// disk), so the derived path is passed through `sanitize_archive_path`
 /// before being returned - this rejects `..`, absolute paths, and backslash
-/// components rather than silently stripping them.
+/// components (harmless `.` components are silently dropped, same as any
+/// normal path normalization).
 #[cfg(feature = "file_io")]
 pub fn uri_to_path(uri: &str, manifest_label: Option<&str>) -> Result<PathBuf> {
     let mut path_str = uri.replace(':', "_");
@@ -288,20 +289,16 @@ pub fn uri_to_path(uri: &str, manifest_label: Option<&str>) -> Result<PathBuf> {
         return sanitize_archive_path(&path_str).map(PathBuf::from);
     }
 
-    let mut path = PathBuf::from(path_str);
-
-    if let Ok(stripped) = path.strip_prefix("/c2pa/") {
-        path = stripped.to_path_buf();
+    if let Some(stripped) = path_str.strip_prefix("/c2pa/") {
+        path_str = stripped.to_owned();
     } else if let Some(manifest_label) = manifest_label {
-        let mut new_path = PathBuf::from(manifest_label.replace(':', "_"));
-        new_path.push(path);
-        path = new_path;
+        // Joined with an explicit `/`, not `PathBuf::push`: on Windows, `push`
+        // inserts `\`, which would mix with the `/`-separated tail and get
+        // rejected below as if it were a backslash-traversal payload.
+        path_str = format!("{}/{path_str}", manifest_label.replace(':', "_"));
     }
 
-    let path_str = path.to_str().ok_or_else(|| {
-        Error::BadParam(format!("Non-UTF-8 resource path derived from URI: {uri}"))
-    })?;
-    sanitize_archive_path(path_str).map(PathBuf::from)
+    sanitize_archive_path(&path_str).map(PathBuf::from)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Changes in this pull request
`Reader::to_folder()` (`sdk/src/reader.rs`) — the public API behind `c2patool <asset> -o <folder>` — writes every claim's binary assertions and databoxes to disk using a path built by `uri_to_path()` (`sdk/src/utils/io_utils.rs`). That path is derived from a JUMBF `jumd` box label read directly from the asset (`db_desc_box.label()` in `Store::from_jumbf_impl`, embedded raw into a URI by `Claim::put_databox`/`to_databox_uri` with no character restriction), so it is fully attacker-controlled. `uri_to_path` performed no traversal sanitization — only `:`→`_` replacement and prefix stripping — so a crafted asset with a databox (or binary assertion) label containing `../` could write attacker-controlled bytes to an attacker-chosen path outside the output directory. `to_folder` has no validation/trust gate, so this triggers even for assets that fail C2PA validation. This is the extraction-side counterpart to the ingest-side fix in PR #2066/#2271 (`sanitize_archive_path`), which never covered this sink.

**Fix:** `uri_to_path` now runs its result through the existing `sanitize_archive_path` helper (reused, not reimplemented) before returning, on every code path, and its signature changed from `-> PathBuf` to `-> Result<PathBuf>` so callers can reject rather than silently write. `Reader::to_folder`'s two call sites (binary assertions and databoxes — both share the exact same bug, since both route through `uri_to_path`) now propagate that `Result` with `?`.


## Tests added
- `test_uri_to_path_rejects_traversal` (`io_utils.rs`) — direct coverage of `..` in the URI tail, `..` in the `manifest_label` prefix, a bare absolute path, and a bare backslash path, plus a positive case confirming legitimate labels still resolve to the expected path (not over-blocked).
- `test_to_folder_rejects_path_traversal_in_databox_label` (`reader.rs`) — full integration test: injects a `Claim` with a malicious databox label via `put_databox` (the exact function the untrusted-parsing path calls) and confirms `to_folder` rejects it and writes nothing outside the target folder.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
