### PR TITLE
fix: Harden against invalid  labels as CAWG identity hard bindings

### DIFF
--- a/sdk/src/assertions/cloud_data.rs
+++ b/sdk/src/assertions/cloud_data.rs
@@ -134,12 +134,7 @@ impl CloudData {
     ///
     /// [`assertion.cloud-data.hardBinding`]: crate::validation_results::validation_codes::ASSERTION_CLOUD_DATA_HARD_BINDING
     pub(crate) fn is_hard_binding(&self) -> bool {
-        let l = self.label.as_str();
-        l == labels::DATA_HASH
-            || l == labels::BOX_HASH
-            || l == labels::COLLECTION_HASH
-            || l == labels::MULTI_ASSET_HASH
-            || l.starts_with(labels::BMFF_HASH)
+        labels::is_hard_binding_label(&self.label)
     }
 
     /// Returns `true` if [`label`](CloudData::label) names an actions assertion

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -248,6 +248,21 @@ pub const HASH_LABELS: [&str; 4] = [DATA_HASH, BOX_HASH, BMFF_HASH, COLLECTION_H
 pub const NON_REDACTABLE_LABELS: [&str; 5] =
     [ACTIONS, DATA_HASH, BOX_HASH, BMFF_HASH, COLLECTION_HASH];
 
+/// Returns `true` if `label` names a hard binding assertion (`c2pa.hash.data`,
+/// any `c2pa.hash.bmff.*`, `c2pa.hash.boxes`, `c2pa.hash.collection.data`, or
+/// `c2pa.hash.multi-asset`).
+///
+/// `BMFF_HASH` is matched by prefix since it's the only one of these still at
+/// creation version > 1, so it's the only one that carries a version suffix
+/// (e.g. `.v3`) in practice; the others are compared exactly.
+pub(crate) fn is_hard_binding_label(label: &str) -> bool {
+    label == DATA_HASH
+        || label == BOX_HASH
+        || label == COLLECTION_HASH
+        || label == MULTI_ASSET_HASH
+        || label.starts_with(BMFF_HASH)
+}
+
 /// Must have a label that ends in '.metadata' and is preceded by an entity-specific namespace.
 /// For example, a 'com.litware.metadata' assertion would be valid.
 pub static METADATA_LABEL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -495,5 +510,38 @@ mod tests {
             parse_label("c2pa.ingredient.V2"),
             ("c2pa.ingredient.V2", 1, 0)
         );
+    }
+
+    /// Regression: only the real hard-binding assertion types (and BMFF's
+    /// versioned variants) count, not any label with a `c2pa.hash.` prefix.
+    /// A fake label like `c2pa.hash.fake` must be rejected - this used to be
+    /// accepted by a naive `starts_with("c2pa.hash.")` check in the CAWG
+    /// identity assertion's hard-binding-presence check.
+    #[test]
+    fn test_is_hard_binding_label() {
+        for label in [
+            DATA_HASH,
+            BOX_HASH,
+            COLLECTION_HASH,
+            MULTI_ASSET_HASH,
+            BMFF_HASH,
+            "c2pa.hash.bmff.v2",
+            "c2pa.hash.bmff.v3",
+        ] {
+            assert!(is_hard_binding_label(label), "expected {label} to match");
+        }
+
+        for label in [
+            "c2pa.hash.fake",
+            "c2pa.hash",
+            "c2pa.hash.",
+            "c2pa.hash.databoxes",
+            "c2pa.actions",
+        ] {
+            assert!(
+                !is_hard_binding_label(label),
+                "expected {label} to be rejected"
+            );
+        }
     }
 }

--- a/sdk/src/identity/identity_assertion/signer_payload.rs
+++ b/sdk/src/identity/identity_assertion/signer_payload.rs
@@ -17,8 +17,9 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dynamic_assertion::PartialClaim, identity::ValidationError, log_current_item,
-    status_tracker::StatusTracker, HashedUri, Manifest,
+    assertions::labels::is_hard_binding_label, dynamic_assertion::PartialClaim,
+    identity::ValidationError, log_current_item, status_tracker::StatusTracker, HashedUri,
+    Manifest,
 };
 
 /// A set of _referenced assertions_ and other related data, known overall as
@@ -93,7 +94,7 @@ impl SignerPayload {
 
         if !ref_assertion_labels.iter().any(|ra| {
             if let Some((_jumbf_prefix, label)) = ra.rsplit_once('/') {
-                label.starts_with("c2pa.hash.")
+                is_hard_binding_label(label)
             } else {
                 false
             }
@@ -190,7 +191,7 @@ impl SignerPayload {
 
         if !ref_assertion_labels.iter().any(|ra| {
             if let Some((_jumbf_prefix, label)) = ra.rsplit_once('/') {
-                label.starts_with("c2pa.hash.")
+                is_hard_binding_label(label)
             } else {
                 false
             }


### PR DESCRIPTION
## Changes in this pull request
### Vulnerability
CAWG identity assertion validation accepted any label starting with `c2pa.hash.` as proof a hard binding was present — including a fake one Core never actually treats as a real hash binding. This let an attacker replay a victim-signed identity assertion onto unrelated content and still get a `Trusted` result.

### Fix
Extracted the correct predicate (already used by `CloudData::is_hard_binding()`) into a shared `labels::is_hard_binding_label()` function, and used it at both CAWG check sites in `signer_payload.rs` instead of the naive prefix match. 

### Tests added
`test_is_hard_binding_label` — covers all real hard-binding labels (including BMFF's versioned variants) plus the exact `c2pa.hash.fake` exploit label and other near-misses.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
