### PR TITLE
fix: remove dbg! call used for testing (backport #2551)

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2594,7 +2594,6 @@ impl Claim {
                                                 .is_some_and(|r| r.contains(redacted_uri));
                                         parent_tested = Some(in_assertions || in_redacted);
                                     } else {
-                                        dbg!("failed here");
                                         parent_tested = Some(false);
                                     }
                                 }


### PR DESCRIPTION
Automated backport of #2551 to `stable`.

Upstream-first: this change already merged to `main`. If the
cherry-pick did not apply cleanly, adapt it so it compiles and
passes tests on this branch.