### PR TITLE
fix: Handling ingredient manifest label collisions (spec v2.4, 18.16.12)

### DIFF
--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -4123,22 +4123,13 @@ impl Store {
                                 to_both.append(&mut differences);
                             }
                         } else {
-                            let new_version = match claim
+                            // First conflict for this label starts at version 1
+                            let new_version = claim
                                 .claim_ingredient_store()
                                 .keys()
-                                .filter_map(|label| match manifest_label_to_parts(label) {
-                                    Some(mp) => mp.version,
-                                    None => None,
-                                })
+                                .filter_map(|label| manifest_label_to_parts(label)?.version)
                                 .max()
-                            {
-                                Some(last_conflict_version) => last_conflict_version + 1,
-                                None => {
-                                    return Err(Error::OtherError(
-                                        "ingredient label malformed".into(),
-                                    ))
-                                }
-                            };
+                                .map_or(1, |last_conflict_version| last_conflict_version + 1);
 
                             // make new ingredient label
                             let mut new_mp = manifest_label_to_parts(&conflict_label)
@@ -6924,6 +6915,59 @@ pub mod tests {
         assert!(redacted_claim
             .get_assertion(labels::SCHEMA_ORG_INTERNAL, 0)
             .is_none());
+    }
+
+    #[test]
+    fn test_ingredient_conflict_first_collision_versions_label() {
+        // Two ingredients sharing a manifest label but differing in content (not by
+        // redaction) must relabel the second starting at version 1, not error.
+        let context = Context::new();
+        let signer = test_signer(SigningAlg::Ps256);
+        let shared_label = "urn:c2pa:550e8400-e29b-41d4-a716-446655440000";
+
+        let signed_ingredient = |variant: &str| -> Vec<u8> {
+            let mut store = Store::from_context(&Context::new());
+            let mut claim = Claim::new_with_user_guid("conflict test", shared_label, 2).unwrap();
+            claim.add_claim_generator_info(ClaimGeneratorInfo::new("conflict_test"));
+            claim
+                .add_databox("text/plain", variant.as_bytes().to_vec(), None)
+                .unwrap();
+            let actions = Actions::new()
+                .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
+            claim.add_assertion(&actions).unwrap();
+            store.commit_claim(claim).unwrap();
+
+            let (format, mut input, mut output) = create_test_streams("earth_apollo17.jpg");
+            store
+                .save_to_stream(format, &mut input, &mut output, signer.as_ref(), &context)
+                .unwrap();
+            output.rewind().unwrap();
+            let (bytes, _) = Store::load_jumbf_from_stream(format, &mut output, &context).unwrap();
+            bytes
+        };
+
+        let bytes_a = signed_ingredient("variant-a");
+        let bytes_b = signed_ingredient("variant-b");
+        let bytes_c = signed_ingredient("variant-c");
+
+        let mut claim = Claim::new("outer conflict test", Some("adobe"), 2);
+        claim.add_claim_generator_info(ClaimGeneratorInfo::new("outer"));
+
+        Store::load_ingredient_to_claim(&mut claim, &bytes_a, None, &context).unwrap();
+        Store::load_ingredient_to_claim(&mut claim, &bytes_b, None, &context).unwrap();
+        Store::load_ingredient_to_claim(&mut claim, &bytes_c, None, &context).unwrap();
+
+        let keys: Vec<&String> = claim.claim_ingredient_store().keys().collect();
+        let has = |label: &str| keys.iter().any(|k| k.as_str() == label);
+        assert!(has(shared_label), "base label missing: {keys:?}");
+        assert!(
+            has(&format!("{shared_label}::1_1")),
+            "first conflict must relabel to version 1: {keys:?}"
+        );
+        assert!(
+            has(&format!("{shared_label}::2_1")),
+            "second conflict must relabel to version 2: {keys:?}"
+        );
     }
 
     #[test]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6919,8 +6919,17 @@ pub mod tests {
 
     #[test]
     fn test_ingredient_conflict_first_collision_versions_label() {
-        // Two ingredients sharing a manifest label but differing in content (not by
-        // redaction) must relabel the second starting at version 1, not error.
+        // A manifest URN identifies a manifest, not its bytes.
+        // The same manifest can reach one asset by two routes
+        // and have only one of the copies change along the way.
+        // Two ingredients (from the different paths)
+        // then carry the same label with different (bytes) content.
+        //
+        // See https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests
+        // (C2PA spec 2.4 section 18.16.12.1)
+        //
+        // Here the three ingredients differ by databox content, so the relabeling path runs.
+        // The first conflict must start at version 1 instead of erroring.
         let context = Context::new();
         let signer = test_signer(SigningAlg::Ps256);
         let shared_label = "urn:c2pa:550e8400-e29b-41d4-a716-446655440000";
@@ -6932,6 +6941,10 @@ pub mod tests {
             claim
                 .add_databox("text/plain", variant.as_bytes().to_vec(), None)
                 .unwrap();
+            // Every standard manifest needs an actions assertion, and one created de novo
+            // leads with c2pa.created carrying a digitalSourceType (C2PA spec 2.4 section
+            // 18.15.2). Required to make the fixture a valid manifest; unrelated to the
+            // label conflict under test.
             let actions = Actions::new()
                 .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
             claim.add_assertion(&actions).unwrap();

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6926,13 +6926,13 @@ pub mod tests {
         // then carry the same label with different (bytes) content.
         //
         // See https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests
-        // (C2PA spec 2.4 section 18.16.12.1)
+        // (C2PA spec 2.4 section 18.16.12)
         //
         // Here the three ingredients differ by databox content, so the relabeling path runs.
         // The first conflict must start at version 1 instead of erroring.
         let context = Context::new();
         let signer = test_signer(SigningAlg::Ps256);
-        let shared_label = "urn:c2pa:550e8400-e29b-41d4-a716-446655440000";
+        let shared_label = "urn:c2pa:11111111-2222-4333-8444-555555555555";
 
         let signed_ingredient = |variant: &str| -> Vec<u8> {
             let mut store = Store::from_context(&Context::new());
@@ -6981,6 +6981,91 @@ pub mod tests {
             has(&format!("{shared_label}::2_1")),
             "second conflict must relabel to version 2: {keys:?}"
         );
+    }
+
+    #[test]
+    fn test_ingredient_conflict_tampered_nested_manifest_relabeled() {
+        // Second example from the spec:
+        // https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests
+        // (C2PA spec 2.4 section 18.16.12.2): manifest A is nested inside both ingredient B
+        use crate::utils::patch::patch_bytes;
+
+        let context = Context::new();
+        let signer = test_signer(SigningAlg::Ps256);
+        let a_label = "urn:c2pa:11111111-2222-4333-8444-555555555555";
+
+        // Databox payload of A, and the search target when corrupting C's copy. The
+        // replacement is the same length, so JUMBF box sizes stay valid and the difference
+        // shows up as a hash mismatch rather than a parse failure.
+        const A_PAYLOAD: &str = "nested-manifest-a-original";
+        const A_TAMPERED: &str = "nested-manifest-a-TAMPERED";
+
+        // Manifest A.
+        let mut store_a = Store::from_context(&Context::new());
+        let mut claim_a = Claim::new_with_user_guid("nested test", a_label, 2).unwrap();
+        claim_a.add_claim_generator_info(ClaimGeneratorInfo::new("manifest_a"));
+        claim_a
+            .add_databox("text/plain", A_PAYLOAD.as_bytes().to_vec(), None)
+            .unwrap();
+        let actions = Actions::new()
+            .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
+        claim_a.add_assertion(&actions).unwrap();
+        store_a.commit_claim(claim_a).unwrap();
+
+        let (format, mut input, mut output) = create_test_streams("earth_apollo17.jpg");
+        store_a
+            .save_to_stream(format, &mut input, &mut output, signer.as_ref(), &context)
+            .unwrap();
+        output.rewind().unwrap();
+        let (bytes_a, _) = Store::load_jumbf_from_stream(format, &mut output, &context).unwrap();
+
+        // Ingredients B and C, each carrying A in its manifest store. commit_claim moves the
+        // claim's ingredients into the store, so A is signed into both.
+        let wrapper = |tag: &str| -> Vec<u8> {
+            let mut store = Store::from_context(&Context::new());
+            let mut claim = Claim::new(tag, Some("adobe"), 2);
+            claim.add_claim_generator_info(ClaimGeneratorInfo::new(tag));
+            let actions = Actions::new()
+                .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
+            claim.add_assertion(&actions).unwrap();
+            Store::load_ingredient_to_claim(&mut claim, &bytes_a, None, &context).unwrap();
+            store.commit_claim(claim).unwrap();
+
+            let (format, mut input, mut output) = create_test_streams("earth_apollo17.jpg");
+            store
+                .save_to_stream(format, &mut input, &mut output, signer.as_ref(), &context)
+                .unwrap();
+            output.rewind().unwrap();
+            let (bytes, _) = Store::load_jumbf_from_stream(format, &mut output, &context).unwrap();
+            bytes
+        };
+
+        let bytes_b = wrapper("ingredient b");
+        let mut bytes_c = wrapper("ingredient c");
+
+        // Corrupt A inside C. patch_bytes errors when the search bytes are absent, so a
+        // successful call is itself the evidence that the tampering landed.
+        patch_bytes(&mut bytes_c, A_PAYLOAD.as_bytes(), A_TAMPERED.as_bytes()).unwrap();
+
+        // Asset D takes both ingredients.
+        let mut claim_d = Claim::new("asset d", Some("adobe"), 2);
+        claim_d.add_claim_generator_info(ClaimGeneratorInfo::new("asset_d"));
+        Store::load_ingredient_to_claim(&mut claim_d, &bytes_b, None, &context).unwrap();
+        Store::load_ingredient_to_claim(&mut claim_d, &bytes_c, None, &context).unwrap();
+
+        let keys: Vec<&String> = claim_d.claim_ingredient_store().keys().collect();
+        assert!(
+            keys.iter().any(|k| k.as_str() == a_label),
+            "original manifest A missing: {keys:?}"
+        );
+        assert!(
+            keys.iter().any(|k| k.as_str() == format!("{a_label}::1_1")),
+            "tampered copy of A must be relabeled to version 1 reason 1: {keys:?}"
+        );
+
+        // Both copies survive: neither overwrites the other.
+        let a_copies = keys.iter().filter(|k| k.starts_with(a_label)).count();
+        assert_eq!(a_copies, 2, "expected both copies of A: {keys:?}");
     }
 
     #[test]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6936,7 +6936,9 @@ pub mod tests {
 
         let signed_ingredient = |variant: &str| -> Vec<u8> {
             let mut store = Store::from_context(&Context::new());
-            let mut claim = Claim::new_with_user_guid("ingredient label conflict test", shared_label, 2).unwrap();
+            let mut claim =
+                Claim::new_with_user_guid("ingredient label conflict test", shared_label, 2)
+                    .unwrap();
             claim.add_claim_generator_info(ClaimGeneratorInfo::new("conflict_test"));
             claim
                 .add_databox("text/plain", variant.as_bytes().to_vec(), None)
@@ -6961,7 +6963,11 @@ pub mod tests {
         let bytes_b = signed_ingredient("variant-b");
         let bytes_c = signed_ingredient("variant-c");
 
-        let mut claim = Claim::new("ingredient label conflict test top level", Some("c2pa-rs-sdk-test"), 2);
+        let mut claim = Claim::new(
+            "ingredient label conflict test top level",
+            Some("c2pa-rs-sdk-test"),
+            2,
+        );
         claim.add_claim_generator_info(ClaimGeneratorInfo::new("outer"));
 
         // No conflict on this load...

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6918,7 +6918,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_ingredient_labels_versdioned_on_conflict() {
+    fn test_ingredient_labels_versioned_on_conflict() {
         // A manifest URN identifies a manifest, not its bytes.
         // The same manifest can reach one asset by two routes
         // and have only one of the copies change along the way.

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -6918,7 +6918,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_ingredient_conflict_first_collision_versions_label() {
+    fn test_ingredient_labels_versdioned_on_conflict() {
         // A manifest URN identifies a manifest, not its bytes.
         // The same manifest can reach one asset by two routes
         // and have only one of the copies change along the way.
@@ -6928,7 +6928,7 @@ pub mod tests {
         // See https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests
         // (C2PA spec 2.4 section 18.16.12)
         //
-        // Here the three ingredients differ by databox content, so the relabeling path runs.
+        // Here the three ingredients differ by databox content, triggering relabelling.
         // The first conflict must start at version 1 instead of erroring.
         let context = Context::new();
         let signer = test_signer(SigningAlg::Ps256);
@@ -6936,15 +6936,11 @@ pub mod tests {
 
         let signed_ingredient = |variant: &str| -> Vec<u8> {
             let mut store = Store::from_context(&Context::new());
-            let mut claim = Claim::new_with_user_guid("conflict test", shared_label, 2).unwrap();
+            let mut claim = Claim::new_with_user_guid("ingredient label conflict test", shared_label, 2).unwrap();
             claim.add_claim_generator_info(ClaimGeneratorInfo::new("conflict_test"));
             claim
                 .add_databox("text/plain", variant.as_bytes().to_vec(), None)
                 .unwrap();
-            // Every standard manifest needs an actions assertion, and one created de novo
-            // leads with c2pa.created carrying a digitalSourceType (C2PA spec 2.4 section
-            // 18.15.2). Required to make the fixture a valid manifest; unrelated to the
-            // label conflict under test.
             let actions = Actions::new()
                 .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
             claim.add_assertion(&actions).unwrap();
@@ -6959,113 +6955,34 @@ pub mod tests {
             bytes
         };
 
+        // Preparing 3 ingredient varints, which will have the same shared URN.
+        // They will have different databox content, dependent on the variant.
         let bytes_a = signed_ingredient("variant-a");
         let bytes_b = signed_ingredient("variant-b");
         let bytes_c = signed_ingredient("variant-c");
 
-        let mut claim = Claim::new("outer conflict test", Some("adobe"), 2);
+        let mut claim = Claim::new("ingredient label conflict test top level", Some("c2pa-rs-sdk-test"), 2);
         claim.add_claim_generator_info(ClaimGeneratorInfo::new("outer"));
 
+        // No conflict on this load...
         Store::load_ingredient_to_claim(&mut claim, &bytes_a, None, &context).unwrap();
+        // First conflict happens at this load.
         Store::load_ingredient_to_claim(&mut claim, &bytes_b, None, &context).unwrap();
+        // This is the second conflict.
         Store::load_ingredient_to_claim(&mut claim, &bytes_c, None, &context).unwrap();
 
         let keys: Vec<&String> = claim.claim_ingredient_store().keys().collect();
         let has = |label: &str| keys.iter().any(|k| k.as_str() == label);
-        assert!(has(shared_label), "base label missing: {keys:?}");
+        assert!(has(shared_label));
+        // Verifies conflict resolution labelling
         assert!(
             has(&format!("{shared_label}::1_1")),
-            "first conflict must relabel to version 1: {keys:?}"
+            "on first conflict, relabel should have version 1, got: {keys:?}"
         );
         assert!(
             has(&format!("{shared_label}::2_1")),
-            "second conflict must relabel to version 2: {keys:?}"
+            "second conflict should relabel to version 2, got: {keys:?}"
         );
-    }
-
-    #[test]
-    fn test_ingredient_conflict_tampered_nested_manifest_relabeled() {
-        // Second example from the spec:
-        // https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests
-        // (C2PA spec 2.4 section 18.16.12.2): manifest A is nested inside both ingredient B
-        use crate::utils::patch::patch_bytes;
-
-        let context = Context::new();
-        let signer = test_signer(SigningAlg::Ps256);
-        let a_label = "urn:c2pa:11111111-2222-4333-8444-555555555555";
-
-        // Databox payload of A, and the search target when corrupting C's copy. The
-        // replacement is the same length, so JUMBF box sizes stay valid and the difference
-        // shows up as a hash mismatch rather than a parse failure.
-        const A_PAYLOAD: &str = "nested-manifest-a-original";
-        const A_TAMPERED: &str = "nested-manifest-a-TAMPERED";
-
-        // Manifest A.
-        let mut store_a = Store::from_context(&Context::new());
-        let mut claim_a = Claim::new_with_user_guid("nested test", a_label, 2).unwrap();
-        claim_a.add_claim_generator_info(ClaimGeneratorInfo::new("manifest_a"));
-        claim_a
-            .add_databox("text/plain", A_PAYLOAD.as_bytes().to_vec(), None)
-            .unwrap();
-        let actions = Actions::new()
-            .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
-        claim_a.add_assertion(&actions).unwrap();
-        store_a.commit_claim(claim_a).unwrap();
-
-        let (format, mut input, mut output) = create_test_streams("earth_apollo17.jpg");
-        store_a
-            .save_to_stream(format, &mut input, &mut output, signer.as_ref(), &context)
-            .unwrap();
-        output.rewind().unwrap();
-        let (bytes_a, _) = Store::load_jumbf_from_stream(format, &mut output, &context).unwrap();
-
-        // Ingredients B and C, each carrying A in its manifest store. commit_claim moves the
-        // claim's ingredients into the store, so A is signed into both.
-        let wrapper = |tag: &str| -> Vec<u8> {
-            let mut store = Store::from_context(&Context::new());
-            let mut claim = Claim::new(tag, Some("adobe"), 2);
-            claim.add_claim_generator_info(ClaimGeneratorInfo::new(tag));
-            let actions = Actions::new()
-                .add_action(Action::new("c2pa.created").set_source_type(DigitalSourceType::Empty));
-            claim.add_assertion(&actions).unwrap();
-            Store::load_ingredient_to_claim(&mut claim, &bytes_a, None, &context).unwrap();
-            store.commit_claim(claim).unwrap();
-
-            let (format, mut input, mut output) = create_test_streams("earth_apollo17.jpg");
-            store
-                .save_to_stream(format, &mut input, &mut output, signer.as_ref(), &context)
-                .unwrap();
-            output.rewind().unwrap();
-            let (bytes, _) = Store::load_jumbf_from_stream(format, &mut output, &context).unwrap();
-            bytes
-        };
-
-        let bytes_b = wrapper("ingredient b");
-        let mut bytes_c = wrapper("ingredient c");
-
-        // Corrupt A inside C. patch_bytes errors when the search bytes are absent, so a
-        // successful call is itself the evidence that the tampering landed.
-        patch_bytes(&mut bytes_c, A_PAYLOAD.as_bytes(), A_TAMPERED.as_bytes()).unwrap();
-
-        // Asset D takes both ingredients.
-        let mut claim_d = Claim::new("asset d", Some("adobe"), 2);
-        claim_d.add_claim_generator_info(ClaimGeneratorInfo::new("asset_d"));
-        Store::load_ingredient_to_claim(&mut claim_d, &bytes_b, None, &context).unwrap();
-        Store::load_ingredient_to_claim(&mut claim_d, &bytes_c, None, &context).unwrap();
-
-        let keys: Vec<&String> = claim_d.claim_ingredient_store().keys().collect();
-        assert!(
-            keys.iter().any(|k| k.as_str() == a_label),
-            "original manifest A missing: {keys:?}"
-        );
-        assert!(
-            keys.iter().any(|k| k.as_str() == format!("{a_label}::1_1")),
-            "tampered copy of A must be relabeled to version 1 reason 1: {keys:?}"
-        );
-
-        // Both copies survive: neither overwrites the other.
-        let a_copies = keys.iter().filter(|k| k.starts_with(a_label)).count();
-        assert_eq!(a_copies, 2, "expected both copies of A: {keys:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Changes in this pull request

`Store::load_ingredient_to_claim` errors on ingredient conflicts in some cases (when instead it should version URNs). 

This is a fix to follow https://spec.c2pa.org/specifications/specifications/2.4/specs/C2PA_Specification.html#_copying_existing_manifests:
The version numbering for the relabelled (conflicting) manifest copy did not find a version on the first conflict (because no version exists yet on first conflict), and `Store::load_ingredient_to_claim` errored with a malformed label error.

The fix is to make the relabel count start at 1 (especially for the first collision, when there is no other version aka it was "None"), which handles label collisions. This is especially relevant for the case when two ingredients reference the same manifest URN, but with different manifest box hashes (and no redaction).
This fix then treats an empty version scan as "no conflicts yet" rather than a malformed label error.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
