### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.18](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.17...c2pa-v0.90.18)
+_04 September 2026_
+
+### Fixed
+
+* Harden against invalid  labels as CAWG identity hard bindings (backport #2538) ([#2581](https://github.com/contentauth/c2pa-rs/pull/2581))
+
 ## [0.90.17](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.16...c2pa-v0.90.17)
 _03 September 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.17"
+version = "0.90.18"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.17"
+version = "0.90.18"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "c2pa_cbor"
-version = "0.77.2"
+version = "0.77.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32d9f47773390b9e3400021ddd9ef7a8d61b8a6501cf72aecd6409d6d447c89"
+checksum = "0b057a673824daf7a5bff38680744d7a082b61edc012c8a6dc0ebfc04c79a08c"
 dependencies = [
  "half",
  "serde",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.17"
+version = "0.90.18"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.17"
+version = "0.27.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.17"
+version = "0.90.18"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2605,7 +2605,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.17"
+version = "0.90.18"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -4624,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.17"
+version = "0.90.18"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.17", default-features = false }
+c2pa = { path = "sdk", version = "0.90.18", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.18](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.17...c2patool-v0.27.18)
+_04 September 2026_
+
 ## [0.27.17](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.16...c2patool-v0.27.17)
 _03 September 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.17"
+version = "0.27.18"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.17 -> 0.90.18 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.17 -> 0.90.18
* `c2patool`: 0.27.17 -> 0.27.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.18](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.17...c2pa-v0.90.18)

_04 September 2026_

### Fixed

* Harden against invalid  labels as CAWG identity hard bindings (backport #2538) ([#2581](https://github.com/contentauth/c2pa-rs/pull/2581))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.16](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.15...c2pa-c-ffi-v0.90.16)

_27 August 2026_

### Fixed

* Resolve new Rust 1.98.0 Clippy lint (chunks_exact_to_as_chunks) (backport #2528) ([#2531](https://github.com/contentauth/c2pa-rs/pull/2531))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.18](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.17...c2patool-v0.27.18)

_04 September 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).