### PR TITLE
fix(ci): Pin cross install to its own lockfile

### DIFF
--- a/.github/workflows/beta-preflight.yml
+++ b/.github/workflows/beta-preflight.yml
@@ -212,7 +212,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation toolset
-        run: cargo install cross
+        run: cargo install cross --locked
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/tier-1b.yml
+++ b/.github/workflows/tier-1b.yml
@@ -168,7 +168,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation toolset
-        run: cargo install cross
+        run: cargo install cross --locked
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
## Summary
- \`cargo install cross\` (in the \`tests-cross\` job of both `tier-1b.yml` and `beta-preflight.yml`) re-resolves cross's dependencies against whatever is currently newest on crates.io, rather than the versions cross itself was built/tested against.
- This just broke the pinned-MSRV (1.88.0) matrix leg: `textwrap@0.16.3` (a transitive dependency) now requires rustc 1.90, so `cargo install cross` fails outright on the 1.88.0 runner — seen on [contentauth/c2pa-rs#2605](https://github.com/contentauth/c2pa-rs/pull/2605)'s CI, unrelated to that PR's actual diff.
- Adding `--locked` makes the install honor cross's shipped `Cargo.lock` instead of re-resolving, which should keep the pinned-MSRV job stable regardless of what's newest on crates.io.

## Test plan
- [ ] CI on this PR should show both `Unit tests (aarch64-unknown-linux-gnu, 1.88.0)` (tier-1b) succeeding once the fix runs (tier-1b only runs on release-line PRs/`check-release` label — may need that label added to trigger it here)
- [ ] No other jobs affected

🤖 Generated with [Claude Code](https://claude.ai/code)