### PR TITLE
Suggested fixes for box-hash exclusions review (#2513)

### DIFF
--- a/sdk/src/assertions/box_hash.rs
+++ b/sdk/src/assertions/box_hash.rs
@@ -86,6 +86,31 @@ pub struct AllowedExclusion {
     pub kind: ExclusionKind,
 }
 
+impl AllowedExclusion {
+    /// The box's entire content is excludable - e.g. the C2PA store itself,
+    /// or a format's dedicated padding box.
+    pub fn whole_box(len: u64) -> Self {
+        AllowedExclusion {
+            start: 0,
+            length: len,
+            kind: ExclusionKind::ManifestOrPadding,
+        }
+    }
+
+    /// Everything past a fixed-size structural header is excludable asset
+    /// metadata (EXIF/XMP/IPTC-equivalent per spec §9.2.6). `total_len` is
+    /// the box's own full length, and `header_len` the number of leading
+    /// bytes (marker/length/type/CRC-adjacent fields, as applicable per
+    /// format) that must stay hashed.
+    pub fn after_header(header_len: u64, total_len: u64) -> Self {
+        AllowedExclusion {
+            start: header_len,
+            length: total_len.saturating_sub(header_len),
+            kind: ExclusionKind::AssetMetadata,
+        }
+    }
+}
+
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq)]
 pub struct BoxMap {
     pub names: Vec<String>,
@@ -131,30 +156,31 @@ impl BoxMap {
     }
 }
 
-/// Resolves `exclusions`' `boxIndex`-relative ranges against `box_ranges`/
-/// `box_allowed_exclusions` (the absolute range and permitted sub-ranges of
-/// each name in a box-hash-map entry, in order). Rejects any exclusion not
-/// fully contained within one single permitted sub-range for its box (spec
-/// §15.12.3: only the C2PA store or asset metadata may be excluded, and only
-/// the actual payload - not header/length fields around it). Returns the
-/// ordered sub-ranges of `[entry_start, entry_start + entry_len)` left to
+/// A named box's absolute `(start, len)` range plus the permitted exclusion
+/// sub-ranges measured for it from the live asset. Keeping these together
+/// (rather than as two parallel vectors) makes it impossible for a caller to
+/// push one without the other.
+type BoxRangeInfo = (u64, u64, Vec<AllowedExclusion>);
+
+/// Resolves `exclusions`' `boxIndex`-relative ranges against `box_ranges`
+/// (the absolute range and permitted sub-ranges of each name in a
+/// box-hash-map entry, in order). Rejects any exclusion not fully contained
+/// within one single permitted sub-range for its box (spec §15.12.3: only
+/// the C2PA store or asset metadata may be excluded, and only the actual
+/// payload - not header/length fields around it), and rejects a permitted
+/// sub-range that would itself reach past its box's real length (a defensive
+/// check against a buggy or malicious `AssetBoxHash` implementor, since
+/// `AllowedExclusion` is otherwise trusted as already self-bounded). Returns
+/// the ordered sub-ranges of `[entry_start, entry_start + entry_len)` left to
 /// hash once the exclusions are punched out, plus whether any referenced
 /// range was `AssetMetadata` (for the informational
 /// `additionalExclusionsPresent` status).
 fn split_exclusions(
-    box_ranges: &[(u64, u64)],
-    box_allowed_exclusions: &[Vec<AllowedExclusion>],
+    box_ranges: &[BoxRangeInfo],
     entry_start: u64,
     entry_len: u64,
     exclusions: &[BoxExclusion],
 ) -> Result<(Vec<HashRange>, bool)> {
-    // `box_allowed_exclusions` is meant to be parallel to `box_ranges` (every
-    // call site pushes to both together); the lookup below degrades safely
-    // rather than panicking if that invariant is ever broken, but assert it
-    // explicitly so a caller mistake fails a debug/test build instead of
-    // silently falling back to always-reject.
-    debug_assert_eq!(box_ranges.len(), box_allowed_exclusions.len());
-
     // Structural problems with the exclusions array itself (bad/missing
     // boxIndex, overflow, unordered ranges) are spec §15.12.3's
     // `assertion.boxesHash.malformed`, not a hash/content mismatch.
@@ -172,18 +198,14 @@ fn split_exclusions(
             None => return Err(malformed()),
         };
 
-        let (box_start, _box_len) = box_ranges.get(box_index).ok_or_else(malformed)?;
+        let (box_start, box_len, allowed) = box_ranges.get(box_index).ok_or_else(malformed)?;
 
         let excl_end = excl.start.checked_add(excl.length).ok_or_else(malformed)?;
 
-        let allowed = box_allowed_exclusions
-            .get(box_index)
-            .map(Vec::as_slice)
-            .unwrap_or(&[]);
         let permitting_range = allowed.iter().find(|a| {
-            a.start
-                .checked_add(a.length)
-                .is_some_and(|a_end| excl.start >= a.start && excl_end <= a_end)
+            a.start.checked_add(a.length).is_some_and(|a_end| {
+                a_end <= *box_len && excl.start >= a.start && excl_end <= a_end
+            })
         });
 
         match permitting_range {
@@ -321,14 +343,15 @@ impl BoxHash {
         for bm in &self.boxes {
             let mut skip_c2pa = false;
             let mut inclusion = HashRange::new(0u64, 0u64);
-            let mut box_ranges: Vec<(u64, u64)> = Vec::with_capacity(bm.names.len());
-            let mut box_allowed_exclusions: Vec<Vec<AllowedExclusion>> =
-                Vec::with_capacity(bm.names.len());
+            let mut box_ranges: Vec<BoxRangeInfo> = Vec::with_capacity(bm.names.len());
             for name in &bm.names {
                 match source_bms.get(source_index) {
                     Some(next_source_bm) if name == &next_source_bm.names[0] => {
-                        box_ranges.push((next_source_bm.range_start, next_source_bm.range_len));
-                        box_allowed_exclusions.push(next_source_bm.allowed_exclusions.clone());
+                        box_ranges.push((
+                            next_source_bm.range_start,
+                            next_source_bm.range_len,
+                            next_source_bm.allowed_exclusions.clone(),
+                        ));
 
                         if inclusion.length() == 0 {
                             inclusion.set_start(next_source_bm.range_start);
@@ -390,13 +413,8 @@ impl BoxHash {
             let inclusions = match &bm.exclusions {
                 None => vec![inclusion],
                 Some(excl) => {
-                    let (ranges, metadata_used) = split_exclusions(
-                        &box_ranges,
-                        &box_allowed_exclusions,
-                        inclusion.start(),
-                        inclusion.length(),
-                        excl,
-                    )?;
+                    let (ranges, metadata_used) =
+                        split_exclusions(&box_ranges, inclusion.start(), inclusion.length(), excl)?;
                     metadata_exclusion_used |= metadata_used;
                     ranges
                 }
@@ -520,8 +538,7 @@ impl BoxHash {
                 range_start: 0,
                 range_len: 0,
             };
-            let mut before_c2pa_ranges: Vec<(u64, u64)> = Vec::new();
-            let mut before_c2pa_allowed: Vec<Vec<AllowedExclusion>> = Vec::new();
+            let mut before_c2pa_ranges: Vec<BoxRangeInfo> = Vec::new();
             let mut before_c2pa_exclusions: Vec<BoxExclusion> = Vec::new();
 
             let mut c2pa_box = BoxMap {
@@ -547,8 +564,7 @@ impl BoxHash {
                 range_start: 0,
                 range_len: 0,
             };
-            let mut after_c2pa_ranges: Vec<(u64, u64)> = Vec::new();
-            let mut after_c2pa_allowed: Vec<Vec<AllowedExclusion>> = Vec::new();
+            let mut after_c2pa_ranges: Vec<BoxRangeInfo> = Vec::new();
             let mut after_c2pa_exclusions: Vec<BoxExclusion> = Vec::new();
 
             let mut is_before_c2pa = true;
@@ -566,18 +582,16 @@ impl BoxHash {
                     continue;
                 }
 
-                let (group, group_ranges, group_allowed, group_exclusions) = if is_before_c2pa {
+                let (group, group_ranges, group_exclusions) = if is_before_c2pa {
                     (
                         &mut before_c2pa,
                         &mut before_c2pa_ranges,
-                        &mut before_c2pa_allowed,
                         &mut before_c2pa_exclusions,
                     )
                 } else {
                     (
                         &mut after_c2pa,
                         &mut after_c2pa_ranges,
-                        &mut after_c2pa_allowed,
                         &mut after_c2pa_exclusions,
                     )
                 };
@@ -586,8 +600,7 @@ impl BoxHash {
                 // position in `group_ranges` (before pushing) is also its
                 // future position in `group.names` - i.e. its `boxIndex`.
                 let box_index_in_group = group_ranges.len();
-                group_ranges.push((bm.range_start, bm.range_len));
-                group_allowed.push(bm.allowed_exclusions.clone());
+                group_ranges.push((bm.range_start, bm.range_len, bm.allowed_exclusions.clone()));
                 for req in exclusion_requests {
                     if req.source_box_index == source_index {
                         group_exclusions.push(BoxExclusion {
@@ -617,35 +630,30 @@ impl BoxHash {
             // Instead of assuming we can combine all of the different ranges of
             // box hashes, we will check the bounds of each one
             let mut boxes = Vec::<BoxMap>::new();
-            let mut boxes_ranges = Vec::<Vec<(u64, u64)>>::new();
-            let mut boxes_allowed = Vec::<Vec<Vec<AllowedExclusion>>>::new();
+            let mut boxes_ranges = Vec::<Vec<BoxRangeInfo>>::new();
             // Only add if we have some before the C2PA box
             if before_c2pa.range_len > 0 {
                 boxes_ranges.push(before_c2pa_ranges);
-                boxes_allowed.push(before_c2pa_allowed);
                 boxes.push(before_c2pa);
             }
             // Do the same for the actual C2PA box
             if c2pa_box.range_len > 0 {
-                boxes_ranges.push(vec![(c2pa_box.range_start, c2pa_box.range_len)]);
-                boxes_allowed.push(vec![c2pa_box.allowed_exclusions.clone()]);
+                boxes_ranges.push(vec![(
+                    c2pa_box.range_start,
+                    c2pa_box.range_len,
+                    c2pa_box.allowed_exclusions.clone(),
+                )]);
                 boxes.push(c2pa_box);
             }
             // And finally, add the boxes after the C2PA box
             if after_c2pa.range_len > 0 {
                 boxes_ranges.push(after_c2pa_ranges);
-                boxes_allowed.push(after_c2pa_allowed);
                 boxes.push(after_c2pa);
             }
             self.boxes = boxes;
 
             // compute the hashes
-            for ((bm, box_ranges), box_allowed) in self
-                .boxes
-                .iter_mut()
-                .zip(boxes_ranges.iter())
-                .zip(boxes_allowed.iter())
-            {
+            for (bm, box_ranges) in self.boxes.iter_mut().zip(boxes_ranges.iter()) {
                 // skip c2pa box
                 if bm.names[0] == C2PA_BOXHASH {
                     continue;
@@ -653,14 +661,7 @@ impl BoxHash {
 
                 let inclusions = match &bm.exclusions {
                     Some(excl) if !excl.is_empty() => {
-                        split_exclusions(
-                            box_ranges,
-                            box_allowed,
-                            bm.range_start,
-                            bm.range_len,
-                            excl,
-                        )?
-                        .0
+                        split_exclusions(box_ranges, bm.range_start, bm.range_len, excl)?.0
                     }
                     _ => vec![HashRange::new(bm.range_start, bm.range_len)],
                 };
@@ -685,8 +686,7 @@ impl BoxHash {
                     continue;
                 }
 
-                let box_ranges = [(bm.range_start, bm.range_len)];
-                let box_allowed = [bm.allowed_exclusions.clone()];
+                let box_ranges = [(bm.range_start, bm.range_len, bm.allowed_exclusions.clone())];
                 let exclusions: Vec<BoxExclusion> = exclusion_requests
                     .iter()
                     .filter(|req| req.source_box_index == source_index)
@@ -700,14 +700,7 @@ impl BoxHash {
                 let inclusions = if exclusions.is_empty() {
                     vec![HashRange::new(bm.range_start, bm.range_len)]
                 } else {
-                    split_exclusions(
-                        &box_ranges,
-                        &box_allowed,
-                        bm.range_start,
-                        bm.range_len,
-                        &exclusions,
-                    )?
-                    .0
+                    split_exclusions(&box_ranges, bm.range_start, bm.range_len, &exclusions)?.0
                 };
 
                 bm.alg = Some(alg.to_string());
@@ -1392,18 +1385,25 @@ mod tests {
     fn test_split_exclusions_basic_example() {
         // box 0: [100, 150), box 1: [150, 230); exclude [110,115) in box 0
         // and [170,180) in box 1.
-        let box_ranges = [(100u64, 50u64), (150u64, 80u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 2] = [
-            vec![AllowedExclusion {
-                start: 0,
-                length: 50,
-                kind: ExclusionKind::AssetMetadata,
-            }],
-            vec![AllowedExclusion {
-                start: 0,
-                length: 80,
-                kind: ExclusionKind::AssetMetadata,
-            }],
+        let box_ranges: [BoxRangeInfo; 2] = [
+            (
+                100,
+                50,
+                vec![AllowedExclusion {
+                    start: 0,
+                    length: 50,
+                    kind: ExclusionKind::AssetMetadata,
+                }],
+            ),
+            (
+                150,
+                80,
+                vec![AllowedExclusion {
+                    start: 0,
+                    length: 80,
+                    kind: ExclusionKind::AssetMetadata,
+                }],
+            ),
         ];
         let exclusions = vec![
             BoxExclusion {
@@ -1417,8 +1417,7 @@ mod tests {
                 box_index: Some(1),
             },
         ];
-        let (ranges, metadata_used) =
-            split_exclusions(&box_ranges, &box_allowed, 100, 130, &exclusions).unwrap();
+        let (ranges, metadata_used) = split_exclusions(&box_ranges, 100, 130, &exclusions).unwrap();
         let simplified: Vec<(u64, u64)> = ranges.iter().map(|r| (r.start(), r.length())).collect();
         assert_eq!(simplified, vec![(100, 10), (115, 55), (180, 50)]);
         assert!(metadata_used);
@@ -1426,44 +1425,53 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_fully_excluded_entry_does_not_fall_back_to_full_range() {
-        let box_ranges = [(5u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 10,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            5,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 10,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 10,
             box_index: None,
         }];
-        let (ranges, _metadata_used) =
-            split_exclusions(&box_ranges, &box_allowed, 5, 10, &exclusions).unwrap();
+        let (ranges, _metadata_used) = split_exclusions(&box_ranges, 5, 10, &exclusions).unwrap();
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].length(), 0);
     }
 
     #[test]
     fn test_split_exclusions_missing_box_index_with_multiple_boxes() {
-        let box_ranges = [(0u64, 10u64), (10u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 2] = [
-            vec![AllowedExclusion {
-                start: 0,
-                length: 10,
-                kind: ExclusionKind::AssetMetadata,
-            }],
-            vec![AllowedExclusion {
-                start: 0,
-                length: 10,
-                kind: ExclusionKind::AssetMetadata,
-            }],
+        let box_ranges: [BoxRangeInfo; 2] = [
+            (
+                0,
+                10,
+                vec![AllowedExclusion {
+                    start: 0,
+                    length: 10,
+                    kind: ExclusionKind::AssetMetadata,
+                }],
+            ),
+            (
+                10,
+                10,
+                vec![AllowedExclusion {
+                    start: 0,
+                    length: 10,
+                    kind: ExclusionKind::AssetMetadata,
+                }],
+            ),
         ];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: None,
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 20, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 20, &exclusions);
         assert!(
             matches!(&result, Err(Error::C2PAValidation(s)) if s == ASSERTION_BOXESHASH_MALFORMED),
             "unexpected result: {result:?}"
@@ -1472,18 +1480,21 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_out_of_range_box_index() {
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 10,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 10,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: Some(5),
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
         assert!(
             matches!(&result, Err(Error::C2PAValidation(s)) if s == ASSERTION_BOXESHASH_MALFORMED),
             "unexpected result: {result:?}"
@@ -1492,18 +1503,21 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_negative_box_index() {
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 10,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 10,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: Some(-1),
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
         assert!(
             matches!(&result, Err(Error::C2PAValidation(s)) if s == ASSERTION_BOXESHASH_MALFORMED),
             "unexpected result: {result:?}"
@@ -1512,18 +1526,49 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_rejects_range_extending_past_box_end() {
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 10,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 10,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 8,
             length: 5,
             box_index: None,
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
+        assert!(
+            matches!(&result, Err(Error::HashMismatch(msg)) if msg.contains("not contained within any permitted range")),
+            "unexpected result: {result:?}"
+        );
+    }
+
+    // A malicious/buggy `AssetBoxHash` implementor could report an
+    // `AllowedExclusion` that itself reaches past the box's real length.
+    // Even though the requested exclusion is fully contained *within* that
+    // over-wide permitted range, it must still be rejected - the permitted
+    // range's own bound against the box's live length is not optional.
+    #[test]
+    fn test_split_exclusions_rejects_allowed_exclusion_wider_than_box() {
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 15,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
+        let exclusions = vec![BoxExclusion {
+            start: 11,
+            length: 2,
+            box_index: None,
+        }];
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
         assert!(
             matches!(&result, Err(Error::HashMismatch(msg)) if msg.contains("not contained within any permitted range")),
             "unexpected result: {result:?}"
@@ -1532,12 +1577,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_overlapping_ranges() {
-        let box_ranges = [(0u64, 20u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 20,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            20,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 20,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![
             BoxExclusion {
                 start: 0,
@@ -1550,7 +1598,7 @@ mod tests {
                 box_index: None,
             },
         ];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 20, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 20, &exclusions);
         assert!(
             matches!(&result, Err(Error::C2PAValidation(s)) if s == ASSERTION_BOXESHASH_MALFORMED),
             "unexpected result: {result:?}"
@@ -1562,12 +1610,15 @@ mod tests {
     // silently sorted into a valid-looking sequence.
     #[test]
     fn test_split_exclusions_out_of_order_ranges_are_rejected_not_reordered() {
-        let box_ranges = [(0u64, 20u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 20,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            20,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 20,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![
             BoxExclusion {
                 start: 10,
@@ -1580,7 +1631,7 @@ mod tests {
                 box_index: None,
             },
         ];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 20, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 20, &exclusions);
         assert!(
             matches!(&result, Err(Error::C2PAValidation(s)) if s == ASSERTION_BOXESHASH_MALFORMED),
             "unexpected result: {result:?}"
@@ -1589,14 +1640,13 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_rejects_box_with_no_allowed_exclusions() {
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![]];
+        let box_ranges: [BoxRangeInfo; 1] = [(0, 10, vec![])];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: None,
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
         assert!(
             matches!(&result, Err(Error::HashMismatch(msg)) if msg.contains("not contained within any permitted range")),
             "unexpected result: {result:?}"
@@ -1608,18 +1658,21 @@ mod tests {
         // The box has a permitted range, but the requested exclusion falls
         // outside it - e.g. covering a PNG chunk's length/type header
         // instead of its data.
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 5,
-            length: 5,
-            kind: ExclusionKind::AssetMetadata,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 5,
+                length: 5,
+                kind: ExclusionKind::AssetMetadata,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: None,
         }];
-        let result = split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions);
+        let result = split_exclusions(&box_ranges, 0, 10, &exclusions);
         assert!(
             matches!(&result, Err(Error::HashMismatch(msg)) if msg.contains("not contained within any permitted range")),
             "unexpected result: {result:?}"
@@ -1628,19 +1681,21 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_allows_manifest_or_padding_without_metadata_signal() {
-        let box_ranges = [(0u64, 10u64)];
-        let box_allowed: [Vec<AllowedExclusion>; 1] = [vec![AllowedExclusion {
-            start: 0,
-            length: 10,
-            kind: ExclusionKind::ManifestOrPadding,
-        }]];
+        let box_ranges: [BoxRangeInfo; 1] = [(
+            0,
+            10,
+            vec![AllowedExclusion {
+                start: 0,
+                length: 10,
+                kind: ExclusionKind::ManifestOrPadding,
+            }],
+        )];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
             box_index: None,
         }];
-        let (_ranges, metadata_used) =
-            split_exclusions(&box_ranges, &box_allowed, 0, 10, &exclusions).unwrap();
+        let (_ranges, metadata_used) = split_exclusions(&box_ranges, 0, 10, &exclusions).unwrap();
         assert!(!metadata_used);
     }
 

--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -817,11 +817,7 @@ impl Block {
             Block::ApplicationExtension(application_extension)
                 if ApplicationExtensionKind::C2pa == application_extension.kind() =>
             {
-                vec![AllowedExclusion {
-                    start: 0,
-                    length: box_len,
-                    kind: ExclusionKind::ManifestOrPadding,
-                }]
+                vec![AllowedExclusion::whole_box(box_len)]
             }
             // XMP is stored the same way as a Comment Extension's body - a
             // length-prefixed sub-block stream - just behind a longer,

--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -29,7 +29,7 @@ use img_parts::{
 use serde_bytes::ByteBuf;
 
 use crate::{
-    assertions::{AllowedExclusion, BoxMap, ExclusionKind, C2PA_BOXHASH},
+    assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
     asset_io::{
         rename_or_move, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
@@ -61,10 +61,17 @@ fn vec_compare(va: &[u8], vb: &[u8]) -> bool {
        .all(|(a,b)| a == b)
 }
 
+// Single source of truth for "does this APP1 payload start with the XMP
+// signature", so the box-hash exclusion classifier below and the unrelated
+// XMP-extraction path can't drift from each other.
+fn is_xmp_signature(bytes: &[u8]) -> bool {
+    bytes.starts_with(XMP_SIGNATURE.as_bytes())
+}
+
 // Return contents of APP1 segment if it is an XMP segment.
 fn extract_xmp(seg: &JpegSegment) -> Option<&str> {
     let (sig, rest) = seg.contents().split_at_checked(XMP_SIGNATURE_BUFFER_SIZE)?;
-    if sig.starts_with(XMP_SIGNATURE.as_bytes()) {
+    if is_xmp_signature(sig) {
         std::str::from_utf8(rest).ok()
     } else {
         None
@@ -727,9 +734,7 @@ fn get_seg_size(input_stream: &mut dyn CAIRead) -> Result<usize> {
 // the segment's payload (after the 4-byte marker+length header).
 fn app_segment_is_recognized_metadata(name: &str, prefix: &[u8]) -> bool {
     match name {
-        "APP1" => {
-            prefix.starts_with(EXIF_SIGNATURE) || prefix.starts_with(XMP_SIGNATURE.as_bytes())
-        }
+        "APP1" => prefix.starts_with(EXIF_SIGNATURE) || is_xmp_signature(prefix),
         "APP13" => prefix.starts_with(PHOTOSHOP_SIGNATURE),
         _ => false,
     }
@@ -741,22 +746,24 @@ fn app_segment_is_recognized_metadata(name: &str, prefix: &[u8]) -> bool {
 // excludable payload is `[4, range_len)`, box-relative, skipping the
 // 4-byte marker+length header.
 fn jpeg_metadata_allowed_exclusions(range_len: u64) -> Vec<AllowedExclusion> {
-    vec![AllowedExclusion {
-        start: 4,
-        length: range_len.saturating_sub(4),
-        kind: ExclusionKind::AssetMetadata,
-    }]
+    vec![AllowedExclusion::after_header(4, range_len)]
 }
 
 fn jpeg_c2pa_allowed_exclusions(range_len: u64) -> Vec<AllowedExclusion> {
-    vec![AllowedExclusion {
-        start: 0,
-        length: range_len,
-        kind: ExclusionKind::ManifestOrPadding,
-    }]
+    vec![AllowedExclusion::whole_box(range_len)]
 }
 
-fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
+/// Leading payload bytes of each APP1/APP13 segment, keyed by that box's
+/// `range_start`.
+type AppSegmentPrefixes = HashMap<u64, Vec<u8>>;
+
+/// Returns the parsed box maps alongside the leading bytes of each APP1/
+/// APP13 segment's payload (keyed by that box's `range_start`, since jfifdump
+/// hands us this payload up front but `range_len` - needed to bound how much
+/// of it matters - isn't known until [`get_box_map`]'s later pass). This lets
+/// that later pass classify APP1/APP13 content without re-seeking and
+/// re-reading bytes already in hand here.
+fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegmentPrefixes)> {
     let segment_names = HashMap::from([
         (0xe0u8, "APP0"),
         (0xe1u8, "APP1"),
@@ -809,6 +816,7 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
     ]);
 
     let mut box_maps = Vec::new();
+    let mut app_prefixes: HashMap<u64, Vec<u8>> = HashMap::new();
     let mut cai_en: Vec<u8> = Vec::new();
     let mut cai_seg_cnt: u32 = 0;
     let mut cai_index = 0;
@@ -927,11 +935,20 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
             }
             jfifdump::SegmentKind::App { nr, data } => {
                 let nr = nr | 0xe0;
-                let _data = data;
 
                 let name = segment_names
                     .get(&nr)
                     .ok_or(Error::InvalidAsset("Unknown segment marker".to_owned()))?;
+
+                // Only APP1/APP13 are ever classified as metadata (see
+                // `app_segment_is_recognized_metadata`), so only stash a
+                // prefix for those - capped at the longest signature we ever
+                // need to check, to avoid holding a large APPn payload (e.g.
+                // an ICC profile) in memory for the rest of this pass.
+                if nr == 0xe1 || nr == 0xed {
+                    let prefix_len = data.len().min(XMP_SIGNATURE_BUFFER_SIZE);
+                    app_prefixes.insert(seg.position as u64, data[..prefix_len].to_vec());
+                }
 
                 let bm = BoxMap {
                     names: vec![name.to_string()],
@@ -1109,12 +1126,12 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
         }
     }
 
-    Ok(box_maps)
+    Ok((box_maps, app_prefixes))
 }
 
 impl AssetBoxHash for JpegIO {
     fn get_box_map(&self, input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
-        let mut box_maps = make_box_maps(input_stream)?;
+        let (mut box_maps, app_prefixes) = make_box_maps(input_stream)?;
 
         // If no C2PA APP11 segment exists in the source, synthesize a placeholder
         // entry at the standard insertion point (immediately after the 2-byte SOI
@@ -1192,15 +1209,10 @@ impl AssetBoxHash for JpegIO {
             match bm.names.first().map(String::as_str) {
                 Some("APP1") | Some("APP13") => {
                     let name = bm.names[0].clone();
-                    let prefix_len =
-                        bm.range_len
-                            .saturating_sub(4)
-                            .min(XMP_SIGNATURE_BUFFER_SIZE as u64) as usize;
-                    input_stream.seek(std::io::SeekFrom::Start(bm.range_start + 4))?;
-                    let mut prefix = vec![0u8; prefix_len];
-                    input_stream.read_exact(&mut prefix)?;
-                    if app_segment_is_recognized_metadata(&name, &prefix) {
-                        bm.allowed_exclusions = jpeg_metadata_allowed_exclusions(bm.range_len);
+                    if let Some(prefix) = app_prefixes.get(&bm.range_start) {
+                        if app_segment_is_recognized_metadata(&name, prefix) {
+                            bm.allowed_exclusions = jpeg_metadata_allowed_exclusions(bm.range_len);
+                        }
                     }
                 }
                 // COM is free-form text with no defined signature to check.
@@ -1300,7 +1312,10 @@ pub mod tests {
     use wasm_bindgen_test::*;
 
     use super::*;
-    use crate::utils::io_utils::{safe_vec, tempdirectory};
+    use crate::{
+        assertions::ExclusionKind,
+        utils::io_utils::{safe_vec, tempdirectory},
+    };
     #[test]
     fn test_extract_xmp() {
         let contents = Bytes::from_static(b"http://ns.adobe.com/xap/1.0/\0stuff");

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -43,7 +43,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use serde_bytes::ByteBuf;
 
 use crate::{
-    assertions::{AllowedExclusion, BoxMap, ExclusionKind, C2PA_BOXHASH},
+    assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
     asset_io::{
         rename_or_move, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
@@ -832,16 +832,11 @@ fn classify_jxl_allowed_exclusions(
     brob_inner_type: Option<[u8; 4]>,
 ) -> Vec<AllowedExclusion> {
     match name {
-        C2PA_BOXHASH => vec![AllowedExclusion {
-            start: 0,
-            length: header_size + data_size,
-            kind: ExclusionKind::ManifestOrPadding,
-        }],
-        "Exif" | "xml " => vec![AllowedExclusion {
-            start: header_size,
-            length: data_size,
-            kind: ExclusionKind::AssetMetadata,
-        }],
+        C2PA_BOXHASH => vec![AllowedExclusion::whole_box(header_size + data_size)],
+        "Exif" | "xml " => vec![AllowedExclusion::after_header(
+            header_size,
+            header_size + data_size,
+        )],
         // "brob" (Brotli-compressed) may wrap either Exif or XMP, per spec's
         // own §18.7.4 JXL example - but the box type alone doesn't prove
         // that: it wraps an arbitrary embedded type, so only a recognized
@@ -850,11 +845,10 @@ fn classify_jxl_allowed_exclusions(
         // content, the same kind of structural field that must never be
         // excludable).
         "brob" if matches!(brob_inner_type, Some(t) if t == BOX_EXIF || t == BOX_XML) => {
-            vec![AllowedExclusion {
-                start: header_size + 4,
-                length: data_size.saturating_sub(4),
-                kind: ExclusionKind::AssetMetadata,
-            }]
+            vec![AllowedExclusion::after_header(
+                header_size + 4,
+                header_size + data_size,
+            )]
         }
         _ => Vec::new(),
     }
@@ -1084,6 +1078,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
+        assertions::ExclusionKind,
         utils::{io_utils::tempdirectory, test::test_context},
         Builder, CallbackSigner, Reader, SigningAlg,
     };

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -22,7 +22,7 @@ use png_pong::chunk::InternationalText;
 use serde_bytes::ByteBuf;
 
 use crate::{
-    assertions::{AllowedExclusion, BoxMap, ExclusionKind, C2PA_BOXHASH},
+    assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
     asset_io::{
         rename_or_move, AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter,
         ComposedManifestRef, HashBlockObjectType, HashObjectPositions, RemoteRefEmbed,
@@ -691,16 +691,8 @@ impl RemoteRefEmbed for PngIO {
 // box-relative: skip only the 8-byte length+type header.
 fn classify_png_allowed_exclusions(name: &str, range_len: u64) -> Vec<AllowedExclusion> {
     match name {
-        C2PA_BOXHASH => vec![AllowedExclusion {
-            start: 0,
-            length: range_len,
-            kind: ExclusionKind::ManifestOrPadding,
-        }],
-        "eXIf" | "iTXt" | "tEXt" | "zTXt" => vec![AllowedExclusion {
-            start: 8,
-            length: range_len.saturating_sub(8),
-            kind: ExclusionKind::AssetMetadata,
-        }],
+        C2PA_BOXHASH => vec![AllowedExclusion::whole_box(range_len)],
+        "eXIf" | "iTXt" | "tEXt" | "zTXt" => vec![AllowedExclusion::after_header(8, range_len)],
         _ => Vec::new(),
     }
 }
@@ -827,9 +819,12 @@ pub mod tests {
     use memchr::memmem;
 
     use super::*;
-    use crate::utils::{
-        io_utils::tempdirectory,
-        test::{self, temp_dir_path},
+    use crate::{
+        assertions::ExclusionKind,
+        utils::{
+            io_utils::tempdirectory,
+            test::{self, temp_dir_path},
+        },
     };
 
     #[test]

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -3028,26 +3028,27 @@ impl Claim {
                             continue;
                         }
                         Err(e) => {
-                            let err_str = match e {
-                                Error::C2PAValidation(es) => {
-                                    if es == validation_status::ASSERTION_BOXESHASH_MALFORMED {
-                                        validation_status::ASSERTION_BOXESHASH_MALFORMED
-                                    } else {
-                                        validation_status::ASSERTION_BOXHASH_MISMATCH
-                                    }
+                            // Classify the status code from the error's shape, but keep
+                            // logging/returning `e` itself below so the actual failure
+                            // reason (which box, which range, what mismatched) isn't lost.
+                            let err_str = match &e {
+                                Error::C2PAValidation(es)
+                                    if es == validation_status::ASSERTION_BOXESHASH_MALFORMED =>
+                                {
+                                    validation_status::ASSERTION_BOXESHASH_MALFORMED
                                 }
                                 _ => validation_status::ASSERTION_BOXHASH_MISMATCH,
                             };
 
                             log_item!(
                                 claim.assertion_uri(&hash_binding_assertion.label()),
-                                format!("asset hash error: {err_str}"),
+                                format!("asset hash error: {e}"),
                                 "verify_internal"
                             )
                             .validation_status(err_str)
                             .failure(
                                 validation_log,
-                                Error::HashMismatch(format!("Asset hash failure: {err_str}")),
+                                Error::HashMismatch(format!("Asset hash failure: {e}")),
                             )?;
                         }
                     }


### PR DESCRIPTION
## Summary

Follow-up on the review of #2513 (general box-hash exclusions). Four small, independently-buildable commits addressing findings from a code review of that PR:

- **`5847df0d`** — `split_exclusions` dropped an independent check (present in the earlier `BoxKind` design) that an exclusion range must not reach past its box's real length, relying instead on every format handler's `AllowedExclusion` happening to already be self-bounded. Restores that check as a bound on the permitted range itself, so a future/third-party `AssetBoxHash` implementor can't have an out-of-bounds `AllowedExclusion` silently accepted. Also collapses the `box_ranges`/`box_allowed_exclusions` parallel-vector bookkeeping (previously guarded only by a `debug_assert_eq!`, absent in release builds) into a single slice, removing the invariant a future caller could violate.
- **`b0275dbc`** — The box-hash verification failure arm in `claim.rs` was logging/returning only the coarse validation-status constant instead of the actual error message, losing the real failure reason. Restores the underlying error's `Display` text in both the log and the returned error, matching this arm's own pre-PR behavior.
- **`d4d1e5f2`** — `make_box_maps` read each JPEG segment's payload via `jfifdump` and discarded it, only for `get_box_map`'s later pass to seek back and re-read a prefix of the same bytes for the metadata-signature check. Threads the APP1/APP13 prefix through instead of re-reading from the stream. Also extracts the one XMP-signature check shared with the pre-existing `extract_xmp` into a single `is_xmp_signature` helper so the two can't drift.
- **`bc1c584f`** — `jpeg_io.rs`/`png_io.rs`/`jpegxl_io.rs` (and GIF's whole-box case) each hand-rolled the same two `AllowedExclusion` shapes. Adds `AllowedExclusion::whole_box`/`after_header` constructors and adopts them everywhere.

All existing tests pass, plus a new test (`test_split_exclusions_rejects_allowed_exclusion_wider_than_box`) covering the restored bound. `cargo +nightly fmt --all -- --check` and `cargo clippy --features file_io -- -D warnings` are clean.

## Test plan
- [x] `cargo test -p c2pa --features file_io --lib` — 1010 passed, 0 failed
- [x] Each commit verified to compile independently (`cargo check` at each SHA)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p c2pa --features file_io --lib -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)