### PR TITLE
chore: Prevent backport bot from recursing on backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   backport:
     name: Backport merged PR
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Add `&& github.event.pull_request.base.ref == 'main'` to the backport job's `if` condition so it only fires for PRs merging into `main`.

## Why

The backport workflow triggers on `pull_request_target: [closed, labeled]` for any branch. When a backport PR (e.g., targeting `stable` or `v0.90`) is merged, the workflow fires again on that PR, finds no `backport-*` labels, and posts a spurious "Backport-action found no target branches to backport this pull request to" comment. Example: https://github.com/contentauth/c2pa-rs/pull/2531#issuecomment-5398544986

Limiting the job to `base.ref == 'main'` stops the recursion without changing any other behavior.

## Test plan

- [ ] Verify the workflow file looks correct
- [ ] After merge, confirm that a subsequent backport PR merge does not trigger a new backport workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)