### PR TITLE
chore: Count integration tests in Codecov coverage (backport #2387)

### DIFF
--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -95,7 +95,7 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.openssl-features}}
         run: |
-          cargo llvm-cov --lib --features "$FEATURES" --lcov --output-path lcov-openssl.info
+          cargo llvm-cov --tests --features "$FEATURES" --lcov --output-path lcov-openssl.info
 
       - name: Filter out tests
         uses: scouten/uncover-tests@af7baaca5bf5189b968573d5f14627c2e1ea0704 # v1.1.0
@@ -154,7 +154,7 @@ jobs:
           RUST_BACKTRACE: "1"
           FEATURES: ${{needs.get-features.outputs.rust-native-features}}
         run: |
-          cargo llvm-cov -p c2pa --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
+          cargo llvm-cov -p c2pa --tests --no-default-features --features "$FEATURES" --lcov --output-path lcov-rust_native_crypto.info
 
       - name: Filter out tests
         uses: scouten/uncover-tests@af7baaca5bf5189b968573d5f14627c2e1ea0704 # v1.1.0


### PR DESCRIPTION
Manual backport of #2387 to `stable`.

The automated backport failed because `stable`'s `.github/workflows/tier-1a.yml` has diverged from `main` (it does not yet carry the `authorize` trust job or the reworked `get-features` step), so the cherry-pick hit context conflicts. The functional change itself is unchanged and applies cleanly: both coverage-generation steps switch from `--lib` to `--tests` so integration tests under `sdk/tests/` count toward Codecov, and the `scouten/uncover-tests` filter is retained for both variants.

Verified the resulting diff on `stable` is exactly the two intended line changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)