### PR TITLE
fix: Mock connected identities DID on Wasm32

### DIFF
--- a/sdk/src/identity/validator.rs
+++ b/sdk/src/identity/validator.rs
@@ -70,13 +70,17 @@ impl AsyncPostValidator for CawgValidator<'_> {
 mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
-    use std::io::Cursor;
+    use std::io::{Cursor, Read};
 
+    use async_trait::async_trait;
     use c2pa_macros::c2pa_test_async;
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    use crate::{Reader, ValidationState};
+    use crate::{
+        http::{AsyncHttpResolver, HttpResolverError},
+        Context, Reader, ValidationState,
+    };
 
     const CONNECTED_IDENTITIES_VALID: &[u8] =
         include_bytes!("tests/fixtures/claim_aggregation/adobe_connected_identities.jpg");
@@ -90,9 +94,32 @@ mod tests {
     // DID document for the `did:web` issuer that both Adobe-signed fixtures above
     // were signed against. Served by a local mock so validation does not depend on
     // reaching the Adobe stage server over the network.
-    #[cfg(not(target_arch = "wasm32"))]
     const CONNECTED_IDENTITIES_DID: &str =
         include_str!("tests/fixtures/claim_aggregation/connected_identities_did.json");
+
+    /// Serves [`CONNECTED_IDENTITIES_DID`] for any request, without opening a
+    /// real socket. `httpmock` (used by [`mock_connected_identities_did`]) needs
+    /// a real TCP listener, which isn't available under WASI, so this resolver
+    /// is what keeps `did:web` resolution hermetic there.
+    struct MockDidResolver;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl AsyncHttpResolver for MockDidResolver {
+        async fn http_resolve_async(
+            &self,
+            _request: http::Request<Vec<u8>>,
+        ) -> Result<http::Response<Box<dyn Read>>, HttpResolverError> {
+            Ok(http::Response::builder()
+                .status(200)
+                .header("content-type", "application/did+json")
+                .body(
+                    Box::new(Cursor::new(CONNECTED_IDENTITIES_DID.as_bytes().to_vec()))
+                        as Box<dyn Read>,
+                )
+                .unwrap())
+        }
+    }
 
     /// Start a local mock server that serves the issuer DID document and redirect
     /// `did:web` resolution for the Adobe stage domain to it. The returned
@@ -121,15 +148,14 @@ mod tests {
     async fn test_connected_identities_valid() {
         crate::settings::set_settings_value("verify.verify_trust", false).unwrap();
 
-        // The proxy above points did:web resolution at a loopback mock server. The default policy
-        // allows direct requests to internal hosts (it only blocks redirects to internal
-        // addresses), so no allow-list is required here.
-        #[cfg(not(target_arch = "wasm32"))]
-        let _did_server = mock_connected_identities_did();
+        // Serve did:web resolution from an in-process resolver rather than a real
+        // network connection, so this test is hermetic on every target (including
+        // WASI, which has no compatible TCP-based mock server).
+        let context = Context::default().with_resolver_async(MockDidResolver);
 
         let mut stream = Cursor::new(CONNECTED_IDENTITIES_VALID);
 
-        let reader = Reader::default()
+        let reader = Reader::from_context(context)
             .with_stream_async("image/jpeg", &mut stream)
             .await
             .unwrap();
@@ -158,10 +184,10 @@ mod tests {
         )
         .unwrap();
         let settings = crate::settings::get_thread_local_settings();
-        let context = crate::Context::new().with_settings(settings).unwrap();
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let _did_server = mock_connected_identities_did();
+        let context = Context::new()
+            .with_settings(settings)
+            .unwrap()
+            .with_resolver_async(MockDidResolver);
 
         let mut stream = Cursor::new(MULTIPLE_IDENTITIES_VALID);
 
@@ -187,7 +213,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[c2pa_test_async]
     async fn ica_issuer_untrusted_does_not_affect_manifest_state() {
-        use crate::{Context, Settings};
+        use crate::Settings;
 
         let _did_server = mock_connected_identities_did();
 


### PR DESCRIPTION
## Changes in this pull request
Tests were intermittently failing because unmocked outgoing http connections were used in WASI tests.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
