### PR TITLE
fix: Preserve numeric arrays in JSON output

### DIFF
--- a/sdk/src/builder.rs
+++ b/sdk/src/builder.rs
@@ -56,7 +56,7 @@ use crate::{
     settings::{builder::TimeStampFetchScope, MAX_ASSERTIONS},
     store::Store,
     utils::{
-        hash_utils::hash_to_b64, merkle::MerkleAccumulator, mime::format_to_mime,
+        json_report, merkle::MerkleAccumulator, mime::format_to_mime,
         path_utils::sanitize_archive_path, xmp_inmemory_utils::XmpInfo,
     },
     AsyncSigner, ClaimGeneratorInfo, EphemeralSigner, HashRange, HashedUri, Ingredient,
@@ -3786,8 +3786,7 @@ impl Builder {
 
 impl std::fmt::Display for Builder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut json = serde_json::to_value(self).map_err(|_| std::fmt::Error)?;
-        json = hash_to_b64(json);
+        let json = json_report::to_value(self).map_err(|_| std::fmt::Error)?;
         let output = serde_json::to_string_pretty(&json).map_err(|_| std::fmt::Error)?;
         f.write_str(&output)
     }
@@ -3970,6 +3969,217 @@ mod tests {
 
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    fn json_report_reader(builder: &Builder) -> Result<Reader> {
+        let mut store = Store::new();
+        store.commit_claim(builder.to_claim()?)?;
+        let mut reader = Reader::from_shared_context(&builder.context);
+        reader.with_store(store, &mut crate::status_tracker::StatusTracker::default())?;
+        Ok(reader)
+    }
+
+    fn assert_json_report_data(
+        reader: &Reader,
+        label: &str,
+        expected: &serde_json::Value,
+    ) -> Result<()> {
+        let active = reader.active_label().expect("active manifest");
+        let report: serde_json::Value = serde_json::from_str(&reader.json_checked()?)?;
+        let assertion = report["manifests"][active]["assertions"]
+            .as_array()
+            .expect("assertions")
+            .iter()
+            .find(|assertion| assertion["label"] == label)
+            .expect("custom assertion");
+        assert_eq!(&assertion["data"], expected, "Reader::json_checked");
+
+        let detailed: serde_json::Value = serde_json::from_str(&reader.detailed_json_checked()?)?;
+        assert_eq!(
+            &detailed["manifests"][active]["assertion_store"][label], expected,
+            "Reader::detailed_json_checked"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_report_preserves_numeric_arrays() -> Result<()> {
+        const LABEL: &str = "org.example.numeric-array";
+        let cases = [
+            json!([96, 384]),
+            json!([0, 255, 256]),
+            json!([0, 255]),
+            json!([]),
+            json!([-1, i64::MIN, i64::MAX]),
+            json!([1.5, -2.5, 96]),
+            json!([96, "text", null, true]),
+            json!([[96, 384], [], [0, 255]]),
+            json!({"values": [96, 384], "hash": [0, 255], "nested": [{"values": []}]}),
+        ];
+
+        for kind in [None, Some(ManifestAssertionKind::Json)] {
+            for data in &cases {
+                let mut definition = json!({
+                    "assertions": [{"label": LABEL, "data": data}]
+                });
+                if let Some(kind) = &kind {
+                    definition["assertions"][0]["kind"] = serde_json::to_value(kind)?;
+                }
+                let builder = Builder::from_context(Context::new()).with_definition(definition)?;
+                let reader = json_report_reader(&builder)?;
+                let internal: serde_json::Value = reader
+                    .active_manifest()
+                    .expect("active manifest")
+                    .find_assertion(LABEL)?;
+                assert_eq!(&internal, data, "assertion data before reporting");
+                assert_json_report_data(&reader, LABEL, data)?;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_report_preserves_cbor_bytes() -> Result<()> {
+        use c2pa_cbor::Value as CborValue;
+
+        const LABEL: &str = "org.example.binary-and-array";
+        let data = CborValue::Map(
+            [
+                (
+                    CborValue::Text("bytes".into()),
+                    CborValue::Bytes(vec![0, 255]),
+                ),
+                (
+                    CborValue::Text("empty_bytes".into()),
+                    CborValue::Bytes(vec![]),
+                ),
+                (
+                    CborValue::Text("values".into()),
+                    CborValue::Array(vec![CborValue::Integer(0), CborValue::Integer(255)]),
+                ),
+                (
+                    CborValue::Text("nested".into()),
+                    CborValue::Array(vec![
+                        CborValue::Bytes(vec![96, 128]),
+                        CborValue::Array(vec![]),
+                    ]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let mut builder = Builder::from_context(Context::new());
+        builder.add_assertion(LABEL, &data)?;
+        let reader = json_report_reader(&builder)?;
+        let expected = json!({
+            "bytes": "AP8=",
+            "empty_bytes": "",
+            "values": [0, 255],
+            "nested": ["YIA=", []]
+        });
+        assert_json_report_data(&reader, LABEL, &expected)?;
+
+        // Reporting must not alter the API representation used for typed decoding.
+        let internal: serde_json::Value = reader
+            .active_manifest()
+            .expect("active manifest")
+            .find_assertion(LABEL)?;
+        assert_eq!(internal, serde_json::to_value(&data)?);
+
+        let detailed: serde_json::Value = serde_json::from_str(&reader.detailed_json_checked()?)?;
+        let claim = &detailed["manifests"][reader.active_label().unwrap()]["claim"];
+        let references = claim["gathered_assertions"]
+            .as_array()
+            .expect("assertion references");
+        assert!(references
+            .iter()
+            .all(|reference| reference["hash"].is_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_report_preserves_builder_display() -> Result<()> {
+        let mut builder = Builder::from_context(Context::new()).with_definition(json!({
+            "assertions": [{"label": "org.example.array", "data": [96, 384]}]
+        }))?;
+        builder.add_assertion(
+            "org.example.bytes",
+            &serde_bytes::ByteBuf::from(vec![0, 255]),
+        )?;
+        let displayed: serde_json::Value = serde_json::from_str(&builder.to_string())?;
+        assert_eq!(displayed["assertions"][0]["data"], json!([96, 384]));
+        assert_eq!(displayed["assertions"][1]["data"], json!("AP8="));
+        assert_eq!(
+            serde_json::to_value(&builder)?["assertions"][1]["data"],
+            json!([0, 255])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_report_uses_each_assertion_instance() -> Result<()> {
+        const LABEL: &str = "org.example.multiple";
+        let mut builder = Builder::from_context(Context::new());
+        builder.add_assertion(LABEL, &json!([0, 255]))?;
+        builder.add_assertion(LABEL, &serde_bytes::ByteBuf::from(vec![0, 255]))?;
+        builder.add_assertion(LABEL, &serde_bytes::ByteBuf::from(vec![]))?;
+        let reader = json_report_reader(&builder)?;
+        let active = reader.active_label().expect("active manifest");
+        let report: serde_json::Value = serde_json::from_str(&reader.json_checked()?)?;
+        let assertions = report["manifests"][active]["assertions"]
+            .as_array()
+            .expect("assertions");
+        let values: Vec<_> = assertions
+            .iter()
+            .filter(|assertion| assertion["label"] == LABEL)
+            .map(|assertion| assertion["data"].clone())
+            .collect();
+        assert_eq!(values, vec![json!([0, 255]), json!("AP8="), json!("")]);
+
+        let detailed: serde_json::Value = serde_json::from_str(&reader.detailed_json_checked()?)?;
+        let assertions = &detailed["manifests"][active]["assertion_store"];
+        assert_eq!(assertions[LABEL], json!([0, 255]));
+        assert_eq!(assertions[format!("{LABEL}__1")], json!("AP8="));
+        assert_eq!(assertions[format!("{LABEL}__2")], json!(""));
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_report_keeps_post_validation_values() -> Result<()> {
+        struct Validator;
+
+        impl crate::reader::PostValidator for Validator {
+            fn validate(
+                &self,
+                _label: &str,
+                _assertion: &crate::ManifestAssertion,
+                _uri: &str,
+                _claim: &crate::dynamic_assertion::PartialClaim,
+                _tracker: &mut crate::status_tracker::StatusTracker,
+            ) -> Result<Option<serde_json::Value>> {
+                Ok(Some(json!({"bytes": [0, 255], "values": [96, 384]})))
+            }
+        }
+
+        const LABEL: &str = "org.example.post-validation";
+        #[derive(Serialize)]
+        struct Data {
+            bytes: serde_bytes::ByteBuf,
+        }
+        let mut builder = Builder::from_context(Context::new());
+        builder.add_assertion(
+            LABEL,
+            &Data {
+                bytes: serde_bytes::ByteBuf::from(vec![0, 255]),
+            },
+        )?;
+        let mut reader = json_report_reader(&builder)?;
+        reader.post_validate(&Validator)?;
+        assert_json_report_data(
+            &reader,
+            LABEL,
+            &json!({"bytes": [0, 255], "values": [96, 384]}),
+        )
+    }
 
     fn parent_json() -> String {
         json!({

--- a/sdk/src/manifest_store_report.rs
+++ b/sdk/src/manifest_store_report.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    assertion::AssertionData, claim::Claim, crypto::base64, store::Store,
+    assertion::AssertionData, claim::Claim, crypto::base64, store::Store, utils::json_report,
     validation_results::ValidationResults, validation_status::ValidationStatus, Result,
     ValidationState,
 };
@@ -97,8 +97,11 @@ impl ManifestReport {
             let (label, instance) = Claim::assertion_label_from_link(&hashlink);
             let label = Claim::label_with_instance(&label, instance);
             let value = match claim_assertion.assertion().decode_data() {
-                AssertionData::Json(_) | AssertionData::Cbor(_) => {
-                    claim_assertion.assertion().as_json_object()? // todo:  this may cause data loss
+                AssertionData::Json(_) => claim_assertion.assertion().as_json_object()?,
+                AssertionData::Cbor(cbor) => {
+                    let mut value = claim_assertion.assertion().as_json_object()?;
+                    json_report::encode_cbor_byte_strings(cbor, &mut value)?;
+                    value
                 }
                 AssertionData::Binary(x) => {
                     serde_json::to_value(format!("<omitted> len = {}", x.len()))?
@@ -129,7 +132,7 @@ impl ManifestReport {
             },
             None => SignatureReport::default(),
         };
-        let mut claim_value = serde_json::to_value(claim)?; // todo:  this will lose tagging info
+        let mut claim_value = json_report::to_value(claim)?; // todo: this will lose tagging info
         if let Value::Object(map) = &mut claim_value {
             map.insert(
                 "claim_version".to_string(),

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -33,7 +33,9 @@ use serde_with::skip_serializing_none;
 #[cfg(feature = "file_io")]
 use crate::utils::io_utils::uri_to_path;
 use crate::{
+    assertion::AssertionData,
     assertions::Metadata,
+    claim::Claim,
     context::{Context, ProgressPhase},
     dynamic_assertion::PartialClaim,
     error::{Error, Result},
@@ -43,7 +45,7 @@ use crate::{
     manifest_store_report::ManifestStoreReport,
     status_tracker::StatusTracker,
     store::Store,
-    utils::hash_utils::hash_to_b64,
+    utils::json_report,
     validation_results::{ValidationResults, ValidationState},
     validation_status::{ValidationStatus, ASSERTION_MISSING, ASSERTION_NOT_REDACTED},
     Ingredient, Manifest, ManifestAssertion, ManifestAssertionKind,
@@ -628,42 +630,43 @@ impl Reader {
         Context::default().io().reader_mime_types()
     }
 
-    /// replace assertion values in the reader json with the values from the assertion_values map
-    /// # Arguments
-    /// * `reader_json` - The reader json to update
-    /// # Returns
-    /// The updated reader json
+    /// Format byte strings for reporting and apply post-validation results.
     fn to_json_formatted(&self) -> Result<Value> {
-        let mut json = serde_json::to_value(self).map_err(Error::JsonError)?;
+        let mut json = json_report::to_value(self)?;
 
-        // If we ran post-validation, we need to update the assertion values in the report
-        if !self.assertion_values.is_empty() {
-            if let Some(manifests) = json.get_mut("manifests").and_then(|m| m.as_object_mut()) {
-                for (manifest_label, manifest) in manifests.iter_mut() {
-                    // Get assertions array once instead of multiple lookups
-                    if let Some(assertions) = manifest
-                        .get_mut("assertions")
-                        .and_then(|a| a.as_array_mut())
-                    {
-                        for assertion in assertions.iter_mut() {
-                            // Get label once and reuse
-                            if let Some(label) = assertion.get("label").and_then(|l| l.as_str()) {
-                                let uri =
-                                    crate::jumbf::labels::to_assertion_uri(manifest_label, label);
-                                if let Some(value) = self.assertion_values.get(&uri) {
-                                    // Only create new string if we need to insert
-                                    if let Some(assertion_mut) = assertion.as_object_mut() {
-                                        assertion_mut.insert("data".to_string(), value.clone());
-                                    }
-                                }
-                            }
+        if let Some(manifests) = json.get_mut("manifests").and_then(|m| m.as_object_mut()) {
+            for (manifest_label, manifest) in manifests {
+                let Some(source_manifest) = self.manifests.get(manifest_label) else {
+                    continue;
+                };
+                let Some(assertions) = manifest.get_mut("assertions").and_then(Value::as_array_mut)
+                else {
+                    continue;
+                };
+                for (assertion, source) in assertions.iter_mut().zip(source_manifest.assertions()) {
+                    let Some(data) = assertion.get_mut("data") else {
+                        continue;
+                    };
+                    let uri =
+                        crate::jumbf::labels::to_assertion_uri(manifest_label, source.label());
+                    if let Some(value) = self.assertion_values.get(&uri) {
+                        *data = value.clone();
+                        continue;
+                    }
+
+                    // Keep the normalized API representation, using the original
+                    // assertion only to distinguish byte strings from arrays.
+                    let label = Claim::label_with_instance(source.label(), source.instance());
+                    let uri = crate::jumbf::labels::to_assertion_uri(manifest_label, &label);
+                    if let Some(original) = self.store.get_assertion_from_uri(&uri) {
+                        if let AssertionData::Cbor(cbor) = original.decode_data() {
+                            json_report::encode_cbor_byte_strings(cbor, data)?;
                         }
                     }
                 }
             }
         }
-        // Convert hash values to base64 strings
-        Ok(hash_to_b64(json))
+        Ok(json)
     }
 
     /// Convert the reader to a JSON value with detailed formatting.
@@ -694,8 +697,6 @@ impl Reader {
                 }
             }
         }
-        // Convert hash values to base64 strings
-        json = hash_to_b64(json);
         Ok(json)
     }
 

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -21,11 +21,10 @@ use std::{
 
 use range_set::RangeSet;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 // direct sha functions
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
+use crate::{utils::io_utils::stream_len, Error, Result};
 
 const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
 
@@ -611,44 +610,6 @@ pub fn concat_and_hash(alg: &str, left: &[u8], right: Option<&[u8]>) -> Vec<u8> 
     }
 
     hash_by_alg(alg, &temp, None)
-}
-
-/// replace byte arrays with base64 encoded strings
-pub fn hash_to_b64(mut value: Value) -> Value {
-    use std::collections::VecDeque;
-
-    let mut queue = VecDeque::new();
-    queue.push_back(&mut value);
-
-    while let Some(current) = queue.pop_front() {
-        match current {
-            Value::Object(obj) => {
-                for (_, v) in obj.iter_mut() {
-                    if let Value::Array(hash_arr) = v {
-                        if !hash_arr.is_empty() && hash_arr.iter().all(|x| x.is_number()) {
-                            // Pre-allocate with capacity to avoid reallocations
-                            let mut hash_bytes = Vec::with_capacity(hash_arr.len());
-                            // Convert numbers to bytes safely
-                            for n in hash_arr.iter() {
-                                if let Some(num) = n.as_u64() {
-                                    hash_bytes.push(num as u8);
-                                }
-                            }
-                            *v = Value::String(encode(&hash_bytes));
-                        }
-                    }
-                    queue.push_back(v);
-                }
-            }
-            Value::Array(arr) => {
-                for v in arr.iter_mut() {
-                    queue.push_back(v);
-                }
-            }
-            _ => {}
-        }
-    }
-    value
 }
 
 #[cfg(test)]

--- a/sdk/src/utils/json_report.rs
+++ b/sdk/src/utils/json_report.rs
@@ -1,0 +1,449 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! JSON reporting that distinguishes byte strings from numeric arrays.
+
+use std::fmt;
+
+use serde::{
+    de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
+    ser, Deserializer, Serialize,
+};
+use serde_json::Value;
+
+use crate::crypto::base64;
+
+/// Serialize bytes as base64 while preserving ordinary sequences, including
+/// sequences of integers in the byte range. This is only for report output.
+pub(crate) fn to_value<T: ?Sized + Serialize>(value: &T) -> serde_json::Result<Value> {
+    serde_json::to_value(ReportValue(value))
+}
+
+// Adapt serialization directly, retaining serde_json::to_value's supported
+// nesting depth and map-key behavior without parsing an intermediate JSON string.
+struct ReportValue<'a, T: ?Sized>(&'a T);
+
+impl<T: ?Sized + Serialize> Serialize for ReportValue<'_, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.0.serialize(Base64Serializer(serializer))
+    }
+}
+
+struct Base64Serializer<S>(S);
+struct Base64Compound<S>(S);
+
+macro_rules! forward_scalar {
+    ($($method:ident($ty:ty)),* $(,)?) => {
+        $(
+            fn $method(self, value: $ty) -> Result<Self::Ok, Self::Error> {
+                self.0.$method(value)
+            }
+        )*
+    };
+}
+
+impl<S: ser::Serializer> ser::Serializer for Base64Serializer<S> {
+    type Error = S::Error;
+    type Ok = S::Ok;
+    type SerializeMap = Base64Compound<S::SerializeMap>;
+    type SerializeSeq = Base64Compound<S::SerializeSeq>;
+    type SerializeStruct = Base64Compound<S::SerializeStruct>;
+    type SerializeStructVariant = Base64Compound<S::SerializeStructVariant>;
+    type SerializeTuple = Base64Compound<S::SerializeTuple>;
+    type SerializeTupleStruct = Base64Compound<S::SerializeTupleStruct>;
+    type SerializeTupleVariant = Base64Compound<S::SerializeTupleVariant>;
+
+    forward_scalar! {
+        serialize_bool(bool),
+        serialize_i8(i8),
+        serialize_i16(i16),
+        serialize_i32(i32),
+        serialize_i64(i64),
+        serialize_i128(i128),
+        serialize_u8(u8),
+        serialize_u16(u16),
+        serialize_u32(u32),
+        serialize_u64(u64),
+        serialize_u128(u128),
+        serialize_f32(f32),
+        serialize_f64(f64),
+        serialize_char(char),
+        serialize_str(&str),
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_str(&base64::encode(value))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_none()
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_some(&ReportValue(value))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_unit()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_unit_struct(name)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_unit_variant(name, index, variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.0.serialize_newtype_struct(name, &ReportValue(value))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        name: &'static str,
+        index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.0
+            .serialize_newtype_variant(name, index, variant, &ReportValue(value))
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.0.serialize_seq(len).map(Base64Compound)
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.0.serialize_tuple(len).map(Base64Compound)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.0.serialize_tuple_struct(name, len).map(Base64Compound)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.0
+            .serialize_tuple_variant(name, index, variant, len)
+            .map(Base64Compound)
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.0.serialize_map(len).map(Base64Compound)
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.0.serialize_struct(name, len).map(Base64Compound)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.0
+            .serialize_struct_variant(name, index, variant, len)
+            .map(Base64Compound)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.0.is_human_readable()
+    }
+}
+
+macro_rules! serialize_sequence {
+    ($trait:ident, $method:ident) => {
+        impl<S: ser::$trait> ser::$trait for Base64Compound<S> {
+            type Error = S::Error;
+            type Ok = S::Ok;
+
+            fn $method<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), S::Error> {
+                self.0.$method(&ReportValue(value))
+            }
+
+            fn end(self) -> Result<S::Ok, S::Error> {
+                self.0.end()
+            }
+        }
+    };
+}
+
+serialize_sequence!(SerializeSeq, serialize_element);
+serialize_sequence!(SerializeTuple, serialize_element);
+serialize_sequence!(SerializeTupleStruct, serialize_field);
+serialize_sequence!(SerializeTupleVariant, serialize_field);
+
+impl<S: ser::SerializeMap> ser::SerializeMap for Base64Compound<S> {
+    type Error = S::Error;
+    type Ok = S::Ok;
+
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), S::Error> {
+        self.0.serialize_key(key)
+    }
+
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_value(&ReportValue(value))
+    }
+
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+macro_rules! serialize_struct {
+    ($trait:ident) => {
+        impl<S: ser::$trait> ser::$trait for Base64Compound<S> {
+            type Error = S::Error;
+            type Ok = S::Ok;
+
+            fn serialize_field<T: ?Sized + Serialize>(
+                &mut self,
+                key: &'static str,
+                value: &T,
+            ) -> Result<(), S::Error> {
+                self.0.serialize_field(key, &ReportValue(value))
+            }
+
+            fn skip_field(&mut self, key: &'static str) -> Result<(), S::Error> {
+                self.0.skip_field(key)
+            }
+
+            fn end(self) -> Result<S::Ok, S::Error> {
+                self.0.end()
+            }
+        }
+    };
+}
+
+serialize_struct!(SerializeStruct);
+serialize_struct!(SerializeStructVariant);
+
+/// Restore byte-string formatting after a CBOR assertion has been converted to
+/// JSON. Use the original CBOR types, never the values or names of JSON fields.
+/// Only matching byte arrays are replaced so normalized report fields are kept.
+pub(crate) fn encode_cbor_byte_strings(cbor: &[u8], report: &mut Value) -> c2pa_cbor::Result<()> {
+    CborBytes(report).deserialize(&mut c2pa_cbor::Deserializer::from_slice(cbor))
+}
+
+// Walk the CBOR directly rather than decoding into c2pa_cbor::Value: that value
+// type only represents i64 integers, whereas report transcoding supports u64.
+struct CborBytes<'a>(&'a mut Value);
+
+impl<'de> DeserializeSeed<'de> for CborBytes<'_> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for CborBytes<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a CBOR assertion value")
+    }
+
+    fn visit_bytes<E>(self, bytes: &[u8]) -> Result<(), E> {
+        if let Some(values) = self.0.as_array() {
+            if values.len() == bytes.len()
+                && values
+                    .iter()
+                    .zip(bytes)
+                    .all(|(value, byte)| value.as_u64() == Some(u64::from(*byte)))
+            {
+                *self.0 = Value::String(base64::encode(bytes));
+            }
+        }
+        Ok(())
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<(), A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        if let Some(values) = self.0.as_array_mut() {
+            for value in values {
+                if sequence.next_element_seed(CborBytes(value))?.is_none() {
+                    return Ok(());
+                }
+            }
+        }
+        while sequence.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(())
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while let Some(key) = map.next_key::<Value>()? {
+            let key = match key {
+                Value::String(key) => Some(key),
+                Value::Number(key) => Some(key.to_string()),
+                Value::Bool(key) => Some(key.to_string()),
+                _ => None,
+            };
+            if let Some(value) = key.as_deref().and_then(|key| self.0.get_mut(key)) {
+                map.next_value_seed(CborBytes(value))?;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_unit<E>(self) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_none<E>(self) -> Result<(), E> {
+        Ok(())
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        self.deserialize(deserializer)
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        self.deserialize(deserializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn json_report_preserves_supported_nesting_depth() -> crate::Result<()> {
+        let mut value = json!([0, 255]);
+        for _ in 0..130 {
+            value = json!({"nested": value});
+        }
+        assert_eq!(to_value(&value)?, serde_json::to_value(&value)?);
+        Ok(())
+    }
+
+    #[test]
+    fn json_report_handles_unsigned_integers_and_numeric_keys() -> crate::Result<()> {
+        #[derive(Serialize)]
+        struct Data {
+            maximum: u64,
+            bytes: serde_bytes::ByteBuf,
+            values: Vec<u64>,
+            nested: std::collections::BTreeMap<u64, serde_bytes::ByteBuf>,
+        }
+        let data = Data {
+            maximum: u64::MAX,
+            bytes: serde_bytes::ByteBuf::from(vec![0, 255]),
+            values: vec![0, 255, 256, u64::MAX],
+            nested: [(u64::MAX, serde_bytes::ByteBuf::from(vec![]))]
+                .into_iter()
+                .collect(),
+        };
+        let mut report = serde_json::to_value(&data)?;
+        encode_cbor_byte_strings(&c2pa_cbor::to_vec(&data)?, &mut report)?;
+        assert_eq!(report, to_value(&data)?);
+        assert_eq!(report["maximum"], json!(u64::MAX));
+        assert_eq!(report["values"], json!([0, 255, 256, u64::MAX]));
+        assert_eq!(report["bytes"], json!("AP8="));
+        assert_eq!(report["nested"][u64::MAX.to_string()], json!(""));
+        Ok(())
+    }
+
+    #[test]
+    fn json_report_keeps_normalized_fields() -> crate::Result<()> {
+        #[derive(Serialize)]
+        struct Data {
+            bytes: serde_bytes::ByteBuf,
+            signature: serde_bytes::ByteBuf,
+            omitted: Vec<serde_bytes::ByteBuf>,
+            nested: serde_bytes::ByteBuf,
+        }
+        let data = Data {
+            bytes: serde_bytes::ByteBuf::from(vec![0, 255]),
+            signature: serde_bytes::ByteBuf::from(vec![96, 128]),
+            omitted: vec![serde_bytes::ByteBuf::from(vec![1, 2])],
+            nested: serde_bytes::ByteBuf::from(vec![0, 255]),
+        };
+        let mut report = json!({
+            "bytes": [96, 384],
+            "signature": {"algorithm": "ES256"},
+            "nested": {"identifier": "resource"},
+            "extra": [0, 255]
+        });
+        let expected = report.clone();
+        encode_cbor_byte_strings(&c2pa_cbor::to_vec(&data)?, &mut report)?;
+        assert_eq!(report, expected);
+        Ok(())
+    }
+}

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod conforming_products;
 #[allow(dead_code)]
 pub(crate) mod hash_utils;
 pub(crate) mod io_utils;
+pub(crate) mod json_report;
 pub(crate) mod merkle;
 pub(crate) mod mime;
 #[allow(dead_code)] // for wasm build


### PR DESCRIPTION
## Changes in this pull request

Custom assertion data such as `[96, 384]` currently appears as `"YIA="` in JSON reports. The array is stored correctly in CBOR; the report formatter mistakes it for bytes and truncates its values while encoding them. This change keeps `[96, 384]` as an array in Reader's normal and detailed JSON reports and in Builder's display output.

Replace the numeric-array heuristic with formatting that uses serialization types. Actual byte strings, including typed claim hashes, remain base64 strings. For assertions already normalized into JSON, use the original CBOR types to identify matching byte fields while preserving the normalized representation. Assertion instances are resolved independently, and post-validation results are kept as supplied. Stored assertion data and the typed API representation remain unchanged. There are no new public APIs or dependencies.

Existing ambiguity when distinct CBOR map keys collapse to the same JSON property remains outside this fix. This does not provide lossless conversion of arbitrary CBOR maps.

Fixes #2570.

### Validation

- Eight new regression tests pass, covering numeric arrays in JSON and CBOR assertions, actual byte strings, Builder display, assertion instances, post-validation values, unsigned integers and numeric keys, normalized fields, and supported nesting depth.
- The original three regression tests fail against the baseline, reproducing the incorrect report output.
- All 148 selected SDK tests pass: 147 in the offline affected-module run and the one remote-fixture test when rerun with network access. This includes Builder, Reader, detailed report, and new helper tests.
- Before/after CLI comparison uses the same signed image with repository test credentials. Normal and detailed reports now preserve all input arrays. The original and fixed crJSON controls agree, the signed file's SHA256 is unchanged, and validation remains `Valid`. Signing and both sets of reads ran without network access.
- Linux builds use Rust 1.88.0. `cargo build -p c2patool --locked --offline` and `cargo +nightly fmt --all -- --check` pass.
- `cargo clippy -p c2pa --locked --all-targets --features file_io,fetch_remote_manifests,add_thumbnails -- -D warnings` was run and fails on existing upstream diagnostics. Every emitted source span was compared with the base commit and is unchanged. No emitted diagnostic points to this patch. This is not a clean Clippy pass.
- Full upstream CI across platforms and feature configurations has not been run locally.

## Checklist

- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment. No new TODO items were added.
