### PR TITLE
macros: enable syn 'full' to fix compile error

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.45"
-syn = { version = "2.0.117" }
+syn = { version = "2.0.117", features = ["full"] }


### PR DESCRIPTION
## Changes in this pull request
Enables syn crate's "full" feature in macros/Cargo.toml so syn::ItemFn and other `Item*` types are available. This fixes a compile error in the c2pa_macros crate that prevented workspace builds and tests from running.

The change is a single-line edit in macros/Cargo.toml:

```
syn = { version = "2.0.117", features = ["full"] }
```

Verification:
- Built and ran tests for the macros crate locally (tests: 0 passed, 0 failed).
- Confirmed the macros crate compiles; further workspace test execution is optional and may take longer.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.