### PR TITLE
update: chacha20 to 0.10.2, superseding yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
Updates `chacha20` from v0.10.1 to v0.10.2 as the former is yanked.

https://github.com/contentauth/c2pa-rs/actions/runs/33114355290/job/98839745667?pr=2545