### PR TITLE
ci: run `cargo-deny` async (or block if dep change) and report errors as issues

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -83,7 +83,7 @@ jobs:
           cargo deny --format json check advisories bans licenses sources \
             2> deny.ndjson 1>/dev/null || true
 
-            # Advisories
+          # Advisories.
           jq -c 'select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory != null)
                  | {id: .fields.advisory.id, title: .fields.advisory.title, package: .fields.advisory.package, url: .fields.advisory.url}' \
             deny.ndjson \

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,189 @@
+name: Dependency audit
+
+# Dependency license / vulnerability audit.
+#
+# cargo-deny checks advisories (RUSTSEC), banned crates, licenses, and sources.
+# Advisories are time-based: a newly published advisory can start failing the
+# audit even when nothing in a given PR touched dependencies, so this workflow
+# splits the audit:
+#   * On a PR, the audit only runs (and blocks) when the PR actually changes
+#     Rust dependencies (Cargo.toml / Cargo.lock) or the deny config. A PR that
+#     touches none of those skips the audit step and the job still reports green,
+#     satisfying the required "License / vulnerability audit" status check
+#     without any branch-protection reconfiguration.
+#   * On every merge to main/stable/backport branch, and daily against main,
+#     the audit always runs and, on failure, opens or updates a GitHub issue
+#     instead of blocking anything.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *'
+  pull_request:
+    branches:
+      - main
+      - stable
+      - 'v0.*'
+      - '*-rc*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+      - stable
+      - 'v0.*'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cargo-deny:
+    name: License / vulnerability audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect dependency changes
+        id: deps
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" HEAD \
+              | grep -qE '(^|/)Cargo\.(toml|lock)$|(^|/)deny\.toml$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "This PR changes Rust dependencies or the deny config, auditing..."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No dependency or deny-config changes in this PR, the audit runs post-merge instead."
+          fi
+
+      - name: Install cargo-deny
+        if: github.event_name != 'pull_request' || steps.deps.outputs.changed == 'true'
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: cargo-deny
+
+      - name: Audit crate dependencies
+        if: github.event_name != 'pull_request' || steps.deps.outputs.changed == 'true'
+        run: cargo deny check advisories bans licenses sources
+
+      - name: Collect failing checks
+        if: failure() && github.event_name != 'pull_request'
+        run: |
+          # Human-readable output.
+          cargo deny check advisories bans licenses sources > deny.txt 2>&1 || true
+          # Machine-readable output
+          cargo deny --format json check advisories bans licenses sources \
+            2> deny.ndjson 1>/dev/null || true
+
+            # Advisories
+          jq -c 'select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory != null)
+                 | {id: .fields.advisory.id, title: .fields.advisory.title, package: .fields.advisory.package, url: .fields.advisory.url}' \
+            deny.ndjson \
+            | jq -s 'unique_by(.id)' > advisories.json
+
+          # Non-advisories.
+          jq -c 'select(.type == "diagnostic" and .fields.severity == "error" and .fields.advisory == null)
+                 | {code: .fields.code,
+                    message: .fields.message,
+                    crate: (.fields.graphs[0]?.Krate | if . then "\(.name) \(.version)" else null end),
+                    note: ([.fields.notes[]? | select(startswith("  ") | not)] | .[0] // null)}' \
+            deny.ndjson \
+            | jq -s 'unique_by([.code, .message, .crate])' > problems.json
+
+          echo "Advisory errors:"; cat advisories.json
+          echo "Other violations:"; cat problems.json
+
+      - name: Open per-advisory issues on failure
+        if: failure() && github.event_name != 'pull_request'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const advisories = JSON.parse(fs.readFileSync('advisories.json', 'utf8'));
+            const problems = JSON.parse(fs.readFileSync('problems.json', 'utf8'));
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const output = fs.readFileSync('deny.txt', 'utf8');
+            const outputDetails = `<details><summary>cargo-deny output</summary>\n\n\`\`\`\`\n${output}\n\`\`\`\`\n\n</details>`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'dependency-audit',
+              per_page: 100,
+            });
+            const openByTitle = new Map(existing.data.map(i => [i.title, i]));
+
+            async function ensureIssue(title, body) {
+              if (openByTitle.has(title)) {
+                console.log(`Already tracked: ${title}`);
+                return;
+              }
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, labels: ['dependency-audit'], body,
+              });
+              console.log(`Opened: ${title}`);
+            }
+
+            for (const advisory of advisories) {
+              const title = `${advisory.id}: ${advisory.title}`;
+              const rustsec = `https://rustsec.org/advisories/${advisory.id}.html`;
+              const body = [
+                `The dependency audit is failing on \`${context.ref}\` because of [${advisory.id}](${rustsec}).`,
+                '',
+                `- Affected crate: \`${advisory.package}\``,
+                `- Advisory: ${rustsec}`,
+                advisory.url ? `- Upstream: ${advisory.url}` : null,
+                '',
+                'Update or patch the affected dependency, or add a scoped ignore to `deny.toml` with justification.',
+                '',
+                `Run: ${run}`,
+                '',
+                outputDetails,
+              ].filter(l => l !== null).join('\n');
+              await ensureIssue(title, body);
+            }
+
+            if (problems.length > 0) {
+              const cap = 40;
+              const lines = problems.slice(0, cap).map(problem => {
+                const where = problem.crate ? `\`${problem.crate}\`` : '';
+                const why = problem.note ? ` (${problem.note.replace(/:$/, '')})` : '';
+                return `- **${problem.code}** ${where}: ${problem.message}${why}`;
+              });
+              const more = problems.length > cap ? [``, `…and ${problems.length - cap} more.`] : [];
+              const title = 'Dependency audit (cargo-deny): license / bans / sources violations';
+              const body = [
+                `The dependency audit is failing on \`${context.ref}\` with the following violations:`,
+                '',
+                ...lines,
+                ...more,
+                '',
+                'Fix the offending dependency, or adjust `deny.toml` (allow the license/source or add a scoped exception) with justification.',
+                '',
+                `Run: ${run}`,
+                '',
+                outputDetails,
+              ].join('\n');
+              await ensureIssue(title, body);
+            }
+
+            if (advisories.length === 0 && problems.length === 0) {
+              await ensureIssue('Dependency audit (cargo-deny) is failing', [
+                `The dependency audit failed on \`${context.ref}\`, but no specific violation could be parsed from its output.`,
+                '',
+                `Run: ${run}`,
+                '',
+                outputDetails,
+              ].join('\n'));
+            }

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -154,28 +154,48 @@ jobs:
               await ensureIssue(title, body);
             }
 
-            if (problems.length > 0) {
-              const cap = 40;
-              const lines = problems.slice(0, cap).map(problem => {
+            // Let's be safe.
+            const SPAM_CAP = 5;
+            if (problems.length > SPAM_CAP) {
+              const lines = problems.slice(0, 40).map(problem => {
                 const where = problem.crate ? `\`${problem.crate}\`` : '';
                 const why = problem.note ? ` (${problem.note.replace(/:$/, '')})` : '';
                 return `- **${problem.code}** ${where}: ${problem.message}${why}`;
               });
-              const more = problems.length > cap ? [``, `…and ${problems.length - cap} more.`] : [];
-              const title = 'Dependency audit (cargo-deny): license / bans / sources violations';
+              const more = problems.length > 40 ? [``, `…and ${problems.length - 40} more.`] : [];
+              const title = 'Dependency audit (cargo-deny): many license / bans / sources violations';
               const body = [
-                `The dependency audit is failing on \`${context.ref}\` with the following violations:`,
+                `The dependency audit is failing on \`${context.ref}\` with ${problems.length} violations (too many to open individually — likely a \`deny.toml\` misconfiguration):`,
                 '',
                 ...lines,
                 ...more,
                 '',
-                'Fix the offending dependency, or adjust `deny.toml` (allow the license/source or add a scoped exception) with justification.',
+                'Fix the offending dependencies, or adjust `deny.toml` (allow the license/source or add a scoped exception) with justification.',
                 '',
                 `Run: ${run}`,
                 '',
                 outputDetails,
               ].join('\n');
               await ensureIssue(title, body);
+            } else {
+              for (const problem of problems) {
+                const crateName = problem.crate ? problem.crate.split(' ')[0] : 'workspace';
+                const why = problem.note ? ` (${problem.note.replace(/:$/, '')})` : '';
+                const title = `Dependency audit (${problem.code}): ${crateName}`;
+                const body = [
+                  `The dependency audit is failing on \`${context.ref}\`: ${problem.message}${why}`,
+                  '',
+                  problem.crate ? `- Crate: \`${problem.crate}\`` : null,
+                  `- Violation: \`${problem.code}\``,
+                  '',
+                  'Fix the offending dependency, or adjust `deny.toml` (allow the license/source or add a scoped exception) with justification.',
+                  '',
+                  `Run: ${run}`,
+                  '',
+                  outputDetails,
+                ].filter(l => l !== null).join('\n');
+                await ensureIssue(title, body);
+              }
             }
 
             if (advisories.length === 0 && problems.length === 0) {

--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -556,17 +556,3 @@ jobs:
 
       - name: Check format
         run: cargo +nightly-2026-01-16 fmt --all -- --check
-
-  cargo-deny:
-    name: License / vulnerability audit
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Audit crate dependencies
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
-        with:
-          command: check advisories bans licenses sources


### PR DESCRIPTION
We run into issues every so often that blocks all PRs because a new general vulnerability appears, even if it is not specific to that PR. This change runs vulnerability audits (1) nightly, (2) on merge to main/stable/backport branches, and (3) when changing dependencies in a PR, then creates a GitHub issue detailing the problem.

I created an example repo to demonstrate how issues are reported: https://github.com/ok-nick/deny-test/issues

Made with the help of Claude.