### PR TITLE
fix: Match BMFF hard-binding label on base, not bare prefix

### DIFF
--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -542,8 +542,11 @@ mod tests {
             "c2pa.hash.",
             "c2pa.hash.databoxes",
             "c2pa.actions",
-            // BMFF must match on its base, not a bare prefix.
+            // BMFF must match on its base, not a bare prefix. A trailing
+            // segment is only stripped when it's a real version token
+            // (`.vN`), so these fakes stay distinct from the base.
             "c2pa.hash.bmfffake",
+            "c2pa.hash.bmff.fake",
             "c2pa.hash.bmff.vfake",
         ] {
             assert!(

--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -257,15 +257,15 @@ pub const NON_REDACTABLE_LABELS: [&str; 5] =
 /// any `c2pa.hash.bmff.*`, `c2pa.hash.boxes`, `c2pa.hash.collection.data`, or
 /// `c2pa.hash.multi-asset`).
 ///
-/// `BMFF_HASH` is matched by prefix since it's the only one of these still at
-/// creation version > 1, so it's the only one that carries a version suffix
-/// (e.g. `.v3`) in practice; the others are compared exactly.
+/// `BMFF_HASH` is matched on its base label (version/instance suffix stripped)
+/// so it accepts `.v2`/`.v3` variants without accepting a fake like
+/// `c2pa.hash.bmfffake`; the others are compared exactly.
 pub(crate) fn is_hard_binding_label(label: &str) -> bool {
     label == DATA_HASH
         || label == BOX_HASH
         || label == COLLECTION_HASH
         || label == MULTI_ASSET_HASH
-        || label.starts_with(BMFF_HASH)
+        || base(label) == BMFF_HASH
 }
 
 /// Must have a label that ends in '.metadata' and is preceded by an entity-specific namespace.
@@ -542,6 +542,9 @@ mod tests {
             "c2pa.hash.",
             "c2pa.hash.databoxes",
             "c2pa.actions",
+            // BMFF must match on its base, not a bare prefix.
+            "c2pa.hash.bmfffake",
+            "c2pa.hash.bmff.vfake",
         ] {
             assert!(
                 !is_hard_binding_label(label),


### PR DESCRIPTION
## Changes in this pull request
Follow up PR based on the review comment in https://github.com/contentauth/c2pa-rs/pull/2581#discussion_r3927498074

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
