### PR TITLE
feat: Make BMFF hash exclusion of /free and /skip boxes configurable

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -635,6 +635,17 @@ impl BmffHash {
 
     // Adds default exclusion ranges for BMFF hashes.  Add as needed.
     pub fn set_default_exclusions(&mut self) -> &[ExclusionsMap] {
+        self.set_default_exclusions_with_options(true)
+    }
+
+    /// Like [`set_default_exclusions`](Self::set_default_exclusions), but lets
+    /// the caller control whether `/free` and `/skip` are excluded from the
+    /// hash. Mirrors
+    /// [`BuilderSettings::bmff_hash_exclude_free_and_skip_boxes`](crate::settings::builder::BuilderSettings::bmff_hash_exclude_free_and_skip_boxes).
+    pub fn set_default_exclusions_with_options(
+        &mut self,
+        exclude_free_and_skip: bool,
+    ) -> &[ExclusionsMap] {
         let exclusions = &mut self.exclusions;
 
         let cp2a_id: [u8; 16] = [
@@ -668,16 +679,18 @@ impl BmffHash {
             exclusions.push(mfra);
         }
 
-        // /free exclusion
-        if !exclusions.iter().any(|e| e.xpath == "/free") {
-            let free = ExclusionsMap::new("/free".to_owned());
-            exclusions.push(free);
-        }
+        if exclude_free_and_skip {
+            // /free exclusion
+            if !exclusions.iter().any(|e| e.xpath == "/free") {
+                let free = ExclusionsMap::new("/free".to_owned());
+                exclusions.push(free);
+            }
 
-        // /skip exclusion
-        if !exclusions.iter().any(|e| e.xpath == "/skip") {
-            let skip = ExclusionsMap::new("/skip".to_owned());
-            exclusions.push(skip);
+            // /skip exclusion
+            if !exclusions.iter().any(|e| e.xpath == "/skip") {
+                let skip = ExclusionsMap::new("/skip".to_owned());
+                exclusions.push(skip);
+            }
         }
 
         /*  no longer mandatory
@@ -2505,6 +2518,29 @@ mod bmff_hash_tests {
 
     use super::*;
     use crate::asset_handlers::bmff_io::{BoxInfoLite, C2PABmffBoxes};
+
+    /// `set_default_exclusions` (no args) must keep excluding `/free`/`/skip`,
+    /// matching its existing, documented default behavior.
+    #[test]
+    fn set_default_exclusions_excludes_free_and_skip() {
+        let mut bmff_hash = BmffHash::new("test", "sha256", None);
+        let exclusions = bmff_hash.set_default_exclusions();
+        assert!(exclusions.iter().any(|e| e.xpath == "/free"));
+        assert!(exclusions.iter().any(|e| e.xpath == "/skip"));
+    }
+
+    /// `set_default_exclusions_with_options(false)` must omit `/free`/`/skip`
+    /// from the exclusion list, so their content is folded into the hash.
+    #[test]
+    fn set_default_exclusions_with_options_false_keeps_free_and_skip_hashed() {
+        let mut bmff_hash = BmffHash::new("test", "sha256", None);
+        let exclusions = bmff_hash.set_default_exclusions_with_options(false);
+        assert!(!exclusions.iter().any(|e| e.xpath == "/free"));
+        assert!(!exclusions.iter().any(|e| e.xpath == "/skip"));
+        // Other mandatory exclusions are unaffected.
+        assert!(exclusions.iter().any(|e| e.xpath == "/ftyp"));
+        assert!(exclusions.iter().any(|e| e.xpath == "/mfra"));
+    }
 
     fn small_mdat_box_info() -> BoxInfoLite {
         // A standard BMFF mdat box with an 8-byte header and no payload (size = 8).

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -65,6 +65,7 @@ use crate::{
     },
     asset_io::CAIRead,
     cbor_types::UriT,
+    settings::Settings,
     utils::{
         hash_utils::{
             concat_and_hash, hash_stream_by_alg, hash_stream_by_alg_with_progress, vec_compare,
@@ -635,17 +636,15 @@ impl BmffHash {
 
     // Adds default exclusion ranges for BMFF hashes.  Add as needed.
     pub fn set_default_exclusions(&mut self) -> &[ExclusionsMap] {
-        self.set_default_exclusions_with_options(true)
+        self.set_default_exclusions_with_options(&Settings::default())
     }
 
-    /// Like [`set_default_exclusions`](Self::set_default_exclusions), but lets
-    /// the caller control whether `/free` and `/skip` are excluded from the
-    /// hash. Mirrors
-    /// [`BuilderSettings::bmff_hash_exclude_free_and_skip_boxes`](crate::settings::builder::BuilderSettings::bmff_hash_exclude_free_and_skip_boxes).
-    pub fn set_default_exclusions_with_options(
-        &mut self,
-        exclude_free_and_skip: bool,
-    ) -> &[ExclusionsMap] {
+    /// Like [`set_default_exclusions`](Self::set_default_exclusions), but takes
+    /// the full [`Settings`] so new BMFF-hash-related options can be added
+    /// without another signature change. Currently only
+    /// [`BuilderSettings::bmff_hash_exclude_free_and_skip_boxes`](crate::settings::builder::BuilderSettings::bmff_hash_exclude_free_and_skip_boxes)
+    /// is consulted.
+    pub fn set_default_exclusions_with_options(&mut self, settings: &Settings) -> &[ExclusionsMap] {
         let exclusions = &mut self.exclusions;
 
         let cp2a_id: [u8; 16] = [
@@ -679,7 +678,7 @@ impl BmffHash {
             exclusions.push(mfra);
         }
 
-        if exclude_free_and_skip {
+        if settings.builder.bmff_hash_exclude_free_and_skip_boxes {
             // /free exclusion
             if !exclusions.iter().any(|e| e.xpath == "/free") {
                 let free = ExclusionsMap::new("/free".to_owned());
@@ -2529,12 +2528,15 @@ mod bmff_hash_tests {
         assert!(exclusions.iter().any(|e| e.xpath == "/skip"));
     }
 
-    /// `set_default_exclusions_with_options(false)` must omit `/free`/`/skip`
-    /// from the exclusion list, so their content is folded into the hash.
+    /// `set_default_exclusions_with_options` with the setting off must omit
+    /// `/free`/`/skip` from the exclusion list, so their content is folded
+    /// into the hash.
     #[test]
     fn set_default_exclusions_with_options_false_keeps_free_and_skip_hashed() {
         let mut bmff_hash = BmffHash::new("test", "sha256", None);
-        let exclusions = bmff_hash.set_default_exclusions_with_options(false);
+        let mut settings = Settings::default();
+        settings.builder.bmff_hash_exclude_free_and_skip_boxes = false;
+        let exclusions = bmff_hash.set_default_exclusions_with_options(&settings);
         assert!(!exclusions.iter().any(|e| e.xpath == "/free"));
         assert!(!exclusions.iter().any(|e| e.xpath == "/skip"));
         // Other mandatory exclusions are unaffected.

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -2568,7 +2568,12 @@ impl Builder {
                 self.bmff_hasher.alg = ph_alg.to_string();
 
                 let mut placeholder_bmff = BmffHash::new("jumbf manifest", ph_alg, None);
-                placeholder_bmff.set_default_exclusions();
+                placeholder_bmff.set_default_exclusions_with_options(
+                    self.context
+                        .settings()
+                        .builder
+                        .bmff_hash_exclude_free_and_skip_boxes,
+                );
                 placeholder_bmff.add_place_holder_hash()?;
                 let assertion_label = placeholder_bmff.to_assertion()?.label();
                 self.add_assertion(&assertion_label, &placeholder_bmff)?;

--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -2568,12 +2568,9 @@ impl Builder {
                 self.bmff_hasher.alg = ph_alg.to_string();
 
                 let mut placeholder_bmff = BmffHash::new("jumbf manifest", ph_alg, None);
-                placeholder_bmff.set_default_exclusions_with_options(
-                    self.context
-                        .settings()
-                        .builder
-                        .bmff_hash_exclude_free_and_skip_boxes,
-                );
+                // Baked into this assertion's exclusions now; later setting
+                // changes won't affect this placeholder or its signed hash.
+                placeholder_bmff.set_default_exclusions_with_options(self.context.settings());
                 placeholder_bmff.add_place_holder_hash()?;
                 let assertion_label = placeholder_bmff.to_assertion()?.label();
                 self.add_assertion(&assertion_label, &placeholder_bmff)?;
@@ -5836,6 +5833,106 @@ mod tests {
         let reader = Reader::default().with_stream("video/mp4", &mut output_stream)?;
         println!("{reader}");
         assert_eq!(reader.validation_state(), ValidationState::Trusted);
+
+        Ok(())
+    }
+
+    /// End-to-end sign + re-read for the `bmff_hash_exclude_free_and_skip_boxes`
+    /// setting, in both positions. `TEST_VIDEO_MP4` has a real, pre-existing
+    /// top-level `/free` box unrelated to the placeholder (which is inserted
+    /// right after `ftyp`), so tampering with that box's payload after signing
+    /// proves whether it was actually covered by the hash.
+    #[test]
+    fn test_bmff_hash_exclude_free_and_skip_boxes_setting() -> Result<()> {
+        use std::io::{Seek, SeekFrom, Write};
+
+        // Finds the byte offset of a top-level box's payload by walking
+        // 4-byte-size + 4-byte-type headers from the start of the stream.
+        fn find_top_level_box_payload_offset(data: &[u8], want_type: &[u8; 4]) -> Option<usize> {
+            let mut pos = 0;
+            while pos + 8 <= data.len() {
+                let size = u32::from_be_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+                if &data[pos + 4..pos + 8] == want_type {
+                    return Some(pos + 8);
+                }
+                if size < 8 {
+                    break;
+                }
+                pos += size;
+            }
+            None
+        }
+
+        // Builds, embeds, hashes, signs, and patches the fixture MP4 under the
+        // given setting, returning the final asset bytes.
+        fn sign_with_setting(exclude_free_and_skip: bool) -> Result<Vec<u8>> {
+            let context = Context::new().with_settings(
+                serde_json::json!({
+                    "builder": { "bmff_hash_exclude_free_and_skip_boxes": exclude_free_and_skip }
+                })
+                .to_string(),
+            )?;
+            let mut builder =
+                Builder::from_context(context).with_definition(simple_manifest_json().as_str())?;
+
+            let composed_placeholder = builder.placeholder("video/mp4")?;
+
+            let bmff_hash: BmffHash = builder.find_assertion(BmffHash::LABEL)?;
+            assert_eq!(
+                bmff_hash.exclusions().iter().any(|e| e.xpath == "/free"),
+                exclude_free_and_skip
+            );
+
+            let mut input_stream = Cursor::new(TEST_VIDEO_MP4);
+            let mut output_stream = Cursor::new(Vec::new());
+            let offset = write_bmff_placeholder_stream(
+                &composed_placeholder,
+                &mut input_stream,
+                &mut output_stream,
+            )?;
+
+            output_stream.rewind()?;
+            builder.update_hash_from_stream("video/mp4", &mut output_stream)?;
+
+            let signed_manifest = builder.sign_embeddable("video/mp4")?;
+
+            output_stream.seek(SeekFrom::Start(offset as u64))?;
+            output_stream.write_all(&signed_manifest)?;
+
+            Ok(output_stream.into_inner())
+        }
+
+        fn is_trusted(data: &[u8]) -> bool {
+            let mut stream = Cursor::new(data.to_vec());
+            let reader = Reader::default()
+                .with_stream("video/mp4", &mut stream)
+                .unwrap();
+            reader.validation_state() == ValidationState::Trusted
+        }
+
+        for exclude_free_and_skip in [true, false] {
+            let mut signed = sign_with_setting(exclude_free_and_skip)?;
+            assert!(
+                is_trusted(&signed),
+                "clean asset (exclude_free_and_skip={exclude_free_and_skip}) must verify as trusted"
+            );
+
+            let free_payload_offset = find_top_level_box_payload_offset(&signed, b"free")
+                .expect("fixture must contain a top-level /free box");
+            signed[free_payload_offset + 100] ^= 0xff;
+
+            if exclude_free_and_skip {
+                assert!(
+                    is_trusted(&signed),
+                    "/free is excluded from the hash, so tampering it must not be detected"
+                );
+            } else {
+                assert!(
+                    !is_trusted(&signed),
+                    "/free is included in the hash, so tampering it must be detected"
+                );
+            }
+        }
 
         Ok(())
     }

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -606,6 +606,11 @@ pub struct BuilderSettings {
     pub auto_timestamp_assertion: TimeStampSettings,
     /// Whether `/free` and `/skip` boxes are excluded from the BMFF/MP4 hard-binding hash.
     ///
+    /// `/free` and `/skip` are reserved/padding space that apps commonly rewrite after
+    /// signing (e.g. to reclaim or repurpose it), so the C2PA spec permits excluding
+    /// them. Set to `false` to fold their content into the hash instead, so any later
+    /// edit to either box invalidates the hard binding like any other content change.
+    ///
     /// The default value is `true`.
     pub bmff_hash_exclude_free_and_skip_boxes: bool,
 }

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -604,6 +604,10 @@ pub struct BuilderSettings {
     ///
     /// [`TimeStamp`]: crate::assertions::TimeStamp
     pub auto_timestamp_assertion: TimeStampSettings,
+    /// Whether `/free` and `/skip` boxes are excluded from the BMFF/MP4 hard-binding hash.
+    ///
+    /// The default value is `true`.
+    pub bmff_hash_exclude_free_and_skip_boxes: bool,
 }
 
 impl Default for BuilderSettings {
@@ -620,6 +624,7 @@ impl Default for BuilderSettings {
             prefer_box_hash: false,
             generate_c2pa_archive: Some(true),
             auto_timestamp_assertion: TimeStampSettings::default(),
+            bmff_hash_exclude_free_and_skip_boxes: true,
         }
     }
 }

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2196,12 +2196,14 @@ impl Store {
         Ok(hashes)
     }
 
-    fn generate_bmff_data_hash_for_stream(alg: &str) -> Result<BmffHash> {
+    fn generate_bmff_data_hash_for_stream(alg: &str, settings: &Settings) -> Result<BmffHash> {
         // The spec has mandatory BMFF exclusion ranges for certain atoms.
         // The function makes sure those are included.
 
         let mut dh = BmffHash::new("jumbf manifest", alg, None);
-        dh.set_default_exclusions();
+        dh.set_default_exclusions_with_options(
+            settings.builder.bmff_hash_exclude_free_and_skip_boxes,
+        );
 
         // fill in temporary hash
         match alg {
@@ -2665,7 +2667,9 @@ impl Store {
         } else {
             let mut bmff_hash = BmffHash::new("jumbf manifest", pc.alg(), None);
 
-            bmff_hash.set_default_exclusions();
+            bmff_hash.set_default_exclusions_with_options(
+                settings.builder.bmff_hash_exclude_free_and_skip_boxes,
+            );
 
             if pc.version() < 2 {
                 bmff_hash.set_bmff_version(2); // backcompat support
@@ -3185,7 +3189,7 @@ impl Store {
                 } else {
                     input_stream.rewind()?;
                 }
-                let mut bmff_hash = Store::generate_bmff_data_hash_for_stream(pc.alg())?;
+                let mut bmff_hash = Store::generate_bmff_data_hash_for_stream(pc.alg(), settings)?;
 
                 if pc.version() < 2 {
                     bmff_hash.set_bmff_version(2); // backcompat support

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -2197,13 +2197,14 @@ impl Store {
     }
 
     fn generate_bmff_data_hash_for_stream(alg: &str, settings: &Settings) -> Result<BmffHash> {
-        // The spec has mandatory BMFF exclusion ranges for certain atoms.
-        // The function makes sure those are included.
+        // The spec mandates BMFF exclusion ranges for certain atoms (/uuid,
+        // /ftyp, /mfra) - those are always added below. /free and /skip are
+        // only spec-*permitted* to exclude, not required, so whether to
+        // exclude them is controlled by
+        // `settings.builder.bmff_hash_exclude_free_and_skip_boxes`.
 
         let mut dh = BmffHash::new("jumbf manifest", alg, None);
-        dh.set_default_exclusions_with_options(
-            settings.builder.bmff_hash_exclude_free_and_skip_boxes,
-        );
+        dh.set_default_exclusions_with_options(settings);
 
         // fill in temporary hash
         match alg {
@@ -2667,9 +2668,7 @@ impl Store {
         } else {
             let mut bmff_hash = BmffHash::new("jumbf manifest", pc.alg(), None);
 
-            bmff_hash.set_default_exclusions_with_options(
-                settings.builder.bmff_hash_exclude_free_and_skip_boxes,
-            );
+            bmff_hash.set_default_exclusions_with_options(settings);
 
             if pc.version() < 2 {
                 bmff_hash.set_bmff_version(2); // backcompat support


### PR DESCRIPTION
c2pa-rs excludes /free and /skip from the BMFF hash by default (spec-permitted, not spec-required). Add builder.bmff_hash_exclude_free_and_skip_boxes (default true, matching existing behavior) so signers who want the stronger guarantee can opt to fold these boxes into the hash instead.

## Changes in this pull request

`BmffHash::set_default_exclusions()` always excludes `/free` and `/skip` boxes from the BMFF/MP4 hard-binding hash. This is spec-permitted but not spec-required, and some signers may want the stronger guarantee of hashing this content instead.

Adds `builder.bmff_hash_exclude_free_and_skip_boxes` (default `true`, matching existing behavior). When set to `false`, `/free`/`/skip` content is folded into the hash rather than excluded.

- **`settings/builder.rs`**: new `bmff_hash_exclude_free_and_skip_boxes: bool` field on `BuilderSettings`.
- **`assertions/bmff_hash.rs`**: new `set_default_exclusions_with_options(exclude_free_and_skip: bool)`; existing `set_default_exclusions()` is unchanged (still defaults to `true`) and just delegates to it, so no breaking API change.
- **`builder.rs` / `store.rs`**: the three production call sites now read the setting from `Context`/`Settings` instead of always excluding.

## Tests added
- `set_default_exclusions_excludes_free_and_skip` — default behavior unchanged.
- `set_default_exclusions_with_options_false_keeps_free_and_skip_hashed` — opt-out correctly omits `/free`/`/skip` while leaving other mandatory exclusions intact.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
