### PR TITLE
fix: Resolve new Rust 1.98.0 Clippy lint (chunks_exact_to_as_chunks) (backport #2528)

### DIFF
--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -528,7 +528,11 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          # Pinned to v47.0.3: v48.0.0 sends malformed wasi-http requests that
+          # some servers (e.g. GitHub Pages) answer with 400 Bad Request instead
+          # of reaching the real response, breaking did:web resolution tests.
+          # See https://github.com/contentauth/c2pa-rs/issues/2530.
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v47.0.3
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
 
       - name: Install clang

--- a/c2pa_c_ffi/src/c_api.rs
+++ b/c2pa_c_ffi/src/c_api.rs
@@ -2359,7 +2359,9 @@ pub unsafe extern "C" fn c2pa_builder_set_data_hash_exclusions(
 
     let flat = std::slice::from_raw_parts(exclusions_ptr, exclusion_count * 2);
     let exclusions: Vec<c2pa::HashRange> = flat
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| c2pa::HashRange::new(pair[0], pair[1]))
         .collect();
 


### PR DESCRIPTION
Manual backport of #2528 to `stable`.

The automated backport action ran and cherry-picked cleanly (no conflicts), but its push was rejected:

```
refusing to allow a Personal Access Token to create or update workflow `.github/workflows/tier-1a.yml` without `workflow` scope
```

because #2528 touches a `.github/workflows/` file (the Wasmtime CI pin) and the bot's PAT lacks the `workflow` scope needed to push workflow-file changes. This PR is that same cherry-pick (commit 37a5d02, `git cherry-pick -x`), pushed manually.

Verified on this branch:
- [x] `cargo clippy` (openssl feature set, all-targets) — clean
- [x] `cargo +nightly fmt --all -- --check` — clean