### PR TITLE
feat: add `Error::AssertionEncoding` error source to error message

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
     AssertionMissing { url: String },
 
     /// The attempt to serialize the assertion (typically to JSON or CBOR) failed.
-    #[error("unable to encode assertion data")]
+    #[error("unable to encode assertion data: {0}")]
     AssertionEncoding(String),
 
     #[error(transparent)]


### PR DESCRIPTION
Adds the source error string of `Error::AssertionEncoding` to its `Display` impl, matching a few of our other errors, and allowing the messages to be seen cross the C FFI boundary (although we should consider including `#[source]` errors over that boundary in the future).

This particular error has bitten us a few times.