### PR TITLE
fix: report CBOR byte strings correctly in crJSON output

### DIFF
--- a/sdk/examples/show.rs
+++ b/sdk/examples/show.rs
@@ -19,9 +19,14 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 {
         let ms = Reader::default().with_file(&args[1])?;
-        println!("{ms}");
+        match args.get(2).map(String::as_str) {
+            Some("detailed") => println!("{}", ms.detailed_json()),
+            Some("crjson") => println!("{}", ms.crjson()),
+            _ => println!("{ms}"),
+        }
     } else {
-        println!("Prints a manifest report (requires a file path argument)")
+        println!("Prints a manifest report (requires a file path argument)");
+        println!("Usage: show <file> [detailed|crjson]");
     }
     Ok(())
 }

--- a/sdk/src/assertion.rs
+++ b/sdk/src/assertion.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 
 use crate::{
     assertions::labels,
+    crypto::base64::encode_b64_wrapped,
     error::{Error, Result},
 };
 
@@ -340,16 +341,9 @@ impl Assertion {
                 .map_err(|e| AssertionDecodeError::from_assertion_and_json_err(self, e)),
 
             AssertionData::Cbor(x) => {
-                let buf: Vec<u8> = Vec::new();
-                let mut from = c2pa_cbor::Deserializer::from_slice(x);
-                let mut to = serde_json::Serializer::new(buf);
-
-                serde_transcode::transcode(&mut from, &mut to)
-                    .map_err(|e| AssertionDecodeError::from_assertion_and_json_err(self, e))?;
-
-                let buf2 = to.into_inner();
-                serde_json::from_slice(&buf2)
-                    .map_err(|e| AssertionDecodeError::from_assertion_and_json_err(self, e))
+                let value: c2pa_cbor::Value = c2pa_cbor::from_slice(x)
+                    .map_err(|e| AssertionDecodeError::from_assertion_and_cbor_err(self, e))?;
+                Ok(cbor_to_crjson(&value))
             }
 
             AssertionData::Binary(x) => {
@@ -497,6 +491,50 @@ impl Assertion {
             }
         }
         Ok(())
+    }
+}
+
+/// Converts a decoded CBOR value into its crJSON-mapped `serde_json::Value` form
+/// (spec: crJSON `cbor_serialised_assertions` mapping table).
+///
+/// Byte strings become `b64'<base64>'`-wrapped strings rather than JSON number
+/// arrays, so a bstr can never be confused with a genuine integer array further
+/// down the pipeline. Tags are unwrapped (dropping the tag number and recursing
+/// into the inner value), which also implements the spec's tag-0 date-time rule.
+/// Non-text map keys are stringified, since JSON object keys must be strings.
+fn cbor_to_crjson(value: &c2pa_cbor::Value) -> Value {
+    use c2pa_cbor::Value as Cbor;
+
+    match value {
+        Cbor::Null => Value::Null,
+        Cbor::Bool(b) => Value::Bool(*b),
+        Cbor::Integer(i) => Value::Number((*i).into()),
+        Cbor::Float(f) => serde_json::Number::from_f64(*f)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        Cbor::Bytes(b) => Value::String(encode_b64_wrapped(b)),
+        Cbor::Text(s) => Value::String(s.clone()),
+        Cbor::Array(a) => Value::Array(a.iter().map(cbor_to_crjson).collect()),
+        Cbor::Map(m) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in m {
+                obj.insert(cbor_key_to_string(k), cbor_to_crjson(v));
+            }
+            Value::Object(obj)
+        }
+        Cbor::Tag(_, inner) => cbor_to_crjson(inner),
+    }
+}
+
+/// Stringifies a CBOR map key for use as a JSON object key.
+fn cbor_key_to_string(key: &c2pa_cbor::Value) -> String {
+    use c2pa_cbor::Value as Cbor;
+
+    match key {
+        Cbor::Text(s) => s.clone(),
+        Cbor::Integer(i) => i.to_string(),
+        Cbor::Bool(b) => b.to_string(),
+        other => cbor_to_crjson(other).to_string(),
     }
 }
 
@@ -711,5 +749,38 @@ pub mod tests {
         let action_restored_obj = action_restored.as_json_object().unwrap();
 
         assert_eq!(action_obj, action_restored_obj);
+    }
+
+    #[test]
+    fn test_cbor_bytes_vs_int_array_crjson_encoding() {
+        #[derive(Serialize)]
+        struct BytesAndArray {
+            raw_bytes: ByteBuf,
+            int_array: Vec<u8>,
+        }
+
+        let value = BytesAndArray {
+            raw_bytes: ByteBuf::from(vec![1, 2, 3, 4]),
+            int_array: vec![5, 6, 7, 8],
+        };
+
+        let data = AssertionData::Cbor(c2pa_cbor::to_vec(&value).unwrap());
+        let assertion = Assertion::new("test.bytes_and_array", None, data);
+
+        let json = assertion.as_json_object().unwrap();
+
+        // A genuine CBOR byte string (major type 2) is reported in crJSON as a
+        // base64-wrapped string, per the spec's `cbor_serialised_assertions` mapping.
+        assert_eq!(
+            json.get("raw_bytes").unwrap().as_str().unwrap(),
+            encode_b64_wrapped(&[1, 2, 3, 4])
+        );
+
+        // A CBOR array of integers (major type 4) is preserved as a JSON number
+        // array, and must never be confused with a byte string.
+        assert_eq!(
+            json.get("int_array").unwrap(),
+            &serde_json::json!([5, 6, 7, 8])
+        );
     }
 }

--- a/sdk/src/crjson.rs
+++ b/sdk/src/crjson.rs
@@ -54,7 +54,7 @@ struct Base64Bytes(Vec<u8>);
 
 impl Serialize for Base64Bytes {
     fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("b64'{}'", base64::encode(&self.0)))
+        s.serialize_str(&base64::encode_b64_wrapped(&self.0))
     }
 }
 
@@ -394,7 +394,7 @@ impl<'a> CrJsonExporter<'a> {
                         key,
                         json!({
                             "identifier": absolute_uri,
-                            "hash": format!("b64'{}'", base64::encode(&assertion_ref.hash()))
+                            "hash": base64::encode_b64_wrapped(&assertion_ref.hash())
                         }),
                     );
                 }
@@ -436,7 +436,7 @@ impl<'a> CrJsonExporter<'a> {
                 Ok(Some(json!({
                     "format": assertion.content_type(),
                     "identifier": absolute_uri,
-                    "hash": format!("b64'{}'", base64::encode(ca.hash()))
+                    "hash": base64::encode_b64_wrapped(ca.hash())
                 })))
             }
             _ => Ok(assertion.as_json_object().ok().map(fix_hash_encoding)),
@@ -659,11 +659,14 @@ fn build_manifest_validation_results(
     }
 }
 
-/// Normalize byte-array hash/pad/signature fields to base64 strings after CBOR→JSON decoding.
+/// Normalize byte-array hash/pad/signature fields to base64 strings, and decode
+/// the CAWG `signature` field into a structured object.
 ///
-/// This is applied to assertion values obtained via [`Assertion::as_json_object`] and to
-/// ingredient assertions serialized via the internal [`Ingredient`] type.
-/// All other output paths use typed structs with [`Base64Bytes`] serialization.
+/// [`Assertion::as_json_object`] now emits CBOR byte strings pre-wrapped as
+/// `b64'<base64>'`, so the array-of-numbers branches below only fire for the
+/// [`Ingredient`] custom serializer path, which still produces plain `Vec<u8>` →
+/// JSON-number-array output. All other output paths use typed structs with
+/// [`Base64Bytes`] serialization.
 fn fix_hash_encoding(value: Value) -> Value {
     match value {
         Value::Object(mut map) => {
@@ -685,7 +688,7 @@ fn fix_hash_encoding(value: Value) -> Value {
                                 .collect();
                             map.insert(
                                 field.to_string(),
-                                json!(format!("b64'{}'", base64::encode(&bytes))),
+                                json!(base64::encode_b64_wrapped(&bytes)),
                             );
                         }
                     }
@@ -694,21 +697,25 @@ fn fix_hash_encoding(value: Value) -> Value {
 
             // Ensure hash-bearing objects also carry a (possibly empty) pad field.
             if map.contains_key("hash") && !map.contains_key("pad") {
-                map.insert("pad".to_string(), json!("b64''"));
+                map.insert("pad".to_string(), json!(base64::encode_b64_wrapped(&[])));
             }
 
             if let Some(sig_val) = map.get("signature") {
-                if let Some(sig_arr) = sig_val.as_array() {
-                    if sig_arr.iter().all(|v| v.is_u64() || v.is_i64()) {
-                        let sig_bytes: Vec<u8> = sig_arr
-                            .iter()
+                let sig_bytes = match sig_val {
+                    // already-decoded crJSON bstr, from Assertion::as_json_object
+                    Value::String(s) => base64::decode_b64_wrapped(s),
+                    // legacy array-of-numbers form
+                    Value::Array(arr) if arr.iter().all(|v| v.is_u64() || v.is_i64()) => Some(
+                        arr.iter()
                             .filter_map(|v| v.as_u64().map(|n| n as u8))
-                            .collect();
-                        let decoded = decode_cawg_signature(&sig_bytes).unwrap_or_else(|_| {
-                            json!(format!("b64'{}'", base64::encode(&sig_bytes)))
-                        });
-                        map.insert("signature".to_string(), decoded);
-                    }
+                            .collect(),
+                    ),
+                    _ => None,
+                };
+                if let Some(sig_bytes) = sig_bytes {
+                    let decoded = decode_cawg_signature(&sig_bytes)
+                        .unwrap_or_else(|_| json!(base64::encode_b64_wrapped(&sig_bytes)));
+                    map.insert("signature".to_string(), decoded);
                 }
             }
 

--- a/sdk/src/crypto/base64.rs
+++ b/sdk/src/crypto/base64.rs
@@ -25,6 +25,20 @@ pub fn decode(data: &str) -> Result<Vec<u8>, DecodeError> {
     general_purpose::STANDARD.decode(data)
 }
 
+/// Encode a byte slice into a crJSON `b64'<base64>'`-wrapped string.
+pub fn encode_b64_wrapped(data: &[u8]) -> String {
+    format!("b64'{}'", encode(data))
+}
+
+/// Decode a crJSON `b64'<base64>'`-wrapped string back into raw bytes.
+///
+/// Returns `None` if `value` isn't wrapped in the `b64'...'` delimiters (e.g. it's
+/// an ordinary string), so callers can tell "not base64" apart from "malformed base64".
+pub fn decode_b64_wrapped(value: &str) -> Option<Vec<u8>> {
+    let inner = value.strip_prefix("b64'")?.strip_suffix('\'')?;
+    decode(inner).ok()
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
@@ -55,5 +69,31 @@ mod tests {
             base64::decode("SGVsbG8sIHdvcmxk"),
             Ok(b"Hello, world".to_vec())
         );
+    }
+
+    #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test
+    )]
+    fn encode_b64_wrapped() {
+        assert_eq!(
+            base64::encode_b64_wrapped(b"Hello, world"),
+            "b64'SGVsbG8sIHdvcmxk'"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", not(target_os = "wasi")),
+        wasm_bindgen_test
+    )]
+    fn decode_b64_wrapped_roundtrip() {
+        let wrapped = base64::encode_b64_wrapped(b"Hello, world");
+        assert_eq!(
+            base64::decode_b64_wrapped(&wrapped),
+            Some(b"Hello, world".to_vec())
+        );
+        assert_eq!(base64::decode_b64_wrapped("not wrapped"), None);
     }
 }

--- a/sdk/src/manifest_assertion.rs
+++ b/sdk/src/manifest_assertion.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use crate::{
     assertion::{AssertionBase, AssertionDecodeError},
     assertions::labels,
+    crypto::base64::decode_b64_wrapped,
     error::{Error, Result},
 };
 
@@ -181,7 +182,8 @@ impl ManifestAssertion {
     /// # }
     /// ```
     pub fn to_assertion<T: DeserializeOwned>(&self) -> Result<T> {
-        serde_json::from_value(self.value()?.to_owned()).map_err(|e| {
+        let value = resolve_b64_wrapped_bytes(self.value()?.to_owned());
+        serde_json::from_value(value).map_err(|e| {
             Error::AssertionDecoding(AssertionDecodeError::from_json_err(
                 self.label.to_owned(),
                 None,
@@ -189,6 +191,29 @@ impl ManifestAssertion {
                 e,
             ))
         })
+    }
+}
+
+/// Reverses crJSON's `b64'<base64>'` byte-string wrapper (as produced for CBOR
+/// byte strings when building this assertion's JSON value) back into a JSON
+/// number array, so typed structs with `Vec<u8>`/`serde_bytes` fields (e.g. the
+/// internal `IdentityAssertion`'s `signature`/`pad1`/`pad2`) still deserialize
+/// correctly.
+fn resolve_b64_wrapped_bytes(value: Value) -> Value {
+    match value {
+        Value::String(s) => match decode_b64_wrapped(&s) {
+            Some(bytes) => {
+                Value::Array(bytes.into_iter().map(|b| Value::Number(b.into())).collect())
+            }
+            None => Value::String(s),
+        },
+        Value::Array(arr) => Value::Array(arr.into_iter().map(resolve_b64_wrapped_bytes).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, resolve_b64_wrapped_bytes(v)))
+                .collect(),
+        ),
+        other => other,
     }
 }
 

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -25,7 +25,11 @@ use serde_json::Value;
 // direct sha functions
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-use crate::{crypto::base64::encode, utils::io_utils::stream_len, Error, Result};
+use crate::{
+    crypto::base64::{decode_b64_wrapped, encode},
+    utils::io_utils::stream_len,
+    Error, Result,
+};
 
 const MAX_HASH_BUF: usize = 256 * 1024 * 1024; // cap memory usage to 256MB
 
@@ -614,6 +618,11 @@ pub fn concat_and_hash(alg: &str, left: &[u8], right: Option<&[u8]>) -> Vec<u8> 
 }
 
 /// replace byte arrays with base64 encoded strings
+///
+/// Also unwraps crJSON `b64'<base64>'` strings (as produced by
+/// [`crate::assertion::Assertion::as_json_object`] for CBOR byte strings) down to
+/// plain base64, since this is the legacy `Reader::json()` convention rather than
+/// the crJSON one.
 pub fn hash_to_b64(mut value: Value) -> Value {
     use std::collections::VecDeque;
 
@@ -624,8 +633,10 @@ pub fn hash_to_b64(mut value: Value) -> Value {
         match current {
             Value::Object(obj) => {
                 for (_, v) in obj.iter_mut() {
-                    if let Value::Array(hash_arr) = v {
-                        if !hash_arr.is_empty() && hash_arr.iter().all(|x| x.is_number()) {
+                    match v {
+                        Value::Array(hash_arr)
+                            if !hash_arr.is_empty() && hash_arr.iter().all(|x| x.is_number()) =>
+                        {
                             // Pre-allocate with capacity to avoid reallocations
                             let mut hash_bytes = Vec::with_capacity(hash_arr.len());
                             // Convert numbers to bytes safely
@@ -636,6 +647,12 @@ pub fn hash_to_b64(mut value: Value) -> Value {
                             }
                             *v = Value::String(encode(&hash_bytes));
                         }
+                        Value::String(s) => {
+                            if let Some(bytes) = decode_b64_wrapped(s) {
+                                *v = Value::String(encode(&bytes));
+                            }
+                        }
+                        _ => {}
                     }
                     queue.push_back(v);
                 }


### PR DESCRIPTION
Assertion::as_json_object now decodes CBOR directly instead of transcoding through serde_json, so byte strings (bstr) are wrapped as crJSON's `b64'<base64>'` strings instead of being flattened into plain JSON number arrays indistinguishable from integer arrays. ManifestAssertion::to_assertion() reverses that wrapping so typed structs with Vec<u8>/serde_bytes fields (e.g. IdentityAssertion's signature/pad1/pad2) still deserialize correctly.

Also adds Reader::crjson()/detailed_json() support to the `show` example, and consolidates ad hoc "b64'...'" formatting into a shared base64::encode_b64_wrapped() helper.
