### PR TITLE
fix!: C2PA 2.4 validation

### DIFF
--- a/cli/tests/fixtures/ingredient_test.json
+++ b/cli/tests/fixtures/ingredient_test.json
@@ -20,15 +20,6 @@
             "data": {
                 "actions": [
                     {
-                        "action": "c2pa.created",
-                        "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/algorithmicMedia",
-                        "softwareAgent": {
-                            "name": "TestApp",
-                            "version": "1.0",
-                            "something": "else"
-                        }
-                    },
-                    {
                         "action": "c2pa.opened",
                         "instanceId": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
                         "parameters": {

--- a/sdk/src/assertions/actions.rs
+++ b/sdk/src/assertions/actions.rs
@@ -252,6 +252,15 @@ pub mod c2pa_action {
     /// BCP-47 (RFC 5646) language codes.
     pub const TRANSLATED: &str = "c2pa.translated";
 
+    /// Watermarking was applied to this area for the purpose of soft binding.  2.3 and earlier.
+    pub const WATERMARKED: &str = "c2pa.watermarked";
+
+    /// Watermarking was applied to this area for the purpose of soft binding. 2.4 or later.
+    pub const WATERMARKED_BOUND: &str = "c2pa.watermarked.bound";
+
+    /// Watermarking was applied to this area without creating a soft binding. 2.4 or later.
+    pub const WATERMARKED_UNBOUND: &str = "c2pa.watermarked.unbound";
+
     /// Something happened, but the claim_generator cannot specify what.
     pub const UNKNOWN: &str = "c2pa.unknown";
 }

--- a/sdk/src/assertions/cloud_data.rs
+++ b/sdk/src/assertions/cloud_data.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     assertion::{Assertion, AssertionBase, AssertionCbor},
     assertions::{assertion_metadata::AssetType, labels, AssertionMetadata},
-    error::Result,
+    error::{Error, Result},
 };
 
 /// The `location` field of a [`CloudData`] assertion: a URL with its
@@ -147,6 +147,81 @@ impl CloudData {
     pub(crate) fn is_actions(&self) -> bool {
         labels::base(&self.label) == labels::ACTIONS
     }
+
+    /// Validates the Cloud Data assertion according to the C2PA 2.4 rules for
+    /// `c2pa.cloud-data` assertions.
+    pub fn validate(&self) -> Result<()> {
+        if self.label.trim().is_empty() {
+            return Err(Error::ValidationRule(
+                "cloud data assertion label must not be empty".to_owned(),
+            ));
+        }
+
+        if self.size < 1 {
+            return Err(Error::ValidationRule(
+                "cloud data assertion size must be >= 1".to_owned(),
+            ));
+        }
+
+        if self.location.url.trim().is_empty() {
+            return Err(Error::ValidationRule(
+                "cloud data assertion location.url must not be empty".to_owned(),
+            ));
+        }
+
+        if self.location.alg.trim().is_empty() {
+            return Err(Error::ValidationRule(
+                "cloud data assertion location.alg must not be empty".to_owned(),
+            ));
+        }
+
+        if self.location.hash.is_empty() {
+            return Err(Error::ValidationRule(
+                "cloud data assertion location.hash must not be empty".to_owned(),
+            ));
+        }
+
+        if self.is_forbidden().is_err() {
+            return Err(Error::ValidationRule(format!(
+                "cloud data assertion must not reference forbidden label '{}', per C2PA 2.4",
+                self.label
+            )));
+        }
+
+        if self.is_hard_binding() {
+            return Err(Error::ValidationRule(format!(
+                "cloud data assertion must not reference hard binding assertions '{}', per C2PA 2.4",
+                self.label
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// check for any forbidden label types, including hard bindings and the cloud-data assertion itself.
+    pub fn is_forbidden(&self) -> Result<()> {
+        // Per C2PA 2.4 §15.10.3.2.1, the referenced assertion must not be any
+        // of the forbidden label types, including hard bindings and the cloud-data
+        // assertion itself.
+        let forbidden = [
+            "c2pa.action",
+            "c2pa.actions",
+            "c2pa.actions.v2",
+            labels::CLOUD_DATA,
+            "c2pa.ingredient",
+            "c2pa.ingredient.v2",
+            "c2pa.ingredient.v3",
+        ];
+
+        if forbidden.contains(&self.label.as_str()) {
+            return Err(Error::ValidationRule(format!(
+                "cloud data assertion must not reference forbidden label '{}', per C2PA 2.4",
+                self.label
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 impl AssertionCbor for CloudData {}
@@ -234,5 +309,19 @@ pub mod tests {
         assert!(make(labels::ACTIONS).is_actions());
         assert!(make("c2pa.actions.v2").is_actions());
         assert!(!make("c2pa.metadata").is_actions());
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_structure() {
+        assert!(CloudData::new("", 1, make_location()).validate().is_err());
+        assert!(CloudData::new("c2pa.metadata", 0, make_location())
+            .validate()
+            .is_err());
+        assert!(CloudData::new("c2pa.hash.data", 1, make_location())
+            .validate()
+            .is_err());
+        assert!(CloudData::new("c2pa.metadata", 1, make_location())
+            .validate()
+            .is_ok());
     }
 }

--- a/sdk/src/assertions/cloud_data.rs
+++ b/sdk/src/assertions/cloud_data.rs
@@ -148,9 +148,10 @@ impl CloudData {
         labels::base(&self.label) == labels::ACTIONS
     }
 
-    /// Validates the Cloud Data assertion according to the C2PA 2.4 rules for
+    /// Validates structure of the Cloud Data assertion according to the C2PA 2.4 rules for
     /// `c2pa.cloud-data` assertions.
-    pub fn validate(&self) -> Result<()> {
+    #[allow(unused)]
+    pub(crate) fn validate(&self) -> Result<()> {
         if self.label.trim().is_empty() {
             return Err(Error::ValidationRule(
                 "cloud data assertion label must not be empty".to_owned(),
@@ -203,7 +204,7 @@ impl CloudData {
         // Per C2PA 2.4 §15.10.3.2.1, the referenced assertion must not be any
         // of the forbidden label types, including hard bindings and the cloud-data
         // assertion itself.
-        let forbidden = [
+        const FORBIDDEN: [&str; 7] = [
             "c2pa.action",
             "c2pa.actions",
             "c2pa.actions.v2",
@@ -213,7 +214,7 @@ impl CloudData {
             "c2pa.ingredient.v3",
         ];
 
-        if forbidden.contains(&self.label.as_str()) {
+        if FORBIDDEN.contains(&self.label.as_str()) {
             return Err(Error::ValidationRule(format!(
                 "cloud data assertion must not reference forbidden label '{}', per C2PA 2.4",
                 self.label

--- a/sdk/src/assertions/external_reference.rs
+++ b/sdk/src/assertions/external_reference.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assertion::{Assertion, AssertionBase, AssertionCbor},
+    assertions::assertion_metadata::AssetType,
     assertions::{cloud_data::HashedExtUri, labels, AssertionMetadata},
     error::{Error, Result},
 };
@@ -35,7 +36,7 @@ pub struct UnhashedExtUri {
 
     /// Optional asset type classifications for the referenced data.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data_types: Option<Vec<crate::assertions::assertion_metadata::AssetType>>,
+    pub data_types: Option<Vec<AssetType>>,
 }
 
 impl UnhashedExtUri {

--- a/sdk/src/assertions/external_reference.rs
+++ b/sdk/src/assertions/external_reference.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     assertion::{Assertion, AssertionBase, AssertionCbor},
-    assertions::assertion_metadata::AssetType,
-    assertions::{cloud_data::HashedExtUri, labels, AssertionMetadata},
+    assertions::{
+        assertion_metadata::AssetType, cloud_data::HashedExtUri, labels, AssertionMetadata,
+    },
     error::{Error, Result},
 };
 

--- a/sdk/src/assertions/external_reference.rs
+++ b/sdk/src/assertions/external_reference.rs
@@ -134,7 +134,8 @@ impl ExternalReference {
     ///
     /// For the hashed form, `alg` and `hash` must both be present and non-empty.
     /// If a `label` is present, it must not be one of the forbidden assertion labels.
-    pub fn validate(&self) -> Result<()> {
+    #[allow(unused)]
+    pub(crate) fn validate(&self) -> Result<()> {
         let url = match &self.location {
             ExternalReferenceLocation::Hashed(h) => h.url.as_str(),
             ExternalReferenceLocation::Unhashed(u) => u.url.as_str(),
@@ -158,7 +159,7 @@ impl ExternalReference {
         }
 
         if let Some(label) = &self.label {
-            let forbidden = [
+            const FORBIDDEN: [&str; 14] = [
                 "c2pa.action",
                 "c2pa.actions",
                 "c2pa.actions.v2",
@@ -175,7 +176,7 @@ impl ExternalReference {
                 "c2pa.ingredient.v3",
             ];
 
-            if forbidden.contains(&label.as_str()) {
+            if FORBIDDEN.contains(&label.as_str()) {
                 return Err(Error::ValidationRule(format!(
                     "external reference label '{}' is forbidden per C2PA 2.4",
                     label

--- a/sdk/src/assertions/external_reference.rs
+++ b/sdk/src/assertions/external_reference.rs
@@ -1,0 +1,296 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    assertion::{Assertion, AssertionBase, AssertionCbor},
+    assertions::{cloud_data::HashedExtUri, labels, AssertionMetadata},
+    error::{Error, Result},
+};
+
+/// An unhashed external reference location.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+pub struct UnhashedExtUri {
+    /// HTTP(S) URL to the externally stored data.
+    pub url: String,
+
+    /// Optional IANA media type for the referenced data.
+    #[serde(rename = "dc:format", skip_serializing_if = "Option::is_none")]
+    pub dc_format: Option<String>,
+
+    /// Optional size of the referenced data in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+
+    /// Optional asset type classifications for the referenced data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_types: Option<Vec<crate::assertions::assertion_metadata::AssetType>>,
+}
+
+impl UnhashedExtUri {
+    /// Create a new unhashed external reference URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            dc_format: None,
+            size: None,
+            data_types: None,
+        }
+    }
+
+    /// Set the media type of the referenced data.
+    pub fn set_dc_format(mut self, dc_format: impl Into<String>) -> Self {
+        self.dc_format = Some(dc_format.into());
+        self
+    }
+
+    /// Set the size of the referenced data in bytes.
+    pub fn set_size(mut self, size: u64) -> Self {
+        self.size = Some(size);
+        self
+    }
+}
+
+/// The `location` field of an external reference assertion: either hashed or
+/// unhashed remote data.
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum ExternalReferenceLocation {
+    Hashed(HashedExtUri),
+    Unhashed(UnhashedExtUri),
+}
+
+impl ExternalReferenceLocation {
+    /// Create a hashed reference location.
+    pub fn hashed(url: impl Into<String>, alg: impl Into<String>, hash: Vec<u8>) -> Self {
+        Self::Hashed(HashedExtUri::new(url, alg, hash))
+    }
+
+    /// Create an unhashed reference location.
+    pub fn unhashed(url: impl Into<String>) -> Self {
+        Self::Unhashed(UnhashedExtUri::new(url))
+    }
+}
+
+/// An external reference assertion points to remotely stored assertion or non-assertion data.
+///
+/// When `location` is hashed, the data is cryptographically bound to the claim at signing time.
+/// When `location` is unhashed, the external data is advisory and may change over time.
+///
+/// See [External Reference - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_external_reference).
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct ExternalReference {
+    /// The remotely stored assertion or data.
+    pub location: ExternalReferenceLocation,
+
+    /// Optional label for the referenced assertion, if relevant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+
+    /// Optional human-readable description of the remotely stored data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Optional metadata about the assertion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<AssertionMetadata>,
+}
+
+impl ExternalReference {
+    pub const LABEL: &'static str = labels::EXTERNAL_REFERENCE;
+
+    /// Creates a new hashed external reference.
+    pub fn new_hashed(url: impl Into<String>, alg: impl Into<String>, hash: Vec<u8>) -> Self {
+        Self {
+            location: ExternalReferenceLocation::hashed(url, alg, hash),
+            label: None,
+            description: None,
+            metadata: None,
+        }
+    }
+
+    /// Creates a new unhashed external reference.
+    pub fn new_unhashed(url: impl Into<String>) -> Self {
+        Self {
+            location: ExternalReferenceLocation::unhashed(url),
+            label: None,
+            description: None,
+            metadata: None,
+        }
+    }
+
+    /// Validates the external reference according to the C2PA 2.4 rules.
+    ///
+    /// For the hashed form, `alg` and `hash` must both be present and non-empty.
+    /// If a `label` is present, it must not be one of the forbidden assertion labels.
+    pub fn validate(&self) -> Result<()> {
+        let url = match &self.location {
+            ExternalReferenceLocation::Hashed(h) => h.url.as_str(),
+            ExternalReferenceLocation::Unhashed(u) => u.url.as_str(),
+        };
+
+        if url.trim().is_empty() {
+            return Err(Error::ValidationRule(
+                "external reference location.url must not be empty".to_owned(),
+            ));
+        }
+
+        match &self.location {
+            ExternalReferenceLocation::Hashed(h) => {
+                if h.alg.trim().is_empty() || h.hash.is_empty() {
+                    return Err(Error::ValidationRule(
+                        "hashed external reference requires both alg and hash fields".to_owned(),
+                    ));
+                }
+            }
+            ExternalReferenceLocation::Unhashed(_) => {}
+        }
+
+        if let Some(label) = &self.label {
+            let forbidden = [
+                "c2pa.action",
+                "c2pa.actions",
+                "c2pa.actions.v2",
+                labels::CLOUD_DATA,
+                labels::EXTERNAL_REFERENCE,
+                "c2pa.hash.bmff.v2",
+                "c2pa.hash.bmff.v3",
+                labels::BOX_HASH,
+                labels::COLLECTION_HASH,
+                labels::DATA_HASH,
+                "c2pa.hash.multi-asset",
+                "c2pa.ingredient",
+                "c2pa.ingredient.v2",
+                "c2pa.ingredient.v3",
+            ];
+
+            if forbidden.contains(&label.as_str()) {
+                return Err(Error::ValidationRule(format!(
+                    "external reference label '{}' is forbidden per C2PA 2.4",
+                    label
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Sets the label of the referenced assertion, if relevant.
+    pub fn set_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Sets a description for the referenced data.
+    pub fn set_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Sets optional metadata about the assertion.
+    pub fn set_metadata(mut self, metadata: AssertionMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+}
+
+impl AssertionCbor for ExternalReference {}
+
+impl AssertionBase for ExternalReference {
+    const LABEL: &'static str = Self::LABEL;
+
+    fn to_assertion(&self) -> Result<Assertion> {
+        Self::to_cbor_assertion(self)
+    }
+
+    fn from_assertion(assertion: &Assertion) -> Result<Self> {
+        Self::from_cbor_assertion(assertion)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    #![allow(clippy::expect_used)]
+    #![allow(clippy::unwrap_used)]
+
+    use crate::{
+        assertion::AssertionBase,
+        assertions::{cloud_data::HashedExtUri, ExternalReference, ExternalReferenceLocation},
+    };
+
+    #[test]
+    fn test_hashed_reference_round_trip() {
+        let original = ExternalReference::new_hashed(
+            "https://example.com/remote-metadata",
+            "sha256",
+            vec![0xde, 0xad, 0xbe, 0xef],
+        )
+        .set_label("c2pa.metadata")
+        .set_description("Remote metadata assertion");
+
+        let assertion = original.to_assertion().expect("to_assertion");
+        assert_eq!(assertion.mime_type(), "application/cbor");
+        assert_eq!(assertion.label(), ExternalReference::LABEL);
+
+        let result = ExternalReference::from_assertion(&assertion).expect("from_assertion");
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_unhashed_reference_round_trip() {
+        let original = ExternalReference::new_unhashed("https://example.com/data.json")
+            .set_label("c2pa.metadata")
+            .set_description("Advisory metadata source");
+
+        let assertion = original.to_assertion().expect("to_assertion");
+        let result = ExternalReference::from_assertion(&assertion).expect("from_assertion");
+
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_validate_requires_url() {
+        let assertion = ExternalReference::new_unhashed("   ");
+        assert!(assertion.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_requires_alg_and_hash_together() {
+        let assertion =
+            ExternalReference::new_hashed("https://example.com/data.json", "sha256", vec![]);
+        assert!(assertion.validate().is_err());
+
+        let assertion = ExternalReference {
+            location: ExternalReferenceLocation::Hashed(HashedExtUri {
+                url: "https://example.com/data.json".to_owned(),
+                alg: String::new(),
+                hash: vec![1, 2, 3],
+                data_types: None,
+            }),
+            label: None,
+            description: None,
+            metadata: None,
+        };
+        assert!(assertion.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_forbidden_labels() {
+        let assertion =
+            ExternalReference::new_hashed("https://example.com/data.json", "sha256", vec![1, 2, 3])
+                .set_label("c2pa.hash.data");
+
+        assert!(assertion.validate().is_err());
+    }
+}

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -442,15 +442,11 @@ impl Ingredient {
             ));
         }
 
-        /*
-        For now we will not enforce this rule, but we should consider enforcing it in the future.
-        This is caught in the verify_ingredient function, but it would be better to prevent it here.
         if self.active_manifest.is_some() && self.digital_source_type.is_some() {
             return Err(serde::ser::Error::custom(
                 "Ingredient v3 activeManifest and digitalSourceType cannot both be present",
             ));
         }
-        */
 
         let mut ingredient_map_len = 1;
         if self.title.is_some() {

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -498,9 +498,6 @@ impl Ingredient {
         if self.metadata.is_some() {
             ingredient_map_len += 1
         }
-        if self.digital_source_type.is_some() {
-            ingredient_map_len += 1
-        }
 
         let mut ingredient_map = serializer.serialize_struct("Ingredient", ingredient_map_len)?;
 
@@ -549,9 +546,6 @@ impl Ingredient {
         }
         if let Some(sba) = &self.soft_binding_algorithms_matched {
             ingredient_map.serialize_field("softBindingAlgorithmsMatched", sba)?;
-        }
-        if let Some(dst) = &self.digital_source_type {
-            ingredient_map.serialize_field("digitalSourceType", dst)?;
         }
         if let Some(md) = &self.metadata {
             ingredient_map.serialize_field("metadata", md)?;

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -78,6 +78,7 @@ pub struct Ingredient {
     pub description: Option<String>,
     pub informational_uri: Option<String>,
     pub data_types: Option<Vec<AssetType>>,
+    pub digital_source_type: Option<String>,
 
     pub validation_results: Option<ValidationResults>,
     pub active_manifest: Option<HashedUri>,
@@ -165,6 +166,7 @@ impl Ingredient {
             && self.validation_results.is_none() // V3 exclusive params
             && self.active_manifest.is_none()
             && self.claim_signature.is_none()
+            && self.digital_source_type.is_none()
     }
 
     /// determines if an ingredient is a v2 ingredient
@@ -174,6 +176,7 @@ impl Ingredient {
         && self.validation_results.is_none() // V3 exclusive params
         && self.active_manifest.is_none()
         && self.claim_signature.is_none()
+        && self.digital_source_type.is_none()
     }
 
     fn is_v3_compatible(&self) -> bool {
@@ -181,8 +184,6 @@ impl Ingredient {
             && self.validation_status.is_none()
             && self.c2pa_manifest.is_none()
             && self.validation_results.is_some()
-            && self.active_manifest.is_some()
-            && self.claim_signature.is_some()
     }
 
     pub fn set_title<S: Into<String>>(mut self, title: S) -> Self {
@@ -228,6 +229,11 @@ impl Ingredient {
 
     pub fn set_thumbnail(mut self, hashed_uri: Option<&HashedUri>) -> Self {
         self.thumbnail = hashed_uri.map(|h| h.to_owned());
+        self
+    }
+
+    pub fn set_digital_source_type(mut self, dst: Option<String>) -> Self {
+        self.digital_source_type = dst;
         self
     }
 
@@ -430,6 +436,7 @@ impl Ingredient {
             ? "informationalURI": tstr .size (1..max-tstr-length), ; URI to an informational page about the ingredient or its data
             ? "softBindingsMatched": bool, ; Whether soft bindings were matched
             ? "softBindingAlgorithmsMatched": [1* tstr] ; Array of algorithm names used for discovering the active manifest
+            ? "digitalSourceType": tstr .size (1..max-tstr-length), ; One of the source types defined at https://cv.iptc.org/newscodes/digitalsourcetype/ or in this specification. Cannot be combined with `activeManifest`.
             ? "metadata": $assertion-metadata-map ; additional information about the assertion
         */
 
@@ -437,6 +444,12 @@ impl Ingredient {
         if self.active_manifest.is_some() && self.validation_results.is_none() {
             return Err(serde::ser::Error::custom(
                 "Ingredient v3 activeManifest requires validationResults to be present",
+            ));
+        }
+
+        if self.active_manifest.is_some() && self.digital_source_type.is_some() {
+            return Err(serde::ser::Error::custom(
+                "Ingredient v3 activeManifest and digitalSourceType cannot both be present",
             ));
         }
 
@@ -481,6 +494,9 @@ impl Ingredient {
             ingredient_map_len += 1
         }
         if self.metadata.is_some() {
+            ingredient_map_len += 1
+        }
+        if self.digital_source_type.is_some() {
             ingredient_map_len += 1
         }
 
@@ -528,6 +544,9 @@ impl Ingredient {
         }
         if let Some(sba) = &self.soft_binding_algorithms_matched {
             ingredient_map.serialize_field("softBindingAlgorithmsMatched", sba)?;
+        }
+        if let Some(dst) = &self.digital_source_type {
+            ingredient_map.serialize_field("digitalSourceType", dst)?;
         }
         if let Some(md) = &self.metadata {
             ingredient_map.serialize_field("metadata", md)?;
@@ -804,6 +823,8 @@ impl AssertionBase for Ingredient {
                     map_cbor_to_type("softBindingsMatched", &ingredient_value);
                 let soft_binding_algorithms_matched: Option<Vec<String>> =
                     map_cbor_to_type("softBindingAlgorithmsMatched", &ingredient_value);
+                let digital_source_type: Option<String> =
+                    map_cbor_to_type("digitalSourceType", &ingredient_value);
                 let metadata: Option<AssertionMetadata> =
                     map_cbor_to_type("metadata", &ingredient_value);
 
@@ -823,6 +844,7 @@ impl AssertionBase for Ingredient {
                     claim_signature,
                     soft_bindings_matched,
                     soft_binding_algorithms_matched,
+                    digital_source_type,
                     version,
                     ..Default::default()
                 }
@@ -1030,6 +1052,8 @@ pub mod tests {
             Some("1.0.0".into()),
         )];
 
+        let digital_source_type = Some("some dst".to_string());
+
         let mut all_vals = Ingredient {
             title: Some("test_title".to_owned()),
             format: Some("image/jpeg".to_owned()),
@@ -1049,6 +1073,7 @@ pub mod tests {
             claim_signature: Some(HashedUri::new("self#jumbf=c2pa/urn:c2pa:5E7B01FC-4932-4BAB-AB32-D4F12A8AA322/c2pa.signature".to_owned(), Some("sha256".to_owned()), &[1,2,3,4,5,6,7,8,9,0])),
             soft_bindings_matched: Some(true),
             soft_binding_algorithms_matched: Some(vec!["alg1".to_owned(), "alg2".to_owned()]),
+            digital_source_type,
             version: 1,
         };
 
@@ -1061,6 +1086,7 @@ pub mod tests {
 
         // Save as V3
         all_vals.version = 3;
+        all_vals.active_manifest = None;
         let v3 = all_vals.to_assertion().unwrap();
 
         // test v1
@@ -1120,15 +1146,16 @@ pub mod tests {
             description: Some("Some ingredient description".to_owned()),
             informational_uri: Some("https://tfhub.dev/deepmind/bigbigan-resnet50/1".to_owned()),
             data_types: Some(data_types),
-            validation_results: Some(validation_results),
-            active_manifest: Some(HashedUri::new("self#jumbf=c2pa/urn:c2pa:5E7B01FC-4932-4BAB-AB32-D4F12A8AA322".to_owned(), Some("sha256".to_owned()), &[1,2,3,4,5,6,7,8,9,0])),
+            validation_results: Some(validation_results.clone()),
+            active_manifest: None,
             claim_signature: Some(HashedUri::new("self#jumbf=c2pa/urn:c2pa:5E7B01FC-4932-4BAB-AB32-D4F12A8AA322/c2pa.signature".to_owned(), Some("sha256".to_owned()), &[1,2,3,4,5,6,7,8,9,0])),
             soft_bindings_matched: Some(true),
             soft_binding_algorithms_matched: Some(vec!["alg1".to_owned(), "alg2".to_owned()]),
+            digital_source_type: Some("some dst".to_string()),
             version: 3,
             ..Default::default()
         };
-        assert_eq!(v3_decoded, v3_expected);
+        assert!(v3_decoded == v3_expected);
         assert!(!v3_decoded.is_v1_compatible());
         assert!(!v3_decoded.is_v2_compatible());
         assert!(v3_decoded.is_v3_compatible());

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -62,6 +62,11 @@ pub const SOFT_BINDING: &str = "c2pa.soft-binding";
 /// See [Cloud data - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_cloud_data).
 pub const CLOUD_DATA: &str = "c2pa.cloud-data";
 
+/// Label for an external reference assertion.
+///
+/// See [External reference - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_external_reference).
+pub const EXTERNAL_REFERENCE: &str = "c2pa.external-reference";
+
 /// Label prefix for a thumbnail assertion.
 ///
 /// See [Thumbnail - C2PA Technical Specification](https://spec.c2pa.org/specifications/specifications/2.3/specs/C2PA_Specification.html#_thumbnail).

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -98,3 +98,6 @@ pub use soft_binding::{SoftBinding, SoftBindingBlock, SoftBindingScope};
 
 mod cloud_data;
 pub use cloud_data::{CloudData, HashedExtUri};
+
+mod external_reference;
+pub use external_reference::{ExternalReference, ExternalReferenceLocation, UnhashedExtUri};

--- a/sdk/src/assertions/mod.rs
+++ b/sdk/src/assertions/mod.rs
@@ -94,7 +94,7 @@ pub use embedded_data::EmbeddedData;
 pub mod region_of_interest;
 
 mod soft_binding;
-pub use soft_binding::{SoftBinding, SoftBindingBlock, SoftBindingScope};
+pub use soft_binding::{SoftBinding, SoftBindingBlock, SoftBindingMetadata, SoftBindingScope};
 
 mod cloud_data;
 pub use cloud_data::{CloudData, HashedExtUri};

--- a/sdk/src/assertions/soft_binding.rs
+++ b/sdk/src/assertions/soft_binding.rs
@@ -128,13 +128,15 @@ pub struct SoftBindingTimespan {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct SoftBindingMetadata {
     /// Additional description of the implementation or author of the binding or the algorithm.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// Contact information for the implementation or author of the binding or the algorithm.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<String>,
 
     /// A web page containing more details about the implementation or author of the binding or the algorithm.
-    #[serde(rename = "informationalUrl")]
+    #[serde(rename = "informationalUrl", skip_serializing_if = "Option::is_none")]
     pub informational_url: Option<String>,
 
     /// Uses flatten to allow these fields to be serialized at the same level as known fields.

--- a/sdk/src/assertions/soft_binding.rs
+++ b/sdk/src/assertions/soft_binding.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
+use c2pa_cbor::Value;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::labels;
 use crate::{
@@ -44,7 +44,7 @@ pub struct SoftBinding {
 
     /// Additional metadata of the soft binding. Useful for binding-specific information.
     #[serde(rename = "bindingMetadata", skip_serializing_if = "Option::is_none")]
-    pub binding_metadata: Option<SoftBindingMetdata>,
+    pub binding_metadata: Option<SoftBindingMetadata>,
 
     #[serde(skip_serializing)]
     url: Option<UriT>,
@@ -126,7 +126,7 @@ pub struct SoftBindingTimespan {
 
 /// Soft binding metadata.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct SoftBindingMetdata {
+pub struct SoftBindingMetadata {
     /// Additional description of the implementation or author of the binding or the algorithm.
     pub description: Option<String>,
 
@@ -139,7 +139,7 @@ pub struct SoftBindingMetdata {
 
     /// Uses flatten to allow these fields to be serialized at the same level as known fields.
     #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
-    additional_fields: HashMap<String, Value>,
+    pub additional_fields: HashMap<String, Value>,
 }
 
 // A parsed C2PA soft binding algorithm registry.

--- a/sdk/src/assertions/soft_binding.rs
+++ b/sdk/src/assertions/soft_binding.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::labels;
 use crate::{
@@ -38,6 +41,10 @@ pub struct SoftBinding {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pad2: Option<serde_bytes::ByteBuf>,
+
+    /// Additional metadata of the soft binding. Useful for binding-specific information.
+    #[serde(rename = "bindingMetadata", skip_serializing_if = "Option::is_none")]
+    pub binding_metadata: Option<SoftBindingMetdata>,
 
     #[serde(skip_serializing)]
     url: Option<UriT>,
@@ -115,6 +122,24 @@ pub struct SoftBindingTimespan {
 
     /// End of the time range (as milliseconds from media start) over which the soft binding value has been computed.
     pub end: u64,
+}
+
+/// Soft binding metadata.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct SoftBindingMetdata {
+    /// Additional description of the implementation or author of the binding or the algorithm.
+    pub description: Option<String>,
+
+    /// Contact information for the implementation or author of the binding or the algorithm.
+    pub contact: Option<String>,
+
+    /// A web page containing more details about the implementation or author of the binding or the algorithm.
+    #[serde(rename = "informationalUrl")]
+    pub informational_url: Option<String>,
+
+    /// Uses flatten to allow these fields to be serialized at the same level as known fields.
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    additional_fields: HashMap<String, Value>,
 }
 
 // A parsed C2PA soft binding algorithm registry.

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -1265,7 +1265,7 @@ impl Claim {
         }
     }
 
-    /// Decpricated in  C2PA 2.4 or greater compatibile manifests.  Replaced by equivelent value in ClaimGeneratorInfo.
+    /// Deprecated in  C2PA 2.4 or greater compatible manifests. Replaced by equiveaent value in ClaimGeneratorInfo.
     pub fn set_spec_version(&mut self, spec_version: Option<String>) {
         self.spec_version = spec_version;
     }

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -338,6 +338,7 @@ pub struct Claim {
 
     claim_version: usize,
 
+    // deprecated in C2PA 2.4
     spec_version: Option<String>, // The version of the specification against which the validation was performed (SemVer formatted string)
 
     // Optional context for settings access (set when created from Builder)
@@ -1096,7 +1097,7 @@ impl Claim {
         &self.instance_id
     }
 
-    /// set title
+    /// set title, deprecated in C2PA 2.4.  Claim generators should create a c2pa.metadata assertion containing the dc:title field.
     pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
@@ -1251,9 +1252,20 @@ impl Claim {
     }
 
     pub fn spec_version(&self) -> Option<&String> {
-        self.spec_version.as_ref()
+        match self.claim_generator_info() {
+            // Spec 2.4 case
+            Some(cgi) => {
+                // for Claims V2 there must be a single CGI item
+                if self.version() > 1 && cgi.len() == 1 {
+                    return cgi[0].get_spec_version();
+                }
+                None
+            }
+            None => self.spec_version.as_ref(), // legacy case where SpecVersion was including in Claim map
+        }
     }
 
+    /// Decpricated in  C2PA 2.4 or greater compatibile manifests.  Replaced by equivelent value in ClaimGeneratorInfo.
     pub fn set_spec_version(&mut self, spec_version: Option<String>) {
         self.spec_version = spec_version;
     }
@@ -2150,6 +2162,7 @@ impl Claim {
         let mut first_actions_assertion = None;
 
         // check created actions then gathered actions if not found in created actions
+        // starting with 2.4 these assertion can only be in created assertions
         for actions in [&created_actions, &gathered_actions] {
             if let Some(assertion) = actions.first() {
                 let first_actions = Actions::from_assertion(assertion.assertion())?;
@@ -2163,6 +2176,39 @@ impl Claim {
                     }
                 }
             }
+        }
+
+        // there can be only 1 of either c2pa.opened or c2pa.created, and they cannot both exist
+        let inception_action_count = {
+            let mut count = 0usize;
+            for assertion in all_actions.iter() {
+                let Ok(actions) = Actions::from_assertion(assertion.assertion()) else {
+                    continue;
+                };
+                for action in actions.actions() {
+                    if action.action() == c2pa_action::OPENED
+                        || action.action() == c2pa_action::CREATED
+                    {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        };
+
+        if inception_action_count > 1 {
+            log_item!(
+                claim_label.clone(),
+                "cannot have more than one c2pa.created or c2pa.opened action",
+                "verify_actions"
+            )
+            .validation_status(validation_status::ASSERTION_ACTION_MALFORMED)
+            .failure(
+                validation_log,
+                Error::ValidationRule(
+                    "cannot have more than one c2pa.created or c2pa.opened action".into(),
+                ),
+            )?;
         }
 
         // 2.a first actions assertion must start with an open or created action, do not apply to update manifests
@@ -2348,23 +2394,25 @@ impl Claim {
                         } else if let Some(ingredients) = &params.ingredients {
                             for h in ingredients {
                                 // can we find a reference in the ingredient list
-                                // is it referenced from this manifest
-                                if claim.ingredient_assertions().iter().any(|i| {
-                                    if let Ok(ingredient) =
-                                        Ingredient::from_assertion(i.assertion())
-                                    {
-                                        if let Some(target_label) =
-                                            assertion_label_from_uri(&h.url())
+                                // is it referenced from this manifest and only once
+                                found_good = claim
+                                    .ingredient_assertions()
+                                    .iter()
+                                    .filter(|i| {
+                                        if let Ok(ingredient) =
+                                            Ingredient::from_assertion(i.assertion())
                                         {
-                                            return target_label == i.label()
-                                                && ingredient.relationship
-                                                    == Relationship::ParentOf;
+                                            if let Some(target_label) =
+                                                assertion_label_from_uri(&h.url())
+                                            {
+                                                return target_label == i.label()
+                                                    && ingredient.relationship
+                                                        == Relationship::ParentOf;
+                                            }
                                         }
-                                    }
-                                    false
-                                }) {
-                                    found_good = 1;
-                                }
+                                        false
+                                    })
+                                    .count();
                             }
                         }
 
@@ -2639,6 +2687,26 @@ impl Claim {
                 }
                 if !icons.is_empty() {
                     Claim::verify_icons(claim, &icons, validation_log)?;
+                }
+
+                // check watermarks for required softbinding
+                if action.action() == c2pa_action::WATERMARKED
+                    || action.action() == c2pa_action::WATERMARKED_BOUND
+                {
+                    // there must be at least one soft binding assertions, in the future there may be
+                    // a requirement to reference the actual soft binding via parameters relatedAssertions field
+                    if claim.soft_binding_assertions().is_empty() {
+                        log_item!(
+                            label.clone(),
+                            "watermark action missing soft binding assertion",
+                            "verify_actions"
+                        )
+                        .validation_status(validation_status::ACTION_ASSERTION_SOFTBINDING_MISSING)
+                        .failure_no_throw(
+                            validation_log,
+                            Error::ValidationRule("the assertion was not redacted".into()),
+                        );
+                    }
                 }
             }
         }
@@ -3453,6 +3521,9 @@ impl Claim {
         // cloud-data assertion validation applies to all claim versions
         Claim::verify_cloud_data(claim, validation_log)?;
 
+        // external-reference assertion validation applies to all claim versions
+        Claim::verify_external_reference(claim, validation_log)?;
+
         Ok(())
     }
 
@@ -3499,9 +3570,12 @@ impl Claim {
     /// The effective algorithm is the assertion-level `alg` field when present,
     /// falling back to the claim-level `alg_soft` field. If neither is present
     /// the assertion is malformed.
+    /// Starting with C2PA 2.4 we no longer require soft binding alg to be on the
+    /// official list.  This allows for future algorithm support without code changes.
+    /// The function now will only check the structure of the assertion.
     fn verify_soft_binding_alg(
         claim: &Claim,
-        soft_binding_algs: &[String],
+        _soft_binding_algs: &[String],
         validation_log: &mut StatusTracker,
     ) -> Result<()> {
         use assertions::SoftBinding;
@@ -3509,7 +3583,7 @@ impl Claim {
         for ca in claim.soft_binding_assertions() {
             let label = to_assertion_uri(claim.label(), &ca.label());
 
-            let soft_binding = match SoftBinding::from_assertion(ca.assertion()) {
+            let _soft_binding = match SoftBinding::from_assertion(ca.assertion()) {
                 Ok(soft_binding) => soft_binding,
                 Err(_) => {
                     log_item!(
@@ -3526,6 +3600,7 @@ impl Claim {
                 }
             };
 
+            /*
             // Effective alg: assertion field takes precedence over claim-level alg_soft.
             let effective_alg = soft_binding
                 .alg
@@ -3561,6 +3636,7 @@ impl Claim {
                 }
                 Some(_) => {}
             }
+            */
         }
         Ok(())
     }
@@ -3574,6 +3650,8 @@ impl Claim {
     ///    `assertion.cloud-data.hardBinding`.
     /// 3. In an update manifest the referenced assertion must not be an actions
     ///    assertion — failure code `assertion.cloud-data.actions`.
+    ///     
+    /// No fetching of the cloud data is performed, only the structure of the assertion is checked.
     fn verify_cloud_data(claim: &Claim, validation_log: &mut StatusTracker) -> Result<()> {
         use assertions::CloudData;
 
@@ -3605,7 +3683,7 @@ impl Claim {
                     "verify_cloud_data"
                 )
                 .validation_status(validation_status::ASSERTION_CLOUD_DATA_MALFORMED)
-                .failure(validation_log, Error::ClaimDecoding(label.clone()))?;
+                .failure_no_throw(validation_log, Error::ClaimDecoding(label.clone()));
             }
 
             // Step 2: hard binding assertions must not be stored as cloud data.
@@ -3616,7 +3694,7 @@ impl Claim {
                     "verify_cloud_data"
                 )
                 .validation_status(validation_status::ASSERTION_CLOUD_DATA_HARD_BINDING)
-                .failure(validation_log, Error::ClaimDecoding(label.clone()))?;
+                .failure_no_throw(validation_log, Error::ClaimDecoding(label.clone()));
             }
 
             // Step 3: actions assertions must not be stored as cloud data in update manifests.
@@ -3627,30 +3705,68 @@ impl Claim {
                     "verify_cloud_data"
                 )
                 .validation_status(validation_status::ASSERTION_CLOUD_DATA_ACTIONS)
-                .failure(validation_log, Error::ClaimDecoding(label.clone()))?;
+                .failure_no_throw(validation_log, Error::ClaimDecoding(label.clone()));
+            }
+
+            // Check for forbbidden label types, including hard bindings and the cloud-data assertion itself.
+            if cloud_data.is_forbidden().is_err() {
+                log_item!(
+                    label.clone(),
+                    "cloud-data assertion references a forbidden label",
+                    "verify_cloud_data"
+                )
+                .validation_status(validation_status::ASSERTION_CLOUD_DATA_MALFORMED)
+                .failure_no_throw(validation_log, Error::ClaimDecoding(label.clone()));
             }
         }
 
         Ok(())
     }
 
-    // Perform metadata validation check
-    fn verify_metadata(claim: &Claim, validation_log: &mut StatusTracker) -> Result<()> {
-        for metadata_assertion in claim.metadata_assertions() {
-            let metadata_assertion = Metadata::from_assertion(metadata_assertion.assertion())?;
-            if !metadata_assertion.is_valid() {
-                let label = to_assertion_uri(claim.label(), metadata_assertion.label());
-                log_item!(
-                    label,
-                    "metadata assertion contains disallowed field",
-                    "verify_internal"
-                )
-                .validation_status(validation_status::ASSERTION_METADATA_DISALLOWED)
-                .failure(
-                    validation_log,
-                    Error::ValidationRule("fields must be in allowed list".into()),
-                )?;
+    /// Validate each `c2pa.external-reference` assertion per C2PA 2.4.
+    /// No fetching of the external reference is performed, only the structure of the assertion is checked.
+    fn verify_external_reference(claim: &Claim, validation_log: &mut StatusTracker) -> Result<()> {
+        use assertions::ExternalReference;
+
+        for ca in claim.assertions_by_type(
+            &Assertion::new(
+                assertions::labels::EXTERNAL_REFERENCE,
+                None,
+                AssertionData::Cbor(Vec::new()),
+            ),
+            None,
+        ) {
+            let label = to_assertion_uri(claim.label(), &ca.label());
+
+            let external_reference = match ExternalReference::from_assertion(ca.assertion()) {
+                Ok(external_reference) => external_reference,
+                Err(_) => {
+                    log_item!(
+                        label.clone(),
+                        "external-reference assertion could not be decoded",
+                        "verify_external_reference"
+                    )
+                    .validation_status(validation_status::ASSERTION_EXTERNAL_REFERENCE_MALFORMED)
+                    .failure_no_throw(validation_log, Error::ClaimDecoding(label.clone()));
+                    continue;
+                }
+            };
+
+            if let Err(err) = external_reference.validate() {
+                log_item!(label.clone(), err.to_string(), "verify_external_reference")
+                    .validation_status(validation_status::ASSERTION_EXTERNAL_REFERENCE_MALFORMED)
+                    .failure_no_throw(validation_log, err);
             }
+        }
+
+        Ok(())
+    }
+
+    // Perform metadata validation check.
+    // Check the structure only.  C2PA 2.4 no longer requires checking against allowed fields.
+    fn verify_metadata(claim: &Claim, _validation_log: &mut StatusTracker) -> Result<()> {
+        for metadata_assertion in claim.metadata_assertions() {
+            Metadata::from_assertion(metadata_assertion.assertion())?;
         }
         Ok(())
     }
@@ -4974,6 +5090,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "validation disabled for C2PA 2.4 forward"]
     fn test_verify_soft_binding_alg_unknown() {
         let settings = Settings::new()
             .with_json(
@@ -5016,6 +5133,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "validation disabled for C2PA 2.4 forward"]
     fn test_verify_soft_binding_alg_missing_alg() {
         let settings = Settings::new()
             .with_json(
@@ -5099,6 +5217,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "validation disabled for C2PA 2.4 forward"]
     fn test_verify_soft_binding_alg_undecodable_does_not_abort() {
         // A soft binding assertion that isn't valid CBOR-encoded SoftBinding data
         // (e.g. reusing the c2pa.soft-binding label for a JSON payload) should be
@@ -5168,6 +5287,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "validation disabled for C2PA 2.4 forward"]
     fn test_verify_soft_binding_alg_continues_past_malformed_assertion() {
         // A claim with three c2pa.soft-binding assertions: the first undecodable,
         // the second valid, and the third using an unsupported algorithm. Skipping
@@ -5308,6 +5428,24 @@ pub mod tests {
         );
     }
 
+    #[test]
+    fn test_spec_version_from_claim_generator_info() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let mut cgi = ClaimGeneratorInfo::new("test app");
+        cgi.set_spec_version("2.4.0");
+        claim.add_claim_generator_info(cgi);
+
+        assert_eq!(claim.spec_version().map(|s| s.as_str()), Some("2.4.0"));
+    }
+
+    #[test]
+    fn test_spec_version_none_when_not_set_in_claim_generator_info() {
+        let mut claim = Claim::new("test", Some("test"), 2);
+        claim.add_claim_generator_info(ClaimGeneratorInfo::new("test app"));
+
+        assert_eq!(claim.spec_version(), None);
+    }
+
     fn make_cloud_data(label: &str) -> assertions::CloudData {
         assertions::CloudData::new(
             label,
@@ -5318,6 +5456,60 @@ pub mod tests {
                 vec![0xde, 0xad, 0xbe, 0xef],
             ),
         )
+    }
+
+    fn make_external_reference(url: &str) -> assertions::ExternalReference {
+        assertions::ExternalReference::new_hashed(url, "sha256", vec![0xde, 0xad, 0xbe, 0xef])
+    }
+
+    #[test]
+    fn test_verify_external_reference_valid() {
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
+        let mut claim = create_test_claim().expect("create test claim");
+
+        claim
+            .add_assertion(&make_external_reference("https://example.com/ext.json"))
+            .expect("add external reference");
+
+        assert!(
+            Claim::verify_external_reference(&claim, &mut validation_log).is_ok(),
+            "valid external-reference assertion should pass"
+        );
+        assert!(validation_log.logged_items().is_empty());
+    }
+
+    #[test]
+    fn test_verify_external_reference_rejects_malformed() {
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
+        let mut claim = create_test_claim().expect("create test claim");
+
+        let bad = assertions::ExternalReference {
+            location: assertions::ExternalReferenceLocation::Hashed(assertions::HashedExtUri {
+                url: "   ".to_owned(),
+                alg: String::new(),
+                hash: vec![],
+                data_types: None,
+            }),
+            label: None,
+            description: None,
+            metadata: None,
+        };
+        claim
+            .add_assertion(&bad)
+            .expect("add malformed external reference");
+
+        Claim::verify_external_reference(&claim, &mut validation_log).unwrap();
+
+        assert!(
+            validation_log
+                .logged_items()
+                .iter()
+                .any(|item| item.validation_status.as_deref()
+                    == Some(validation_status::ASSERTION_EXTERNAL_REFERENCE_MALFORMED)),
+            "should log ASSERTION_EXTERNAL_REFERENCE_MALFORMED"
+        );
     }
 
     #[test]
@@ -5356,8 +5548,8 @@ pub mod tests {
         );
         claim.add_assertion(&cd).expect("add cloud data");
 
-        let result = Claim::verify_cloud_data(&claim, &mut validation_log);
-        assert!(result.is_err(), "size=0 should fail");
+        Claim::verify_cloud_data(&claim, &mut validation_log).unwrap();
+
         assert!(
             validation_log
                 .logged_items()
@@ -5424,6 +5616,7 @@ pub mod tests {
     // Positive: a c2pa.translated action with both BCP-47 language codes present
     // must not be reported as malformed.
     #[test]
+    #[ignore = "validation disabled for C2PA 2.4 forward"]
     fn test_verify_translated_action_with_languages_valid() {
         let translated = Action::new(c2pa_action::TRANSLATED)
             .set_parameter("source_language", "en-US")
@@ -5438,6 +5631,118 @@ pub mod tests {
     }
 
     #[test]
+    fn test_verify_actions_rejects_multiple_inception_actions_in_one_assertion() {
+        use crate::assertions::DigitalSourceType;
+
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let actions = Actions::new()
+            .add_action(Action::new(c2pa_action::CREATED).set_source_type(DigitalSourceType::Empty))
+            .add_action(Action::new(c2pa_action::OPENED));
+        claim.add_assertion(&actions).expect("add actions");
+
+        let svi = StoreValidationInfo::default();
+        let settings = Settings::default();
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::ContinueWhenPossible);
+
+        Claim::verify_actions(&claim, &svi, &mut validation_log, &settings)
+            .expect("verify_actions should not throw");
+
+        assert!(
+            validation_log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "an actions assertion containing more than one c2pa.created/c2pa.opened action should be malformed"
+        );
+    }
+
+    #[test]
+    fn test_verify_actions_rejects_both_created_and_opened_actions() {
+        use crate::assertions::DigitalSourceType;
+
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let created_actions = Actions::new().add_action(
+            Action::new(c2pa_action::CREATED).set_source_type(DigitalSourceType::Empty),
+        );
+        let opened_actions = Actions::new().add_action(Action::new(c2pa_action::OPENED));
+
+        claim
+            .add_assertion(&created_actions)
+            .expect("add created actions");
+        claim
+            .add_assertion(&opened_actions)
+            .expect("add opened actions");
+
+        let svi = StoreValidationInfo::default();
+        let settings = Settings::default();
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::ContinueWhenPossible);
+
+        Claim::verify_actions(&claim, &svi, &mut validation_log, &settings)
+            .expect("verify_actions should not throw");
+
+        assert!(
+            validation_log.has_status(validation_status::ASSERTION_ACTION_MALFORMED),
+            "a claim containing both c2pa.created and c2pa.opened actions should be malformed"
+        );
+    }
+
+    // Builds a v2 claim whose actions assertion contains a valid c2pa.created
+    // action followed by the given watermark action, optionally adds a soft
+    // binding assertion, runs verify_actions, and returns the validation log.
+    fn verify_watermark_action(action: Action, with_soft_binding: bool) -> StatusTracker {
+        use crate::assertions::DigitalSourceType;
+
+        let mut claim = Claim::new("test", Some("test"), 2);
+        let actions = Actions::new()
+            .add_action(
+                Action::new(c2pa_action::CREATED)
+                    .set_source_type(DigitalSourceType::TrainedAlgorithmicMedia),
+            )
+            .add_action(action);
+        claim.add_assertion(&actions).expect("add actions");
+
+        if with_soft_binding {
+            claim
+                .add_assertion(&make_soft_binding(Some("com.example.wm")))
+                .expect("add soft binding");
+        }
+
+        let svi = StoreValidationInfo::default();
+        let settings = Settings::default();
+        let mut validation_log =
+            StatusTracker::with_error_behavior(ErrorBehavior::ContinueWhenPossible);
+        Claim::verify_actions(&claim, &svi, &mut validation_log, &settings)
+            .expect("verify_actions should not throw");
+        validation_log
+    }
+
+    #[test]
+    fn test_watermarked_action_without_soft_binding_logs_missing() {
+        let log = verify_watermark_action(Action::new(c2pa_action::WATERMARKED), false);
+        assert!(
+            log.has_status(validation_status::ACTION_ASSERTION_SOFTBINDING_MISSING),
+            "c2pa.watermarked without soft binding should log ACTION_ASSERTION_SOFTBINDING_MISSING"
+        );
+    }
+
+    #[test]
+    fn test_watermarked_bound_action_without_soft_binding_logs_missing() {
+        let log = verify_watermark_action(Action::new(c2pa_action::WATERMARKED_BOUND), false);
+        assert!(
+            log.has_status(validation_status::ACTION_ASSERTION_SOFTBINDING_MISSING),
+            "c2pa.watermarked.bound without soft binding should log ACTION_ASSERTION_SOFTBINDING_MISSING"
+        );
+    }
+
+    #[test]
+    fn test_watermarked_action_with_soft_binding_passes() {
+        let log = verify_watermark_action(Action::new(c2pa_action::WATERMARKED), true);
+        assert!(
+            !log.has_status(validation_status::ACTION_ASSERTION_SOFTBINDING_MISSING),
+            "c2pa.watermarked with soft binding present should not log ACTION_ASSERTION_SOFTBINDING_MISSING"
+        );
+    }
+
+    #[test]
     fn test_verify_cloud_data_hard_binding_rejected() {
         let mut validation_log =
             StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
@@ -5448,8 +5753,8 @@ pub mod tests {
             .add_assertion(&make_cloud_data(assertions::labels::DATA_HASH))
             .expect("add cloud data");
 
-        let result = Claim::verify_cloud_data(&claim, &mut validation_log);
-        assert!(result.is_err(), "hard binding in cloud-data should fail");
+        Claim::verify_cloud_data(&claim, &mut validation_log).unwrap();
+
         assert!(
             validation_log
                 .logged_items()
@@ -5471,11 +5776,8 @@ pub mod tests {
             .add_assertion(&make_cloud_data(assertions::labels::ACTIONS))
             .expect("add cloud data");
 
-        let result = Claim::verify_cloud_data(&claim, &mut validation_log);
-        assert!(
-            result.is_err(),
-            "actions in cloud-data of update manifest should fail"
-        );
+        Claim::verify_cloud_data(&claim, &mut validation_log).unwrap();
+
         assert!(
             validation_log
                 .logged_items()
@@ -5487,7 +5789,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_verify_cloud_data_actions_in_non_update_manifest_allowed() {
+    fn test_verify_cloud_data_actions_in_non_update_manifest_not_allowed() {
         let mut validation_log =
             StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
         let mut claim = create_test_claim().expect("create test claim");
@@ -5497,10 +5799,11 @@ pub mod tests {
             .add_assertion(&make_cloud_data(assertions::labels::ACTIONS))
             .expect("add cloud data");
 
+        Claim::verify_cloud_data(&claim, &mut validation_log).unwrap();
+
         assert!(
-            Claim::verify_cloud_data(&claim, &mut validation_log).is_ok(),
-            "actions in cloud-data of a non-update manifest should pass"
+            validation_log.has_any_error(),
+            "actions in cloud-data of a non-update manifest should fail"
         );
-        assert!(validation_log.logged_items().is_empty());
     }
 }

--- a/sdk/src/claim_generator_info.rs
+++ b/sdk/src/claim_generator_info.rs
@@ -41,6 +41,9 @@ pub struct ClaimGeneratorInfo {
         skip_serializing_if = "Option::is_none"
     )]
     pub operating_system: Option<String>,
+    /// The version of the specification used to produce this manifest (SemVer)
+    #[serde(rename = "specVersion", skip_serializing_if = "Option::is_none")]
+    pub spec_version: Option<String>,
     // Any other values that are not part of the standard
     #[serde(flatten)]
     pub(crate) other: HashMap<String, Value>,
@@ -53,6 +56,7 @@ impl Default for ClaimGeneratorInfo {
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
             icon: None,
             operating_system: None,
+            spec_version: None,
             other: HashMap::new(),
         }
     }
@@ -65,6 +69,7 @@ impl ClaimGeneratorInfo {
             version: None,
             icon: None,
             operating_system: None, // todo: decide if we want to fill in this value
+            spec_version: None,
             other: HashMap::new(),
         }
     }
@@ -84,6 +89,16 @@ impl ClaimGeneratorInfo {
     pub fn set_icon<S: Into<UriOrResource>>(&mut self, uri_or_resource: S) -> &mut Self {
         self.icon = Some(uri_or_resource.into());
         self
+    }
+
+    /// Get the SpecVersion
+    pub fn get_spec_version(&self) -> Option<&String> {
+        self.spec_version.as_ref()
+    }
+
+    /// Sets the SpecVersion used to create this manifest
+    pub fn set_spec_version<S: Into<String>>(&mut self, spec_version: S) {
+        self.spec_version = Some(spec_version.into());
     }
 
     /// Adds a new key/value pair to the generator info.

--- a/sdk/src/settings/builder.rs
+++ b/sdk/src/settings/builder.rs
@@ -214,6 +214,7 @@ impl TryFrom<ClaimGeneratorInfoSettings> for ClaimGeneratorInfo {
                     ClaimGeneratorInfoOperatingSystem::Other(name) => name,
                 })
             },
+            spec_version: None,
             other: value
                 .other
                 .into_iter()
@@ -246,6 +247,7 @@ impl TryFrom<&ClaimGeneratorInfoSettings> for ClaimGeneratorInfo {
                     ClaimGeneratorInfoOperatingSystem::Other(name) => name.clone(),
                 })
             },
+            spec_version: None,
             other: value
                 .other
                 .iter()

--- a/sdk/src/spec_versions.rs
+++ b/sdk/src/spec_versions.rs
@@ -15,7 +15,7 @@
 #[allow(dead_code)]
 pub const C2PA_GENERATOR_VERSION: &str = "2.2.0";
 /// C2PA Validator Version
-pub const C2PA_VALIDATOR_VERSION: &str = "2.3.0";
+pub const C2PA_VALIDATOR_VERSION: &str = "2.4.0";
 
 // C2PA TSA Trust URI
 #[allow(dead_code)]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1688,7 +1688,7 @@ impl Store {
                         .validation_status(validation_status::ASSERTION_INGREDIENT_MALFORMED)
                         .failure(
                             validation_log,
-                            Error::HashMismatch(
+                            Error::ValidationRule(
                                 "ingredient assertion cannot have both activeManifest and digitalSourceType".to_string(),
                             ),
                         )?;
@@ -1711,7 +1711,7 @@ impl Store {
                         .validation_status(validation_status::ASSERTION_INGREDIENT_MALFORMED)
                         .failure(
                             validation_log,
-                            Error::HashMismatch(
+                            Error::ValidationRule(
                                 "ingredient V3 missing validation status".to_string(),
                             ),
                         )?;
@@ -1796,7 +1796,7 @@ impl Store {
                                 )
                                 .failure_as_err(
                                     validation_log,
-                                    Error::HashMismatch(
+                                    Error::ValidationRule(
                                         "ingredient claimSignature missing".to_string(),
                                     ),
                                 )
@@ -1827,7 +1827,7 @@ impl Store {
                             )
                             .failure(
                                 validation_log,
-                                Error::HashMismatch(
+                                Error::ValidationRule(
                                     "ingredient claimSignature mismatch".to_string(),
                                 ),
                             )?;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -9368,46 +9368,6 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_ingredient_checks_rejects_active_manifest_and_digital_source_type() {
-        let ingredient = Ingredient {
-            active_manifest: Some(HashedUri::new(
-                "self#jumbf=c2pa/urn:c2pa:5E7B01FC-4932-4BAB-AB32-D4F12A8AA322".to_owned(),
-                Some("sha256".to_owned()),
-                &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
-            )),
-            digital_source_type: Some(DigitalSourceType::TrainedAlgorithmicData),
-            validation_results: Some(ValidationResults::default()),
-            relationship: Relationship::InputTo,
-            version: 3,
-            ..Default::default()
-        };
-        let mut claim = Claim::new("ingredient_malformed_test", Some("contentauth"), 2);
-        claim.add_assertion(&ingredient).unwrap();
-
-        let store = Store::new();
-        let svi = StoreValidationInfo::default();
-        let mut validation_log =
-            StatusTracker::with_error_behavior(ErrorBehavior::StopOnFirstError);
-        let context = Context::new();
-
-        let result = Store::ingredient_checks(
-            &store,
-            &claim,
-            &svi,
-            &mut validation_log,
-            0,
-            &context,
-            &mut HashSet::new(),
-        );
-
-        assert!(result.is_err());
-        assert!(validation_log.logged_items().iter().any(|item| {
-            item.validation_status.as_deref()
-                == Some(validation_status::ASSERTION_INGREDIENT_MALFORMED)
-        }));
-    }
-
     // Verify that when an ingredient assertion is included in final_redactions, the claim it
     // referenced is removed from the incoming store and from svi.ingredient_references.
     #[test]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1677,6 +1677,23 @@ impl Store {
                 .failure_as_err(validation_log, e)
             })?;
 
+            if ingredient_assertion.active_manifest.is_some()
+                && ingredient_assertion.digital_source_type.is_some()
+            {
+                log_item!(
+                            jumbf::labels::to_assertion_uri(claim.label(), &i.label()),
+                            "ingredient assertion cannot have both activeManifest and digitalSourceType",
+                            "ingredient_checks"
+                        )
+                        .validation_status(validation_status::ASSERTION_INGREDIENT_MALFORMED)
+                        .failure(
+                            validation_log,
+                            Error::HashMismatch(
+                                "ingredient assertion cannot have both activeManifest and digitalSourceType".to_string(),
+                            ),
+                        )?;
+            }
+
             validation_log
                 .push_ingredient_uri(jumbf::labels::to_assertion_uri(claim.label(), &i.label()));
 

--- a/sdk/src/validation_results.rs
+++ b/sdk/src/validation_results.rs
@@ -1035,6 +1035,11 @@ pub mod validation_codes {
     /// Any corresponding URL should point to a C2PA assertion.
     pub const ACTION_ASSERTION_REDACTED: &str = "assertion.action.redacted";
 
+    /// An `action` assertion missing required soft binding
+    ///
+    /// Any corresponding URL should point to a C2PA assertion.
+    pub const ACTION_ASSERTION_SOFTBINDING_MISSING: &str = "assertion.action.softBindingMissing";
+
     /// The hash of a byte range of the asset does not match the
     /// hash declared in the data hash assertion.
     ///
@@ -1069,6 +1074,17 @@ pub mod validation_codes {
     ///
     /// Any corresponding URL should point to a C2PA assertion.
     pub const ASSERTION_CLOUD_DATA_ACTIONS: &str = "assertion.cloud-data.actions";
+
+    /// A cloud data assertion was incomplete or malformed.
+    ///
+    /// Any corresponding URL should point to a C2PA assertion.
+    pub const ASSERTION_CLOUD_DATA_MALFORMED: &str = "assertion.cloud-data.malformed";
+
+    /// An external reference assertion was incomplete or malformed.
+    ///
+    /// Any corresponding URL should point to a C2PA assertion.
+    pub const ASSERTION_EXTERNAL_REFERENCE_MALFORMED: &str =
+        "assertion.external-reference.malformed";
 
     /// The value of an `alg` header, or other header that specifies an
     /// algorithm used to compute the value of another field, is unknown
@@ -1162,11 +1178,6 @@ pub mod validation_codes {
     ///
     /// Any corresponding URL should point to a C2PA assertion box.
     pub const ASSERTION_BOXESHASH_MALFORMED: &str = "assertion.boxesHash.malformed";
-
-    /// The cloud-data assertion was incomplete.
-    ///
-    /// Any corresponding URL should point to a C2PA assertion box.
-    pub const ASSERTION_CLOUD_DATA_MALFORMED: &str = "assertion.cloud-data.malformed";
 
     /// A hash of an asset in the collection does not match hash declared in
     /// the collection data hash assertion.
@@ -1662,7 +1673,7 @@ pub mod tests {
         assert_eq!(
             validation_results.to_string(),
             concat!(
-                "spec validation version: 2.3.0\n",
+                "spec validation version: 2.4.0\n",
                 "state: Invalid\n",
                 "  success: claimSignature.validated, claimSignature.insideValidity\n",
                 "  informational:\n",

--- a/sdk/tests/known_good/CA_test.json
+++ b/sdk/tests/known_good/CA_test.json
@@ -1,167 +1,6 @@
 {
-  "active_manifest": "urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb",
+  "active_manifest": "urn:c2pa:166b2168-fa12-4583-9933-689438504ed4",
   "manifests": {
-    "urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb": {
-      "claim_generator_info": [
-        {
-          "name": "c2pa-rs testing",
-          "version": "1.0.0",
-          "operating_system": "auto",
-          "org.contentauth.c2pa_rs": "0.91.0-dev"
-        }
-      ],
-      "instance_id": "",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.thumbnail.claim"
-      },
-      "ingredients": [
-        {
-          "format": "image/jpeg",
-          "instance_id": "xmp:iid:4a3913aa-4be7-4aa5-913c-91bc7dffee31",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf",
-          "validation_results": {
-            "activeManifest": {
-              "success": [
-                {
-                  "code": "timeStamp.validated",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
-                  "explanation": "timestamp message digest matched: DigiCert Timestamp 2023"
-                },
-                {
-                  "code": "timeStamp.trusted",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
-                  "explanation": "legacy timestamp cert trusted: DigiCert Timestamp 2023"
-                },
-                {
-                  "code": "signingCredential.trusted",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
-                  "explanation": "signing certificate trusted, found in [https://c2pa-rs/test_cert_trust_list] trust anchors"
-                },
-                {
-                  "code": "claimSignature.insideValidity",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "claimSignature.validated",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
-                  "explanation": "claim signature valid"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.ingredient.jpeg",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient.jpeg"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/stds.schema-org.CreativeWork",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/stds.schema-org.CreativeWork"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.actions",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions"
-                },
-                {
-                  "code": "assertion.hashedURI.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
-                },
-                {
-                  "code": "assertion.dataHash.match",
-                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.hash.data",
-                  "explanation": "data hash valid"
-                }
-              ],
-              "informational": [],
-              "failure": []
-            },
-            "ingredientDeltas": [
-              {
-                "ingredientAssertionURI": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
-                "validationDeltas": {
-                  "success": [],
-                  "informational": [
-                    {
-                      "code": "ingredient.unknownProvenance",
-                      "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
-                      "explanation": "A.jpg: ingredient does not have provenance"
-                    }
-                  ],
-                  "failure": []
-                }
-              }
-            ],
-            "specVersion": "2.3.0",
-            "trustListUri": "https://c2pa-rs/test_cert_trust_list"
-          },
-          "manifest_data": {
-            "format": "application/c2pa",
-            "identifier": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf"
-          },
-          "label": "c2pa.ingredient.v3"
-        }
-      ],
-      "assertions": [
-        {
-          "label": "c2pa.actions.v2",
-          "data": {
-            "actions": [
-              {
-                "action": "c2pa.opened",
-                "parameters": {
-                  "ingredients": [
-                    {
-                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
-                      "hash": "9+Uw9CEiv8U6NYtloMhP8JbNiHIZsGQD3e3bIPPLuOY="
-                    }
-                  ]
-                }
-              },
-              {
-                "action": "c2pa.published"
-              },
-              {
-                "action": "c2pa.edited",
-                "softwareAgent": {
-                  "name": "TestApp",
-                  "version": "1.0.0"
-                },
-                "parameters": {
-                  "description": "edited",
-                  "name": "any value"
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "common_name": "C2PA Signer",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153",
-        "time": "2026-07-31T12:37:48+00:00"
-      },
-      "label": "urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb",
-      "claim_version": 2
-    },
     "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf": {
       "claim_generator": "make_test_images/0.33.1 c2pa-rs/0.33.1",
       "claim_generator_info": [
@@ -242,6 +81,173 @@
       },
       "label": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf",
       "claim_version": 1
+    },
+    "urn:c2pa:166b2168-fa12-4583-9933-689438504ed4": {
+      "claim_generator_info": [
+        {
+          "name": "c2pa-rs testing",
+          "version": "1.0.0",
+          "operating_system": "auto",
+          "org.contentauth.c2pa_rs": "0.91.0-dev"
+        }
+      ],
+      "instance_id": "",
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.thumbnail.claim"
+      },
+      "ingredients": [
+        {
+          "format": "image/jpeg",
+          "instance_id": "xmp:iid:141fa201-e5a4-43da-8998-5ca6da1f2edc",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf",
+          "validation_results": {
+            "activeManifest": {
+              "success": [
+                {
+                  "code": "timeStamp.validated",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "timestamp message digest matched: DigiCert Timestamp 2023"
+                },
+                {
+                  "code": "timeStamp.trusted",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "legacy timestamp cert trusted: DigiCert Timestamp 2023"
+                },
+                {
+                  "code": "signingCredential.trusted",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "signing certificate trusted, found in [https://c2pa-rs/test_cert_trust_list] trust anchors"
+                },
+                {
+                  "code": "claimSignature.insideValidity",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "claimSignature.validated",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "claim signature valid"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.claim.jpeg",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.thumbnail.ingredient.jpeg",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.ingredient.jpeg"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/stds.schema-org.CreativeWork",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/stds.schema-org.CreativeWork"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.actions",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions"
+                },
+                {
+                  "code": "assertion.hashedURI.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
+                },
+                {
+                  "code": "assertion.dataHash.match",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.hash.data",
+                  "explanation": "data hash valid"
+                }
+              ],
+              "informational": [
+                {
+                  "code": "signingCredential.ocsp.skipped",
+                  "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.signature",
+                  "explanation": "OCSP fetching skipped"
+                }
+              ],
+              "failure": []
+            },
+            "ingredientDeltas": [
+              {
+                "ingredientAssertionURI": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
+                "validationDeltas": {
+                  "success": [],
+                  "informational": [
+                    {
+                      "code": "ingredient.unknownProvenance",
+                      "url": "self#jumbf=/c2pa/contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf/c2pa.assertions/c2pa.ingredient",
+                      "explanation": "A.jpg: ingredient does not have provenance"
+                    }
+                  ],
+                  "failure": []
+                }
+              }
+            ],
+            "specVersion": "2.4.0",
+            "trustListUri": "https://c2pa-rs/test_cert_trust_list"
+          },
+          "manifest_data": {
+            "format": "application/c2pa",
+            "identifier": "contentauth:urn:uuid:c2677d4b-0a93-4444-876f-ed2f2d40b8cf"
+          },
+          "label": "c2pa.ingredient.v3"
+        }
+      ],
+      "assertions": [
+        {
+          "label": "c2pa.actions.v2",
+          "data": {
+            "actions": [
+              {
+                "action": "c2pa.opened",
+                "parameters": {
+                  "ingredients": [
+                    {
+                      "url": "self#jumbf=c2pa.assertions/c2pa.ingredient.v3",
+                      "hash": "hD2DdqC+tOBPu7He7mjKBYJiwuoKLvejj6HBM7qw4m8="
+                    }
+                  ]
+                }
+              },
+              {
+                "action": "c2pa.published"
+              },
+              {
+                "action": "c2pa.edited",
+                "softwareAgent": {
+                  "name": "TestApp",
+                  "version": "1.0.0"
+                },
+                "parameters": {
+                  "description": "edited",
+                  "name": "any value"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "signature_info": {
+        "alg": "Ps256",
+        "issuer": "C2PA Test Signing Cert",
+        "common_name": "C2PA Signer",
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "time": "2026-09-02T13:37:56+00:00"
+      },
+      "label": "urn:c2pa:166b2168-fa12-4583-9933-689438504ed4",
+      "claim_version": 2
     }
   },
   "validation_results": {
@@ -249,61 +255,67 @@
       "success": [
         {
           "code": "timeStamp.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
           "explanation": "timestamp message digest matched: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1"
         },
         {
           "code": "timeStamp.trusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.signature",
-          "explanation": "timestamp cert trusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1, trust list: https://digicert_tsa"
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
+          "explanation": "timestamp cert trusted: DigiCert SHA256 RSA4096 Timestamp Responder 2025 1, trust list: https://digicert.com/tsa_root"
         },
         {
           "code": "signingCredential.trusted",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
           "explanation": "signing certificate trusted, found in [https://c2pa-rs/test_cert_trust_list] trust anchors"
         },
         {
           "code": "claimSignature.insideValidity",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "claimSignature.validated",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.signature",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
           "explanation": "claim signature valid"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.hash.data",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.hash.data"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.thumbnail.claim",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.thumbnail.claim",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.thumbnail.claim"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.ingredient.v3",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.ingredient.v3",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.ingredient.v3"
         },
         {
           "code": "assertion.hashedURI.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.actions.v2",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.actions.v2",
           "explanation": "hashed uri matched: self#jumbf=c2pa.assertions/c2pa.actions.v2"
         },
         {
           "code": "assertion.dataHash.match",
-          "url": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.hash.data",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.hash.data",
           "explanation": "data hash valid"
         }
       ],
-      "informational": [],
+      "informational": [
+        {
+          "code": "signingCredential.ocsp.skipped",
+          "url": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.signature",
+          "explanation": "OCSP fetching skipped"
+        }
+      ],
       "failure": []
     },
     "ingredientDeltas": [
       {
-        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:6a7b4294-cf23-44a2-be02-044ca2109ceb/c2pa.assertions/c2pa.ingredient.v3",
+        "ingredientAssertionURI": "self#jumbf=/c2pa/urn:c2pa:166b2168-fa12-4583-9933-689438504ed4/c2pa.assertions/c2pa.ingredient.v3",
         "validationDeltas": {
           "success": [
             {
@@ -317,7 +329,8 @@
         }
       }
     ],
-    "specVersion": "2.3.0"
+    "specVersion": "2.4.0",
+    "trustListUri": "https://c2pa-rs/test_cert_trust_list"
   },
   "validation_state": "Trusted"
 }


### PR DESCRIPTION
## Changes in this pull request
Relax validation on soft bindings assertions
Relax validation on metadata assertions
Updated Cloud Data assertion validation (no fetching)
External Reference assertion validation (no fetching)
Updated Action assertion rules
Fix unit tests in violation of 2.4


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
