### PR TITLE
fix: Propagate created flag to metadata assertions (backport #2459)

### DIFF
--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -613,14 +613,16 @@ impl Manifest {
                     let assertion_metadata = AssertionMetadata::from_assertion(assertion)?;
                     let manifest_assertion =
                         ManifestAssertion::from_assertion(&assertion_metadata)?
-                            .set_instance(claim_assertion.instance());
+                            .set_instance(claim_assertion.instance())
+                            .set_created(created);
                     manifest.assertions.push(manifest_assertion);
                 } // all other labels that end in .metadata are Metadata assertions
                 label if label.ends_with(".metadata") => {
                     let metadata = Metadata::from_assertion(assertion)?;
                     let manifest_assertion = ManifestAssertion::from_assertion(&metadata)?
                         .set_kind(ManifestAssertionKind::Json)
-                        .set_instance(claim_assertion.instance());
+                        .set_instance(claim_assertion.instance())
+                        .set_created(created);
                     manifest.assertions.push(manifest_assertion);
                 }
                 label

--- a/sdk/tests/test_builder.rs
+++ b/sdk/tests/test_builder.rs
@@ -616,6 +616,84 @@ fn test_metadata_formats_json_manifest() -> Result<()> {
     Ok(())
 }
 
+/// The created/gathered attribution must be kept in the read path for metadata assertions.
+#[test]
+fn test_metadata_assertion_created_flag_round_trips() -> Result<()> {
+    let context = test_context().into_shared();
+
+    let manifest_json = r#"
+    {
+        "assertions": [
+            {
+                "label": "c2pa.metadata",
+                "kind": "Json",
+                "created": true,
+                "data": {
+                    "@context": { "exif": "http://ns.adobe.com/exif/1.0/" },
+                    "exif:GPSLatitude": "39,21.102N"
+                }
+            },
+            {
+                "label": "cawg.metadata",
+                "kind": "Json",
+                "data": {
+                    "@context": { "cawg": "http://cawg.org/ns/1.0/" },
+                    "cawg:SomeField": "SomeValue"
+                }
+            },
+            {
+                "label": "c2pa.assertion.metadata",
+                "created": true,
+                "data": {
+                    "@context": { "custom": "http://custom.org/ns/1.0/" },
+                    "custom:Field": "CustomValue"
+                }
+            }
+        ]
+    }
+    "#;
+
+    let mut builder = Builder::from_shared_context(&context).with_definition(manifest_json)?;
+    const TEST_IMAGE: &[u8] = include_bytes!("fixtures/CA.jpg");
+    let format = "image/jpeg";
+    let mut source = Cursor::new(TEST_IMAGE);
+    let mut dest = Cursor::new(Vec::new());
+
+    builder.sign(context.signer()?, format, &mut source, &mut dest)?;
+
+    dest.set_position(0);
+    let reader = Reader::from_shared_context(&context).with_stream(format, &mut dest)?;
+
+    let created_of = |label: &str| -> bool {
+        reader
+            .active_manifest()
+            .unwrap()
+            .assertions()
+            .iter()
+            .find(|a| a.label() == label)
+            .unwrap_or_else(|| panic!("{label} should be present"))
+            .created()
+    };
+
+    // `c2pa.metadata` and `cawg.metadata` decode as Metadata,
+    // `c2pa.assertion.metadata` decodes as AssertionMetadata.
+    assert!(
+        created_of("c2pa.metadata"),
+        "a created c2pa.metadata assertion reads back as created"
+    );
+    assert!(
+        created_of("c2pa.assertion.metadata"),
+        "a created c2pa.assertion.metadata assertion reads back as created"
+    );
+    // A gathered assertion must stay gathered.
+    assert!(
+        !created_of("cawg.metadata"),
+        "a gathered metadata assertion must not read back as created"
+    );
+
+    Ok(())
+}
+
 /// Test that path traversal attempts in archive resources are blocked
 #[test]
 fn test_archive_path_traversal_protection() -> Result<()> {


### PR DESCRIPTION
Automated backport of #2459 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.