### PR TITLE
ci: Automate breaking-train promotion (`promote.yml`) and move RC build tags out of the `c2pa-v*` namespace

### DIFF
--- a/.github/workflows/library-release.yml
+++ b/.github/workflows/library-release.yml
@@ -1,10 +1,11 @@
 name: Publish c2pa-library binaries
 
-# Triggered by `c2pa-v*` tags, which come from two places (see
-# docs/release-process.md):
-#   * release-plz, on a release-line branch -> a real tag like `c2pa-v0.90.0`.
-#   * release-rc.yml, when a release-candidate build is cut -> a prerelease tag
-#     like `c2pa-v0.90.0-rc.1`.
+# Triggered by two tag namespaces (see docs/release-process.md):
+#   * `c2pa-v*` -> a real release tag from release-plz on a release-line branch,
+#     e.g. `c2pa-v0.90.0`.
+#   * `c2pa-rc-v*` -> a release-candidate build tag from release-rc.yml, e.g.
+#     `c2pa-rc-v0.90.0-rc.1`. RC builds are kept out of the `c2pa-v*` namespace
+#     so release-plz never mistakes them for a publish.
 # Either way the binaries are built here; the GitHub release is always marked as
 # a prerelease (pre-1.0). Nothing here publishes to crates.io. Git tags are
 # repo-global, so no branch filter is needed.
@@ -12,7 +13,8 @@ name: Publish c2pa-library binaries
 on:
   push:
     tags:
-      - "c2pa-v*" # Trigger on version tags (e.g., c2pa-v0.90.0)
+      - "c2pa-v*" # Real releases from release-plz (e.g. c2pa-v0.90.0).
+      - "c2pa-rc-v*" # RC builds from release-rc.yml (e.g. c2pa-rc-v0.90.0-rc.1).
   workflow_dispatch:
 
 jobs:
@@ -167,9 +169,9 @@ jobs:
           # the version from a filename.
           TAG_NAME="${{ github.ref_name }}"
           case "$TAG_NAME" in
-            c2pa-v*) ;;
+            c2pa-v* | c2pa-rc-v*) ;;
             *)
-              echo "::error::Expected a c2pa-v* tag ref, got '$TAG_NAME'. Run this workflow on a c2pa-v* tag."
+              echo "::error::Expected a c2pa-v* or c2pa-rc-v* tag ref, got '$TAG_NAME'."
               exit 1
               ;;
           esac
@@ -188,7 +190,14 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ steps.extract_tag.outputs.tag_name }}"
-          PREFIX="c2pa-v"
+
+          # RC build tags live in their own `c2pa-rc-v*` namespace, so baseline
+          # the notes on the previous tag of the SAME kind: an RC build against
+          # the prior RC build, a real release against the prior real release.
+          case "$TAG" in
+            c2pa-rc-v*) PREFIX="c2pa-rc-v" ;;
+            *) PREFIX="c2pa-v" ;;
+          esac
           repo="${{ github.repository }}"
           # All tags for this crate, plus the current one, sorted ascending.
           matching=$(gh api --paginate "repos/$repo/git/matching-refs/tags/$PREFIX" \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,146 @@
+name: Promote release candidate
+
+# Promotes a baked release-candidate branch (`0.N.0-rc`) onto the `stable`
+# release line – the deliberate, manual final step of a breaking train's bake
+# (see docs/release-process.md).
+#
+# This workflow does NOT publish. It resets the candidate's version back to the
+# last published release and force-pushes the baked train onto `stable`; the
+# existing `release-pr.yml` then opens the reviewed `0.N.0` version + changelog
+# PR, and merging THAT is what publishes (via `release.yml`).
+#
+# Why reset the version rather than strip `-rc` to the final number: a push to
+# `stable` whose version is already ahead of crates.io makes `release.yml` run
+# `release-plz release` and publish immediately, which would skip the reviewed
+# release PR and its generated changelog. Resetting to the last published
+# version keeps `stable` level with the registry, so `release-pr.yml` – not this
+# workflow – computes the train's bump and writes the changelog.
+#
+# Prerequisites:
+#   * The `RELEASE_PLZ_ORG_TOKEN` identity must be allowed to force-push
+#     `stable` and to create `v0.*` branches (branch-protection bypass).
+#   * Release-candidate build tags must live OUTSIDE the `c2pa-v*` namespace
+#     (see release-rc.yml), so release-plz baselines the changelog on the last
+#     real release rather than on an `-rc.N` build tag.
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    name: Promote release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to run outside a release-candidate branch
+        run: |
+          # An RC branch is named `<version>-rc` (no numeric suffix). Guard
+          # against dispatching against main / stable / a v0.x line.
+          case "${{ github.ref_name }}" in
+            *-rc) echo "Promoting RC branch ${{ github.ref_name }}." ;;
+            *)
+              echo "::error::promote must be dispatched on a *-rc branch, not '${{ github.ref_name }}'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout RC branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_ORG_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      # `cargo set-version` (from cargo-edit) keeps intra-workspace dependency
+      # requirements in sync when it moves a crate's version.
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-edit
+          version: "0.13.6"
+
+      - name: Compute promotion versions
+        id: ver
+        run: |
+          set -euo pipefail
+          meta() { cargo metadata --format-version=1 --no-deps | jq -r ".packages[]|select(.name==\"$1\")|.version"; }
+
+          # The candidate version currently on the RC branch, e.g. 0.90.0-rc.3.
+          RC_C2PA=$(meta c2pa)
+
+          # The outgoing `stable` version is what is on crates.io (stable tracks
+          # the latest published release). It names the snapshot branch and is
+          # the version we reset to so release-plz recomputes the train's bump.
+          git fetch origin stable
+          OLD_C2PA=$(git show origin/stable:Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)
+          if [ -z "$OLD_C2PA" ]; then
+            echo "::error::Could not read the outgoing c2pa version from origin/stable:Cargo.toml."
+            exit 1
+          fi
+
+          # e.g. 0.89.3 -> v0.89.
+          OLD_LINE="v$(echo "$OLD_C2PA" | cut -d. -f1,2)"
+
+          {
+            echo "rc_c2pa=$RC_C2PA"
+            echo "old_c2pa=$OLD_C2PA"
+            echo "old_line=$OLD_LINE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Promoting ${{ github.ref_name }} ($RC_C2PA) onto stable; resetting to $OLD_C2PA so release-pr.yml computes the train bump."
+
+      - name: Snapshot outgoing stable line
+        run: |
+          set -euo pipefail
+          LINE="${{ steps.ver.outputs.old_line }}"
+          if git ls-remote --exit-code --heads origin "$LINE" >/dev/null 2>&1; then
+            echo "Snapshot branch $LINE already exists; leaving it as-is."
+          else
+            # Point the retiring line at the current tip of stable so critical
+            # backports to the old release can still target it.
+            git push origin "refs/remotes/origin/stable:refs/heads/$LINE"
+            echo "Created snapshot branch $LINE from stable."
+          fi
+
+      - name: Reset candidate to the last published version
+        run: |
+          set -euo pipefail
+          # Move c2pa (and c2pa-c-ffi, which shares the workspace version) back to
+          # the last published number. `stable` then sits level with crates.io,
+          # so the force-push below does not trigger an immediate publish; the
+          # bump is left for release-pr.yml to compute and for a human to review.
+          cargo set-version -p c2pa "${{ steps.ver.outputs.old_c2pa }}"
+
+      - name: Force-push baked train onto stable
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: promote ${{ github.ref_name }} onto stable (reset to ${{ steps.ver.outputs.old_c2pa }} for release-plz)"
+
+          # Force-push rather than merge so stable's history becomes exactly the
+          # coherent set of changes baked on the RC branch (see
+          # docs/release-process.md). The push triggers release-pr.yml, which
+          # opens the reviewed version + changelog PR. Pushed with a PAT so that
+          # downstream workflow actually runs – a push made with the default
+          # GITHUB_TOKEN does not cascade into other workflows.
+          git push --force origin "HEAD:stable"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Release candidate promoted"
+            echo ""
+            echo "- Branch \`${{ github.ref_name }}\` (candidate \`${{ steps.ver.outputs.rc_c2pa }}\`) force-pushed onto \`stable\`, reset to \`${{ steps.ver.outputs.old_c2pa }}\`."
+            echo "- Outgoing \`stable\` snapshotted as \`${{ steps.ver.outputs.old_line }}\` for backports."
+            echo ""
+            echo "\`release-pr.yml\` will open the reviewed version + changelog PR on \`stable\`. **Merging that PR publishes to crates.io.**"
+            echo ""
+            echo "If release-plz under-bumps (the train is breaking by policy but \`cargo-semver-checks\` detected no break), force the final number on that PR with \`release-plz set-version\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -16,6 +16,11 @@ name: Cut release-candidate build
 # This workflow only sets versions and pushes a tag. The tag then drives the
 # binary build in library-release.yml, which marks `-rc.` tags as prereleases.
 #
+# RC build tags live in their own `c2pa-rc-v*` namespace, deliberately OUTSIDE
+# the `c2pa-v*` namespace that release-plz keys on. That keeps release-plz from
+# ever mistaking an RC build tag for a botched publish, and lets it baseline the
+# promoted release's changelog on the last real release rather than an RC build.
+#
 # Publishing is gated by branch/tag names, not by this workflow: the tags
 # contain `-rc.` and never match a crates.io publish trigger (release.yml only
 # runs on `stable` / `v0.*` branch pushes), so an RC build can never reach
@@ -87,7 +92,7 @@ jobs:
           RC_C2PA="${BASE_C2PA}-rc.${N}"
           {
             echo "rc_c2pa=$RC_C2PA"
-            echo "tag_c2pa=c2pa-v${RC_C2PA}"
+            echo "tag_c2pa=c2pa-rc-v${RC_C2PA}"
           } >> "$GITHUB_OUTPUT"
           echo "Cutting c2pa $RC_C2PA (build #$N)."
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -58,7 +58,7 @@ Breaking changes and larger refactors are batched onto a scheduled train:
 
 1. On the scheduled date, a release-candidate branch `0.(x+1).0-rc` is cut from `main`, and its first build `0.(x+1).0-rc.1` is cut immediately (versions set, tagged, prerelease binaries built). **RC branches are not published to crates.io** (their name keeps them off every crates.io publish trigger), but each build **does** get a prerelease GitHub release with binaries so downstream consumers that depend on pre-built binaries can validate during the bake. See [RC builds](#release-candidate-builds).
 2. **Bake period: minimum three business days.** Only bug fixes are accepted during the bake, and they follow upstream-first (fix on `main`, cherry-pick to the candidate). After fixes land, cut a fresh build (`-rc.2`, `-rc.3`, …) so downstream has updated binaries to test. Hold longer than three business days if needed to validate across the downstream projects we maintain.
-3. **Promote** (a deliberate, manual step): first snapshot the outgoing `stable` as `v0.<old>` so the retiring line is available for backports, then force-push the candidate onto `stable`. We force-push rather than merge so that `stable`'s history becomes exactly the coherent set of changes made on `main`, superseding whatever adaptations were needed while manually backporting Track 1 fixes onto the old `stable` line. `release-plz` then opens the `0.(x+1).0` version/changelog PR on `stable`; merging it publishes the breaking release.
+3. **Promote** (a deliberate step): dispatch [`promote.yml`](#release-promotion) on the RC branch. It snapshots the outgoing `stable` as `v0.<old>` (so the retiring line is available for backports), then force-pushes the candidate onto `stable` — force-pushed rather than merged so that `stable`'s history becomes exactly the coherent set of changes made on `main`, superseding whatever adaptations were needed while manually backporting Track 1 fixes onto the old `stable` line. The candidate's version is reset to the last published release as part of the promotion, so `release-plz` (via [`release-pr.yml`](#release-plz)) then opens the `0.(x+1).0` version/changelog PR on `stable`; merging **that** publishes the breaking release. See [Release promotion](#release-promotion) for why the version is reset rather than stripped.
 
 ### Cadence: scheduled, but not forced
 
@@ -130,7 +130,7 @@ We use [`release-plz`](https://release-plz.dev) (via the [GitHub Action wrapper]
 
 Binary builds are therefore entirely **tag-driven**, independent of how a tag was created:
 
-* [`library-release.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/library-release.yml) builds the `c2pa` / `c2pa-c-ffi` native libraries for every supported target on any `c2pa-v*` tag.
+* [`library-release.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/library-release.yml) builds the `c2pa` / `c2pa-c-ffi` native libraries for every supported target on any `c2pa-v*` (real release) or `c2pa-rc-v*` (RC build) tag.
 
 A tag whose name contains `-rc.` yields a **prerelease** GitHub release; nothing on this path publishes to crates.io.
 
@@ -177,9 +177,21 @@ By default, `cargo-semver-checks` ignores features named `unstable`, `nightly`, 
 
 ### Release-candidate builds
 
-[`release-rc.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/release-rc.yml) cuts a numbered candidate **build** (`-rc.1`, `-rc.2`, …) from a candidate **branch** (`0.N.0-rc`). It sets the `-rc.N` version on the branch (bumping `c2pa`, which `c2pa-c-ffi` follows via the shared workspace version), commits, and pushes the `c2pa-v…-rc.N` tag. That tag triggers the tag-driven binary workflow above, which publishes a **prerelease** GitHub release with binaries. Nothing here reaches crates.io: the build exists so downstream projects that consume pre-built binaries (rather than building from source) can validate the candidate during its bake.
+[`release-rc.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/release-rc.yml) cuts a numbered candidate **build** (`-rc.1`, `-rc.2`, …) from a candidate **branch** (`0.N.0-rc`). It sets the `-rc.N` version on the branch (bumping `c2pa`, which `c2pa-c-ffi` follows via the shared workspace version), commits, and pushes the `c2pa-rc-v…-rc.N` tag. That build tag lives in the `c2pa-rc-v*` namespace, deliberately **outside** the `c2pa-v*` namespace `release-plz` keys on — so `release-plz` never mistakes an RC build for a botched publish, and it baselines a promoted release's changelog on the last real release rather than on an RC build. The tag still triggers the tag-driven binary workflow above, which publishes a **prerelease** GitHub release with binaries. Nothing here reaches crates.io: the build exists so downstream projects that consume pre-built binaries (rather than building from source) can validate the candidate during its bake.
 
 The first build (`-rc.1`) is cut automatically when the train is cut. A maintainer re-runs this workflow (via `workflow_dispatch` on the RC branch) to cut a fresh build after bugfixes have been cherry-picked onto the branch during the bake. Tags are pushed with a PAT (`RELEASE_PLZ_TOKEN`) so the tag-driven binary workflows actually run: pushes made with the default `GITHUB_TOKEN` do not cascade into other workflows.
+
+### Release promotion
+
+[`promote.yml`](https://github.com/contentauth/c2pa-rs/blob/main/.github/workflows/promote.yml) automates the promotion step of the breaking train (Track 2, step 3). A maintainer dispatches it (via `workflow_dispatch`) on the baked RC branch, and it:
+
+1. **Snapshots** the outgoing `stable` as a `v0.<old>` branch, so the retiring line stays available for backports.
+2. **Resets** the candidate's version back to the last published release (`cargo set-version`, which also fixes intra-workspace deps), then **force-pushes** the baked train onto `stable`.
+3. Leaves the rest to the normal release machinery: the push to `stable` triggers [`release-pr.yml`](#release-plz), which opens the reviewed `0.(x+1).0` version + changelog PR. Merging **that** PR publishes.
+
+**Why reset the version rather than strip `-rc` to the final number.** A push to `stable` whose version is already ahead of crates.io makes [`release.yml`](#release-plz) run `release-plz release` and publish immediately — which would bypass the reviewed release PR and its generated changelog. Resetting to the last published version keeps `stable` level with the registry, so the bump and changelog are computed by `release-pr.yml` and land in a PR a human merges. If `release-plz` under-bumps (the train is breaking by policy but `cargo-semver-checks` detected no break), force the final number on that PR with [`release-plz set-version`](https://release-plz.dev/docs/usage/set-version).
+
+Promotion depends on RC build tags living outside the `c2pa-v*` namespace (see [RC builds](#release-candidate-builds)); otherwise `release-plz` would baseline the promoted changelog on an RC build tag and cover only the bake bugfixes. Force-pushing `stable` and creating the `v0.*` snapshot require the `RELEASE_PLZ_ORG_TOKEN` identity to be allowed to bypass those branches' protection (see [branch protection](#branch-protection)).
 
 ### Cross-repo canary
 


### PR DESCRIPTION
## Summary

Automates the **promotion** step of the breaking train (Track 2, step 3 in `docs/release-process.md`), which was a hand-run `git` dance, and removes the root cause of the release-plz guard failure that necessitated it.

Supersedes #2315 (which was written for the pre-c2patool-split, 3-crate world removed by #2617; this targets post-#2617 `main` and shares none of its code).

## What it does

**`promote.yml`** (`workflow_dispatch` on the `0.N.0-rc` branch):

1. **Snapshots** the outgoing `stable` as `v0.<old>` for backports.
2. **Resets** the candidate to the last published version (`cargo set-version`, which also fixes intra-workspace deps), then **force-pushes** the baked train onto `stable`.
3. Leaves the rest to the normal machinery: the push triggers `release-pr.yml`, which opens the reviewed `0.N.0` version + changelog PR. Merging **that** publishes.

### Why reset the version instead of stripping `-rc`

A push to `stable` whose version is already ahead of crates.io makes `release.yml` run `release-plz release` and **publish immediately** — bypassing the reviewed release PR and its generated changelog. Resetting keeps `stable` level with the registry, so the bump + changelog are computed by `release-pr.yml` and land in a PR a human merges. If release-plz under-bumps (breaking by policy but `cargo-semver-checks` saw no break), the reviewer forces the number on that PR with [`release-plz set-version`](https://release-plz.dev/docs/usage/set-version).

### RC build tags move out of the `c2pa-v*` namespace

RC builds are now tagged **`c2pa-rc-v*`** (was `c2pa-v…-rc.N`). Because release-plz keys on `c2pa-v*`, keeping RC builds out of that namespace means release-plz:

- never mistakes an RC build tag for a botched publish (the original guard-collision failure), and
- baselines a promoted release's changelog on the **last real release** rather than an RC build — so the changelog covers the whole train, not just bake bugfixes.

`library-release.yml` is updated to build on **both** namespaces and to baseline its release notes on the same-kind previous tag (which also fixes real-release notes previously baselining on an RC tag).

## Notes

- **`update-schemas.yml`** also triggers on `c2pa-v*`; after this change RC builds no longer trigger it (real releases still do). That looks correct — schema updates should track releases, not bake builds — so it's left unchanged. Flag if you'd prefer RC builds to trigger it.
- **Branch protection:** force-pushing `stable` and creating the `v0.*` snapshot require the `RELEASE_PLZ_ORG_TOKEN` identity to be in those branches' bypass lists.
- **Existing `c2pa-v…-rc.*` tags** from the 0.90 train are left as-is; the new scheme applies to the next train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)