### PR TITLE
fix: Resolve new Rust 1.98.0 Clippy lint (chunks_exact_to_as_chunks)

### DIFF
--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -485,7 +485,11 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          # Pinned to v47.0.3: v48.0.0 sends malformed wasi-http requests that
+          # some servers (e.g. GitHub Pages) answer with 400 Bad Request instead
+          # of reaching the real response, breaking did:web resolution tests.
+          # See https://github.com/contentauth/c2pa-rs/issues/2530.
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v47.0.3
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
 
       - name: Install clang

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -2355,7 +2355,9 @@ pub unsafe extern "C" fn c2pa_builder_set_data_hash_exclusions(
 
     let flat = std::slice::from_raw_parts(exclusions_ptr, exclusion_count * 2);
     let exclusions: Vec<c2pa::HashRange> = flat
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| c2pa::HashRange::new(pair[0], pair[1]))
         .collect();
 


### PR DESCRIPTION
## Summary
- Rust 1.98.0 ships a new Clippy lint, [`chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks), which recommends `as_chunks` over `chunks_exact` for constant chunk sizes.
- This fired on one call site in [`c2pa_builder_set_data_hash_exclusions`](c2pa_c_ffi/src/c_api.rs), which failed CI's `cargo clippy -- -Dwarnings` gate once runners pick up 1.98.0 as stable.
- Swept the whole workspace (`--workspace --all-features --all-targets`) and each CI feature combination (openssl, rust_native_crypto, both combined) — this was the only new warning.
- Unrelated to Rust 1.98.0: the `Unit tests (WASI)` check also started failing on this PR. Root-caused to Wasmtime v48.0.0 (released the same day as this PR, and installed unpinned by CI) sending malformed wasi-http requests that get answered with a spurious `400 Bad Request` instead of the real response — confirmed by rebuilding the identical wasm test binary and running it against both v47.0.3 (passes, correct 404) and v48.0.0 (fails, 400). Pinned CI to v47.0.3 as a stopgap and filed [#2530](https://github.com/contentauth/c2pa-rs/issues/2530) to track the upstream regression and un-pinning later.

## Test plan
- [x] `cargo clippy --features "<CI openssl feature set>" --all-targets -- -Dwarnings` — clean
- [x] `cargo clippy --features "<CI rust_native_crypto feature set>" --all-targets -- -Dwarnings` — clean
- [x] `cargo clippy --workspace --all-features --all-targets` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo test -p c2pa-c-ffi` — 129 passed
- [x] Reproduced the WASI failure locally with wasmtime v47.0.3 (pass) vs v48.0.0 (fail) against the identical test binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)