### PR TITLE
feat: add `Error::AssertionEncoding` error source to error message (backport #2544)

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
     AssertionMissing { url: String },
 
     /// The attempt to serialize the assertion (typically to JSON or CBOR) failed.
-    #[error("unable to encode assertion data")]
+    #[error("unable to encode assertion data: {0}")]
     AssertionEncoding(String),
 
     #[error(transparent)]


### PR DESCRIPTION
Automated backport of #2544 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.