### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.20](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.19...c2pa-v0.90.20)
+_04 September 2026_
+
+### Added
+
+* Add ZIP support (+ EPUB, Office Open XML, Open Document, and OpenXPS) and Collection Data Hash assertion (backport #499) ([#2596](https://github.com/contentauth/c2pa-rs/pull/2596))
+
 ## [0.90.19](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.18...c2pa-v0.90.19)
 _04 September 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.19"
+version = "0.90.20"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.19"
+version = "0.90.20"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.19"
+version = "0.90.20"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.19"
+version = "0.27.20"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -871,7 +871,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1332,7 +1332,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.19"
+version = "0.90.20"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -1703,7 +1703,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2605,7 +2605,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.19"
+version = "0.90.20"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -3693,7 +3693,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3986,7 +3986,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4095,7 +4095,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4106,7 +4106,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4428,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4549,7 +4549,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4662,7 +4662,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5586,7 +5586,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.19"
+version = "0.90.20"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.19", default-features = false }
+c2pa = { path = "sdk", version = "0.90.20", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.20](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.19...c2patool-v0.27.20)
+_04 September 2026_
+
 ## [0.27.19](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.18...c2patool-v0.27.19)
 _04 September 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.19"
+version = "0.27.20"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.19 -> 0.90.20 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.19 -> 0.90.20
* `c2patool`: 0.27.19 -> 0.27.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.20](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.19...c2pa-v0.90.20)

_04 September 2026_

### Added

* Add ZIP support (+ EPUB, Office Open XML, Open Document, and OpenXPS) and Collection Data Hash assertion (backport #499) ([#2596](https://github.com/contentauth/c2pa-rs/pull/2596))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.16](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.15...c2pa-c-ffi-v0.90.16)

_27 August 2026_

### Fixed

* Resolve new Rust 1.98.0 Clippy lint (chunks_exact_to_as_chunks) (backport #2528) ([#2531](https://github.com/contentauth/c2pa-rs/pull/2531))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.20](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.19...c2patool-v0.27.20)

_04 September 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).