### PR TITLE
chore: Skip backport workflow when PR has no backport-xxx label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,10 @@ permissions:
 jobs:
   backport:
     name: Backport merged PR
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'backport-')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- The backport job was running on every merged PR, even those without any `backport-xxx` label
- When no matching labels were found, `korthout/backport-action` would post a "found no target branches" comment — noise on PRs that were never meant to be backported (see [#2447 comment](https://github.com/contentauth/c2pa-rs/pull/2447#issuecomment-5479799349))
- Added a guard to the job's `if` condition: the job now only runs when the PR has at least one label whose name contains `backport-`

## Test plan

- [ ] Verify a PR merged to `main` **without** a `backport-xxx` label no longer triggers the workflow
- [ ] Verify a PR merged to `main` **with** a `backport-stable` or `backport-vX.Y` label still creates a backport PR as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)