### PR TITLE
fix: Reject fragmented BMFF fragments matching a Merkle map without an initHash

### DIFF
--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1682,6 +1682,12 @@ impl BmffHash {
                             {
                                 return Err(Error::HashMismatch("Fragment not valid".to_string()));
                             }
+                        } else {
+                            // A fragmented BMFF MerkleMap must carry an initHash; without
+                            // it the fragment would go entirely unverified.
+                            return Err(Error::HashMismatch(
+                                "BMFF fragment MerkleMap missing required initHash".to_string(),
+                            ));
                         }
                     } else {
                         return Err(Error::HashMismatch("Fragment had no MerkleMap".to_string()));
@@ -1802,6 +1808,12 @@ impl BmffHash {
                         if !mm.check_merkle_tree(alg, &hash, bmff_mm.location, &bmff_mm.hashes) {
                             return Err(Error::HashMismatch("Fragment not valid".to_string()));
                         }
+                    } else {
+                        // A fragmented BMFF MerkleMap must carry an initHash; without
+                        // it the fragment would go entirely unverified.
+                        return Err(Error::HashMismatch(
+                            "BMFF fragment MerkleMap missing required initHash".to_string(),
+                        ));
                     }
                 } else {
                     return Err(Error::HashMismatch("Fragment had no MerkleMap".to_string()));

--- a/sdk/src/assertions/bmff_hash.rs
+++ b/sdk/src/assertions/bmff_hash.rs
@@ -1683,10 +1683,10 @@ impl BmffHash {
                                 return Err(Error::HashMismatch("Fragment not valid".to_string()));
                             }
                         } else {
-                            // A fragmented BMFF MerkleMap must carry an initHash; without
-                            // it the fragment would go entirely unverified.
-                            return Err(Error::HashMismatch(
-                                "BMFF fragment MerkleMap missing required initHash".to_string(),
+                            // A fragmented BMFF MerkleMap must carry an initHash; a
+                            // missing required field is a malformed assertion.
+                            return Err(Error::C2PAValidation(
+                                ASSERTION_BMFFHASH_MALFORMED.to_string(),
                             ));
                         }
                     } else {
@@ -1809,10 +1809,10 @@ impl BmffHash {
                             return Err(Error::HashMismatch("Fragment not valid".to_string()));
                         }
                     } else {
-                        // A fragmented BMFF MerkleMap must carry an initHash; without
-                        // it the fragment would go entirely unverified.
-                        return Err(Error::HashMismatch(
-                            "BMFF fragment MerkleMap missing required initHash".to_string(),
+                        // A fragmented BMFF MerkleMap must carry an initHash; a
+                        // missing required field is a malformed assertion.
+                        return Err(Error::C2PAValidation(
+                            ASSERTION_BMFFHASH_MALFORMED.to_string(),
                         ));
                     }
                 } else {

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -1321,3 +1321,48 @@ fn fragment_with_no_init_hash_is_rejected() {
         "expected HashMismatch, got: {err:?}"
     );
 }
+
+/// Same regression for the multi-file `verify_stream_segments` path (fragments
+/// supplied as file paths).
+#[cfg(feature = "file_io")]
+#[test]
+fn fragment_files_with_no_init_hash_is_rejected() {
+    use std::io::Write;
+
+    let ftyp = build_box(b"ftyp", b"isom\x00\x00\x00\x00isom");
+    let fragment = [
+        ftyp.clone(),
+        build_merkle_uuid_box(1, 1, 0),
+        build_box(b"mdat", b"arbitrary attacker-controlled frame bytes"),
+    ]
+    .concat();
+
+    let dir = tempfile::tempdir().unwrap();
+    let frag_path = dir.path().join("frag.m4s");
+    std::fs::File::create(&frag_path)
+        .unwrap()
+        .write_all(&fragment)
+        .unwrap();
+
+    let mut bmff_hash = BmffHash::new("test", "sha256", None);
+    bmff_hash.add_exclusions(&mut vec![ExclusionsMap::new("/uuid".to_owned())]);
+    bmff_hash.set_merkle(vec![MerkleMap {
+        unique_id: 1,
+        local_id: 1,
+        count: 1,
+        alg: Some("sha256".into()),
+        init_hash: None,
+        hashes: VecByteBuf(vec![ByteBuf::from(vec![0xaau8; 32])]),
+        fixed_block_size: None,
+        variable_block_sizes: Some(vec![41]),
+    }]);
+
+    let mut init_stream = Cursor::new(ftyp);
+    let err = bmff_hash
+        .verify_stream_segments(&mut init_stream, &vec![frag_path], None)
+        .expect_err("a fragment matching an initHash-less MerkleMap must be rejected");
+    assert!(
+        matches!(err, c2pa::Error::HashMismatch(_)),
+        "expected HashMismatch, got: {err:?}"
+    );
+}

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -1317,8 +1317,8 @@ fn fragment_with_no_init_hash_is_rejected() {
         .verify_stream_segment(&mut init_stream, &mut fragment_stream, None)
         .expect_err("a fragment matching an initHash-less MerkleMap must be rejected");
     assert!(
-        matches!(err, c2pa::Error::HashMismatch(_)),
-        "expected HashMismatch, got: {err:?}"
+        matches!(err, c2pa::Error::C2PAValidation(_)),
+        "expected C2PAValidation (bmffHash malformed), got: {err:?}"
     );
 }
 
@@ -1362,7 +1362,7 @@ fn fragment_files_with_no_init_hash_is_rejected() {
         .verify_stream_segments(&mut init_stream, &vec![frag_path], None)
         .expect_err("a fragment matching an initHash-less MerkleMap must be rejected");
     assert!(
-        matches!(err, c2pa::Error::HashMismatch(_)),
-        "expected HashMismatch, got: {err:?}"
+        matches!(err, c2pa::Error::C2PAValidation(_)),
+        "expected C2PAValidation (bmffHash malformed), got: {err:?}"
     );
 }

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -1284,3 +1284,40 @@ fn location_u32_max_does_not_panic() {
         "expected a clean rejection, got: {err:?}"
     );
 }
+
+/// Regression: a fragment matching a `MerkleMap` with no `initHash` must be
+/// rejected, not silently accepted as valid.
+#[test]
+fn fragment_with_no_init_hash_is_rejected() {
+    let ftyp = build_box(b"ftyp", b"isom\x00\x00\x00\x00isom");
+    let fragment = [
+        ftyp.clone(),
+        build_merkle_uuid_box(1, 1, 0),
+        build_box(b"mdat", b"arbitrary attacker-controlled frame bytes"),
+    ]
+    .concat();
+
+    // Matching map has init_hash = None and a proof hash that matches nothing.
+    let mut bmff_hash = BmffHash::new("test", "sha256", None);
+    bmff_hash.add_exclusions(&mut vec![ExclusionsMap::new("/uuid".to_owned())]);
+    bmff_hash.set_merkle(vec![MerkleMap {
+        unique_id: 1,
+        local_id: 1,
+        count: 1,
+        alg: Some("sha256".into()),
+        init_hash: None,
+        hashes: VecByteBuf(vec![ByteBuf::from(vec![0xaau8; 32])]),
+        fixed_block_size: None,
+        variable_block_sizes: Some(vec![41]),
+    }]);
+
+    let mut init_stream = Cursor::new(ftyp);
+    let mut fragment_stream = Cursor::new(fragment);
+    let err = bmff_hash
+        .verify_stream_segment(&mut init_stream, &mut fragment_stream, None)
+        .expect_err("a fragment matching an initHash-less MerkleMap must be rejected");
+    assert!(
+        matches!(err, c2pa::Error::HashMismatch(_)),
+        "expected HashMismatch, got: {err:?}"
+    );
+}

--- a/sdk/tests/bmff_timed_media_merkle.rs
+++ b/sdk/tests/bmff_timed_media_merkle.rs
@@ -1323,8 +1323,8 @@ fn fragment_with_no_init_hash_is_rejected() {
 }
 
 /// Same regression for the multi-file `verify_stream_segments` path (fragments
-/// supplied as file paths).
-#[cfg(feature = "file_io")]
+/// supplied as file paths). Filesystem-based, so not run on wasm.
+#[cfg(all(feature = "file_io", not(target_arch = "wasm32")))]
 #[test]
 fn fragment_files_with_no_init_hash_is_rejected() {
     use std::io::Write;


### PR DESCRIPTION


## Changes in this pull request

### Vulnerability
In `BmffHash::verify_stream_segment` / `verify_stream_segments`, fragment hashing and the Merkle check were nested under `if let Some(init_hash)`, so a fragment matching a `MerkleMap` with `init_hash == None` skipped all verification and returned `Ok` — tampered fragment content verified as trusted. Such maps are reachable via public `Builder` APIs, and fragments select their map by attacker-editable `(uniqueId, localId)`. In scope per SECURITY.md (validation bypass).

### Fix
Both multi-file verifiers now reject a fragment matching an `initHash`-less `MerkleMap`. A missing required field is a malformed assertion, so this returns `Error::C2PAValidation(ASSERTION_BMFFHASH_MALFORMED)` (per review) — surfacing as `assertion.bmffHash.malformed` rather than `.mismatch`, consistent with `verify_self`'s structural checks. Legitimate fragmented verification is unaffected; the single-file path already verified the Merkle tree unconditionally.

### Tests added
`fragment_with_no_init_hash_is_rejected` / `fragment_files_with_no_init_hash_is_rejected` — assert the tampered fragment is rejected with `Error::C2PAValidation`; fail on the old code (returned `Ok`), pass with the fix. Positive round-trip stays covered by `test_builder_fragmented`.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
