### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.15](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.14...c2pa-v0.90.15)
+_13 August 2026_
+
+### Fixed
+
+* Hardening against potential deep recursion in update manifests with parent cycles (backport #2493) ([#2501](https://github.com/contentauth/c2pa-rs/pull/2501))
+
 ## [0.90.14](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.13...c2pa-v0.90.14)
 _13 August 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.14"
+version = "0.90.15"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.14"
+version = "0.90.15"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.14"
+version = "0.90.15"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.14"
+version = "0.27.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.14"
+version = "0.90.15"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2603,7 +2603,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.14"
+version = "0.90.15"
 dependencies = [
  "anyhow",
  "c2pa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.14"
+version = "0.90.15"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.14", default-features = false }
+c2pa = { path = "sdk", version = "0.90.15", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.15](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.14...c2patool-v0.27.15)
+_13 August 2026_
+
 ## [0.27.14](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.13...c2patool-v0.27.14)
 _13 August 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.14"
+version = "0.27.15"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.14 -> 0.90.15 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.14 -> 0.90.15
* `c2patool`: 0.27.14 -> 0.27.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.15](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.14...c2pa-v0.90.15)

_13 August 2026_

### Fixed

* Hardening against potential deep recursion in update manifests with parent cycles (backport #2493) ([#2501](https://github.com/contentauth/c2pa-rs/pull/2501))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.4](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.3...c2pa-c-ffi-v0.90.4)

_04 August 2026_

### Fixed

* Emscripten build which lost its header (backport #2395) ([#2396](https://github.com/contentauth/c2pa-rs/pull/2396))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.15](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.14...c2patool-v0.27.15)

_13 August 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).