### PR TITLE
fix: Reject data hash exclusions for detached manifests without a matching C2PA box

### DIFF
--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -2959,8 +2959,33 @@ impl Claim {
                     }
 
                     if !dh.is_remote_hash() {
-                        // there are extra exclusion then log the information code about extra exclusion
                         if let Some(exclusions) = &dh.exclusions {
+                            // Exclusions only make sense for a manifest embedded in this asset;
+                            // a detached manifest's exclusion is a hole for unrelated content.
+                            // If the caller didn't read the manifest out of this asset, fall back
+                            // to checking whether the asset really does have a C2PA box there.
+                            let box_present_in_asset = svi
+                                .manifest_store_range
+                                .as_ref()
+                                .is_some_and(|range| exclusions.contains(range));
+                            let has_real_exclusion = exclusions.iter().any(|e| e.length() > 0);
+                            if has_real_exclusion && !svi.is_embedded && !box_present_in_asset {
+                                log_item!(
+                                    claim.assertion_uri(&hash_binding_assertion.label()),
+                                    "data hash exclusions not valid for a detached manifest",
+                                    "verify_internal"
+                                )
+                                .validation_status(validation_status::ASSERTION_DATAHASH_MISMATCH)
+                                .failure(
+                                    validation_log,
+                                    Error::HashMismatch(
+                                        "data hash exclusions not valid for a detached manifest"
+                                            .to_string(),
+                                    ),
+                                )?;
+                            }
+
+                            // there are extra exclusion then log the information code about extra exclusion
                             if exclusions.len() > 1 {
                                 log_item!(
                                     claim.assertion_uri(&hash_binding_assertion.label()),

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -883,35 +883,39 @@ impl Ingredient {
     ) -> Result<Self> {
         let mut validation_log = StatusTracker::default();
 
-        // retrieve the manifest bytes from embedded or remote and convert to store if found
+        // retrieve the manifest bytes from embedded or remote and convert to store if found;
+        // also track whether the bytes came from parsing `stream` itself (embedded) as
+        // opposed to `manifest_data()` or a remote fallback (not embedded).
         let jumbf_result = match self.manifest_data() {
-            Some(data) => Ok(data.into_owned()),
+            Some(data) => Ok((data.into_owned(), false)),
             None => if _sync {
                 Store::load_jumbf_from_stream(format, stream, context)
             } else {
                 Store::load_jumbf_from_stream_async(format, stream, context).await
             }
-            .map(|(manifest_bytes, _)| manifest_bytes),
+            .map(|(manifest_bytes, remote_url)| (manifest_bytes, remote_url.is_none())),
         };
 
         // We can't use functional combinators since we can't use async callbacks (https://github.com/rust-lang/rust/issues/62290)
         let (mut result, manifest_bytes) = match jumbf_result {
-            Ok(manifest_bytes) => {
+            Ok((manifest_bytes, embedded)) => {
                 let result = if _sync {
-                    Store::from_manifest_data_and_stream(
+                    Store::from_manifest_data_and_stream_with_embedded(
                         &manifest_bytes,
                         format,
                         &mut *stream,
                         &mut validation_log,
                         context,
+                        embedded,
                     )
                 } else {
-                    Store::from_manifest_data_and_stream_async(
+                    Store::from_manifest_data_and_stream_with_embedded_async(
                         &manifest_bytes,
                         format,
                         &mut *stream,
                         &mut validation_log,
                         context,
+                        embedded,
                     )
                     .await
                 };

--- a/sdk/src/reader.rs
+++ b/sdk/src/reader.rs
@@ -1385,6 +1385,70 @@ pub mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
+    fn test_detached_manifest_exclusion_hole_rejected() {
+        use crate::{assertions::DataHash, Builder};
+
+        // Sign a real asset (embedded); the attacker never holds this key.
+        let victim_src = include_bytes!("../tests/fixtures/no_manifest.jpg");
+        let signer = test_signer(SigningAlg::Ps256);
+        let mut builder = Builder::from_context(test_context())
+            .with_definition(r#"{"title": "victim"}"#)
+            .unwrap();
+        let mut source = Cursor::new(victim_src.to_vec());
+        let mut dest = Cursor::new(Vec::new());
+        builder
+            .sign(signer.as_ref(), "image/jpeg", &mut source, &mut dest)
+            .unwrap();
+        let victim = dest.into_inner();
+
+        // Attacker lifts the signed manifest store out, byte-verbatim, no re-signing.
+        let context = test_context();
+        let mut victim_stream = Cursor::new(victim.clone());
+        let (jumbf, _remote) =
+            crate::store::Store::load_jumbf_from_stream("image/jpeg", &mut victim_stream, &context)
+                .unwrap();
+
+        // Read the signed exclusion range straight off the claim.
+        let store = crate::store::Store::from_stream(
+            "image/jpeg",
+            Cursor::new(victim.clone()),
+            &mut StatusTracker::default(),
+            &context,
+        )
+        .unwrap();
+        let claim = store.provenance_claim().unwrap();
+        let dh_assertion = claim
+            .hash_assertions()
+            .into_iter()
+            .find(|a| a.label_raw().starts_with(DataHash::LABEL))
+            .unwrap();
+        let dh = DataHash::from_assertion(dh_assertion.assertion()).unwrap();
+        let range = &dh.exclusions.unwrap()[0];
+        let (excl_start, excl_len) = (range.start() as usize, range.length() as usize);
+
+        // Overwrite exactly that range with unrelated content, keeping every byte
+        // outside it untouched.
+        let mut forged = victim.clone();
+        for b in forged[excl_start..excl_start + excl_len].iter_mut() {
+            *b = 0x41;
+        }
+
+        // Validate the forged pair through the detached-manifest path (c2patool
+        // --external-manifest / a sidecar or remote manifest workflow).
+        let result =
+            Reader::from_manifest_data_and_stream(&jumbf, "image/jpeg", Cursor::new(forged));
+        let state = result
+            .map(|r| r.validation_state())
+            .unwrap_or(ValidationState::Invalid);
+        assert_ne!(
+            state,
+            ValidationState::Trusted,
+            "a detached manifest's exclusion must not let unrelated content inside it pass validation"
+        );
+    }
+
+    #[test]
     fn test_reader_embedded() -> Result<()> {
         let reader =
             Reader::default().with_stream("image/jpeg", Cursor::new(IMAGE_WITH_MANIFEST))?;

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -112,6 +112,7 @@ pub(crate) struct StoreValidationInfo<'a> {
     pub update_manifest_label: Option<String>,    // label of the update manifest if it exists
     pub manifest_store_range: Option<HashRange>, // range of the manifest store in the asset for data hash exclusions
     pub certificate_statuses: HashMap<String, Vec<Vec<u8>>>, // list of certificate status assertions for each serial
+    pub is_embedded: bool, // whether the manifest was read out of the asset being validated, vs. supplied separately (sidecar/remote)
 }
 
 /// A `Store` maintains a list of `Claim` structs.
@@ -1907,7 +1908,10 @@ impl Store {
         context: &Context,
     ) -> Result<StoreValidationInfo<'a>> {
         let io = context.io();
-        let mut svi = StoreValidationInfo::default();
+        let mut svi = StoreValidationInfo {
+            is_embedded: self.embedded,
+            ..Default::default()
+        };
         Store::get_claim_referenced_manifests(claim, self, &mut svi, true, validation_log)?;
 
         // find the manifest with the hash binding
@@ -2032,7 +2036,7 @@ impl Store {
                         let ocsp_ders = svi
                             .certificate_statuses
                             .entry(response.certificate_serial_num)
-                            .or_insert(Vec::new());
+                            .or_default();
                         ocsp_ders.push(response.ocsp_der);
                     }
                 }
@@ -3069,6 +3073,13 @@ impl Store {
 
                 context.check_progress(ProgressPhase::Embedding, 1, 1)?;
 
+                // Sidecar/remote-only signing doesn't embed the manifest into
+                // output_stream; anything else does.
+                self.embedded = !matches!(
+                    self.provenance_claim().map(|pc| pc.remote_manifest()),
+                    Some(RemoteManifest::SideCar) | Some(RemoteManifest::Remote(_))
+                );
+
                 if context.settings().verify.verify_after_sign {
                     let output_len = stream_len(output_stream)?;
                     let validate_hash = context.settings().verify.verify_after_sign_hash;
@@ -3723,29 +3734,32 @@ impl Store {
                 .failure_no_throw(validation_log, e);
         })?;
 
+        // Known here, before verification runs, so verify_hash_binding can tell an
+        // embedded manifest (this asset's own bytes) from a detached one.
+        let embedded = remote_url.is_none();
         let store = if _sync {
-            Self::from_manifest_data_and_stream(
+            Self::from_manifest_data_and_stream_with_embedded(
                 &manifest_bytes,
                 format,
                 &mut stream,
                 validation_log,
                 context,
+                embedded,
             )
         } else {
-            Self::from_manifest_data_and_stream_async(
+            Self::from_manifest_data_and_stream_with_embedded_async(
                 &manifest_bytes,
                 format,
                 &mut stream,
                 validation_log,
                 context,
+                embedded,
             )
             .await
         };
 
         let mut store = store?;
-        if remote_url.is_none() {
-            store.embedded = true;
-        } else {
+        if !embedded {
             store.remote_url = remote_url;
         }
 
@@ -3757,18 +3771,52 @@ impl Store {
     pub fn from_manifest_data_and_stream(
         c2pa_data: &[u8],
         format: &str,
+        stream: impl Read + Seek + MaybeSend,
+        validation_log: &mut StatusTracker,
+        context: &Context,
+    ) -> Result<Self> {
+        if _sync {
+            Self::from_manifest_data_and_stream_with_embedded(
+                c2pa_data,
+                format,
+                stream,
+                validation_log,
+                context,
+                false,
+            )
+        } else {
+            Self::from_manifest_data_and_stream_with_embedded_async(
+                c2pa_data,
+                format,
+                stream,
+                validation_log,
+                context,
+                false,
+            )
+            .await
+        }
+    }
+
+    /// Load store from a manifest data and stream, marking whether `c2pa_data` was read out
+    /// of `stream` itself (embedded) as opposed to supplied separately (sidecar/remote).
+    #[async_generic]
+    pub(crate) fn from_manifest_data_and_stream_with_embedded(
+        c2pa_data: &[u8],
+        format: &str,
         mut stream: impl Read + Seek + MaybeSend,
         validation_log: &mut StatusTracker,
         context: &Context,
+        embedded: bool,
     ) -> Result<Self> {
         stream.rewind()?;
 
         // First we convert the JUMBF into a usable store.
-        let store = Store::from_jumbf_with_context(c2pa_data, validation_log, context)
+        let mut store = Store::from_jumbf_with_context(c2pa_data, validation_log, context)
             .inspect_err(|e| {
                 log_item!("asset", "error loading file", "load_from_asset")
                     .failure_no_throw(validation_log, e);
             })?;
+        store.embedded = embedded;
 
         if context.settings().verify.verify_after_reading {
             stream.rewind()?;


### PR DESCRIPTION


## Changes in this pull request

### Vulnerability
A `c2pa.hash.data` assertion's `exclusions` range exists to skip the manifest's own embedded bytes. Presented as a detached manifest (sidecar, remote, or `c2patool --external-manifest`), the verifier applied that exclusion verbatim to whatever asset it was handed, without checking the excluded bytes were ever a C2PA box. An attacker with no signing key can extract a legitimately-signed manifest, overwrite exactly its declared exclusion range in a copy of the asset with unrelated content, and have it validate as `Trusted`. Confirmed via reproduction: a manifest lifted from a signed asset, paired with a copy whose exclusion range was overwritten with a self-contained different image, validated `Trusted` with no failures — while the file actually decoded to the attacker's content. In scope per SECURITY.md (validation bypass).

### Fix
Reject a non-empty (non-zero-length) `c2pa.hash.data` exclusion unless either: the manifest was read out of the asset being validated (`Store.embedded`, now tracked through both the read path and the sign-then-verify path), or the exclusion range matches a C2PA box actually present in the asset right now (via the existing `object_locations`-derived `manifest_store_range`, already used for update-manifest exclusion adjustment). This closes the bypass while still allowing the legitimate case of validating a manifest against the same asset it's still embedded in via the detached-loading API.

### Tests added
`test_detached_manifest_exclusion_hole_rejected` (reader.rs) — signs a real asset, extracts the manifest, overwrites exactly its exclusion range with unrelated bytes, and asserts the detached-manifest validation path (`Reader::from_manifest_data_and_stream`) does not report `Trusted`. Verified this test fails (reports `Trusted`) without the fix.
## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
