### PR TITLE
Fix JPEG XL Exif box exclusion; more box-hash cleanup (#2513 re-review)

### DIFF
--- a/sdk/src/assertions/box_hash.rs
+++ b/sdk/src/assertions/box_hash.rs
@@ -109,6 +109,26 @@ impl AllowedExclusion {
             kind: ExclusionKind::AssetMetadata,
         }
     }
+
+    fn end(&self) -> Option<u64> {
+        self.start.checked_add(self.length)
+    }
+
+    /// Whether this permitted range itself stays within its box's real
+    /// length - a defense against a buggy or malicious `AssetBoxHash`
+    /// implementor reporting a range that reaches past the box it's
+    /// attached to. `AllowedExclusion` is otherwise trusted as already
+    /// self-bounded, so this is checked independently rather than assumed.
+    fn is_bounded_by(&self, box_len: u64) -> bool {
+        self.end().is_some_and(|end| end <= box_len)
+    }
+
+    /// Whether `[range_start, range_end)` is fully contained within this
+    /// permitted range.
+    fn contains(&self, range_start: u64, range_end: u64) -> bool {
+        self.end()
+            .is_some_and(|end| range_start >= self.start && range_end <= end)
+    }
 }
 
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq)]
@@ -156,11 +176,17 @@ impl BoxMap {
     }
 }
 
-/// A named box's absolute `(start, len)` range plus the permitted exclusion
-/// sub-ranges measured for it from the live asset. Keeping these together
-/// (rather than as two parallel vectors) makes it impossible for a caller to
-/// push one without the other.
-type BoxRangeInfo = (u64, u64, Vec<AllowedExclusion>);
+/// A named box's absolute range plus the permitted exclusion sub-ranges
+/// measured for it from the live asset. Keeping these together (rather than
+/// as two parallel vectors) makes it impossible for a caller to push one
+/// without the other, and naming the fields (rather than a positional tuple)
+/// rules out transposing `start`/`len` at a construction or destructuring
+/// site.
+struct BoxRangeInfo {
+    start: u64,
+    len: u64,
+    allowed_exclusions: Vec<AllowedExclusion>,
+}
 
 /// Resolves `exclusions`' `boxIndex`-relative ranges against `box_ranges`
 /// (the absolute range and permitted sub-ranges of each name in a
@@ -198,15 +224,16 @@ fn split_exclusions(
             None => return Err(malformed()),
         };
 
-        let (box_start, box_len, allowed) = box_ranges.get(box_index).ok_or_else(malformed)?;
+        let range_info = box_ranges.get(box_index).ok_or_else(malformed)?;
+        let box_start = range_info.start;
 
         let excl_end = excl.start.checked_add(excl.length).ok_or_else(malformed)?;
 
-        let permitting_range = allowed.iter().find(|a| {
-            a.start.checked_add(a.length).is_some_and(|a_end| {
-                a_end <= *box_len && excl.start >= a.start && excl_end <= a_end
-            })
-        });
+        let permitting_range = range_info
+            .allowed_exclusions
+            .iter()
+            .filter(|a| a.is_bounded_by(range_info.len))
+            .find(|a| a.contains(excl.start, excl_end));
 
         match permitting_range {
             None => {
@@ -347,11 +374,11 @@ impl BoxHash {
             for name in &bm.names {
                 match source_bms.get(source_index) {
                     Some(next_source_bm) if name == &next_source_bm.names[0] => {
-                        box_ranges.push((
-                            next_source_bm.range_start,
-                            next_source_bm.range_len,
-                            next_source_bm.allowed_exclusions.clone(),
-                        ));
+                        box_ranges.push(BoxRangeInfo {
+                            start: next_source_bm.range_start,
+                            len: next_source_bm.range_len,
+                            allowed_exclusions: next_source_bm.allowed_exclusions.clone(),
+                        });
 
                         if inclusion.length() == 0 {
                             inclusion.set_start(next_source_bm.range_start);
@@ -528,41 +555,20 @@ impl BoxHash {
 
         if minimal_form {
             let mut before_c2pa = BoxMap {
-                names: Vec::new(),
                 alg: Some(alg.to_string()),
-                hash: ByteBuf::from(vec![]),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: Vec::new(),
-                pad: ByteBuf::from(vec![]),
-                range_start: 0,
-                range_len: 0,
+                ..Default::default()
             };
             let mut before_c2pa_ranges: Vec<BoxRangeInfo> = Vec::new();
             let mut before_c2pa_exclusions: Vec<BoxExclusion> = Vec::new();
 
             let mut c2pa_box = BoxMap {
-                names: Vec::new(),
                 alg: Some(alg.to_string()),
-                hash: ByteBuf::from(vec![]),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: Vec::new(),
-                pad: ByteBuf::from(vec![]),
-                range_start: 0,
-                range_len: 0,
+                ..Default::default()
             };
 
             let mut after_c2pa = BoxMap {
-                names: Vec::new(),
                 alg: Some(alg.to_string()),
-                hash: ByteBuf::from(vec![]),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: Vec::new(),
-                pad: ByteBuf::from(vec![]),
-                range_start: 0,
-                range_len: 0,
+                ..Default::default()
             };
             let mut after_c2pa_ranges: Vec<BoxRangeInfo> = Vec::new();
             let mut after_c2pa_exclusions: Vec<BoxExclusion> = Vec::new();
@@ -600,7 +606,11 @@ impl BoxHash {
                 // position in `group_ranges` (before pushing) is also its
                 // future position in `group.names` - i.e. its `boxIndex`.
                 let box_index_in_group = group_ranges.len();
-                group_ranges.push((bm.range_start, bm.range_len, bm.allowed_exclusions.clone()));
+                group_ranges.push(BoxRangeInfo {
+                    start: bm.range_start,
+                    len: bm.range_len,
+                    allowed_exclusions: bm.allowed_exclusions.clone(),
+                });
                 for req in exclusion_requests {
                     if req.source_box_index == source_index {
                         group_exclusions.push(BoxExclusion {
@@ -638,11 +648,11 @@ impl BoxHash {
             }
             // Do the same for the actual C2PA box
             if c2pa_box.range_len > 0 {
-                boxes_ranges.push(vec![(
-                    c2pa_box.range_start,
-                    c2pa_box.range_len,
-                    c2pa_box.allowed_exclusions.clone(),
-                )]);
+                boxes_ranges.push(vec![BoxRangeInfo {
+                    start: c2pa_box.range_start,
+                    len: c2pa_box.range_len,
+                    allowed_exclusions: c2pa_box.allowed_exclusions.clone(),
+                }]);
                 boxes.push(c2pa_box);
             }
             // And finally, add the boxes after the C2PA box
@@ -686,7 +696,11 @@ impl BoxHash {
                     continue;
                 }
 
-                let box_ranges = [(bm.range_start, bm.range_len, bm.allowed_exclusions.clone())];
+                let box_ranges = [BoxRangeInfo {
+                    start: bm.range_start,
+                    len: bm.range_len,
+                    allowed_exclusions: bm.allowed_exclusions.clone(),
+                }];
                 let exclusions: Vec<BoxExclusion> = exclusion_requests
                     .iter()
                     .filter(|req| req.source_box_index == source_index)
@@ -1386,24 +1400,24 @@ mod tests {
         // box 0: [100, 150), box 1: [150, 230); exclude [110,115) in box 0
         // and [170,180) in box 1.
         let box_ranges: [BoxRangeInfo; 2] = [
-            (
-                100,
-                50,
-                vec![AllowedExclusion {
+            BoxRangeInfo {
+                start: 100,
+                len: 50,
+                allowed_exclusions: vec![AllowedExclusion {
                     start: 0,
                     length: 50,
                     kind: ExclusionKind::AssetMetadata,
                 }],
-            ),
-            (
-                150,
-                80,
-                vec![AllowedExclusion {
+            },
+            BoxRangeInfo {
+                start: 150,
+                len: 80,
+                allowed_exclusions: vec![AllowedExclusion {
                     start: 0,
                     length: 80,
                     kind: ExclusionKind::AssetMetadata,
                 }],
-            ),
+            },
         ];
         let exclusions = vec![
             BoxExclusion {
@@ -1425,15 +1439,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_fully_excluded_entry_does_not_fall_back_to_full_range() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            5,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 5,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 10,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 10,
@@ -1447,24 +1461,24 @@ mod tests {
     #[test]
     fn test_split_exclusions_missing_box_index_with_multiple_boxes() {
         let box_ranges: [BoxRangeInfo; 2] = [
-            (
-                0,
-                10,
-                vec![AllowedExclusion {
+            BoxRangeInfo {
+                start: 0,
+                len: 10,
+                allowed_exclusions: vec![AllowedExclusion {
                     start: 0,
                     length: 10,
                     kind: ExclusionKind::AssetMetadata,
                 }],
-            ),
-            (
-                10,
-                10,
-                vec![AllowedExclusion {
+            },
+            BoxRangeInfo {
+                start: 10,
+                len: 10,
+                allowed_exclusions: vec![AllowedExclusion {
                     start: 0,
                     length: 10,
                     kind: ExclusionKind::AssetMetadata,
                 }],
-            ),
+            },
         ];
         let exclusions = vec![BoxExclusion {
             start: 0,
@@ -1480,15 +1494,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_out_of_range_box_index() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 10,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
@@ -1503,15 +1517,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_negative_box_index() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 10,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
@@ -1526,15 +1540,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_rejects_range_extending_past_box_end() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 10,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 8,
             length: 5,
@@ -1554,15 +1568,15 @@ mod tests {
     // range's own bound against the box's live length is not optional.
     #[test]
     fn test_split_exclusions_rejects_allowed_exclusion_wider_than_box() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 15,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 11,
             length: 2,
@@ -1577,15 +1591,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_overlapping_ranges() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            20,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 20,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 20,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![
             BoxExclusion {
                 start: 0,
@@ -1610,15 +1624,15 @@ mod tests {
     // silently sorted into a valid-looking sequence.
     #[test]
     fn test_split_exclusions_out_of_order_ranges_are_rejected_not_reordered() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            20,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 20,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 20,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![
             BoxExclusion {
                 start: 10,
@@ -1640,7 +1654,11 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_rejects_box_with_no_allowed_exclusions() {
-        let box_ranges: [BoxRangeInfo; 1] = [(0, 10, vec![])];
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![],
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
@@ -1658,15 +1676,15 @@ mod tests {
         // The box has a permitted range, but the requested exclusion falls
         // outside it - e.g. covering a PNG chunk's length/type header
         // instead of its data.
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 5,
                 length: 5,
                 kind: ExclusionKind::AssetMetadata,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,
@@ -1681,15 +1699,15 @@ mod tests {
 
     #[test]
     fn test_split_exclusions_allows_manifest_or_padding_without_metadata_signal() {
-        let box_ranges: [BoxRangeInfo; 1] = [(
-            0,
-            10,
-            vec![AllowedExclusion {
+        let box_ranges: [BoxRangeInfo; 1] = [BoxRangeInfo {
+            start: 0,
+            len: 10,
+            allowed_exclusions: vec![AllowedExclusion {
                 start: 0,
                 length: 10,
                 kind: ExclusionKind::ManifestOrPadding,
             }],
-        )];
+        }];
         let exclusions = vec![BoxExclusion {
             start: 0,
             length: 1,

--- a/sdk/src/asset_handlers/c2pa_io.rs
+++ b/sdk/src/asset_handlers/c2pa_io.rs
@@ -13,10 +13,8 @@
 
 use std::{fs::File, path::Path};
 
-use serde_bytes::ByteBuf;
-
 use crate::{
-    assertions::{AllowedExclusion, BoxMap, ExclusionKind, C2PA_BOXHASH},
+    assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
     asset_io::{
         AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, ComposedManifestRef,
         HashBlockObjectType, HashObjectPositions,
@@ -150,17 +148,8 @@ impl AssetBoxHash for C2paIO {
         let c2pa_box_map = BoxMap {
             names: vec![C2PA_BOXHASH.to_string()],
             alg: Some(alg.to_string()),
-            hash: ByteBuf::from(vec![]),
-            excluded: None,
-            exclusions: None,
-            allowed_exclusions: vec![AllowedExclusion {
-                start: 0,
-                length: 0,
-                kind: ExclusionKind::ManifestOrPadding,
-            }],
-            pad: ByteBuf::from(vec![]),
-            range_start: 0,
-            range_len: 0,
+            allowed_exclusions: vec![AllowedExclusion::whole_box(0)],
+            ..Default::default()
         };
 
         let box_maps = vec![c2pa_box_map];

--- a/sdk/src/asset_handlers/gif_io.rs
+++ b/sdk/src/asset_handlers/gif_io.rs
@@ -19,7 +19,6 @@ use std::{
 };
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
-use serde_bytes::ByteBuf;
 use tempfile::Builder;
 
 use crate::{
@@ -643,14 +642,10 @@ impl BlockMarker<Block> {
 
         Ok(BoxMap {
             names,
-            alg: None,
-            hash: ByteBuf::from(Vec::new()),
-            excluded: None,
-            exclusions: None,
             allowed_exclusions: self.block.allowed_exclusions(self.len()),
-            pad: ByteBuf::from(Vec::new()),
             range_start: self.start(),
             range_len: self.len(),
+            ..Default::default()
         })
     }
 }
@@ -827,28 +822,18 @@ impl Block {
             Block::ApplicationExtension(application_extension)
                 if ApplicationExtensionKind::Xmp == application_extension.kind() =>
             {
-                sub_block_data_ranges(&application_extension.data_sub_blocks.bytes)
-                    .into_iter()
-                    .map(|(offset, length)| AllowedExclusion {
-                        start: offset + 14,
-                        length,
-                        kind: ExclusionKind::AssetMetadata,
-                    })
-                    .collect()
+                metadata_exclusions_from_sub_blocks(
+                    &application_extension.data_sub_blocks.bytes,
+                    14,
+                )
             }
             // Comment Extension bodies are a length-prefixed sub-block stream
             // (1-byte length + data, repeated, 0x00-terminated) with no
             // single fixed header, so each sub-block's data gets its own
-            // range, skipping every length-prefix byte and the terminator.
+            // range, skipping every length-prefix byte and the terminator -
+            // the 2-byte extension introducer + label.
             Block::CommentExtension(comment) => {
-                sub_block_data_ranges(&comment.data_sub_blocks.bytes)
-                    .into_iter()
-                    .map(|(offset, length)| AllowedExclusion {
-                        start: offset + 2, // skip the extension introducer + label
-                        length,
-                        kind: ExclusionKind::AssetMetadata,
-                    })
-                    .collect()
+                metadata_exclusions_from_sub_blocks(&comment.data_sub_blocks.bytes, 2)
             }
             _ => Vec::new(),
         }
@@ -1227,6 +1212,24 @@ fn sub_block_data_ranges(encoded_bytes: &[u8]) -> Vec<(u64, u64)> {
     ranges
 }
 
+/// One `AllowedExclusion` per sub-block's data in a length-prefixed,
+/// 0x00-terminated sub-block stream (shared by the Comment Extension and XMP
+/// Application Extension cases, which differ only in their fixed-size
+/// header's length).
+fn metadata_exclusions_from_sub_blocks(
+    encoded_bytes: &[u8],
+    header_len: u64,
+) -> Vec<AllowedExclusion> {
+    sub_block_data_ranges(encoded_bytes)
+        .into_iter()
+        .map(|(offset, length)| AllowedExclusion {
+            start: offset + header_len,
+            length,
+            kind: ExclusionKind::AssetMetadata,
+        })
+        .collect()
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum GifError {
     #[error("invalid file signature: {reason}")]
@@ -1587,42 +1590,27 @@ mod tests {
             box_map.first(),
             Some(&BoxMap {
                 names: vec!["GIF89a".to_owned()],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: vec![],
-                pad: ByteBuf::from(Vec::new()),
                 range_start: 0,
-                range_len: 6
+                range_len: 6,
+                ..Default::default()
             })
         );
         assert_eq!(
             box_map.get(box_map.len() / 2),
             Some(&BoxMap {
                 names: vec!["2C".to_owned()],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: vec![],
-                pad: ByteBuf::from(Vec::new()),
                 range_start: 368494,
-                range_len: 778
+                range_len: 778,
+                ..Default::default()
             })
         );
         assert_eq!(
             box_map.last(),
             Some(&BoxMap {
                 names: vec!["3B".to_owned()],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
-                allowed_exclusions: vec![],
-                pad: ByteBuf::from(Vec::new()),
                 range_start: SAMPLE1.len() as u64 - 1,
-                range_len: 1
+                range_len: 1,
+                ..Default::default()
             })
         );
         assert_eq!(box_map.len(), 276);

--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -26,7 +26,6 @@ use img_parts::{
     },
     Bytes, DynImage,
 };
-use serde_bytes::ByteBuf;
 
 use crate::{
     assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
@@ -832,14 +831,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Eoi => {
                 let bm = BoxMap {
                     names: vec!["EOI".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -847,14 +840,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Soi => {
                 let bm = BoxMap {
                     names: vec!["SOI".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -899,14 +886,9 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
 
                             let c2pa_bm = BoxMap {
                                 names: vec![C2PA_BOXHASH.to_string()],
-                                alg: None,
-                                hash: ByteBuf::from(Vec::new()),
-                                excluded: None,
-                                exclusions: None,
-                                allowed_exclusions: Vec::new(),
-                                pad: ByteBuf::from(Vec::new()),
                                 range_start: seg.position as u64,
                                 range_len: (raw_bytes.len() + 4) as u64,
+                                ..Default::default()
                             };
 
                             box_maps.push(c2pa_bm);
@@ -918,14 +900,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
 
                             let bm = BoxMap {
                                 names: vec![name.to_string()],
-                                alg: None,
-                                hash: ByteBuf::from(Vec::new()),
-                                excluded: None,
-                                exclusions: None,
-                                allowed_exclusions: Vec::new(),
-                                pad: ByteBuf::from(Vec::new()),
                                 range_start: seg.position as u64,
-                                range_len: 0,
+                                ..Default::default()
                             };
 
                             box_maps.push(bm);
@@ -944,22 +920,19 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
                 // `app_segment_is_recognized_metadata`), so only stash a
                 // prefix for those - capped at the longest signature we ever
                 // need to check, to avoid holding a large APPn payload (e.g.
-                // an ICC profile) in memory for the rest of this pass.
-                if nr == 0xe1 || nr == 0xed {
+                // an ICC profile) in memory for the rest of this pass. Keyed
+                // off the same resolved `name` the classifier itself checks
+                // against, rather than re-deriving it from `nr`, so the two
+                // checks can't drift out of sync with `segment_names`.
+                if *name == "APP1" || *name == "APP13" {
                     let prefix_len = data.len().min(XMP_SIGNATURE_BUFFER_SIZE);
                     app_prefixes.insert(seg.position as u64, data[..prefix_len].to_vec());
                 }
 
                 let bm = BoxMap {
                     names: vec![name.to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -967,14 +940,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::App0Jfif(_) => {
                 let bm = BoxMap {
                     names: vec!["APP0".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -982,14 +949,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Dqt(_) => {
                 let bm = BoxMap {
                     names: vec!["DQT".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -997,14 +958,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Dht(_) => {
                 let bm = BoxMap {
                     names: vec!["DHT".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1012,14 +967,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Dac(_) => {
                 let bm = BoxMap {
                     names: vec!["DAC".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1031,14 +980,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
 
                 let bm = BoxMap {
                     names: vec![name.to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1046,14 +989,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Scan(_s) => {
                 let bm = BoxMap {
                     names: vec!["SOS".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1061,14 +998,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Dri(_) => {
                 let bm = BoxMap {
                     names: vec!["DRI".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1077,14 +1008,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
                 let name = format!("RST{}", r.nr);
                 let bm = BoxMap {
                     names: vec![name.clone()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1092,14 +1017,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
             jfifdump::SegmentKind::Comment(_) => {
                 let bm = BoxMap {
                     names: vec!["COM".to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1111,14 +1030,8 @@ fn make_box_maps(input_stream: &mut dyn CAIRead) -> Result<(Vec<BoxMap>, AppSegm
 
                 let bm = BoxMap {
                     names: vec![name.to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
-                    allowed_exclusions: Vec::new(),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: seg.position as u64,
-                    range_len: 0,
+                    ..Default::default()
                 };
 
                 box_maps.push(bm);
@@ -1148,14 +1061,8 @@ impl AssetBoxHash for JpegIO {
         if !has_c2pa {
             let mut c2pa_box = BoxMap {
                 names: vec![C2PA_BOXHASH.to_string()],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
                 excluded: Some(true),
-                exclusions: None,
-                allowed_exclusions: Vec::new(),
-                pad: ByteBuf::from(Vec::new()),
-                range_start: 0,
-                range_len: 0,
+                ..Default::default()
             };
             // SOI is always first; insert the C2PA box right after it or after APP0 if it exists.
             let app0_index = box_maps

--- a/sdk/src/asset_handlers/jpegxl_io.rs
+++ b/sdk/src/asset_handlers/jpegxl_io.rs
@@ -40,7 +40,6 @@ use std::{
 };
 
 use byteorder::{BigEndian, ReadBytesExt};
-use serde_bytes::ByteBuf;
 
 use crate::{
     assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
@@ -833,7 +832,17 @@ fn classify_jxl_allowed_exclusions(
 ) -> Vec<AllowedExclusion> {
     match name {
         C2PA_BOXHASH => vec![AllowedExclusion::whole_box(header_size + data_size)],
-        "Exif" | "xml " => vec![AllowedExclusion::after_header(
+        // A bare `Exif` box's payload is prefixed by a mandatory 4-byte
+        // big-endian `exif_tiff_header_offset` field (the same convention
+        // HEIF uses for its Exif item, per ISO/IEC 23008-12 Annex A) before
+        // the actual TIFF/Exif data - a structural field that must stay
+        // hashed, the same as the embedded-type field the "brob" case below
+        // skips. `xml ` (raw XMP text) has no such field.
+        "Exif" => vec![AllowedExclusion::after_header(
+            header_size + 4,
+            header_size + data_size,
+        )],
+        "xml " => vec![AllowedExclusion::after_header(
             header_size,
             header_size + data_size,
         )],
@@ -902,14 +911,10 @@ impl AssetBoxHash for JpegXlIO {
 
             box_maps.push(BoxMap {
                 names: vec![name],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
                 allowed_exclusions,
-                pad: ByteBuf::from(Vec::new()),
                 range_start: b.offset,
                 range_len: total,
+                ..Default::default()
             });
         }
 
@@ -924,14 +929,9 @@ impl AssetBoxHash for JpegXlIO {
 
             let c2pa_box = BoxMap {
                 names: vec![C2PA_BOXHASH.to_string()],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
                 allowed_exclusions: classify_jxl_allowed_exclusions(C2PA_BOXHASH, 0, 0, None),
-                pad: ByteBuf::from(Vec::new()),
                 range_start, // will be patched to correct offset by add_required_jumb_to_stream
-                range_len: 0,
+                ..Default::default()
             };
 
             // Insert the C2PA box after ftyp.
@@ -1113,11 +1113,14 @@ pub mod tests {
                 kind: ExclusionKind::ManifestOrPadding,
             }]
         );
+        // A bare `Exif` box's payload starts with a 4-byte
+        // `exif_tiff_header_offset` field, so the excludable range starts
+        // 4 bytes further in than `xml `'s (which has no such field).
         assert_eq!(
             classify_jxl_allowed_exclusions("Exif", 8, 12, None),
             vec![AllowedExclusion {
-                start: 8,
-                length: 12,
+                start: 12,
+                length: 8,
                 kind: ExclusionKind::AssetMetadata,
             }]
         );

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -19,7 +19,6 @@ use std::{
 
 use byteorder::{BigEndian, ReadBytesExt};
 use png_pong::chunk::InternationalText;
-use serde_bytes::ByteBuf;
 
 use crate::{
     assertions::{AllowedExclusion, BoxMap, C2PA_BOXHASH},
@@ -710,14 +709,10 @@ impl AssetBoxHash for PngIO {
         // add PNGh header
         let pngh_bm = BoxMap {
             names: vec!["PNGh".to_string()],
-            alg: None,
-            hash: ByteBuf::from(Vec::new()),
-            excluded: None,
-            exclusions: None,
             allowed_exclusions: classify_png_allowed_exclusions("PNGh", 8),
-            pad: ByteBuf::from(Vec::new()),
             range_start: 0,
             range_len: 8,
+            ..Default::default()
         };
         box_maps.push(pngh_bm);
 
@@ -728,14 +723,10 @@ impl AssetBoxHash for PngIO {
                 let range_len = pc.length as u64 + 12; // length(4) + name(4) + crc(4)
                 let c2pa_bm = BoxMap {
                     names: vec![C2PA_BOXHASH.to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
-                    excluded: None,
-                    exclusions: None,
                     allowed_exclusions: classify_png_allowed_exclusions(C2PA_BOXHASH, range_len),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: pc.start,
                     range_len,
+                    ..Default::default()
                 };
                 box_maps.push(c2pa_bm);
                 continue;
@@ -748,14 +739,10 @@ impl AssetBoxHash for PngIO {
             let allowed_exclusions = classify_png_allowed_exclusions(&pc.name_str, range_len);
             let bm = BoxMap {
                 names: vec![pc.name_str],
-                alg: None,
-                hash: ByteBuf::from(Vec::new()),
-                excluded: None,
-                exclusions: None,
                 allowed_exclusions,
-                pad: ByteBuf::from(Vec::new()),
                 range_start: pc.start,
                 range_len,
+                ..Default::default()
             };
             box_maps.push(bm);
 
@@ -767,14 +754,10 @@ impl AssetBoxHash for PngIO {
             if !has_c2pa && is_ihdr {
                 let synthetic = BoxMap {
                     names: vec![C2PA_BOXHASH.to_string()],
-                    alg: None,
-                    hash: ByteBuf::from(Vec::new()),
                     excluded: Some(true),
-                    exclusions: None,
                     allowed_exclusions: classify_png_allowed_exclusions(C2PA_BOXHASH, 0),
-                    pad: ByteBuf::from(Vec::new()),
                     range_start: chunk_end,
-                    range_len: 0,
+                    ..Default::default()
                 };
                 box_maps.push(synthetic);
             }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2688,6 +2688,20 @@ impl Claim {
         Ok(())
     }
 
+    /// Classifies a hash-verification failure into its format's `malformed`
+    /// or `mismatch` validation-status constant, based on whether `e` carries
+    /// that format's own `malformed` code.
+    fn classify_hash_verification_error(
+        e: &Error,
+        malformed: &'static str,
+        mismatch: &'static str,
+    ) -> &'static str {
+        match e {
+            Error::C2PAValidation(es) if es == malformed => malformed,
+            _ => mismatch,
+        }
+    }
+
     pub(crate) fn verify_hash_binding(
         claim: &Claim,
         asset_data: &mut ClaimAssetData<'_>,
@@ -2916,26 +2930,21 @@ impl Claim {
                             continue;
                         }
                         Err(e) => {
-                            let err_str = match e {
-                                Error::C2PAValidation(es) => {
-                                    if es == validation_status::ASSERTION_BMFFHASH_MALFORMED {
-                                        validation_status::ASSERTION_BMFFHASH_MALFORMED
-                                    } else {
-                                        validation_status::ASSERTION_BMFFHASH_MISMATCH
-                                    }
-                                }
-                                _ => validation_status::ASSERTION_BMFFHASH_MISMATCH,
-                            };
+                            let err_str = Self::classify_hash_verification_error(
+                                &e,
+                                validation_status::ASSERTION_BMFFHASH_MALFORMED,
+                                validation_status::ASSERTION_BMFFHASH_MISMATCH,
+                            );
 
                             log_item!(
                                 claim.assertion_uri(&hash_binding_assertion.label()),
-                                format!("asset hash error, name: {name}, error: {}", err_str),
+                                format!("asset hash error, name: {name}, error: {e}"),
                                 "verify_internal"
                             )
                             .validation_status(err_str)
                             .failure(
                                 validation_log,
-                                Error::HashMismatch(format!("Asset hash failure: {err_str}")),
+                                Error::HashMismatch(format!("Asset hash failure: {e}")),
                             )?;
                         }
                     }
@@ -3028,17 +3037,11 @@ impl Claim {
                             continue;
                         }
                         Err(e) => {
-                            // Classify the status code from the error's shape, but keep
-                            // logging/returning `e` itself below so the actual failure
-                            // reason (which box, which range, what mismatched) isn't lost.
-                            let err_str = match &e {
-                                Error::C2PAValidation(es)
-                                    if es == validation_status::ASSERTION_BOXESHASH_MALFORMED =>
-                                {
-                                    validation_status::ASSERTION_BOXESHASH_MALFORMED
-                                }
-                                _ => validation_status::ASSERTION_BOXHASH_MISMATCH,
-                            };
+                            let err_str = Self::classify_hash_verification_error(
+                                &e,
+                                validation_status::ASSERTION_BOXESHASH_MALFORMED,
+                                validation_status::ASSERTION_BOXHASH_MISMATCH,
+                            );
 
                             log_item!(
                                 claim.assertion_uri(&hash_binding_assertion.label()),


### PR DESCRIPTION
## Summary

Follow-up on a re-review of #2513 after #2543 was merged into this branch. All of #2543's fixes verified as correctly landed with no regressions (via a fresh 8-angle review pass). This PR fixes one new correctness bug found in the original feature code, plus several cleanup items.

- **`25942785`** (fix) — `classify_jxl_allowed_exclusions` treated a bare (non-`brob`) `Exif` box's entire payload as excludable `AssetMetadata` right after the box header. Per the JPEG XL/HEIF Exif-in-box convention, that payload actually begins with a mandatory 4-byte big-endian `exif_tiff_header_offset` structural field before the real TIFF/Exif data — the same class of leading structural field the neighboring `"brob"` arm already correctly skips. A signed JPEG XL asset's Exif box offset field could be altered post-signing without invalidating the box hash. Verified against libjxl's own documented box format. Also applies the existing `BoxMap` `..Default::default()` pattern to this file's two literals.
- **`40274d42`** (cleanup) — `c2pa_io.rs` still hand-constructed the `AllowedExclusion` shape that `AllowedExclusion::whole_box(0)` was introduced to replace.
- **`3f411148`** (cleanup) — the box-hash and BMFF-hash error-classification arms in `claim.rs` had already drifted from duplicating the same "classify as MALFORMED/MISMATCH" logic (one discarded the original error, one didn't). Extracted a shared helper; both arms now keep the original error's detail.
- **`464a1ee0`** (cleanup) — `gif_io.rs`'s XMP and Comment Extension sub-block-to-`AllowedExclusion` mapping was duplicated; extracted `metadata_exclusions_from_sub_blocks`.
- **`bbd9ee4c`**, **`ceffa245`** (cleanup) — `png_io.rs`/`jpeg_io.rs` `BoxMap` literals now use `..Default::default()` instead of spelling out every boilerplate field (`BoxMap` already derives `Default`); `jpeg_io.rs` also fixed a spot where APP1/APP13 were identified two different ways (numeric marker vs. resolved name) that could silently drift apart.
- **`2ac80c4c`** (cleanup) — extracted `AllowedExclusion::is_bounded_by`/`contains` so the box-length defense-in-depth check (added in #2543) is a named, harder-to-accidentally-drop step instead of one clause in a larger `&&` chain; turned `BoxRangeInfo` from a `(u64, u64, Vec<AllowedExclusion>)` tuple into a named struct to remove a start/len transposition risk.

**Deliberately not changed:** `jpeg_io.rs`'s `AppSegmentPrefixes` (a `HashMap` keyed by `range_start`) was flagged as possibly over-engineered vs. a parallel `Vec`, but `make_box_maps` has ~15 independent `box_maps.push()` call sites — a parallel `Vec` would require every one of them to push a matching entry in lockstep, reintroducing exactly the parallel-vector fragility fixed elsewhere in this PR. The `HashMap` keyed by a stable identifier is the safer choice here.

## Test plan
- [x] `cargo test -p c2pa --features file_io --lib` — 1027 passed, 0 failed (includes an updated `test_classify_jxl_allowed_exclusions` case covering the Exif fix)
- [x] Each commit verified to compile independently (`cargo check` at each SHA)
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p c2pa --features file_io --lib -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)