### PR TITLE
chore: Add awaiting-cla-signature label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -15,6 +15,10 @@
   color: "0e8a16"
   description: "Maintainer trusts this fork PR; allow secret-dependent CI to run"
 
+- name: awaiting-cla-signature
+  color: "d93f0b"
+  description: "Third-party PR is blocked until the author signs the Adobe CLA"
+
 - name: check-release
   color: "1d76db"
   description: "Force the full Tier 1A+1B+2 suite on this PR"


### PR DESCRIPTION
## Summary
- Adds a new `awaiting-cla-signature` label to [labels.yml](.github/labels.yml), for flagging third-party PRs where the author hasn't signed the required Adobe Contributor License Agreement.

## Test plan
- [ ] `labels.yml` sync workflow picks up the new label on merge (no manual action needed beyond merging)