### PR TITLE
update: bump sha1 from 0.10.7 to 0.11.0 (backport #2456)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "spki",
  "static-iref",
@@ -1889,7 +1889,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -4194,6 +4194,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -167,7 +167,7 @@ serde_derive = "1.0.228"
 serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde_with = "3.20.0"
 serde-transcode = "1.1.1"
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 sha2 = "0.11.0"
 spki = { version = "0.7.3", optional = true }
 static-iref = "3.0"


### PR DESCRIPTION
Automated backport of #2456 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.