### PR TITLE
fix: Avoid QoS runtime detection warning

### DIFF
--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -14,6 +14,7 @@
 use std::{
     fs::File,
     io::{Cursor, Read, Seek, SeekFrom},
+    num::NonZeroUsize,
     ops::RangeInclusive,
     path::Path,
 };
@@ -27,41 +28,6 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
 
 const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
-
-// Tests that need the chunked read-ahead path override this per thread.
-#[cfg(test)]
-thread_local! {
-    static MAX_HASH_BUF_OVERRIDE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
-}
-
-// Restores the previous value on drop.
-#[cfg(test)]
-struct MaxHashBufGuard(Option<usize>);
-
-#[cfg(test)]
-impl MaxHashBufGuard {
-    fn new(size: usize) -> Self {
-        MaxHashBufGuard(MAX_HASH_BUF_OVERRIDE.with(|o| o.replace(Some(size))))
-    }
-}
-
-#[cfg(test)]
-impl Drop for MaxHashBufGuard {
-    fn drop(&mut self) {
-        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(self.0));
-    }
-}
-
-#[inline]
-fn max_hash_buf() -> usize {
-    #[cfg(test)]
-    {
-        if let Some(size) = MAX_HASH_BUF_OVERRIDE.with(|o| o.get()) {
-            return size;
-        }
-    }
-    MAX_HASH_BUF
-}
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// Defines a hash range to be used with `hash_stream_by_alg`
@@ -265,6 +231,33 @@ where
     R: Read + Seek + ?Sized,
     F: FnMut(u32, u32) -> Result<()>,
 {
+    let max_hash_buf = NonZeroUsize::new(MAX_HASH_BUF)
+        .ok_or(Error::BadParam("invalid max_hash_buf".to_string()))?;
+    hash_stream_by_alg_with_progress_impl(
+        alg,
+        data,
+        hash_range,
+        is_exclusion,
+        progress,
+        max_hash_buf,
+    )
+}
+
+/// Make `hash_stream_by_alg_with_progress` configurable with `max_hash_buf`.
+/// Currently used only in tests to lower the `max_hash_buf` limit.
+fn hash_stream_by_alg_with_progress_impl<R, F>(
+    alg: &str,
+    data: &mut R,
+    hash_range: Option<Vec<HashRange>>,
+    is_exclusion: bool,
+    progress: &mut F,
+    max_hash_buf: NonZeroUsize,
+) -> Result<Vec<u8>>
+where
+    R: Read + Seek + ?Sized,
+    F: FnMut(u32, u32) -> Result<()>,
+{
+    let max_hash_buf = max_hash_buf.get();
     let mut bmff_v2_starts: Vec<u64> = Vec::new();
 
     use Hasher::*;
@@ -428,7 +421,7 @@ where
         .iter()
         .map(|r| {
             let len = r.end() - r.start() + 1;
-            (len as usize).div_ceil(max_hash_buf()) as u32
+            (len as usize).div_ceil(max_hash_buf) as u32
         })
         .sum();
     let mut step: u32 = 0;
@@ -453,7 +446,7 @@ where
             data.seek(SeekFrom::Start(*start))?;
 
             loop {
-                let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
+                let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf)];
 
                 data.read_exact(&mut chunk)?;
 
@@ -489,7 +482,7 @@ where
             // move to start of range
             data.seek(SeekFrom::Start(*start))?;
 
-            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
+            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf)];
             data.read_exact(&mut chunk)?;
 
             loop {
@@ -512,7 +505,7 @@ where
                     .map_err(|_| Error::ThreadReceiveError)?;
 
                 // read next chunk while we wait for hash
-                let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
+                let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf)];
                 data.read_exact(&mut next_chunk)?;
 
                 hasher_enum = match rx.recv() {
@@ -649,6 +642,11 @@ mod tests {
 
     use super::*;
 
+    // Small enough that a few KB of test data spans multiple chunks.
+    fn test_hash_buf() -> NonZeroUsize {
+        NonZeroUsize::new(1024).unwrap()
+    }
+
     // Attacker-controlled HashRange with start+length > u64::MAX must return Err,
     // not panic, in both the exclusion and inclusion paths.
     #[test]
@@ -704,19 +702,26 @@ mod tests {
     // none for the final chunk regardless of whether it hashed inline.
     #[test]
     fn progress_sequence_multi_chunk() {
-        let _guard = MaxHashBufGuard::new(1024);
-        let data = vec![0u8; 3 * 1024]; // 3 chunks at the overridden buffer size
+        let data = vec![0u8; 3 * 1024]; // 3 chunks at the 1024 buffer size below
         let mut reader = Cursor::new(&data);
         let mut seen: Vec<(u32, u32)> = Vec::new();
         let mut cb = |step, total| {
             seen.push((step, total));
             Ok(())
         };
-        hash_stream_by_alg_with_progress("sha256", &mut reader, None, true, &mut cb).unwrap();
+        hash_stream_by_alg_with_progress_impl(
+            "sha256",
+            &mut reader,
+            None,
+            true,
+            &mut cb,
+            test_hash_buf(),
+        )
+        .unwrap();
         assert_eq!(seen, vec![(1, 3), (2, 3), (3, 3)]);
     }
 
-    // 3 chunks at the overridden buffer size, non-uniform.
+    // 3 chunks at the 1024 buffer size passed below, non-uniform.
     // A reordered or dropped chunk changes the hash.
     // Expected value computed with:
     //   python3 -c "import hashlib
@@ -724,10 +729,17 @@ mod tests {
     //   print(hashlib.sha256(d).hexdigest())"
     #[test]
     fn multi_chunk_digest_matches_known_value() {
-        let _guard = MaxHashBufGuard::new(1024);
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
-        let hash = hash_stream_by_alg("sha256", &mut reader, None, true).unwrap();
+        let hash = hash_stream_by_alg_with_progress_impl(
+            "sha256",
+            &mut reader,
+            None,
+            true,
+            &mut |_, _| Ok(()),
+            test_hash_buf(),
+        )
+        .unwrap();
 
         assert_eq!(
             hash,
@@ -742,11 +754,18 @@ mod tests {
     //   print(hashlib.sha256(d[:1000] + d[1100:]).hexdigest())"
     #[test]
     fn multi_chunk_digest_survives_range_splits() {
-        let _guard = MaxHashBufGuard::new(1024);
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
         let hr = vec![HashRange::new(1000, 100)];
-        let hash = hash_stream_by_alg("sha256", &mut reader, Some(hr), true).unwrap();
+        let hash = hash_stream_by_alg_with_progress_impl(
+            "sha256",
+            &mut reader,
+            Some(hr),
+            true,
+            &mut |_, _| Ok(()),
+            test_hash_buf(),
+        )
+        .unwrap();
 
         assert_eq!(
             hash,

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -244,7 +244,7 @@ where
 }
 
 /// Make `hash_stream_by_alg_with_progress` configurable with `max_hash_buf`.
-/// Currently used only in tests to lower the `max_hash_buf` limit.
+/// e.g. makes it configurable in tests too.
 fn hash_stream_by_alg_with_progress_impl<R, F>(
     alg: &str,
     data: &mut R,
@@ -501,8 +501,7 @@ where
                     .spawn(move || {
                         hasher_enum.update(&chunk);
                         tx.send(hasher_enum).unwrap_or_default();
-                    })
-                    .map_err(|_| Error::ThreadReceiveError)?;
+                    })?;
 
                 // read next chunk while we wait for hash
                 let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf)];

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -617,6 +617,8 @@ mod tests {
 
     use std::io::Cursor;
 
+    use hex_literal::hex;
+
     use super::*;
 
     // Attacker-controlled HashRange with start+length > u64::MAX must return Err,
@@ -683,5 +685,41 @@ mod tests {
         };
         hash_stream_by_alg_with_progress("sha256", &mut reader, None, true, &mut cb).unwrap();
         assert_eq!(seen, vec![(1, 3), (2, 3), (3, 3)]);
+    }
+
+    // 3 chunks at the test MAX_HASH_BUF, non-uniform.
+    // A reordered or dropped chunk changes the hash.
+    // Expected value computed with:
+    //   python3 -c "import hashlib
+    //   d = bytes((i % 251) for i in range(3*1024))
+    //   print(hashlib.sha256(d).hexdigest())"
+    #[test]
+    fn multi_chunk_digest_matches_known_value() {
+        let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
+        let mut reader = Cursor::new(&data);
+        let hash = hash_stream_by_alg("sha256", &mut reader, None, true).unwrap();
+
+        assert_eq!(
+            hash,
+            hex!("5f24b2f16026ec7d0450a5a08283d3cfd47302fe859f579ed79fe7d2663b73f9")
+        );
+    }
+
+    // Exclusion splits this into a 1-chunk range and a 2-chunk range.
+    // Expected value computed with:
+    //   python3 -c "import hashlib
+    //   d = bytes((i % 251) for i in range(3*1024))
+    //   print(hashlib.sha256(d[:1000] + d[1100:]).hexdigest())"
+    #[test]
+    fn multi_chunk_digest_survives_range_splits() {
+        let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
+        let mut reader = Cursor::new(&data);
+        let hr = vec![HashRange::new(1000, 100)];
+        let hash = hash_stream_by_alg("sha256", &mut reader, Some(hr), true).unwrap();
+
+        assert_eq!(
+            hash,
+            hex!("e3301ce38a42503098530b98cd1b652a10c5caf890735017dd0012ec319f04e5")
+        );
     }
 }

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -34,6 +34,24 @@ thread_local! {
     static MAX_HASH_BUF_OVERRIDE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
+// Restores the previous value on drop.
+#[cfg(test)]
+struct MaxHashBufGuard(Option<usize>);
+
+#[cfg(test)]
+impl MaxHashBufGuard {
+    fn new(size: usize) -> Self {
+        MaxHashBufGuard(MAX_HASH_BUF_OVERRIDE.with(|o| o.replace(Some(size))))
+    }
+}
+
+#[cfg(test)]
+impl Drop for MaxHashBufGuard {
+    fn drop(&mut self) {
+        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(self.0));
+    }
+}
+
 #[inline]
 fn max_hash_buf() -> usize {
     #[cfg(test)]
@@ -686,7 +704,7 @@ mod tests {
     // none for the final chunk regardless of whether it hashed inline.
     #[test]
     fn progress_sequence_multi_chunk() {
-        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
+        let _guard = MaxHashBufGuard::new(1024);
         let data = vec![0u8; 3 * 1024]; // 3 chunks at the overridden buffer size
         let mut reader = Cursor::new(&data);
         let mut seen: Vec<(u32, u32)> = Vec::new();
@@ -706,7 +724,7 @@ mod tests {
     //   print(hashlib.sha256(d).hexdigest())"
     #[test]
     fn multi_chunk_digest_matches_known_value() {
-        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
+        let _guard = MaxHashBufGuard::new(1024);
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
         let hash = hash_stream_by_alg("sha256", &mut reader, None, true).unwrap();
@@ -724,7 +742,7 @@ mod tests {
     //   print(hashlib.sha256(d[:1000] + d[1100:]).hexdigest())"
     #[test]
     fn multi_chunk_digest_survives_range_splits() {
-        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
+        let _guard = MaxHashBufGuard::new(1024);
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
         let hr = vec![HashRange::new(1000, 100)];
@@ -736,4 +754,3 @@ mod tests {
         );
     }
 }
-

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -26,12 +26,24 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
 
-#[cfg(not(test))]
 const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
 
-// Smaller for testing to hit the paths where it buffers.
+// Tests that need the chunked read-ahead path override this per thread.
 #[cfg(test)]
-const MAX_HASH_BUF: usize = 1024;
+thread_local! {
+    static MAX_HASH_BUF_OVERRIDE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[inline]
+fn max_hash_buf() -> usize {
+    #[cfg(test)]
+    {
+        if let Some(size) = MAX_HASH_BUF_OVERRIDE.with(|o| o.get()) {
+            return size;
+        }
+    }
+    MAX_HASH_BUF
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// Defines a hash range to be used with `hash_stream_by_alg`
@@ -398,7 +410,7 @@ where
         .iter()
         .map(|r| {
             let len = r.end() - r.start() + 1;
-            (len as usize).div_ceil(MAX_HASH_BUF) as u32
+            (len as usize).div_ceil(max_hash_buf()) as u32
         })
         .sum();
     let mut step: u32 = 0;
@@ -423,7 +435,7 @@ where
             data.seek(SeekFrom::Start(*start))?;
 
             loop {
-                let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+                let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
 
                 data.read_exact(&mut chunk)?;
 
@@ -441,9 +453,7 @@ where
         }
     } else {
         // hash the data for ranges, reading the next chunk on this thread while
-        // the current one hashes on a worker.
-        // Only one worker hashes at a time since the Hasher moves through the channel,
-        // so this hides read latency (hash is still moving ahead sequentially).
+        // the current one hashes on a worker (hash is still moving ahead sequentially).
         for r in ranges {
             step += 1;
             progress(step, total)?;
@@ -461,7 +471,7 @@ where
             // move to start of range
             data.seek(SeekFrom::Start(*start))?;
 
-            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+            let mut chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
             data.read_exact(&mut chunk)?;
 
             loop {
@@ -484,7 +494,7 @@ where
                     .map_err(|_| Error::ThreadReceiveError)?;
 
                 // read next chunk while we wait for hash
-                let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
+                let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, max_hash_buf())];
                 data.read_exact(&mut next_chunk)?;
 
                 hasher_enum = match rx.recv() {
@@ -676,7 +686,8 @@ mod tests {
     // none for the final chunk regardless of whether it hashed inline.
     #[test]
     fn progress_sequence_multi_chunk() {
-        let data = vec![0u8; 3 * 1024]; // 3 chunks at the test MAX_HASH_BUF
+        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
+        let data = vec![0u8; 3 * 1024]; // 3 chunks at the overridden buffer size
         let mut reader = Cursor::new(&data);
         let mut seen: Vec<(u32, u32)> = Vec::new();
         let mut cb = |step, total| {
@@ -687,7 +698,7 @@ mod tests {
         assert_eq!(seen, vec![(1, 3), (2, 3), (3, 3)]);
     }
 
-    // 3 chunks at the test MAX_HASH_BUF, non-uniform.
+    // 3 chunks at the overridden buffer size, non-uniform.
     // A reordered or dropped chunk changes the hash.
     // Expected value computed with:
     //   python3 -c "import hashlib
@@ -695,6 +706,7 @@ mod tests {
     //   print(hashlib.sha256(d).hexdigest())"
     #[test]
     fn multi_chunk_digest_matches_known_value() {
+        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
         let hash = hash_stream_by_alg("sha256", &mut reader, None, true).unwrap();
@@ -712,6 +724,7 @@ mod tests {
     //   print(hashlib.sha256(d[:1000] + d[1100:]).hexdigest())"
     #[test]
     fn multi_chunk_digest_survives_range_splits() {
+        MAX_HASH_BUF_OVERRIDE.with(|o| o.set(Some(1024)));
         let data: Vec<u8> = (0..3 * 1024).map(|i| (i % 251) as u8).collect();
         let mut reader = Cursor::new(&data);
         let hr = vec![HashRange::new(1000, 100)];
@@ -723,3 +736,4 @@ mod tests {
         );
     }
 }
+

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -26,7 +26,12 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
 
+#[cfg(not(test))]
 const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
+
+// Smaller for testing to hit the paths where it buffers.
+#[cfg(test)]
+const MAX_HASH_BUF: usize = 1024;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// Defines a hash range to be used with `hash_stream_by_alg`
@@ -435,7 +440,10 @@ where
             }
         }
     } else {
-        // hash the data for ranges
+        // hash the data for ranges, reading the next chunk on this thread while
+        // the current one hashes on a worker.
+        // Only one worker hashes at a time since the Hasher moves through the channel,
+        // so this hides read latency (hash is still moving ahead sequentially).
         for r in ranges {
             step += 1;
             progress(step, total)?;
@@ -457,23 +465,23 @@ where
             data.read_exact(&mut chunk)?;
 
             loop {
-                let (tx, rx) = std::sync::mpsc::channel();
-
                 chunk_left -= chunk.len() as u64;
 
-                std::thread::spawn(move || {
-                    hasher_enum.update(&chunk);
-                    tx.send(hasher_enum).unwrap_or_default();
-                });
-
-                // are we done
+                // with no next chunk to read there is nothing to overlap, so hash inline.
                 if chunk_left == 0 {
-                    hasher_enum = match rx.recv() {
-                        Ok(hasher) => hasher,
-                        Err(_) => return Err(Error::ThreadReceiveError),
-                    };
+                    hasher_enum.update(&chunk);
                     break;
                 }
+
+                let (tx, rx) = std::sync::mpsc::channel();
+
+                std::thread::Builder::new()
+                    .name("c2pa-hash".to_string())
+                    .spawn(move || {
+                        hasher_enum.update(&chunk);
+                        tx.send(hasher_enum).unwrap_or_default();
+                    })
+                    .map_err(|_| Error::ThreadReceiveError)?;
 
                 // read next chunk while we wait for hash
                 let mut next_chunk = vec![0u8; std::cmp::min(chunk_left as usize, MAX_HASH_BUF)];
@@ -660,5 +668,20 @@ mod tests {
             matches!(result, Err(Error::OperationCancelled)),
             "expected OperationCancelled, got {result:?}"
         );
+    }
+
+    // One tick per range before any read, one after each non-final chunk,
+    // none for the final chunk regardless of whether it hashed inline.
+    #[test]
+    fn progress_sequence_multi_chunk() {
+        let data = vec![0u8; 3 * 1024]; // 3 chunks at the test MAX_HASH_BUF
+        let mut reader = Cursor::new(&data);
+        let mut seen: Vec<(u32, u32)> = Vec::new();
+        let mut cb = |step, total| {
+            seen.push((step, total));
+            Ok(())
+        };
+        hash_stream_by_alg_with_progress("sha256", &mut reader, None, true, &mut cb).unwrap();
+        assert_eq!(seen, vec![(1, 3), (2, 3), (3, 3)]);
     }
 }


### PR DESCRIPTION
## Changes in this pull request
- Avoids spawning a hash worker thread when there is nothing to overlap, which avoids the warning from Apple's Thread Performance Checker which reports a priority inversion during signing on iOS/iPadOS:
```
Thread running at User-interactive quality-of-service class waiting on a lower QoS thread running at Default quality-of-service class. 
```

The loop in `hash_stream_by_alg_with_progress` spawns a worker thread per chunk to read the next chunk while the current worker hashes. On Apple platforms (iOS) a thread created by `std::thread::spawn` runs at `QOS_CLASS_DEFAULT` (~default priority) and does not inherit the spawner's priority, so a user-interactive caller (higher priority) blocking on that worker (default priority is lower priority) gets flagged with the warning about the inversion of QoS/priority levels.

So, here we hash inline for "small" cases, and spawn the worker only on-demand. The read-ahead behaviour for ranges larger than `MAX_HASH_BUF` is unchanged (and hash output is unchanged too, as is the progress callback). Also, names the thread so it is easier to identify.

Note: Ranges larger than `MAX_HASH_BUF` still spawn a `QOS_CLASS_DEFAULT` thread and can still trigger the warning on iOS, but this change will spare the (runtime check) warning for smaller assets (which are likely to be more common cases than 256MB+ ones).

Note 2: It should not impact perf for larger files, since the larger-filesize path is kept as-is.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
