### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ As of December 2025 and until the 1.0.0 version is released, the CAI team will o
 
 ## [Unreleased]
 
+## [0.90.22](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.21...c2pa-v0.90.22)
+_10 September 2026_
+
+### Fixed
+
+* Normalize path URIs on collection hash (backport #2605) ([#2625](https://github.com/contentauth/c2pa-rs/pull/2625))
+
 ## [0.90.21](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.20...c2pa-v0.90.21)
 _09 September 2026_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "bitvec"
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.90.21"
+version = "0.90.22"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa-c-ffi"
-version = "0.90.21"
+version = "0.90.22"
 dependencies = [
  "c2pa",
  "cbindgen",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "c2pa_macros"
-version = "0.90.21"
+version = "0.90.22"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.27.21"
+version = "0.27.22"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "export_schema"
-version = "0.90.21"
+version = "0.90.22"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2242,7 +2242,7 @@ version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24993fcabcbc07c8ac076a8e62db8593d1a5c4dbe81d57e531d2b7cb7f737380"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "flate2",
 ]
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
  "aes",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cbc",
  "chrono",
  "ecb",
@@ -2617,7 +2617,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "make_test_images"
-version = "0.90.21"
+version = "0.90.22"
 dependencies = [
  "anyhow",
  "c2pa",
@@ -2794,7 +2794,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2997,7 +2997,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3243,7 +3243,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3380,7 +3380,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -3712,7 +3712,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -3918,7 +3918,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4054,7 +4054,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4508,7 +4508,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4828,7 +4828,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-util",
  "http",
@@ -5036,9 +5036,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5449,7 +5449,7 @@ version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 
 # members in this workspace can share this version setting
 [workspace.package]
-version = "0.90.21"
+version = "0.90.22"
 
 [workspace.dependencies]
-c2pa = { path = "sdk", version = "0.90.21", default-features = false }
+c2pa = { path = "sdk", version = "0.90.22", default-features = false }
 
 [profile.dev]
 opt-level = 1          # allows test code to run faster at a small compile time cost

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.22](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.21...c2patool-v0.27.22)
+_10 September 2026_
+
 ## [0.27.21](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.20...c2patool-v0.27.21)
 _09 September 2026_
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2patool"
 default-run = "c2patool"
-version = "0.27.21"
+version = "0.27.22"
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
     "Gavin Peacock <gpeacock@adobe.com>",


### PR DESCRIPTION



## 🤖 New release

* `c2pa`: 0.90.21 -> 0.90.22 (✓ API compatible changes)
* `c2pa-c-ffi`: 0.90.21 -> 0.90.22
* `c2patool`: 0.27.21 -> 0.27.22

<details><summary><i><b>Changelog</b></i></summary><p>

## `c2pa`

<blockquote>

## [0.90.22](https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.21...c2pa-v0.90.22)

_10 September 2026_

### Fixed

* Normalize path URIs on collection hash (backport #2605) ([#2625](https://github.com/contentauth/c2pa-rs/pull/2625))
</blockquote>

## `c2pa-c-ffi`

<blockquote>

## [0.90.16](https://github.com/contentauth/c2pa-rs/compare/c2pa-c-ffi-v0.90.15...c2pa-c-ffi-v0.90.16)

_27 August 2026_

### Fixed

* Resolve new Rust 1.98.0 Clippy lint (chunks_exact_to_as_chunks) (backport #2528) ([#2531](https://github.com/contentauth/c2pa-rs/pull/2531))
</blockquote>

## `c2patool`

<blockquote>

## [0.27.22](https://github.com/contentauth/c2pa-rs/compare/c2patool-v0.27.21...c2patool-v0.27.22)

_10 September 2026_
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).