### PR TITLE
fix: remove dbg! call used for testing

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2594,7 +2594,6 @@ impl Claim {
                                                 .is_some_and(|r| r.contains(redacted_uri));
                                         parent_tested = Some(in_assertions || in_redacted);
                                     } else {
-                                        dbg!("failed here");
                                         parent_tested = Some(false);
                                     }
                                 }


### PR DESCRIPTION
It looks like this slipped through the cracks at some point while debugging redaction.