### PR TITLE
fix: run Tier 1A on all PRs regardless of target branch

### DIFF
--- a/.github/workflows/tier-1a.yml
+++ b/.github/workflows/tier-1a.yml
@@ -24,11 +24,6 @@ on:
   schedule:
     - cron: '0 8 * * *'
   pull_request:
-    branches:
-      - main
-      - stable
-      - 'v0.*'
-      - '*-rc*'
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Summary

- The `pull_request` trigger in `tier-1a.yml` had a `branches` filter listing only `main`, `stable`, `v0.*`, and `*-rc*`
- GitHub matches that filter against the PR's *base* branch, so any PR targeting a feature-stacking branch (e.g. `gpeacock/c_ffi_opaque_ids` in [PR #2569](https://github.com/contentauth/c2pa-rs/pull/2569)) silently skipped the entire Tier 1A suite
- Removing the filter makes Tier 1A fire on every PR; the `push` trigger keeps its branch filter unchanged

## Test plan

- [ ] Confirm Tier 1A checks appear on this PR itself
- [ ] Confirm Tier 1A checks appear on [PR #2569](https://github.com/contentauth/c2pa-rs/pull/2569) after this merges (or after re-syncing its head)

🤖 Generated with [Claude Code](https://claude.com/claude-code)