### PR TITLE
fix: Reject BMFF update manifest without a paired original manifest

### DIFF
--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -1937,6 +1937,13 @@ impl CAIReader for BmffIO {
                     "original manifest without update manifest".to_string(),
                 ));
             }
+        } else if c2pa_boxes.update_bytes.is_some() {
+            // `update` only ever exists paired with `original` (spec Annex
+            // A.5.3). Falling through here would silently drop a
+            // still-signed update manifest instead of erroring.
+            return Err(Error::C2PAValidation(
+                "update manifest without original manifest".to_string(),
+            ));
         }
 
         c2pa_boxes.manifest_bytes.ok_or(Error::JumbfNotFound)
@@ -3460,6 +3467,77 @@ pub mod tests {
             get_uuid_box_purpose(&mut reader, node),
             Err(Error::InvalidAsset(_))
         ));
+    }
+
+    // Regression tests for the `original`/`update` box_purpose pairing.
+    //
+    // Per C2PA spec Annex A.5.3, `original` and `update` boxes always travel
+    // together. `read_cai` must reject either appearing without its pair
+    // rather than silently falling back to `manifest_bytes` and dropping a
+    // still-signed manifest.
+
+    fn minimal_ftyp() -> Vec<u8> {
+        let mut data = Vec::new();
+        // ftyp box (16 bytes): size=16, type='ftyp', major_brand='mp41', minor_version=0
+        data.extend_from_slice(&16u32.to_be_bytes());
+        data.extend_from_slice(b"ftyp");
+        data.extend_from_slice(b"mp41");
+        data.extend_from_slice(&0u32.to_be_bytes());
+        data
+    }
+
+    #[test]
+    fn test_read_cai_rejects_update_without_original() {
+        let mut data = minimal_ftyp();
+        // Simulates the retagged asset: the box that should be `original` has
+        // been retagged to plain `manifest`, but the paired `update` box is
+        // still present and untouched.
+        write_c2pa_box(&mut data, b"dummy manifest bytes", MANIFEST, &[], 0).unwrap();
+        write_c2pa_box(&mut data, b"dummy update bytes", UPDATE, &[], 0).unwrap();
+
+        let bmff_io = BmffIO::new("mp4");
+        let mut source = Cursor::new(data);
+        let result = bmff_io.read_cai(&mut source);
+        assert!(
+            matches!(
+                result,
+                Err(Error::C2PAValidation(ref m)) if m == "update manifest without original manifest"
+            ),
+            "expected update-without-original to be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_read_cai_rejects_original_without_update() {
+        let mut data = minimal_ftyp();
+        write_c2pa_box(&mut data, b"dummy original bytes", ORIGINAL, &[], 0).unwrap();
+
+        let bmff_io = BmffIO::new("mp4");
+        let mut source = Cursor::new(data);
+        let result = bmff_io.read_cai(&mut source);
+        assert!(
+            matches!(
+                result,
+                Err(Error::C2PAValidation(ref m)) if m == "original manifest without update manifest"
+            ),
+            "expected original-without-update to be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_read_cai_accepts_ordinary_manifest_alone() {
+        // A plain, never-updated asset has only a `manifest`-purposed box -
+        // neither pairing check should fire for it.
+        let mut data = minimal_ftyp();
+        write_c2pa_box(&mut data, b"dummy manifest bytes", MANIFEST, &[], 0).unwrap();
+
+        let bmff_io = BmffIO::new("mp4");
+        let mut source = Cursor::new(data);
+        let result = bmff_io.read_cai(&mut source);
+        assert!(
+            matches!(result, Ok(ref bytes) if bytes == b"dummy manifest bytes"),
+            "expected ordinary manifest-only asset to be read as-is, got {result:?}"
+        );
     }
 
     // Regression: `_skip_bytes(reader, size)` used `size as i64`, which wraps


### PR DESCRIPTION
## Changes in this pull request
`BmffIO::read_cai` (`sdk/src/asset_handlers/bmff_io.rs`) sorts C2PA `uuid` boxes into `manifest_bytes`/`original_bytes`/`update_bytes` by `box_purpose`, then merges `original` + `update` for Update Manifest assets. It errored on "`original` present, `update` missing" but had no check for the reverse — an `update` box with no `original` silently fell through to returning `manifest_bytes` alone, dropping a still-signed manifest with no error.

Since `box_purpose` is excluded from the C2PA hash (by design, for update workflows), an 8-byte ASCII retag (`original` → `manifest`) reproduces this without breaking any hash check. Reproduced with the reporter's files: baseline reports `Valid`/2 manifests, retagged reports `Valid`/1 manifest — a signed manifest silently vanishes. In scope per `SECURITY.md`'s "Failure to detect invalid/untrusted status" category.

**Fix:** added the missing symmetric branch — `update_bytes` present without `original_bytes` now errors (`"update manifest without original manifest"`), mirroring the existing reverse check. `write_cai` already enforces both directions in one condition; `read_cai` was missing half of it.

## Tests added
- `test_read_cai_rejects_update_without_original` — reproduces the retagged state; confirmed fails without the fix, passes with it.
- `test_read_cai_rejects_original_without_update` — the pre-existing error path had no test.
- `test_read_cai_accepts_ordinary_manifest_alone` — positive case.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
