### PR TITLE
fix: Preserve identity assertions in split-signing paths (backport #2421)

### DIFF
--- a/sdk/src/identity/builder/async_identity_assertion_signer.rs
+++ b/sdk/src/identity/builder/async_identity_assertion_signer.rs
@@ -11,6 +11,8 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::{
@@ -33,7 +35,7 @@ pub struct AsyncIdentityAssertionSigner {
     #[cfg(target_arch = "wasm32")]
     signer: Box<dyn AsyncRawSigner>,
 
-    identity_assertions: std::sync::RwLock<Vec<AsyncIdentityAssertionBuilder>>,
+    identity_assertions: std::sync::RwLock<Vec<Arc<AsyncIdentityAssertionBuilder>>>,
 }
 
 impl AsyncIdentityAssertionSigner {
@@ -84,16 +86,20 @@ impl AsyncIdentityAssertionSigner {
     /// Add an [`AsyncIdentityAssertionBuilder`] to be used when signing the
     /// next [`Manifest`].
     ///
-    /// IMPORTANT: When [`sign()`] is called, the list of
-    /// [`AsyncIdentityAssertionBuilder`]s will be cleared.
+    /// The registered assertions are retained after signing so that the same
+    /// signer can be used across every signing path, including the split
+    /// signing paths ([`Builder::placeholder`] + [`Builder::sign_embeddable`])
+    /// that query [`dynamic_assertions()`] more than once per manifest.
     ///
     /// [`Manifest`]: crate::Manifest
-    /// [`sign()`]: Self::sign
+    /// [`Builder::placeholder`]: crate::Builder::placeholder
+    /// [`Builder::sign_embeddable`]: crate::Builder::sign_embeddable
+    /// [`dynamic_assertions()`]: AsyncSigner::dynamic_assertions
     pub fn add_identity_assertion(&mut self, iab: AsyncIdentityAssertionBuilder) {
         #[allow(clippy::unwrap_used)]
         let mut identity_assertions = self.identity_assertions.write().unwrap();
         // TO DO: Replace with error handling in the very unlikely case of a panic here.
-        identity_assertions.push(iab);
+        identity_assertions.push(Arc::new(iab));
     }
 }
 
@@ -147,16 +153,18 @@ impl AsyncSigner for AsyncIdentityAssertionSigner {
 
     fn dynamic_assertions(&self) -> Vec<Box<dyn AsyncDynamicAssertion>> {
         #[allow(clippy::unwrap_used)]
-        let mut identity_assertions = self.identity_assertions.write().unwrap();
+        let identity_assertions = self.identity_assertions.read().unwrap();
         // TO DO: Replace with error handling in the very unlikely case of a panic here.
 
-        let ia_clone = identity_assertions.split_off(0);
-        let mut dynamic_assertions: Vec<Box<dyn AsyncDynamicAssertion>> = vec![];
-
-        for ia in ia_clone.into_iter() {
-            dynamic_assertions.push(Box::new(ia));
-        }
-
-        dynamic_assertions
+        // Hand out shared clones instead of draining the list. Several signing
+        // paths (notably `Builder::placeholder` + `Builder::sign_embeddable`)
+        // call this method more than once per manifest – once to reserve
+        // placeholder slots and again to write the assertion content. Draining
+        // on the first call left later calls empty, which silently dropped the
+        // identity assertion (see issue #2055).
+        identity_assertions
+            .iter()
+            .map(|ia| Box::new(Arc::clone(ia)) as Box<dyn AsyncDynamicAssertion>)
+            .collect()
     }
 }

--- a/sdk/src/identity/builder/identity_assertion_builder.rs
+++ b/sdk/src/identity/builder/identity_assertion_builder.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
@@ -128,6 +128,32 @@ impl DynamicAssertion for IdentityAssertionBuilder {
     }
 }
 
+/// Allows an [`IdentityAssertionSigner`] to hand out shared clones of a single
+/// [`IdentityAssertionBuilder`] each time [`dynamic_assertions()`] is called,
+/// so that the same builder can service both the placeholder-reservation and
+/// content-writing passes of a split signing operation.
+///
+/// [`IdentityAssertionSigner`]: crate::identity::builder::IdentityAssertionSigner
+/// [`dynamic_assertions()`]: crate::Signer::dynamic_assertions
+impl DynamicAssertion for Arc<IdentityAssertionBuilder> {
+    fn label(&self) -> String {
+        self.as_ref().label()
+    }
+
+    fn reserve_size(&self) -> crate::Result<usize> {
+        self.as_ref().reserve_size()
+    }
+
+    fn content(
+        &self,
+        label: &str,
+        size: Option<usize>,
+        claim: &PartialClaim,
+    ) -> crate::Result<DynamicAssertionContent> {
+        self.as_ref().content(label, size, claim)
+    }
+}
+
 /// An `AsyncIdentityAssertionBuilder` gathers together the necessary components
 /// for an identity assertion. When added to an
 /// [`AsyncIdentityAssertionSigner`], it ensures that the proper data is added
@@ -236,6 +262,35 @@ impl AsyncDynamicAssertion for AsyncIdentityAssertionBuilder {
         let signature_result = self.credential_holder.sign(&signer_payload).await;
 
         finalize_identity_assertion(signer_payload, size, signature_result)
+    }
+}
+
+/// Allows an [`AsyncIdentityAssertionSigner`] to hand out shared clones of a
+/// single [`AsyncIdentityAssertionBuilder`] each time [`dynamic_assertions()`]
+/// is called, so that the same builder can service both the
+/// placeholder-reservation and content-writing passes of a split signing
+/// operation.
+///
+/// [`AsyncIdentityAssertionSigner`]: crate::identity::builder::AsyncIdentityAssertionSigner
+/// [`dynamic_assertions()`]: crate::AsyncSigner::dynamic_assertions
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl AsyncDynamicAssertion for Arc<AsyncIdentityAssertionBuilder> {
+    fn label(&self) -> String {
+        self.as_ref().label()
+    }
+
+    fn reserve_size(&self) -> crate::Result<usize> {
+        self.as_ref().reserve_size()
+    }
+
+    async fn content(
+        &self,
+        label: &str,
+        size: Option<usize>,
+        claim: &PartialClaim,
+    ) -> crate::Result<DynamicAssertionContent> {
+        self.as_ref().content(label, size, claim).await
     }
 }
 

--- a/sdk/src/identity/builder/identity_assertion_signer.rs
+++ b/sdk/src/identity/builder/identity_assertion_signer.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use crate::{
     crypto::raw_signature::{RawSigner, SigningAlg},
@@ -27,7 +27,7 @@ use crate::{
 /// [`Manifest`]: crate::Manifest
 pub struct IdentityAssertionSigner {
     signer: Box<dyn RawSigner + Send + Sync>,
-    identity_assertions: RwLock<Vec<IdentityAssertionBuilder>>,
+    identity_assertions: RwLock<Vec<Arc<IdentityAssertionBuilder>>>,
 }
 
 impl IdentityAssertionSigner {
@@ -62,17 +62,21 @@ impl IdentityAssertionSigner {
     /// Add an [`IdentityAssertionBuilder`] to be used when signing the
     /// next [`Manifest`].
     ///
-    /// IMPORTANT: When [`sign()`] is called, the list of
-    /// [`IdentityAssertionBuilder`]s will be cleared.
+    /// The registered assertions are retained after signing so that the same
+    /// signer can be used across every signing path, including the split
+    /// signing paths ([`Builder::placeholder`] + [`Builder::sign_embeddable`])
+    /// that query [`dynamic_assertions()`] more than once per manifest.
     ///
     /// [`Manifest`]: crate::Manifest
-    /// [`sign()`]: Self::sign
+    /// [`Builder::placeholder`]: crate::Builder::placeholder
+    /// [`Builder::sign_embeddable`]: crate::Builder::sign_embeddable
+    /// [`dynamic_assertions()`]: Signer::dynamic_assertions
     pub fn add_identity_assertion(&mut self, iab: IdentityAssertionBuilder) {
         #[allow(clippy::unwrap_used)]
         let mut identity_assertions = self.identity_assertions.write().unwrap();
         // TO DO: Replace with error handling in the very unlikely case of a panic here.
 
-        identity_assertions.push(iab);
+        identity_assertions.push(Arc::new(iab));
     }
 }
 
@@ -123,16 +127,18 @@ impl Signer for IdentityAssertionSigner {
 
     fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
         #[allow(clippy::unwrap_used)]
-        let mut identity_assertions = self.identity_assertions.write().unwrap();
+        let identity_assertions = self.identity_assertions.read().unwrap();
         // TO DO: Replace with error handling in the very unlikely case of a panic here.
 
-        let ia_clone = identity_assertions.split_off(0);
-        let mut dynamic_assertions: Vec<Box<dyn DynamicAssertion>> = vec![];
-
-        for ia in ia_clone.into_iter() {
-            dynamic_assertions.push(Box::new(ia));
-        }
-
-        dynamic_assertions
+        // Hand out shared clones instead of draining the list. Several signing
+        // paths (notably `Builder::placeholder` + `Builder::sign_embeddable`)
+        // call this method more than once per manifest – once to reserve
+        // placeholder slots and again to write the assertion content. Draining
+        // on the first call left later calls empty, which silently dropped the
+        // identity assertion (see issue #2055).
+        identity_assertions
+            .iter()
+            .map(|ia| Box::new(Arc::clone(ia)) as Box<dyn DynamicAssertion>)
+            .collect()
     }
 }

--- a/sdk/src/identity/tests/embeddable_signing.rs
+++ b/sdk/src/identity/tests/embeddable_signing.rs
@@ -1,0 +1,211 @@
+// Copyright 2025 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! Regression tests for issue #2055: identity assertions were silently dropped
+//! by the split-signing (embeddable) paths because
+//! `IdentityAssertionSigner::dynamic_assertions()` drained its list on the
+//! first call.
+
+use std::io::{Cursor, Seek, SeekFrom, Write};
+
+use crate::{
+    assertions::DataHash,
+    identity::{
+        builder::{IdentityAssertionBuilder, IdentityAssertionSigner},
+        x509::X509CredentialHolder,
+    },
+    utils::test::write_jpeg_placeholder_stream,
+    Builder, Context, HashRange, Reader, SigningAlg,
+};
+
+// A clean JPEG (no embedded manifest) used as the asset we sign.
+const TEST_IMAGE: &[u8] = include_bytes!("../../../tests/fixtures/cloud.jpg");
+
+// A JPEG that already carries a manifest, used as a parent ingredient so the v3
+// ingredient requirements are satisfied.
+const TEST_INGREDIENT: &[u8] = include_bytes!("../../../tests/fixtures/CA.jpg");
+const TEST_THUMBNAIL: &[u8] = include_bytes!("../../../tests/fixtures/thumbnail.jpg");
+
+/// Build an [`IdentityAssertionSigner`] (PS256 claim signer) that carries a
+/// single CAWG X.509 (Ed25519) identity assertion.
+fn identity_signer() -> IdentityAssertionSigner {
+    let mut c2pa_signer = IdentityAssertionSigner::from_test_credentials(SigningAlg::Ps256);
+
+    let (cawg_cert_chain, cawg_private_key) =
+        super::fixtures::cert_chain_and_private_key_for_alg(SigningAlg::Ed25519);
+
+    let cawg_raw_signer =
+        c2pa_raw_crypto::signer_from_private_key(&cawg_private_key, SigningAlg::Ed25519).unwrap();
+
+    let cawg_cert_chain_der = crate::crypto::cert_chain_pem_to_der(&cawg_cert_chain).unwrap();
+
+    let x509_holder = X509CredentialHolder::from_raw_signer(cawg_raw_signer, cawg_cert_chain_der);
+    c2pa_signer
+        .add_identity_assertion(IdentityAssertionBuilder::for_credential_holder(x509_holder));
+
+    c2pa_signer
+}
+
+/// A context whose signer is an [`IdentityAssertionSigner`] and whose settings
+/// preserve raw `cawg.identity` assertion bytes so we can confirm the assertion
+/// is present after signing.
+fn identity_context() -> std::sync::Arc<Context> {
+    let settings = crate::settings::Settings::default()
+        .with_value("core.decode_identity_assertions", false)
+        .unwrap();
+
+    Context::new()
+        .with_settings(settings)
+        .unwrap()
+        .with_signer(identity_signer())
+        .into_shared()
+}
+
+fn has_identity_assertion(reader: &Reader) -> bool {
+    reader
+        .active_manifest()
+        .unwrap()
+        .assertions()
+        .iter()
+        .any(|a| a.label().starts_with("cawg.identity"))
+}
+
+/// Regression test for issue #2055.
+///
+/// The split-signing path (`Builder::placeholder` + `Builder::sign_embeddable`)
+/// must include the `cawg.identity` assertion, matching what `Builder::sign`
+/// produces. Before the fix, `dynamic_assertions()` drained on the first call,
+/// so the second call (which writes the assertion content) saw an empty list
+/// and the identity assertion was silently dropped.
+#[test]
+fn sign_embeddable_includes_identity_assertion() {
+    let format = "image/jpeg";
+    let context = identity_context();
+
+    let mut builder = Builder::from_shared_context(&context)
+        .with_definition(super::fixtures::manifest_json())
+        .unwrap();
+    builder
+        .add_ingredient_from_stream(
+            super::fixtures::parent_json(),
+            format,
+            &mut Cursor::new(TEST_INGREDIENT),
+        )
+        .unwrap();
+    builder
+        .add_resource("thumbnail.jpg", Cursor::new(TEST_THUMBNAIL))
+        .unwrap();
+
+    // Reserve placeholder space (this is the first `dynamic_assertions()` call).
+    let composed_placeholder = builder.placeholder(format).unwrap();
+    assert!(!composed_placeholder.is_empty());
+
+    // Embed the composed placeholder in a real JPEG.
+    let mut input_stream = Cursor::new(TEST_IMAGE);
+    let mut output_stream = Cursor::new(Vec::new());
+    let offset = write_jpeg_placeholder_stream(
+        &composed_placeholder,
+        format,
+        &mut input_stream,
+        &mut output_stream,
+        None,
+    )
+    .unwrap();
+
+    builder
+        .set_data_hash_exclusions(vec![HashRange::new(
+            offset as u64,
+            composed_placeholder.len() as u64,
+        )])
+        .unwrap();
+    output_stream.rewind().unwrap();
+    builder
+        .update_hash_from_stream(format, &mut output_stream)
+        .unwrap();
+
+    // Sign (this is the second `dynamic_assertions()` call, which must still
+    // return the identity assertion).
+    let signed_manifest = builder.sign_embeddable(format).unwrap();
+    assert!(signed_manifest.len() <= composed_placeholder.len());
+
+    // Patch the signed manifest over the placeholder.
+    output_stream.seek(SeekFrom::Start(offset as u64)).unwrap();
+    output_stream.write_all(&signed_manifest).unwrap();
+    output_stream.rewind().unwrap();
+
+    let reader = Reader::from_shared_context(&context)
+        .with_stream(format, &mut output_stream)
+        .unwrap();
+
+    assert_eq!(reader.validation_status(), None);
+    assert!(
+        has_identity_assertion(&reader),
+        "cawg.identity assertion missing from sign_embeddable() output"
+    );
+}
+
+/// The data-hashed placeholder workflow cannot reserve space for dynamic
+/// assertions, so signing with an [`IdentityAssertionSigner`] must fail loudly
+/// rather than silently emit a manifest without the identity assertion.
+#[test]
+fn data_hashed_embeddable_rejects_identity_signer() {
+    let format = "application/c2pa";
+    let signer = identity_signer();
+
+    let mut builder = Builder::default()
+        .with_definition(super::fixtures::manifest_json())
+        .unwrap();
+    builder
+        .add_ingredient_from_stream(
+            super::fixtures::parent_json(),
+            "image/jpeg",
+            &mut Cursor::new(TEST_INGREDIENT),
+        )
+        .unwrap();
+    builder
+        .add_resource("thumbnail.jpg", Cursor::new(TEST_THUMBNAIL))
+        .unwrap();
+
+    let placeholder = builder
+        .data_hashed_placeholder(crate::Signer::reserve_size(&signer), format)
+        .unwrap();
+
+    let mut dh = DataHash::new("source_hash", "sha256");
+    dh.exclusions = Some(vec![HashRange::new(0, placeholder.len() as u64)]);
+    let mut ph_stream = Cursor::new(placeholder.clone());
+    dh.gen_hash_from_stream(&mut ph_stream).unwrap();
+
+    let result = builder.sign_data_hashed_embeddable(&signer, &dh, format);
+
+    assert!(
+        result.is_err(),
+        "sign_data_hashed_embeddable must reject a signer with dynamic assertions instead of \
+         silently dropping them"
+    );
+}
+
+/// The signer must return its identity assertions on every call, not just the
+/// first (the root cause of issue #2055).
+#[test]
+fn dynamic_assertions_are_not_drained() {
+    use crate::Signer;
+
+    let signer = identity_signer();
+
+    assert_eq!(signer.dynamic_assertions().len(), 1);
+    assert_eq!(
+        signer.dynamic_assertions().len(),
+        1,
+        "dynamic_assertions() must be idempotent across repeated calls"
+    );
+}

--- a/sdk/src/identity/tests/embeddable_signing.rs
+++ b/sdk/src/identity/tests/embeddable_signing.rs
@@ -20,6 +20,7 @@ use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use crate::{
     assertions::DataHash,
+    crypto::raw_signature,
     identity::{
         builder::{IdentityAssertionBuilder, IdentityAssertionSigner},
         x509::X509CredentialHolder,
@@ -44,12 +45,15 @@ fn identity_signer() -> IdentityAssertionSigner {
     let (cawg_cert_chain, cawg_private_key) =
         super::fixtures::cert_chain_and_private_key_for_alg(SigningAlg::Ed25519);
 
-    let cawg_raw_signer =
-        c2pa_raw_crypto::signer_from_private_key(&cawg_private_key, SigningAlg::Ed25519).unwrap();
+    let cawg_raw_signer = raw_signature::signer_from_cert_chain_and_private_key(
+        &cawg_cert_chain,
+        &cawg_private_key,
+        SigningAlg::Ed25519,
+        None,
+    )
+    .unwrap();
 
-    let cawg_cert_chain_der = crate::crypto::cert_chain_pem_to_der(&cawg_cert_chain).unwrap();
-
-    let x509_holder = X509CredentialHolder::from_raw_signer(cawg_raw_signer, cawg_cert_chain_der);
+    let x509_holder = X509CredentialHolder::from_raw_signer(cawg_raw_signer);
     c2pa_signer
         .add_identity_assertion(IdentityAssertionBuilder::for_credential_holder(x509_holder));
 

--- a/sdk/src/identity/tests/mod.rs
+++ b/sdk/src/identity/tests/mod.rs
@@ -16,6 +16,8 @@
 #![allow(clippy::unwrap_used)]
 
 mod claim_aggregation;
+#[cfg(not(target_arch = "wasm32"))]
+mod embeddable_signing;
 mod examples;
 pub(crate) mod fixtures;
 mod validation_method;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2300,47 +2300,59 @@ impl Store {
             ));
         };
 
-        // Write dynamic assertions only if placeholders were added during placeholder generation.
-        // We check if the dynamic assertion labels exist in the claim - if not, placeholders
-        // weren't added and we should skip writing to avoid size mismatches.
+        // Write any dynamic assertions exposed by the signer. The caller
+        // (`Builder::sign_embeddable`) reserves matching placeholder slots via
+        // `add_dynamic_assertion_placeholders` before calling this, so the assertion
+        // content replaces those slots in place. This must reuse the same
+        // `dynamic_assertions()` result across the whole operation – draining it on an
+        // earlier call is what silently dropped identity assertions in issue #2055.
         let dynamic_assertions = signer.dynamic_assertions();
         if !dynamic_assertions.is_empty() {
-            // Check if placeholders exist for these dynamic assertions
-            let has_placeholders = {
-                dynamic_assertions
-                    .iter()
-                    .all(|da| pc.assertion_hashed_uri_from_label(&da.label()).is_some())
-            };
+            // Every dynamic assertion needs a reserved placeholder slot to replace.
+            // Surface any that are missing with an actionable message instead of
+            // letting `write_dynamic_assertions` fail later with an opaque
+            // `Error::NotFound`.
+            let missing: Vec<String> = dynamic_assertions
+                .iter()
+                .map(|da| da.label())
+                .filter(|label| pc.assertion_hashed_uri_from_label(label).is_none())
+                .collect();
 
-            if has_placeholders {
-                let mut preliminary_claim = PartialClaim::default();
-                {
-                    for assertion in pc.assertions() {
-                        preliminary_claim.add_assertion(assertion);
-                    }
-                }
-
-                // Drop pc before calling write_dynamic_assertions
-                let _ = pc;
-
-                let _modified =
-                    self.write_dynamic_assertions(&dynamic_assertions, &mut preliminary_claim)?;
-
-                // Get pc again
-                let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
-                let sig = self.sign_claim(pc, signer, signer.reserve_size(), settings)?;
-
-                let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
-                pc.set_signature_val(sig);
-
-                let jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
-
-                if context.settings().verify.verify_after_sign {
-                    self.verify_store_strict(None, context)?;
-                }
-
-                return Ok(jumbf_bytes);
+            if !missing.is_empty() {
+                return Err(Error::BadParam(format!(
+                    "no placeholder slots were reserved for dynamic assertions [{}]; \
+                     call add_dynamic_assertion_placeholders() before signing",
+                    missing.join(", ")
+                )));
             }
+
+            let mut preliminary_claim = PartialClaim::default();
+            {
+                for assertion in pc.assertions() {
+                    preliminary_claim.add_assertion(assertion);
+                }
+            }
+
+            // Drop pc before calling write_dynamic_assertions
+            let _ = pc;
+
+            let _modified =
+                self.write_dynamic_assertions(&dynamic_assertions, &mut preliminary_claim)?;
+
+            // Get pc again
+            let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+            let sig = self.sign_claim(pc, signer, signer.reserve_size(), settings)?;
+
+            let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+            pc.set_signature_val(sig);
+
+            let jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+
+            if context.settings().verify.verify_after_sign {
+                self.verify_store_strict(None, context)?;
+            }
+
+            return Ok(jumbf_bytes);
         }
 
         context.check_progress(ProgressPhase::Signing, 1, 1)?;
@@ -2430,37 +2442,18 @@ impl Store {
     ) -> Result<Vec<u8>> {
         self.prep_embeddable_store(dh, asset_reader, context)?;
 
-        // Write dynamic assertions only if placeholders were added during placeholder generation.
-        // We check if the dynamic assertion labels exist in the claim - if not, placeholders
-        // weren't added and we should skip writing to avoid size mismatches.
-        let dynamic_assertions = signer.dynamic_assertions();
-        if !dynamic_assertions.is_empty() {
-            // Check if placeholders exist for these dynamic assertions
-            let has_placeholders = {
-                let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
-                dynamic_assertions
-                    .iter()
-                    .all(|da| pc.assertion_hashed_uri_from_label(&da.label()).is_some())
-            };
-
-            if has_placeholders {
-                let mut preliminary_claim = PartialClaim::default();
-                {
-                    let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
-                    for assertion in pc.assertions() {
-                        preliminary_claim.add_assertion(assertion);
-                    }
-                }
-                if _sync {
-                    self.write_dynamic_assertions(&dynamic_assertions, &mut preliminary_claim)?;
-                } else {
-                    self.write_dynamic_assertions_async(
-                        &dynamic_assertions,
-                        &mut preliminary_claim,
-                    )
-                    .await?;
-                }
-            }
+        // The data-hashed placeholder (`get_data_hashed_manifest_placeholder`) does not
+        // reserve space for dynamic assertions, so there is no way to embed them here
+        // without breaking the size contract the caller already committed to. Fail loudly
+        // rather than silently dropping the assertions (see issue #2055); callers that need
+        // dynamic assertions should use Builder::placeholder() + Builder::sign_embeddable().
+        if !signer.dynamic_assertions().is_empty() {
+            return Err(Error::BadParam(
+                "signer has dynamic assertions (e.g. CAWG identity) that the data-hashed \
+                 embeddable workflow cannot represent; use Builder::placeholder() followed \
+                 by Builder::sign_embeddable() instead"
+                    .to_string(),
+            ));
         }
 
         context.check_progress(ProgressPhase::Signing, 1, 1)?;
@@ -8172,6 +8165,79 @@ pub mod tests {
             Store::from_stream("image/jpeg", &mut output_file, &mut report, &context).unwrap();
 
         assert!(!report.has_any_error());
+    }
+
+    #[test]
+    fn test_sign_manifest_errors_when_dynamic_placeholders_missing() {
+        // A signer that advertises a dynamic assertion but whose placeholder slot is
+        // never reserved. `sign_manifest` must reject it with an actionable error that
+        // names the offending assertion, rather than the opaque `Error::NotFound` that
+        // `write_dynamic_assertions` would otherwise raise (see issue #2055 review).
+        #[derive(Debug)]
+        struct TestDynamicAssertion {}
+
+        impl DynamicAssertion for TestDynamicAssertion {
+            fn label(&self) -> String {
+                "com.mycompany.myassertion".to_string()
+            }
+
+            fn reserve_size(&self) -> Result<usize> {
+                Ok(64)
+            }
+
+            fn content(
+                &self,
+                _label: &str,
+                _size: Option<usize>,
+                _claim: &PartialClaim,
+            ) -> Result<DynamicAssertionContent> {
+                Ok(DynamicAssertionContent::Cbor(Vec::new()))
+            }
+        }
+
+        struct DynamicSigner(Box<dyn Signer>);
+
+        impl crate::Signer for DynamicSigner {
+            fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
+                self.0.sign(data)
+            }
+
+            fn alg(&self) -> SigningAlg {
+                self.0.alg()
+            }
+
+            fn certs(&self) -> Result<Vec<Vec<u8>>> {
+                self.0.certs()
+            }
+
+            fn reserve_size(&self) -> usize {
+                self.0.reserve_size()
+            }
+
+            fn dynamic_assertions(&self) -> Vec<Box<dyn DynamicAssertion>> {
+                vec![Box::new(TestDynamicAssertion {})]
+            }
+        }
+
+        let context = crate::context::Context::new();
+        let signer = DynamicSigner(test_signer(SigningAlg::Ps256));
+
+        let mut store = Store::from_context(&context);
+        store.commit_claim(create_test_claim().unwrap()).unwrap();
+
+        // Reserve the hard-binding placeholder only – no dynamic-assertion slots.
+        store
+            .get_data_hashed_manifest_placeholder(Signer::reserve_size(&signer), "jpeg")
+            .unwrap();
+
+        let err = store.sign_manifest(&signer, &context).unwrap_err();
+        match err {
+            Error::BadParam(msg) => assert!(
+                msg.contains("com.mycompany.myassertion"),
+                "error should name the assertion missing a placeholder slot: {msg}"
+            ),
+            other => panic!("expected Error::BadParam, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Automated backport of #2421 to `stable`.

Upstream-first: this change already merged to `main`. The automated
[backport-action](https://github.com/korthout/backport-action) run failed
to cherry-pick cleanly, so this was done by hand:

- Cherry-picked merge commit b0a3c2bd onto `stable`.
- Resolved a conflict in `sdk/src/identity/builder/identity_assertion_signer.rs`:
  `stable` doesn't yet have the `cert_chain` field that main's version of the
  struct carries (added by an unrelated, not-yet-backported commit), so the
  struct/field-type change from #2421 was applied without introducing that
  field.
- Adapted the new regression test in
  `sdk/src/identity/tests/embeddable_signing.rs`, which used
  `c2pa_raw_crypto::signer_from_private_key` and the two-argument
  `X509CredentialHolder::from_raw_signer(signer, cert_chain_der)` — both from
  the c2pa-raw-crypto split (#2231), which hasn't been backported to `stable`.
  Switched to stable's `crate::crypto::raw_signature::
  signer_from_cert_chain_and_private_key` and the single-argument
  `from_raw_signer`, matching the existing pattern in
  `x509_credential_holder::tests::simple_case`.

No other functional changes vs. the original PR.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy -p c2pa --lib --tests` clean
- [x] `cargo test -p c2pa --lib identity::` — 77 passed, 0 failed
- [x] `cargo test -p c2pa --lib store::` — same 3 pre-existing fixture
      failures (`libpng-test.png` not found) reproduced on unmodified
      `stable`; unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)