### PR TITLE
fix: downgrade `cargo-udeps` build from source version to match supported nightly version

### DIFF
--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -236,7 +236,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
 
       - name: Install cargo-udeps
-        run: cargo binstall --no-confirm cargo-udeps@0.1.61
+        run: cargo binstall --no-confirm cargo-udeps@0.1.60
 
       # Experimental (`unstable_`) features are excluded (see get-features); an
       # unstable-only optional dependency stays unactivated and so is never


### PR DESCRIPTION
`cargo-udeps` v0.1.61 requires a nightly version ahead of what we have pinned. For now downgrade `cargo-udeps`.

Source: https://github.com/contentauth/c2pa-rs/actions/runs/33009119144/job/98310610656?pr=2504